### PR TITLE
chan_echolink and chan_usrp should free frames returned by ast_dsp_process

### DIFF
--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -2005,6 +2005,7 @@ static int el_xwrite(struct ast_channel *ast, struct ast_frame *frame)
 						x = 1;
 					}
 				}
+				ast_frfree(f1);
 			}
 			if (!x)
 				ast_queue_frame(ast, &fr);

--- a/channels/chan_usrp.c
+++ b/channels/chan_usrp.c
@@ -562,6 +562,7 @@ static int usrp_xwrite(struct ast_channel *ast, struct ast_frame *frame)
 						ast_log(LOG_NOTICE, "Got DTMF char %c\n", f->subclass.integer);
 					ast_queue_frame(ast, f);
 				}
+				ast_frfree(f);
 			}
 		}
 	}


### PR DESCRIPTION
chan_echolink and chan_usrp should free frames returned by ast_dsp_process.

This could be associated with #158 and #160.

This closes #164.