### PR TITLE
chan_echolink:  Remove el_do_debug

### DIFF
--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -574,7 +574,6 @@ static struct ast_channel_tech el_tech = {
 * CLI extensions
 */
 
-static int el_do_debug(int fd, int argc, const char *const *argv);
 static int el_do_dbdump(int fd, int argc, const char *const *argv);
 static int el_do_dbget(int fd, int argc, const char *const *argv);
 


### PR DESCRIPTION
Updated chan_echolink to remove el_do_debug definition.  This was missed in the previous change.  This corrects #151.