### PR TITLE
chan_echolink: Correct internal database all node delete and connected node delete

### DIFF
--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -2504,7 +2504,7 @@ static void el_db_delete_all_nodes(void)
 	struct eldb *node;
 	
 	ast_mutex_lock(&el_db_lock);
-	while( el_db_nodenum != NULL ) {
+	while (el_db_nodenum) {
 		node = *(struct eldb **) el_db_nodenum;
 		el_db_delete_indexes(node);
 		ast_free(node);


### PR DESCRIPTION
The el_zapem routine was removing all currently connected nodes.  This was wrong, it should have been deleting all database nodes from the tree.  The routine has been renamed from el_zapem to el_db_delete_all_nodes.  It now properly deletes all nodes from the internal database node trees.  The my_stupid_free routine was not needed and removed.

The find_delete routine removes a current node from the connected nodes tree.  The routine was not freeing the memory used by the el_node structure.

While I was doing this working, I removed all forward declarations that were not necessary.

I moved the structs associated with RTCP below the struct for RTP.  This put them all in the same location.

This closes #175