### PR TITLE
Extensions.conf: New blacklist/whitelist

### DIFF
--- a/configs/rpt/extensions.conf
+++ b/configs/rpt/extensions.conf
@@ -17,9 +17,12 @@ exten => _XXXX!,1,NoOp(Connect from node: ${CALLERID(num)})
 	same => n,NoOp(The IAXPEER is ${IAXPEER(CURRENTCHANNEL)})
 	same => n,NoOp(The Channel IP is ${CHANNEL(peerip)})
 	same => n,GotoIf($["${CHANNEL(peerip)}" = "127.0.0.1"]?connect)  ;permit local IPs
-	same => n,GotoIf(${DB_EXISTS(whitelist/${EXTEN}/${CALLERID(num)})}?connect)
-	same => n,GotoIf(${DB_EXISTS(blacklist/${EXTEN}/${CALLERID(num)})}?:connect)
-	same => n,NoOp(${EXTEN} black listed)
+	same => n,GotoIf($[${DB_KEYCOUNT(whitelist/${EXTEN})} = 0]?blacklist) ;No whitelist
+	same => n,GotoIf(${DB_EXISTS(whitelist/${EXTEN}/${CALLERID(num)})}?connect) ;permit whitelist
+	same => n,NoOp(${EXTEN} not white listed)
+	same => n,Hangup
+	same => n(blacklist),GotoIf(${DB_EXISTS(blacklist/${EXTEN}/${CALLERID(num)})}?:connect) ;deny blacklist
+	same => n,NoOp(${EXTEN} is black listed)
 	same => n,Hangup
 	same => n(connect),rpt(${EXTEN})
 


### PR DESCRIPTION
Proposal for combined blacklist and whitelist.

- Requires no user changes to configs to implement blacklist or whitelist
- Allows nodes to have different list
- Whitelisted nodes ignore blacklist
- `database put whitelist/1999 2000 "whitelist node 2000 for node 1999"`
- `database put blacklist/1998 2000 "blacklist node 2000 for node 1998"`

Related to #278