### PR TITLE
Update chan_tlb to address a channel deadlock

### DIFF
--- a/channels/chan_tlb.c
+++ b/channels/chan_tlb.c
@@ -1390,8 +1390,8 @@ static int TLB_xwrite(struct ast_channel *ast, struct ast_frame *frame)
 }
 
 /*!
- * \brief Start a new Echolink call.
- * \param pvt			Pointer to echolink private.
+ * \brief Start a new TLB call.
+ * \param pvt			Pointer to TLB private.
  * \param state			State.
  * \param nodenum		Node number to call.
  * \param assignedids	Pointer to unique ID string assigned to the channel.


### PR DESCRIPTION
This updates chan_tlb with address a deadlock on the channel.  The channel was not unlocked when it was created.

This closes #339