### PR TITLE
chan_echolink: Minor changes after code review for seg fault

### DIFF
--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -1794,7 +1794,7 @@ static void send_info(const void *nodep, const VISIT which, const int depth)
 	struct sockaddr_in sin;
 	char pkt[5120], *cp;
 	struct el_instance *instp = (*(struct el_node **) nodep)->instp;
-	int i;
+	int i, j;
 
 	if ((which == leaf) || (which == postorder)) {
 
@@ -1804,7 +1804,15 @@ static void send_info(const void *nodep, const VISIT which, const int depth)
 		sin.sin_addr.s_addr = inet_addr((*(struct el_node **) nodep)->ip);
 		
 		i = snprintf(pkt, sizeof(pkt), "oNDATA\rWelcome to Allstar Node %s\r", instp->astnode);
-		snprintf(pkt + i, sizeof(pkt) - i, "Echolink Node %s\rNumber %u\r \r", instp->mycall, instp->mynode);
+		if (i >= sizeof(pkt)) {
+			ast_log(LOG_WARNING, "Exceeded buffer size");
+			return;
+		}
+		j = snprintf(pkt + i, sizeof(pkt) - i, "Echolink Node %s\rNumber %u\r \r", instp->mycall, instp->mynode);
+		if (j >= sizeof(pkt) - i) {
+			ast_log(LOG_WARNING, "Exceeded buffer size");
+			return;
+		}
 		
 		if ((*(struct el_node **) nodep)->pvt && (*(struct el_node **) nodep)->pvt->linkstr) {
 			i = strlen(pkt);


### PR DESCRIPTION
I made small adjustments to the code while looking for the memory overwrite issue reported in #248.

I changed the number of links to be reported to match the same size as used in app_rpt (250 max). One buffer was resized to match the size used in app_rpt for links (5120 bytes).

The el_text routine was not calculating the size of the buffer needed to report the links properly.  It was under sizing the buffer.

Corrected the use of length returned by snprintf.  I removed the returned length and changed it to use the sizeof function.

The memory overwrite could have happened in another module.  The faulting code looks ok. I ran a number of simulations with no problems.

I recommend closing #248 and continue to monitor for faults.  I further recommend recompiling with malloc_debug on the user system to monitor this problem.