### PR TITLE
chan_usbradio and chan_simpleusb: Bad file descriptor on startup

### DIFF
--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -730,7 +730,7 @@ static void kickptt(struct chan_simpleusb_pvt *o)
 	if (!o) {
 		return;
 	}
-	if (o->pttkick[1] < 1) {
+	if (o->pttkick[1] == -1) {
 		return;
 	}
 	res = write(o->pttkick[1], &c, 1);

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -763,7 +763,7 @@ static void kickptt(struct chan_usbradio_pvt *o)
 	if (!o) {
 		return;
 	}
-	if (o->pttkick[1] < 1) {
+	if (o->pttkick[1] == -1) {
 		return;
 	}
 	res = write(o->pttkick[1], &c, 1);


### PR DESCRIPTION
chan_usbradio and chan_simpleusb are reporting a bad file description when asterisk is initially launched.

This was the result of not testing the pipe variable properly.

This closes #191.