### PR TITLE
rpt.conf: Update for default events on GPIO4

### DIFF
--- a/configs/rpt/rpt.conf
+++ b/configs/rpt/rpt.conf
@@ -134,7 +134,7 @@ linkunkeyct = ct8                   ; sent when a transmission received over the
                                     ; 1. node number in this stanza (us)
                                     ; 2. node number being disconnected from us (them)
 
-;events=events                      ; Events Management https://wiki.allstarlink.org/wiki/Event_Management
+events=events                      ; Events Management https://wiki.allstarlink.org/wiki/Event_Management
 
 ;lnkactenable = 0                   ; Set to 1 to enable the link activity timer. Applicable to standard nodes only.
 
@@ -612,9 +612,11 @@ calltermwait = 2000                 ; Time to wait before announcing "call termi
 ;door = daq-cham-1,9,1,2017,*7,-
 ;pwrfail = daq-cham-1,10,0,2017,*911111,-
 
-;[events]
+[events]
 ;;;;; Events Management ;;;;;
 ;status,2 = c|f|RPT_NUMLINKS               ; Say time of day when all links disconnect.
+;cop,62,GPIO4:1 = c|t|RPT_RXKEYED
+;cop,62,GPIO4:0 = c|f|RPT_RXKEYED
 
 [controlstates]
 ;;;;; Control states ;;;;;


### PR DESCRIPTION
This updates rpt.conf to enable the events section and add commented out defaults for GPIO4.

This was requested by KE6PCV, however, I find this useful also.  I use sound card devices from two manufactures that support the GPIO4 LED.