### PR TITLE
chan_echolink: Changes for asterisk standards

### DIFF
--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -3401,7 +3401,7 @@ static void *el_reader(void *data)
 			continue;
 		}
 		if (i < 0) {
-			ast_log(LOG_ERROR, "Fatal error in poll!  errno %i.\n", errno);
+			ast_log(LOG_ERROR, "Fatal error, poll returned %d: %s\n", i, strerror(errno));
 			run_forever = 0;
 			break;
 		}
@@ -3492,7 +3492,7 @@ static void *el_reader(void *data)
 								i = do_new_call(instp, NULL, call, name);
 								if (i < 0) {
 									/* we failed to create a new call - error reported by do_new_call */
-									i=0;
+									i = 0;
 								}
 							}
 							if (i) {	/* if not authorized or do_new_call failed*/


### PR DESCRIPTION
This commit updates chan_echolink to conform to the asterisk coding standards. The biggest change was using opening and closing braces on if, do, and while statements. All routines were evaluated and const was added as appropriate. Initialization of some function variables at declaration were removed when the variable was actually assigned to first later in the code. Casts to and from void were removed. New variables were added to some routines so that multiple casts would not be needed later in the code.

Some function declarations were changed to clarify the variable names. Several functions used single letter variables. They now have a more meaningful name. el_node's structure was changed to declare el_pvt as pvt instead of p.

Three logic changes were made: is_rtcp_bye and is_rtcp_sdes now exit their internal loops when they find the sdes packet. There was no need to continue the loop. The code to open and close /dev/null was moved to __mythread_exit.

The logging and debugging statements were reworded to make a complete sentence and/or clarify the data.

mythread_exit was removed after discussion.  It is not needed.

Addressed problem with nodes that start with '4' not being reported.

This closes #189