### PR TITLE
chan_simpleusb: Removed unneeded code

### DIFF
--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1107,9 +1107,7 @@ static void *hidthread(void *arg)
 			if (o->wanteeprom) {
 				ast_mutex_lock(&o->eepromlock);
 				if (o->eepromctl == 1) {	/* to read */
-					unsigned short checksum;
 					/* if CS okay */
-					checksum = ast_radio_get_eeprom(usb_handle, o->eeprom);
 					if (!ast_radio_get_eeprom(usb_handle, o->eeprom)) {
 						if (o->eeprom[EEPROM_USER_MAGIC_ADDR] != EEPROM_MAGIC) {
 							ast_log(LOG_ERROR, "Channel %s: EEPROM bad magic number\n", o->name);


### PR DESCRIPTION
chan_simpleusb, removed unneeded code that resulted in a compile error.

For some reason it compiled clean on my computer, but the code in question should have been deleted before the last push.  I have addressed that issue in the cm119b_update branch.

This closes #231