### PR TITLE
app_rpt: Is not processing GPIOx:x events properly

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -877,8 +877,10 @@ void rpt_event_process(struct rpt *myrpt)
 				if (argc > 1)
 					ast_copy_string(myrpt->cmdAction.param, argv[1], MAXDTMF - 1);
 				myrpt->cmdAction.digits[0] = 0;
-				if (argc > 2)
+				if (argc > 2) {
 					ast_copy_string(myrpt->cmdAction.digits, argv[2], MAXDTMF - 1);
+					snprintf(myrpt->cmdAction.param, MAXDTMF - 1, "%s,%s", argv[1], argv[2]);
+				}
 				myrpt->cmdAction.command_source = SOURCE_RPT;
 				myrpt->cmdAction.state = CMD_STATE_READY;
 			} else {
@@ -7154,7 +7156,8 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 			int j, k;
 			char string[100];
 
-			if (sscanf(myrpt->p.lconn[i], "GPIO%d=%d", &j, &k) == 2) {
+			if (sscanf(myrpt->p.lconn[i], "GPIO%d=%d", &j, &k) == 2 ||
+				sscanf(myrpt->p.lconn[i], "GPIO%d:%d", &j, &k) == 2) {
 				sprintf(string, "GPIO %d %d", j, k);
 				ast_sendtext(myrpt->rxchannel, string);
 			} else if (sscanf(myrpt->p.lconn[i], "PP%d=%d", &j, &k) == 2) {
@@ -7906,7 +7909,8 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 			int j, k;
 			char string[100];
 
-			if (sscanf(myrpt->p.ldisc[i], "GPIO%d=%d", &j, &k) == 2) {
+			if (sscanf(myrpt->p.ldisc[i], "GPIO%d=%d", &j, &k) == 2 ||
+				sscanf(myrpt->p.ldisc[i], "GPIO%d:%d", &j, &k) == 2) {
 				sprintf(string, "GPIO %d %d", j, k);
 				ast_sendtext(myrpt->rxchannel, string);
 			} else if (sscanf(myrpt->p.ldisc[i], "PP%d=%d", &j, &k) == 2) {

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -1704,17 +1704,19 @@ int function_cop(struct rpt *myrpt, char *param, char *digitbuf, int command_sou
 		return DC_COMPLETE;
 #endif
 	case 61:					/* send GPIO change */
-	case 62:					/* same, without function complete (quietly, oooooooh baby!) */
+	case 62:					/* same, without function complete (quietly) */
 		if (argc < 1)
 			break;
 		/* ignore if not a USB channel */
-		if (!strcasecmp(ast_channel_tech(myrpt->rxchannel)->type, "radio") &&
-			!strcasecmp(ast_channel_tech(myrpt->rxchannel)->type, "beagle") &&
-			!strcasecmp(ast_channel_tech(myrpt->rxchannel)->type, "simpleusb"))
-			break;
+		if (strcasecmp(ast_channel_tech(myrpt->rxchannel)->type, "radio") &&
+			strcasecmp(ast_channel_tech(myrpt->rxchannel)->type, "beagle") &&
+			strcasecmp(ast_channel_tech(myrpt->rxchannel)->type, "simpleusb")) {
+				break;
+			}
 		/* go thru all the specs */
 		for (i = 1; i < argc; i++) {
-			if (sscanf(argv[i], "GPIO%d=%d", &j, &k) == 2) {
+			if (sscanf(argv[i], "GPIO%d=%d", &j, &k) == 2 ||
+				sscanf(argv[i], "GPIO%d:%d", &j, &k) == 2) {
 				sprintf(string, "GPIO %d %d", j, k);
 				ast_sendtext(myrpt->rxchannel, string);
 			} else if (sscanf(argv[i], "PP%d=%d", &j, &k) == 2) {
@@ -1722,8 +1724,9 @@ int function_cop(struct rpt *myrpt, char *param, char *digitbuf, int command_sou
 				ast_sendtext(myrpt->rxchannel, string);
 			}
 		}
-		if (myatoi(argv[0]) == 61)
+		if (myatoi(argv[0]) == 61) {
 			rpt_telemetry(myrpt, COMPLETE, NULL);
+		}
 		return DC_COMPLETE;
 	case 63:					/* send pre-configured APRSTT notification */
 	case 64:


### PR DESCRIPTION
app_rpt is not processing GPIOx:x events properly.  Several changes were made to recognize the format used in the event section.  A change was also made in the event routine to properly pass the GPIOx:x information for use by the cop function processing routine.

This has been tested on my system and it works properly.

This closes #210