### PR TITLE
Posible fix for Event Management Issue #91

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -524,7 +524,7 @@ static void tone_detect_init(tone_detect_state_t *s, int freq, int duration, int
 
 	/* If we want to remove tone, it is important to have block size not
 	   to exceed frame size. Otherwise by the moment tone is detected it is too late
- 	   to squelch it from previous frames */
+	   to squelch it from previous frames */
 	s->block_size = TONE_SAMPLES_IN_FRAME;
 
 	periods_in_block = s->block_size * freq / TONE_SAMPLE_RATE;
@@ -3392,7 +3392,7 @@ static void *rpt(void *this)
 	rpt_update_boolean(myrpt, "RPT_AUTOPATCHUP", -1);
 	rpt_update_boolean(myrpt, "RPT_NUMLINKS", -1);
 	rpt_update_boolean(myrpt, "RPT_NUMALINKS", -1);
-    rpt_update_boolean(myrpt, "RPT_LINKS", -1);
+	rpt_update_boolean(myrpt, "RPT_LINKS", -1);
 	myrpt->ready = 1;
 	while (ms >= 0) {
 		struct ast_frame *f, *f1, *f2;


### PR DESCRIPTION
Without this fix RPT_NUMALINKS does not exist on node startup. This creates warnings on startup and on first connect as listed here. However, upon first connect, the RPT_NUMALINKS var is created, the event triggers and performs the desired action.

```
root@NewASL ➜  app_rpt git:(master) asterisk -r
Asterisk 20.1.0, Copyright (C) 1999 - 2022, Sangoma Technologies Corporation and others.
Created by Mark Spencer <markster@digium.com>
Asterisk comes with ABSOLUTELY NO WARRANTY; type 'core show warranty' for details.
This is free software, with components licensed under the GNU General Public
License version 2 and other licenses; you are welcome to redistribute it under
certain conditions. Type 'core show license' for details.
=========================================================================
Connected to Asterisk 20.1.0 currently running on NewASL (pid = 246659)
[2023-02-20 15:03:59.146]     -- Hungup 'DAHDI/pseudo-921543352'
[2023-02-20 15:04:01.628] WARNING[246716]: ast_expr2.fl:470 ast_yyerror: ast_yyerror():  syntax error: syntax error, unexpected '>=', expecting $end; Input:
 >= 1
 ^
[2023-02-20 15:04:01.629] WARNING[246716]: ast_expr2.fl:474 ast_yyerror: If you have questions, please refer to https://wiki.asterisk.org/wiki/display/AST/Channel+Variables
NewASL*CLI> rpt showvars 25334
Variable listing for node 25334:
   XX_MAXLINKS=0
   MAXLINKS=0
   RPT_TXKEYED=0
   RPT_ETXKEYED=0
   RPT_RXKEYED=0
   RPT_LINKS=0
   RPT_NUMLINKS=0
   RPT_AUTOPATCHUP=0
    -- 8 variables
NewASL*CLI> rpt fun 25334 *32510
[2023-02-20 15:04:35.525] WARNING[246716]: ast_expr2.fl:470 ast_yyerror: ast_yyerror():  syntax error: syntax error, unexpected '>=', expecting $end; Input:
 >= 1
 ^
[2023-02-20 15:04:35.525] WARNING[246716]: ast_expr2.fl:474 ast_yyerror: If you have questions, please refer to https://wiki.asterisk.org/wiki/display/AST/Channel+Variables
[2023-02-20 15:04:35.525] WARNING[246716]: ast_expr2.fl:470 ast_yyerror: ast_yyerror():  syntax error: syntax error, unexpected '>=', expecting $end; Input:
 >= 1
 ^
[2023-02-20 15:04:35.525] WARNING[246716]: ast_expr2.fl:474 ast_yyerror: If you have questions, please refer to https://wiki.asterisk.org/wiki/display/AST/Channel+Variables
[2023-02-20 15:04:35.645]     -- Hungup 'DAHDI/pseudo-897991673'
[2023-02-20 15:04:35.644] WARNING[246716]: ast_expr2.fl:470 ast_yyerror: ast_yyerror():  syntax error: syntax error, unexpected '>=', expecting $end; Input:
 >= 1
 ^
[2023-02-20 15:04:35.644] WARNING[246716]: ast_expr2.fl:474 ast_yyerror: If you have questions, please refer to https://wiki.asterisk.org/wiki/display/AST/Channel+Variables
[2023-02-20 15:04:36.195] WARNING[246716]: ast_expr2.fl:470 ast_yyerror: ast_yyerror():  syntax error: syntax error, unexpected '>=', expecting $end; Input:
 >= 1
 ^
[2023-02-20 15:04:36.195] WARNING[246716]: ast_expr2.fl:474 ast_yyerror: If you have questions, please refer to https://wiki.asterisk.org/wiki/display/AST/Channel+Variables
[2023-02-20 15:04:36.227]     -- Call accepted by 144.202.112.210:4569 (format ulaw)
[2023-02-20 15:04:36.227]     -- Format for call is (ulaw)
[2023-02-20 15:04:36.313]     -- Event on node 25334 doing rpt command cop,49 for condition c|t|MAXLINKS
[2023-02-20 15:04:38.152]     -- Hungup 'DAHDI/pseudo-402756792'
[2023-02-20 15:04:39.717]     -- <DAHDI/pseudo-284268256> Playing 'rpt/node.gsm' (language 'en')
[2023-02-20 15:04:40.359]     -- <DAHDI/pseudo-284268256> Playing 'digits/2.ulaw' (language 'en')
[2023-02-20 15:04:41.107]     -- <DAHDI/pseudo-284268256> Playing 'digits/5.ulaw' (language 'en')
[2023-02-20 15:04:41.929]     -- <DAHDI/pseudo-284268256> Playing 'digits/1.ulaw' (language 'en')
[2023-02-20 15:04:42.841]     -- <DAHDI/pseudo-284268256> Playing 'digits/0.ulaw' (language 'en')
[2023-02-20 15:04:43.717]     -- <DAHDI/pseudo-284268256> Playing 'rpt/connected.gsm' (language 'en')
[2023-02-20 15:04:44.517]     -- <DAHDI/pseudo-284268256> Playing 'digits/2.ulaw' (language 'en')
[2023-02-20 15:04:45.266]     -- <DAHDI/pseudo-284268256> Playing 'rpt/node.gsm' (language 'en')
[2023-02-20 15:04:45.908]     -- <DAHDI/pseudo-284268256> Playing 'digits/2.ulaw' (language 'en')
[2023-02-20 15:04:46.657]     -- <DAHDI/pseudo-284268256> Playing 'digits/5.ulaw' (language 'en')
[2023-02-20 15:04:47.478]     -- <DAHDI/pseudo-284268256> Playing 'digits/3.ulaw' (language 'en')
[2023-02-20 15:04:48.317]     -- <DAHDI/pseudo-284268256> Playing 'digits/3.ulaw' (language 'en')
[2023-02-20 15:04:49.157]     -- <DAHDI/pseudo-284268256> Playing 'digits/4.ulaw' (language 'en')
[2023-02-20 15:04:49.959]     -- Hungup 'DAHDI/pseudo-284268256'
[2023-02-20 15:04:51.545]     -- <DAHDI/pseudo-1552544202> Playing 'letters/n.ulaw' (language 'en')
[2023-02-20 15:04:52.164]     -- <DAHDI/pseudo-1552544202> Playing 'letters/o.ulaw' (language 'en')
[2023-02-20 15:04:52.816]     -- <DAHDI/pseudo-1552544202> Playing 'letters/i.ulaw' (language 'en')
[2023-02-20 15:04:53.491]     -- <DAHDI/pseudo-1552544202> Playing 'letters/c.ulaw' (language 'en')
[2023-02-20 15:04:54.357]     -- <DAHDI/pseudo-1552544202> Playing 'letters/e.ulaw' (language 'en')
[2023-02-20 15:04:55.020]     -- Hungup 'DAHDI/pseudo-1552544202'
NewASL*CLI>
```
FYI, the event is
```
[events]
MAXLINKS = v|e|$[${RPT_NUMALINKS} >= 1]  ; Test inbound links for GE n links
cop,49 = c|t|MAXLINKS                    ; Disable links if MAXLINKS goes true
cop,50 = c|f|MAXLINKS                    ; Enable links if MAXLINKS goes false
```