### PR TITLE
Format extensions.conf 

### DIFF
--- a/configs/rpt/extensions.conf
+++ b/configs/rpt/extensions.conf
@@ -11,39 +11,36 @@ NODE = 1999   ; change this to your node number
 exten => i,1,Hangup
 
 [radio-secure]
-;exten => ${NODE},n,rpt(${EXTEN})
+;exten => ${NODE},1,rpt(${EXTEN})
 exten => _XXXX!,1,NoOp(Connect from node: ${CALLERID(num)})
- same => n,NoOp(Connect to: ${EXTEN})
- ;same => n,Set(FRAME_TRACE()=CONTROL,TEXT,TEXT_DATA)
- ;same => n,Set(FRAME_TRACE(black)=DTMF_BEGIN)
- same => n,rpt(${EXTEN})
+	same => n,NoOp(Connect to: ${EXTEN})
+	;same => n,Set(FRAME_TRACE()=CONTROL,TEXT,TEXT_DATA)
+	;same => n,Set(FRAME_TRACE(black)=DTMF_BEGIN)
+	same => n,rpt(${EXTEN})
 
-[iaxrpt]                                ; entered from iaxrpt in iax.conf
-exten => _XXXX!,1,rpt(${EXTEN}|X)       ; NODE is the Name field in iaxrpt
-                                        ; Info: The X option passed to the Rpt application
-                                        ; disables the normal security checks.
-                                        ; Because incoming connections are validated in iax.conf,
-                                        ; and we don't know where the user will be coming from in advance,
-                                        ; the X option is required.
+[iaxrpt]
+; Entered from iaxrpt in iax.conf
+; Info: The X option passed to the Rpt application
+; disables the normal security checks.
+; Because incoming connections are validated in iax.conf,
+; and we don't know where the user will be coming from in advance,
+; the X option is required.
+exten => ${NODE},1,rpt(${EXTEN}|X)       ; NODE is the Name field in iaxrpt
 
 [iax-client]				; for IAX VIOP clients.				
 exten => ${NODE},1,Ringing
- same => n,Wait(3)
- same => n,Answer
- same => n,Set(NODENUM=${CALLERID(number)})
- same => n,Playback(rpt/node,noanswer)
- same => n,SayDigits(${EXTEN})
- same => n,Set(CALLERID(num)=0)
- same => n,Rpt(${NODE}|P|${CALLERID(name)})
- same => n,Hangup
- same => n(hangit),Answer
- same => n,Wait(1)
- same => n,Hangup
+	same => n,Answer(3000)
+	same => n,Set(NODENUM=${CALLERID(number)})
+	same => n,Playback(rpt/node,noanswer)
+	same => n,SayDigits(${EXTEN})
+	same => n,Set(CALLERID(num)=0)
+	same => n,Rpt(${NODE}|P|${CALLERID(name)})
+	same => n,Hangup
 
 ; Comment-out the following clause if you want Allstar Autopatch service
 [pstn-out]
 exten => _NXXNXXXXXX,1,playback(ss-noservice)
- same => n,Congestion
+	same => n,Congestion
 
 ; Un-comment out the following clause if you want Allstar Autopatch service
 ;[pstn-out]
@@ -51,50 +48,49 @@ exten => _NXXNXXXXXX,1,playback(ss-noservice)
 ; same => n,Busy
 
 [invalidnum]
-exten => s,1,Wait,3
- same => n,Playback,ss-noservice
- same => n,Wait,1
- same => n,Hangup
+exten => s,1,Wait(3)
+	same => n,Playback(ss-noservice)
+	same => n,Wait(1)
+	same => n,Hangup
 
 [radio]
-exten => _X11,1,Goto(check_route|${EXTEN}|1);
+exten => _X11,1,Goto(check_route,${EXTEN},1);
 exten => _NXXXXXX,1,Goto(check_route,1${HOMENPA}${EXTEN},1)
 exten => _1XXXXXXXXXX,1,Goto(check_route,${EXTEN},1)
 exten => _07XX,1,Goto(parkedcalls,${EXTEN:1},1)
-exten => 00,1,Goto(my-ip|s|1)
+exten => 00,1,Goto(my-ip,s,1)
 
 [check_route]
 exten => _X.,1,Noop(${EXTEN})
 ; no 800
-exten => _1800NXXXXXX,2,Goto(invalidnum|s|1)
-exten => _1888NXXXXXX,2,Goto(invalidnum|s|1)
-exten => _1877NXXXXXX,2,Goto(invalidnum|s|1)
-exten => _1866NXXXXXX,2,Goto(invalidnum|s|1)
-exten => _1855NXXXXXX,2,Goto(invalidnum|s|1)
+exten => _1800NXXXXXX,2,Goto(invalidnum,s,1)
+exten => _1888NXXXXXX,2,Goto(invalidnum,s,1)
+exten => _1877NXXXXXX,2,Goto(invalidnum,s,1)
+exten => _1866NXXXXXX,2,Goto(invalidnum,s,1)
+exten => _1855NXXXXXX,2,Goto(invalidnum,s,1)
 ; no X00 NPA
-exten => _1X00XXXXXXX,2,Goto(invalidnum|s|1)
+exten => _1X00XXXXXXX,2,Goto(invalidnum,s,1)
 ; no X11 NPA
-exten => _1X11XXXXXXX,2,Goto(invalidnum|s|1)
+exten => _1X11XXXXXXX,2,Goto(invalidnum,s,1)
 ; no X11 
-exten => _X11,2,Goto(invalidnum|s|1)
+exten => _X11,2,Goto(invalidnum,s,1)
 ; no 555 Prefix in any NPA
-exten => _1NXX555XXXX,2,Goto(invalidnum|s|1)
+exten => _1NXX555XXXX,2,Goto(invalidnum,s,1)
 ; no 976 Prefix in any NPA
-exten => _1NXX976XXXX,2,Goto(invalidnum|s|1)
+exten => _1NXX976XXXX,2,Goto(invalidnum,s,1)
 ; no NPA=809
-exten => _1809XXXXXXX,2,Goto(invalidnum|s|1)
+exten => _1809XXXXXXX,2,Goto(invalidnum,s,1)
 ; no NPA=900
-exten => _1900XXXXXXX,2,Goto(invalidnum|s|1)
+exten => _1900XXXXXXX,2,Goto(invalidnum,s,1)
 
 ; okay, route it
-exten => _1NXXXXXXXXX,2,Goto(pstn-out|${EXTEN:1}|1)
-exten => _X.,2,Goto(invalidnum|s|1)
+exten => _1NXXXXXXXXX,2,Goto(pstn-out,${EXTEN:1},1)
+exten => _X.,2,Goto(invalidnum,s,1)
 
 [my-ip]
-exten => s,1,Set(MYADDR=${CURL(http://myip.vg)})
- same => n,Wait,1
- same => n,SayAlpha(${MYADDR})
- same => n,Hangup
+exten => s,n,Wait(1)
+	same => SayAlpha(${CURL(http://myip.vg)})
+	same => n,Hangup
 
 [allstar-sys]
 exten => _1.,1,Rpt(${EXTEN:1}|Rrpt/node:NODE:rpt/in-call:digits/0:PARKED|120)
@@ -135,21 +131,21 @@ exten => _5.,n,Hangup
 [allstar-public]
 
 exten => s,1,Ringing
- same => n,Set(RESP=${CURL(https://register.allstarlink.org/cgi-bin/authwebphone.pl?${CALLERID(name)})})
- same => n,Set(NODENUM=${CALLERID(number)})
- same => n,GotoIf($["${RESP:0:1}" = "?"]?hangit)
- same => n,GotoIf($["${RESP:0:1}" = ""]?hangit)
- same => n,GotoIf($["${RESP:0:5}" != "OHYES"]?hangit)
- same => n,Set(CALLSIGN=${RESP:5})
- same => n,Wait(3)
- same => n,Playback(rpt/node,noanswer)
- same => n,Saydigits(${NODENUM})
- same => n,Set(CALLERID(name)=${CALLSIGN})
- same => n,Set(CALLERID(num)=0)
- same => n,Rpt(${NODENUM}|X)
- same => n,Hangup
- same => n(hangit),Answer
- same => n,Wait(1)
- same => n,Hangup
+	same => n,Set(RESP=${CURL(https://register.allstarlink.org/cgi-bin/authwebphone.pl?${CALLERID(name)})})
+	same => n,Set(NODENUM=${CALLERID(number)})
+	same => n,GotoIf($["${RESP:0:1}" = "?"]?hangit)
+	same => n,GotoIf($["${RESP:0:1}" = ""]?hangit)
+	same => n,GotoIf($["${RESP:0:5}" != "OHYES"]?hangit)
+	same => n,Set(CALLSIGN=${RESP:5})
+	same => n,Wait(3)
+	same => n,Playback(rpt/node,noanswer)
+	same => n,Saydigits(${NODENUM})
+	same => n,Set(CALLERID(name)=${CALLSIGN})
+	same => n,Set(CALLERID(num)=0)
+	same => n,Rpt(${NODENUM}|X)
+	same => n,Hangup
+	same => n(hangit),Answer
+	same => n,Wait(1)
+	same => n,Hangup
 
 #tryinclude custom/extensions.conf


### PR DESCRIPTION
Use "same => " syntax where appropriate.
Replace " = " with " => " where appropriate.
Replace "|" with "," where appropriate.
Replace "rpt," with "rpt()" as needed.

Changes to be committed:
 modified:   extensions.conf