### PR TITLE
Use "connected to" sound file to enable translations of telemetry

### DIFF
--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -633,9 +633,8 @@ void handle_varcmd_tele(struct rpt *myrpt, struct ast_channel *mychannel, char *
 		}
 		res = saynode(myrpt, mychannel, strs[2]);
 		if (!res) {
-			res = ast_stream_and_wait(mychannel, "rpt/connected", "");
+			res = ast_stream_and_wait(mychannel, "rpt/connected-to", "");
 		}
-		res = ast_stream_and_wait(mychannel, "digits/2", "");
 		saynode(myrpt, mychannel, strs[1]);
 		return;
 	}
@@ -1650,10 +1649,7 @@ treataslocal:
 		}
 		res = saynode(myrpt, mychannel, mytele->mylink.name);
 		if (!res) {
-			res = ast_stream_and_wait(mychannel, "rpt/connected", "");
-		}
-		if (!res) {
-			res = ast_stream_and_wait(mychannel, "digits/2", "");
+			res = ast_stream_and_wait(mychannel, "rpt/connected-to", "");
 		}
 		res = saynode(myrpt, mychannel, myrpt->name);
 		imdone = 1;


### PR DESCRIPTION
An alternative fix for the telemetry sound file issue that is discussed in https://github.com/InterLinked1/app_rpt/pull/143.
Issue https://github.com/InterLinked1/app_rpt/issues/142.
This time without the merge conflict.