### PR TITLE
chan_echolink: Add cli command to show connected nodes

### DIFF
--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -667,7 +667,8 @@ static void print_nodes(const void *nodep, const VISIT which, const int depth)
 	if ((which == leaf) || (which == postorder)) {
 		ast_cli(nodeoutfd, "%s|%s|%s\n",
 				node->nodenum,
-				node->callsign, (*(struct eldb **) nodep)->ipaddr);
+				node->callsign, 
+				node->ipaddr);
 	}
 }
 


### PR DESCRIPTION
This adds a new echolink cli command to show the connected nodes.  It shows the node number, call sign, ip address and device name.

This closes #176