### PR TITLE
chan_echolink: Should not free frame used in ast_dsp_process

### DIFF
--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -1989,7 +1989,6 @@ static int el_xwrite(struct ast_channel *ast, struct ast_frame *frame)
 			if (p->dsp && (!instp->useless_flag_1)) {
 				f2 = ast_translate(p->xpath, &fr, 0);
 				f1 = ast_dsp_process(NULL, p->dsp, f2);
-				ast_frfree(f2);
 				if ((f1->frametype == AST_FRAME_DTMF_END) || (f1->frametype == AST_FRAME_DTMF_BEGIN))
 				{
 					if ((f1->subclass.integer != 'm') && (f1->subclass.integer != 'u')) {


### PR DESCRIPTION
chan_echolink is freeing a frame that was already freed by ast_dsp_process.  This addresses https://github.com/InterLinked1/app_rpt/issues/147.