### PR TITLE
chan_usbradio: Change to prevent buffer overflow

### DIFF
--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -1460,7 +1460,7 @@ static int soundcard_writeframe(struct chan_usbradio_pvt *o, short *data)
 	 *  filling the buffer when asterisk clock > usb sound clock
 	 */
 	if (!o->pmrChan->txPttIn && !o->pmrChan->txPttOut) {
-		//return 0;
+		return 0;
 	}
 	/*
 	 * Nothing complex to manage the audio device queue.


### PR DESCRIPTION
This changes chan_usbradio to only send audio to the sound device when the PTT is active.  This helps address a problem with the internal timing difference causing the driver to overflow the sound device's internal buffer.

This makes chan_usbradio work like chan_simpleusb.  chan_simpleusb only sends audio when PTT is active.