### PR TITLE
Update modules.conf to load timing drivers

### DIFF
--- a/configs/rpt/modules.conf
+++ b/configs/rpt/modules.conf
@@ -23,7 +23,6 @@
 [modules]
 autoload=no
 
-;load => res_timing_timerfd.so       ; Debug
 ;load => func_frame_trace            ; Debug
 
 ; Applications
@@ -199,6 +198,7 @@ noload => res_clioriginate.so       ; Call origination from the CLI
 noload => res_convert.so            ; File format conversion CLI command
 load => res_crypto.so               ; Cryptographic Digital Signatures
 noload => res_features.so           ; Call Features Resource
+load => res_rpt_http_registrations.so   ; ASL3 app_rpt http registrations
 noload => res_indications.so        ; Indications Resource
 noload => res_jabber.so             ; AJI - Asterisk Jabber Interface
 noload => res_monitor.so            ; Call Monitoring Resource
@@ -206,6 +206,7 @@ noload => res_musiconhold.so        ; Music On Hold Resource
 load => res_smdi.so                 ; Simplified Message Desk Interface (SMDI)
 noload => res_snmp.so               ; SNMP [Sub]Agent for Asterisk
 noload => res_speech.so             ; Generic Speech Recognition API
-load => res_rpt_http_registrations.so   ; ASL3 app_rpt http registrations
+load => res_timing_dahdi.so         ; DAHDI Timing Interface
+load => res_timing_timerfd.so       ; Timerfd Timing Interface
 
 [global]


### PR DESCRIPTION
Updated modules.conf to load the timing drivers res_timer_timerfd and res_timer_dahdi.

This addresses the DMTF crash in usbradio.  Closes #80.