### PR TITLE
chan_simplesub / chan_usbradio: Address HID has died and code cleanup

### DIFF
--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -108,11 +108,6 @@
 #define	PP_PORT "/dev/parport0"
 #define	PP_IOPORT 0x378
 
-/* Previous versions of this driver assumed 32 gpio pins
- * the current and prior cm-xxx devices only support 8 gpio lines.
- */
-#define GPIO_PINCOUNT 8
-
 #define	PAGER_SRC "PAGER"
 #define	ENDPAGE_STR "ENDPAGE"
 #define AMPVAL 12000
@@ -869,7 +864,7 @@ static void *hidthread(void *arg)
 	int i, j, k, res;
 	struct usb_device *usb_dev;
 	struct usb_dev_handle *usb_handle;
-	struct chan_simpleusb_pvt *o = (struct chan_simpleusb_pvt *) arg, *ao;
+	struct chan_simpleusb_pvt *o = arg, *ao;
 	struct timeval then;
 	struct ast_config *cfg1;
 	struct ast_variable *v;

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -86,11 +86,6 @@
 #define	PP_PORT "/dev/parport0"
 #define	PP_IOPORT 0x378
 
-/* Previous versions of this driver assumed 32 gpio pins
- * the current and prior cm-xxx devices only support 8 gpio lines.
- */
-#define GPIO_PINCOUNT 8
-
 #include "./xpmr/xpmr.h"
 #ifdef HAVE_XPMRX
 #include "./xpmrx/xpmrx.h"
@@ -879,7 +874,7 @@ static void *pulserthread(void *arg)
  * kill the node and restart everything.  This helps to detect problems with a
  * hung USB device.
  *
- * \param argv		Pointer to chan_simpleusb_pvt structure associated with this thread.
+ * \param argv		Pointer to chan_usbradio_pvt structure associated with this thread.
  */
 static void *hidthread(void *arg)
 {
@@ -888,7 +883,7 @@ static void *hidthread(void *arg)
 	int i, j, k, res;
 	struct usb_device *usb_dev;
 	struct usb_dev_handle *usb_handle;
-	struct chan_usbradio_pvt *o = (struct chan_usbradio_pvt *) arg, *ao;
+	struct chan_usbradio_pvt *o = arg, *ao;
 	struct timeval then;
 	struct ast_config *cfg1;
 	struct ast_variable *v;

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -81,6 +81,12 @@
 #define	EEPROM_TXCTCSSADJ	15
 #define	EEPROM_RXSQUELCHADJ	16
 
+/* Previous versions of this driver assumed 32 gpio pins
+ * the current and prior cm-xxx devices only support 8 gpio lines.
+ */
+#define GPIO_PINCOUNT 8
+
+
 /*
  * Helper macros to parse config arguments. They will go in a common
  * header file if their usage is globally accepted. In the meantime,


### PR DESCRIPTION
chan_simpleusb and chan_usbradio have exhibited a timing issue when initializing usb devices on a Dell 5070 computer. This resulted in a HID has died error message.  The issue was caused by the routine not updating the lasthidtime often enough.  This issue has been addressed and works.  This closes #219.

The hidthread routine was carefully documented.  Coding standards were applied.  I discovered that the CMxxx devices only support 8 GPIO lines.  The code was originally setup for 32 gpio lines.  A define was added to the program to set the limit to 8 lines.  The storage and associated loops were updated with this new define.  This saved some cpu time.

The hidthread routine contained special initialization code for the N1KDO usb device.  After discussions with Tim, he approved removing that code.  This device has not been manufactured in 15 years and the 4 port version was never mass produced.  This code contributed to the issue above.  I got information directly from N1KDO on the device.  An N1KDO device will still be recognized.  I believe this code was associated with the 4 port version.

The routine was using ast_select instead of ast_poll.  It has been updated to use ast_poll.  This moved initialization of the polling variables outside of the loop.

This routine should have been almost identical in both chan_simpleusb and chan_usbradio.  Changes were made to bring them both into agreement.  Some variables were renamed, some commands were moved slightly.  A diff of the two functions now show them to be in better agreement.

The code to check the parallel port for input was being executed regardless of whether we had a parallel port.  The code now checks to see if we have a parallel port and skips over that code, saving cpu cycles.

Code to reset the pointers in the internal linked list was wrapped with  #if 0 .. #endif.  This code did not change anything.  The list pointers were always found to be correct.  This code can be safely removed after further testing.  There have been no problems on two of my systems that run two usb devices.