### PR TITLE
CI: Build in devmode.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
           chmod +x phreaknet.sh
           ./phreaknet.sh make
           phreaknet update
-          phreaknet install --dahdi --lightweight --alsa --fast
+          phreaknet install --dahdi --lightweight --alsa --fast --devmode
           /etc/init.d/asterisk restart
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Always build in developer mode, for more stringent compiler warnings. This was supposed to be included, but was omitted previously.