### PR TITLE
changing register= to register=> as preferred by asterisk samples, typos

### DIFF
--- a/configs/rpt/iax.conf
+++ b/configs/rpt/iax.conf
@@ -1,11 +1,11 @@
 ; Inter-Asterisk eXchange driver definition
 
 [general]
-; !!! IAX registartion will be discontinued at some point !!!
+; !!! IAX registration will be discontinued at some point !!!
 ; Setup rpt_http_registartions.conf instead.
 ; remove the leading ";"
-;register=1999:12345@register.allstarlink.org    ; This must be changed to your node number, password 
-;register=1998:12345@register.allstarlink.org
+;register => 1999:12345@register.allstarlink.org    ; This must be changed to your node number, password 
+;register => 1998:12345@register.allstarlink.org
 
 bindport = 4569                 ; bindport and bindaddr may be specified
 

--- a/configs/rpt/manager.conf
+++ b/configs/rpt/manager.conf
@@ -12,5 +12,5 @@ bindaddr = 127.0.0.1				; Comment when not localhost access
 secret = make4An1ce-secret
 read = all,system,call,log,verbose,command,agent,user,config
 write = all,system,call,log,verbose,command,agent,user,config
-;deny = 0.0.0.0/0.0.0 				; Uncomment when not localhost
+;deny = 0.0.0.0/0.0.0.0				; Uncomment when not localhost
 ;permit=1.2.3.4/255.255.255.255     ; Uncomment when not localhost

--- a/configs/rpt/modules.conf
+++ b/configs/rpt/modules.conf
@@ -12,7 +12,7 @@
 ; To disable a module: noload => module_name.so
 
 ; You will want to enable the channel driver modules you will be using.
-; There are below in the Channle Driver section
+; There are below in the Channel Driver section
 ; The most common Channel drivers for app_rpt are:
 ; chan_echolink.so   echolink channel driver
 ; chan_simpleusb.so  Simple USB Radio Interface Channel Drive

--- a/configs/rpt/rpt_http_registrations.conf
+++ b/configs/rpt/rpt_http_registrations.conf
@@ -1,5 +1,5 @@
 [general]
 
 [registrations]
-;register=1999:12345@register.allstarlink.org	; This must be changed to your node number, password
-;register=1998:12345@register.allstarlink.org
+;register => 1999:12345@register.allstarlink.org	; This must be changed to your node number, password
+;register => 1998:12345@register.allstarlink.org


### PR DESCRIPTION
asterisk 20 sample configs use "register => " instead of "register=". Not sure if it matters. Plus various other typo fixes for config files.