### PR TITLE
 chan_usrp: Correct channel name for xstat

### DIFF
--- a/channels/chan_usrp.c
+++ b/channels/chan_usrp.c
@@ -265,7 +265,7 @@ static struct usrp_pvt *usrp_alloc(void *data)
 	if (pvt) {
 		memset(pvt, 0, sizeof(struct usrp_pvt));
 
-		snprintf(pvt->stream, sizeof(pvt->stream), "%s:%d", args.hisip, atoi(args.hisport));
+		snprintf(pvt->stream, sizeof(pvt->stream), "%s:%d:%d", args.hisip, atoi(args.hisport), atoi(args.myport));
 		pvt->rxq.qe_forw = &pvt->rxq;
 		pvt->rxq.qe_back = &pvt->rxq;
 


### PR DESCRIPTION
chan_usrp is not creating the channel name that matches the name used in app_rpt.  This causes rpt_manager_do_xstat to report that the channel does not exist.

chan_usrp now creates name in the same format as expected in app_rpt.

This closes #254