### PR TITLE
chan_simpleusb, chan_usbradio: Reduce frequency of device string not found messages

### DIFF
--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -200,7 +200,7 @@ struct chan_simpleusb_pvt {
 	int boost;					/* input boost, scaled by BOOST_SCALE */
 	char devicenum;
 	char devstr[128];
-	unsigned int device_error : 1;	/* this is set when we cannot find the USB device */
+	unsigned int device_error:1;	/* this is set when we cannot find the USB device */
 	int spkrmax;
 	int micmax;
 	int micplaymax;

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -200,7 +200,7 @@ struct chan_usbradio_pvt {
 	int boost;					/* input boost, scaled by BOOST_SCALE */
 	char devicenum;
 	char devstr[128];
-	unsigned int device_error : 1;	/* this is set when we cannot find the USB device */
+	unsigned int device_error:1;	/* this is set when we cannot find the USB device */
 	int spkrmax;
 	int micmax;
 	int micplaymax;


### PR DESCRIPTION
This changes chan_simpleusb and chan_usbradio to reduce frequency of device string not found messages.

The message will now be repeated every 4.25 minutes.

This closes #229