### PR TITLE
Correct incorrect "archivedir" filesystem permissions

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4735,7 +4735,7 @@ static void *rpt(void *this)
 	if (myrpt->p.archivedir)
 		mkdir(myrpt->p.archivedir, 0700);
 	sprintf(tmpstr, "%s/%s", myrpt->p.archivedir, myrpt->name);
-	mkdir(tmpstr, 0755);
+	mkdir(tmpstr, 0775);
 	myrpt->ready = 0;
 	rpt_mutex_lock(&myrpt->lock);
 	myrpt->remrx = 0;
@@ -7032,7 +7032,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 
 		mkdir(myrpt->p.archivedir, 0700);
 		sprintf(mycmd, "%s/%s", myrpt->p.archivedir, myrpt->name);
-		mkdir(mycmd, 0755);
+		mkdir(mycmd, 0775);
 		time(&myt);
 		strftime(mydate, sizeof(mydate) - 1, "%Y%m%d%H%M%S", localtime(&myt));
 		sprintf(mycmd, "mixmonitor start %s %s/%s/%s.wav49 a", ast_channel_name(chan), myrpt->p.archivedir, myrpt->name,

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2958,7 +2958,7 @@ static inline void log_keyed(struct rpt *myrpt)
 		time(&myt);
 		strftime(mydate, sizeof(mydate) - 1, "%Y%m%d%H%M%S", localtime(&myt));
 		sprintf(myfname, "%s/%s/%s", myrpt->p.archivedir, myrpt->name, mydate);
-		myrpt->monstream = ast_writefile(myfname, "wav49", "app_rpt Air Archive", O_CREAT | O_APPEND, 0, 0600);
+		myrpt->monstream = ast_writefile(myfname, "wav49", "app_rpt Air Archive", O_CREAT | O_APPEND, 0, 0644);
 		if (myrpt->p.monminblocks) {
 			blocksleft = diskavail(myrpt);
 			if (blocksleft >= myrpt->p.monminblocks) {
@@ -4735,7 +4735,7 @@ static void *rpt(void *this)
 	if (myrpt->p.archivedir)
 		mkdir(myrpt->p.archivedir, 0700);
 	sprintf(tmpstr, "%s/%s", myrpt->p.archivedir, myrpt->name);
-	mkdir(tmpstr, 0700);
+	mkdir(tmpstr, 0755);
 	myrpt->ready = 0;
 	rpt_mutex_lock(&myrpt->lock);
 	myrpt->remrx = 0;
@@ -5767,7 +5767,7 @@ static void *rpt_master(void *ignore)
 			*space = 0;
 			strftime(datestr, sizeof(datestr) - 1, "%Y%m%d", localtime(&nodep->timestamp));
 			sprintf(fname, "%s/%s/%s.txt", nodep->archivedir, nodep->str, datestr);
-			fd = open(fname, O_WRONLY | O_CREAT | O_APPEND, 0600);
+			fd = open(fname, O_WRONLY | O_CREAT | O_APPEND, 0644);
 			if (fd == -1) {
 				ast_log(LOG_ERROR, "Cannot open node log file %s for write: %s", fname, strerror(errno));
 				ast_free(nodep);
@@ -7032,7 +7032,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 
 		mkdir(myrpt->p.archivedir, 0700);
 		sprintf(mycmd, "%s/%s", myrpt->p.archivedir, myrpt->name);
-		mkdir(mycmd, 0700);
+		mkdir(mycmd, 0755);
 		time(&myt);
 		strftime(mydate, sizeof(mydate) - 1, "%Y%m%d%H%M%S", localtime(&myt));
 		sprintf(mycmd, "mixmonitor start %s %s/%s/%s.wav49 a", ast_channel_name(chan), myrpt->p.archivedir, myrpt->name,

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4733,9 +4733,9 @@ static void *rpt(void *this)
 	struct timeval looptimestart;
 
 	if (myrpt->p.archivedir)
-		mkdir(myrpt->p.archivedir, 0600);
+		mkdir(myrpt->p.archivedir, 0700);
 	sprintf(tmpstr, "%s/%s", myrpt->p.archivedir, myrpt->name);
-	mkdir(tmpstr, 0600);
+	mkdir(tmpstr, 0700);
 	myrpt->ready = 0;
 	rpt_mutex_lock(&myrpt->lock);
 	myrpt->remrx = 0;
@@ -5769,12 +5769,12 @@ static void *rpt_master(void *ignore)
 			sprintf(fname, "%s/%s/%s.txt", nodep->archivedir, nodep->str, datestr);
 			fd = open(fname, O_WRONLY | O_CREAT | O_APPEND, 0600);
 			if (fd == -1) {
-				ast_log(LOG_ERROR, "Cannot open node log file %s for write: %s", space + 1, strerror(errno));
+				ast_log(LOG_ERROR, "Cannot open node log file %s for write: %s", fname, strerror(errno));
 				ast_free(nodep);
 				continue;
 			}
 			if (write(fd, space + 1, strlen(space + 1)) != strlen(space + 1)) {
-				ast_log(LOG_ERROR, "Cannot write node log file %s for write: %s", space + 1, strerror(errno));
+				ast_log(LOG_ERROR, "Cannot write node log file %s for write: %s", fname, strerror(errno));
 				ast_free(nodep);
 				continue;
 			}
@@ -7030,9 +7030,9 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 		time_t myt;
 		long blocksleft;
 
-		mkdir(myrpt->p.archivedir, 0600);
+		mkdir(myrpt->p.archivedir, 0700);
 		sprintf(mycmd, "%s/%s", myrpt->p.archivedir, myrpt->name);
-		mkdir(mycmd, 0600);
+		mkdir(mycmd, 0700);
 		time(&myt);
 		strftime(mydate, sizeof(mydate) - 1, "%Y%m%d%H%M%S", localtime(&myt));
 		sprintf(mycmd, "mixmonitor start %s %s/%s/%s.wav49 a", ast_channel_name(chan), myrpt->p.archivedir, myrpt->name,


### PR DESCRIPTION
Newly created directories should be created with the eXecute bit set (e.g. 0700). Found and fixed a few calls to mkdir() that were setting mode 0600 (incorrect) instead of the mode 0700 (expected).

Also corrected two log messages that were correctly/fully reporting the specific filenames that could not be opened.