### PR TITLE
simpleusb.conf: Fix syntax typos.

### DIFF
--- a/configs/samples/simpleusb.conf.sample
+++ b/configs/samples/simpleusb.conf.sample
@@ -63,14 +63,14 @@
 
 ;plfilter = yes                 ; enable PL filter
 
-;rxondelay = 0               	; Number of 20mSec intervals following the release of PTT.
+;rxondelay = 0                  ; Number of 20mSec intervals following the release of PTT.
 								; Uncomment and/or adjust for simplex nodes to eliminate "Ping Ponging"
 								; or "Relay Racing". A positive value here will instruct the usbradio
 								; driver to ignore the COR line for a specified number of 20mSec
 								; intervals following the release of PTT. Use this ONLY on simplex
 								; nodes, and leave commented out for repeaters or other full duplex nodes.
 
-'txoffdelay = 0              	; Ignore the reciever for a specified number of 20 millisecond
+;txoffdelay = 0                 ; Ignore the reciever for a specified number of 20 millisecond
 								; intervals after the transmitter unkeys.
 								; This is useful when setting up a half-duplex link with an existing
 								; repeater, where you need to ignore the repeater's hangtime.
@@ -84,11 +84,11 @@
                                 ; no - Do not output anything
                                 ; voice - output voice only
 
-'invertptt = 0                  ; Invert PTT: 0,1
+;invertptt = 0                  ; Invert PTT: 0,1
                                 ; 0 - ground to transmit
                                 ; 1 - open to transmit
 
-'preemphasis = 0                ; Perform standard 6db/octave pre-emphasis
+;preemphasis = 0                ; Perform standard 6db/octave pre-emphasis
 
 ; pager = no                    ; no,a,b (e.g. pager = b means "put the normal repeat audio on channel A, and the pager audio on channel B")
 


### PR DESCRIPTION
Replace some apostrophes with semicolons.

Resolves: #312