### PR TITLE
fix rpt logger example to be in line with asterisk example files

### DIFF
--- a/configs/rpt/logger.conf
+++ b/configs/rpt/logger.conf
@@ -14,7 +14,7 @@ dateformat=%F %T.%3q   ; with milliseconds
 ;
 ; Special filename "console" represents the system console
 ;
-;debug => debug
+;debug.log => debug
 console => notice,warning,error,dtmf
 ;console => notice,warning,error,debug,verbose
-messages => notice,warning,error
+messages.log => notice,warning,error


### PR DESCRIPTION
The following commit in asterisk added .log extension to the messages log file in the sample configuration: https://gerrit.asterisk.org/c/asterisk/+/15696/2/configs/samples/logger.conf.sample
Maybe we want to align our default logger.conf with that one? At least this way the logrotate will be looking at the right file.