### PR TITLE
chan_usbradio / chan_simpleusb: Changes for queue size / buffer error reporting

### DIFF
--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1337,7 +1337,7 @@ static int used_blocks(struct chan_simpleusb_pvt *o)
 			o->name, info.fragstotal, info.fragsize, info.fragments, info.bytes);
 		o->total_blocks = info.fragments;
 		/* Check the queue size, it cannot exceed the total fragments */
-		if (info.fragstotal >= o->queuesize) {
+		if (o->queuesize >= info.fragstotal) {
 			o->queuesize = info.fragstotal - 1;
 			if (o->queuesize < 2) {
 				o->queuesize = QUEUE_SIZE;

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -1389,7 +1389,7 @@ static int used_blocks(struct chan_usbradio_pvt *o)
 			o->name, info.fragstotal, info.fragsize, info.fragments, info.bytes);
 		o->total_blocks = info.fragments;
 		/* Check the queue size, it cannot exceed the total fragments */
-		if (info.fragstotal >= o->queuesize) {
+		if (o->queuesize >= info.fragstotal) {
 			o->queuesize = info.fragstotal - 1;
 			if (o->queuesize < 2) {
 				o->queuesize = QUEUE_SIZE;
@@ -1435,8 +1435,11 @@ static int soundcard_writeframe(struct chan_usbradio_pvt *o, short *data)
 	 */
 	res = used_blocks(o);
 	if (res > o->queuesize) {	/* no room to write a block */
-		ast_log(LOG_WARNING, "Channel %s: Sound device write buffer overflow - used %d blocks\n",
-			o->name, res);
+		/* Only report a buffer overflow when we are transmitting */
+		if (o->pmrChan->txPttIn || o->pmrChan->txPttOut) {
+			ast_log(LOG_WARNING, "Channel %s: Sound device write buffer overflow - used %d blocks\n",
+				o->name, res);
+		}
 		return 0;
 	}
 


### PR DESCRIPTION
chan_usbradio / chan_simpleusb corrected the test for queuesize being larger than the available buffers.

chan_usbradio has code added to prevent the reporting of buffer overflows if we are not in transmit.

Related to #273