### PR TITLE
app_rpt:  Change telemetry digits/2 to rpt/to

### DIFF
--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -635,7 +635,7 @@ void handle_varcmd_tele(struct rpt *myrpt, struct ast_channel *mychannel, char *
 		if (!res) {
 			res = ast_stream_and_wait(mychannel, "rpt/connected", "");
 		}
-		res = ast_stream_and_wait(mychannel, "digits/2", "");
+		res = ast_stream_and_wait(mychannel, "rpt/to", "");
 		saynode(myrpt, mychannel, strs[1]);
 		return;
 	}
@@ -1653,7 +1653,7 @@ treataslocal:
 			res = ast_stream_and_wait(mychannel, "rpt/connected", "");
 		}
 		if (!res) {
-			res = ast_stream_and_wait(mychannel, "digits/2", "");
+			res = ast_stream_and_wait(mychannel, "rpt/to", "");
 		}
 		res = saynode(myrpt, mychannel, myrpt->name);
 		imdone = 1;


### PR DESCRIPTION
This changes app_rpt's telemetry to use "rpt/to" instead of "digits/2".  This addresses #142.

The use of digits/2 causes a problem for other languages like French.

A pull request has been made on AllStarLink/ASL-Asterisk to add to.ulaw to the rpt/sounds folder.