### PR TITLE
app_rpt.c: Add RPT_ALINKS and RPT_NUMALINKS

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4900,7 +4900,6 @@ static void *rpt(void *this)
 	rpt_update_boolean(myrpt, "RPT_NUMALINKS", -1);
 	rpt_update_boolean(myrpt, "RPT_LINKS", -1);
 	rpt_update_boolean(myrpt, "RPT_ALINKS", -1);
- 	rpt_update_boolean(myrpt, "RPT_NUMALINKS", -1);
 	myrpt->ready = 1;
 	looptimestart = ast_tvnow();
 


### PR DESCRIPTION
Thanks to ASL2 PR by mkmer

RPT_ALINKS and RPT_NUMALINKS are not initialized at startup. Once a remote node connects/disconnects the vars become available. Until a connection, MANY errors to be logged like this: WARNING[627] ast_expr2.fl: ast_yyerror():  syntax error: syntax error, unexpected '='TILDE, expecting $end; Input: when using an event test for remote adjacent nodes as found in https://wiki.allstarlink.org/wiki/Event_Management

Simply adding the vars at startup (just like RPT_LINKS and RPT_NUMLINKS) addresses the issue.

Appoligies for the whitespace stripping.