### PR TITLE
chan_echolink:  Address problem with maintaining the internal database

### DIFF
--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -779,7 +779,7 @@ static struct eldb *el_db_find_ipaddr(const char *ipaddr)
 static void el_db_delete_entries(struct eldb *node)
 {
 	const struct eldb *mynode_num, *mynode_ip, *mynode_call;
-		
+
 	if (!node) {
 		return;
 	}
@@ -800,7 +800,7 @@ static void el_db_delete_entries(struct eldb *node)
 	}
 	
 	if (!(mynode_num == mynode_ip && mynode_ip == mynode_call)) {
-		ast_log(LOG_WARNING, "Echolink internal database corruption removing callsign %s node number=%p node ip=%p node call=%p", node->callsign, mynode_num, mynode_ip, mynode_call);
+		ast_log(LOG_ERROR, "Echolink internal database corruption removing callsign %s node number=%p node ip=%p node call=%p", node->callsign, mynode_num, mynode_ip, mynode_call);
 	}
 
 	ast_free(node);


### PR DESCRIPTION
chan_echolink crashed when it received a request from the echolink server to process a full directory.  chan_echolink attempted to free the three internal binary trees and ran into a problem with a double free.  The node had already been freed but not removed from the binary tree.

There was an issue with one of the trees.  The delete routine was not finding the entry and leaving it in the tree.  This could be unrelated to the problem being report, it however represented a memory leak and a problem.

I consolidated some of the tree delete code into one routine.  This eliminated one routine and associated call.

While I was making changes, I addressed the issue with several char fields were being defined by size plus 1.  The 'define' that was used already contained the necessary size to include the trailing null character.

I replaced several uses of the define with the sizeof operator, as recommended.

This closes #196.