### PR TITLE
app_rpt: Corrects Couldn't get mute status for chan_echolink.

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4294,7 +4294,7 @@ static inline int process_link_channels(struct rpt *myrpt, struct ast_channel *w
 			if (l->mode != 1)
 				*totx = 0;
 			if (l->phonemode == 0 && l->chan && (l->lasttx != *totx)) {
-				if (totx && !l->voterlink) {
+				if (*totx && !l->voterlink) {
 					if (l->newkey < 2)
 						ast_indicate(l->chan, AST_CONTROL_RADIO_KEY);
 				} else {

--- a/apps/app_rpt/rpt_bridging.c
+++ b/apps/app_rpt/rpt_bridging.c
@@ -527,6 +527,11 @@ int rpt_parrot_add(struct rpt *myrpt)
 static int dahdi_conf_get_muted(struct ast_channel *chan)
 {
 	int muted;
+	
+	if (strcasecmp(ast_channel_tech(chan)->type, "DAHDI")) {
+		return 0;
+	}
+	
 	if (ioctl(ast_channel_fd(chan, 0), DAHDI_GETCONFMUTE, &muted) == -1) {
 		ast_log(LOG_WARNING, "Couldn't get mute status on %s: %s\n", ast_channel_name(chan), strerror(errno));
 		muted = 0;
@@ -647,8 +652,7 @@ int dahdi_rx_offhook(struct ast_channel *chan)
 
 int dahdi_set_hook(struct ast_channel *chan, int offhook)
 {
-	int i = DAHDI_OFFHOOK;
-	if (ioctl(ast_channel_fd(chan, 0), DAHDI_HOOK, &i) == -1) {
+	if (ioctl(ast_channel_fd(chan, 0), DAHDI_HOOK, &offhook) == -1) {
 		ast_log(LOG_ERROR, "Can't set hook on %s: %s\n", ast_channel_name(chan), strerror(errno));
 		return -1;
 	}


### PR DESCRIPTION
This corrects the "Couldn't get mute status on echolink/el0-3: Bad file descriptor". There were a couple of previous changes that caused this issue along with chan_echolink not getting an AST_CONTROL_RADIO_KEY command.  This resulted in the echolink client hung in receive.

This closes #303.