### PR TITLE
chan_simpleusb / chan_usbradio: Fix tune menu-support, add show settings

### DIFF
--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -3560,7 +3560,7 @@ static char *handle_susb_show_settings(struct ast_cli_entry *e, int cmd, struct 
 	case CLI_GENERATE:
 		return NULL;
 	}
-	//show the settings
+	
 	o = find_desc(simpleusb_active);
 	if (o) {
 		_menu_print(a->fd, o);

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -4983,7 +4983,7 @@ static char *handle_show_settings(struct ast_cli_entry *e, int cmd, struct ast_c
 	case CLI_GENERATE:
 		return NULL;
 	}
-	//show the settings
+	
 	o = find_desc(usbradio_active);
 	if (o) {
 		_menu_print(a->fd, o);


### PR DESCRIPTION
chan_simpleusb and chan_usbradio have been updated to restore the susb tune menu-support and radio tune menu-support command option.  This command was missed in the last update to add command tab support.

The last update removed the ability to type susb tune or radio tune with no options to see the current settings. This is no longer possible with tab completion.  A new command has been added.

Both drivers now have the ability to show settings using susb show settings or radio show settings.

This closes #256