### PR TITLE
app_rpt / chan_usrp: Bug fixes

### DIFF
--- a/apps/app_rpt/rpt_cli.c
+++ b/apps/app_rpt/rpt_cli.c
@@ -1201,7 +1201,7 @@ static char *handle_cli_dump(struct ast_cli_entry *e, int cmd, struct ast_cli_ar
 {
 	switch (cmd) {
 	case CLI_INIT:
-		e->command = "rpt dump level";
+		e->command = "rpt dump";
 		e->usage =
 			"Usage: rpt dump <nodename>\n"
 			"	Dumps struct debug info to log\n";

--- a/channels/chan_usrp.c
+++ b/channels/chan_usrp.c
@@ -519,6 +519,7 @@ static int usrp_xwrite(struct ast_channel *ast, struct ast_frame *frame)
 				p->rxkey = 1;
 		} else {
 			if (!p->rxkey) {
+				memset(&fr, 0, sizeof(fr));
 				fr.datalen = 0;
 				fr.samples = 0;
 				fr.frametype = AST_FRAME_CONTROL;
@@ -661,6 +662,7 @@ static struct ast_channel *usrp_new(struct usrp_pvt *i, int state, const struct 
 		ast_channel_context_set(tmp, context);
 		ast_channel_exten_set(tmp, "s");
 		ast_channel_language_set(tmp, "");
+		ast_channel_unlock(tmp);
 		i->owner = tmp;
 		i->u = ast_module_user_add(tmp);
 		if (state != AST_STATE_DOWN) {
@@ -712,7 +714,7 @@ static int unload_module(void)
 
 static int load_module(void)
 {
-	ast_cli_unregister_multiple(cli_usrp_show, ARRAY_LEN(cli_usrp_show));
+	ast_cli_register_multiple(cli_usrp_show, ARRAY_LEN(cli_usrp_show));
 	if (!(usrp_tech.capabilities = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT))) {
 		return AST_MODULE_LOAD_DECLINE;
 	}


### PR DESCRIPTION
This pull request addresses the following issues:

app_rpt: Should recognize an empty string for the `scheduler =` entry.  #193

app_rpt: The rpt() and rpt_exec() routines depend on ast_waitfor_nandfds for loop timing.  On slower systems, the internal timers do not run reliably or accurately.  In my case, they did not run at all.  The timing for these functions has been upgraded to use an actual time calculation.  This makes the internal timers calculate properly in all cases. #195

app_rpt: The rpt dump cli command was not working.  This is corrected.  #192

chan_usrp:  Should unlock the channel when it is created.   This is corrected. #194

chan_usrp: The usrp show cli command was not working.  It was being unregistered instead of registered.  #194

chan_usrp:  Crashed when receiving audio due to a frame not being initialized.  This has been corrected #198

These changes close #192, #193, #194, #195, and #198