### PR TITLE
chan_simpleusb / chan_usbradio: Modify cos operation

### DIFF
--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -2260,6 +2260,13 @@ static struct ast_frame *simpleusb_read(struct ast_channel *c)
 		sd = 1;
 	}
 	o->rx_ctcss_active = sd;
+	
+	/* Special case where cd and sd have been configured for no */
+	if (o->rxcdtype == CD_IGNORE && o->rxsdtype == SD_IGNORE) {
+		cd = 0;
+		sd = 0;
+	}
+	
 	/* Timer for how long TX has been unkeyed - used with txoffdelay */
 	if (o->txoffdelay) {
 		if (o->txkeyed == 1) {

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -2266,6 +2266,13 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 		sd = 1;
 	}
 	o->rx_ctcss_active = sd;
+		
+	/* Special case where cd and sd have been configured for no */
+	if (o->rxcdtype == CD_IGNORE && o->rxsdtype == SD_IGNORE) {
+		cd = 0;
+		sd = 0;
+	}
+
 	/* Timer for how long TX has been unkeyed - used with txoffdelay */
 	if (o->txoffdelay) {
 		if (o->txkeyed == 1) {
@@ -2277,6 +2284,8 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 			}
 		}
 	}
+	
+	/* Check conditions and set receiver active */
 	if (cd && sd) {
 		//if(!o->rxkeyed)o->pmrChan->dd.b.doitnow=1;
 		if (o->rxkeyed || ((o->txoffcnt >= o->txoffdelay) && (o->rxoncnt >= o->rxondelay))) {


### PR DESCRIPTION
chan_simpleusb and chan_usbradio should not activate the receiver 
when the carrierfrom and ctcssfrom are set to no.

This closes #329.