### PR TITLE
chan_simpleusb, chan_usbradio:  Correct inconsistent active device messages

### DIFF
--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -2777,7 +2777,7 @@ static int susb_tune(int fd, int argc, const char *const *argv)
 		return RESULT_SUCCESS;
 	}
 	if (!o->hasusb) {
-		ast_cli(fd, "Device %s is selected, the associated USB device string %s was not found\n", o->name, o->devstr);
+		ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 		return RESULT_SUCCESS;
 	} else if (!strcasecmp(argv[2], "rx")) {
 		i = 0;
@@ -3083,7 +3083,6 @@ static void tune_menusupport(int fd, struct chan_simpleusb_pvt *o, const char *c
 {
 	int x, oldverbose;
 	struct chan_simpleusb_pvt *oy = NULL;
-	const char usb_not_assigned[] = "Device %s is selected, the associated USB device string %s was not found\n";
 
 	oldverbose = option_verbose;
 	option_verbose = 0;
@@ -3118,28 +3117,28 @@ static void tune_menusupport(int fd, struct chan_simpleusb_pvt *o, const char *c
 		break;
 	case 'b':					/* receiver tune display */
 		if (!o->hasusb) {
-			ast_cli(fd, usb_not_assigned, o->name, o->devstr);
+			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
 		}
 		tune_rxdisplay(fd, o);
 		break;
 	case 'c':					/* receive menu */
 		if (!o->hasusb) {
-			ast_cli(fd, usb_not_assigned, o->name, o->devstr);
+			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
 		}
 		_menu_rx(fd, o, cmd + 1);
 		break;
 	case 'f':					/* tx A menu */
 		if (!o->hasusb) {
-			ast_cli(fd, usb_not_assigned, o->name, o->devstr);
+			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
 		}
 		_menu_txa(fd, o, cmd + 1);
 		break;
 	case 'g':					/* tx B menu */
 		if (!o->hasusb) {
-			ast_cli(fd, usb_not_assigned, o->name, o->devstr);
+			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
 		}
 		_menu_txb(fd, o, cmd + 1);
@@ -3160,7 +3159,7 @@ static void tune_menusupport(int fd, struct chan_simpleusb_pvt *o, const char *c
 		break;
 	case 'l':					/* send test tone */
 		if (!o->hasusb) {
-			ast_cli(fd, usb_not_assigned, o->name, o->devstr);
+			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
 		}
 		tune_flash(fd, o, 1);

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -2781,7 +2781,7 @@ static int radio_tune(int fd, int argc, const char *const *argv)
 	}
 
 	if (!o->hasusb) {
-		ast_cli(fd, "Device %s is selected, the associated USB device string %s was not found\n", o->name, o->devstr);
+		ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 		return RESULT_SUCCESS;
 	}
 
@@ -3777,7 +3777,6 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 {
 	int x, oldverbose, flatrx, txhasctcss;
 	struct chan_usbradio_pvt *oy = NULL;
-	const char usb_not_assigned[] = "Device %s is selected, the associated USB device string %s was not found\n";
 
 	oldverbose = option_verbose;
 	option_verbose = 0;
@@ -3821,63 +3820,63 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 		break;
 	case 'a':					/* receive tune */
 		if (!o->hasusb) {
-			ast_cli(fd, usb_not_assigned, o->name, o->devstr);
+			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
 		}
 		tune_rxinput(fd, o, 1, 1);
 		break;
 	case 'b':					/* receive tune display */
 		if (!o->hasusb) {
-			ast_cli(fd, usb_not_assigned, o->name, o->devstr);
+			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
 		}
 		do_rxdisplay(fd, o);
 		break;
 	case 'c':					/* set receive voice level */
 		if (!o->hasusb) {
-			ast_cli(fd, usb_not_assigned, o->name, o->devstr);
+			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
 		}
 		_menu_rxvoice(fd, o, cmd + 1);
 		break;
 	case 'd':					/* set receive ctcss level */
 		if (!o->hasusb) {
-			ast_cli(fd, usb_not_assigned, o->name, o->devstr);
+			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
 		}
 		tune_rxctcss(fd, o, 1);
 		break;
 	case 'e':					/* set squelch level */
 		if (!o->hasusb) {
-			ast_cli(fd, usb_not_assigned, o->name, o->devstr);
+			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
 		}
 		_menu_rxsquelch(fd, o, cmd + 1);
 		break;
 	case 'f':					/* set voice transmit level */
 		if (!o->hasusb) {
-			ast_cli(fd, usb_not_assigned, o->name, o->devstr);
+			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
 		}
 		_menu_txvoice(fd, o, cmd + 1);
 		break;
 	case 'g':					/* set aux transmit level */
 		if (!o->hasusb) {
-			ast_cli(fd, usb_not_assigned, o->name, o->devstr);
+			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
 		}
 		_menu_auxvoice(fd, o, cmd + 1);
 		break;
 	case 'h':					/* transmit a test tone */
 		if (!o->hasusb) {
-			ast_cli(fd, usb_not_assigned, o->name, o->devstr);
+			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
 		}
 		_menu_txtone(fd, o, cmd + 1);
 		break;
 	case 'i':					/* tune receive level */
 		if (!o->hasusb) {
-			ast_cli(fd, usb_not_assigned, o->name, o->devstr);
+			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
 		}
 		tune_rxvoice(fd, o, 1);
@@ -3898,7 +3897,7 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 		break;
 	case 'l':					/* transmit test tone */
 		if (!o->hasusb) {
-			ast_cli(fd, usb_not_assigned, o->name, o->devstr);
+			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
 		}
 		tune_flash(fd, o, 1);

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -214,6 +214,10 @@ struct usbecho {
 	struct qelem *q_prev;
 	short data[FRAME_SIZE];
 };
+/*
+ * Message definition used in usb channel drivers.
+ */
+#define USB_UNASSIGNED_FMT	"Device %s is selected, the associated USB device string %s was not found\n"
 
 /*! \brief Round double number to a long
  *


### PR DESCRIPTION
chan_simpleusb and chan_usbradio printed inconsistent messages when using the susb tune commands and the associated USB device was not found.

The message now reads "Device xxxx is selected, the associated USB device string yyyy was not found".

This will help users understand the nature of the problem.

This closes #258.