### PR TITLE
Set and comment res_timing_timerfd.so is preferred for ASL3.

### DIFF
--- a/configs/rpt/modules.conf
+++ b/configs/rpt/modules.conf
@@ -207,7 +207,7 @@ load => res_smdi.so                 ; Simplified Message Desk Interface (SMDI)
 noload => res_snmp.so               ; SNMP [Sub]Agent for Asterisk
 noload => res_speech.so             ; Generic Speech Recognition API
 load => res_timing_dahdi.so         ; DAHDI Timing Interface
-load => res_timing_timerfd.so       ; Timerfd Timing Interface
+load => res_timing_timerfd.so       ; Timerfd Timing Interface is preferred for ASL3
 load => res_usbradio.so             ; ASL3 required for both simpleusb and usbradio
 
 [global]


### PR DESCRIPTION
Update modules.conf with res_timing_timerfd.so comment. Move res_timing_dahdi.so in with other resources.