### PR TITLE
app_rpt: Correct 5 digit node lookup from 4 digit node

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -424,6 +424,7 @@ static int nrpts = 0;
 
 /* general settings */
 enum rpt_dns_method rpt_node_lookup_method = DEFAULT_NODE_LOOKUP_METHOD;
+int rpt_maximum_node_length = 6;
 
 int max_chan_stat[] = { 22000, 1000, 22000, 100, 22000, 2000, 22000 };
 
@@ -5536,6 +5537,14 @@ static int load_config(int reload)
 			ast_log(LOG_WARNING,"Configuration error: node_lookup_method, %s, is not valid", val);
 			rpt_node_lookup_method = DEFAULT_NODE_LOOKUP_METHOD;
 		}
+	}
+	val = (char *) ast_variable_retrieve(cfg, "general", "maximum_node_length");
+	if (val) {
+		i = atoi(val);
+		if (i < 4) {
+			i = 4;
+		}
+		rpt_maximum_node_length = i;
 	}
 
 	/* process the sections looking for the nodes */

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -5544,6 +5544,9 @@ static int load_config(int reload)
 		if (i < 4) {
 			i = 4;
 		}
+		if (i > 63) {
+			i = 63;
+		}
 		rpt_maximum_node_length = i;
 	}
 

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -424,7 +424,7 @@ static int nrpts = 0;
 
 /* general settings */
 enum rpt_dns_method rpt_node_lookup_method = DEFAULT_NODE_LOOKUP_METHOD;
-int rpt_maximum_node_length = 6;
+int rpt_max_dns_node_length = 6;
 
 int max_chan_stat[] = { 22000, 1000, 22000, 100, 22000, 2000, 22000 };
 
@@ -5538,7 +5538,7 @@ static int load_config(int reload)
 			rpt_node_lookup_method = DEFAULT_NODE_LOOKUP_METHOD;
 		}
 	}
-	val = (char *) ast_variable_retrieve(cfg, "general", "maximum_node_length");
+	val = (char *) ast_variable_retrieve(cfg, "general", "max_dns_node_length");
 	if (val) {
 		i = atoi(val);
 		if (i < 4) {
@@ -5547,7 +5547,7 @@ static int load_config(int reload)
 		if (i > 63) {
 			i = 63;
 		}
-		rpt_maximum_node_length = i;
+		rpt_max_dns_node_length = i;
 	}
 
 	/* process the sections looking for the nodes */

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -143,7 +143,6 @@ typedef struct {
 #define	MAX_EXTNODEFILES 50
 #define	MAX_LOCALLINKNODES 50
 #define	MAX_LSTUFF 20
-#define MIN_NODE_LENGTH 6		
 
 #define ISRANGER(name) (name[0] == '9')
 

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -143,6 +143,7 @@ typedef struct {
 #define	MAX_EXTNODEFILES 50
 #define	MAX_LOCALLINKNODES 50
 #define	MAX_LSTUFF 20
+#define MIN_NODE_LENGTH 6		
 
 #define ISRANGER(name) (name[0] == '9')
 

--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -33,7 +33,7 @@
 
 extern struct rpt rpt_vars[MAXRPTS];
 extern enum rpt_dns_method rpt_node_lookup_method;
-extern int rpt_maximum_node_length;
+extern int rpt_max_dns_node_length;
 
 static struct ast_flags config_flags = { CONFIG_FLAG_WITHCOMMENTS };
 
@@ -616,7 +616,7 @@ int node_lookup(struct rpt *myrpt, char *digitbuf, char *nodedata, size_t nodeda
 			}
 			ast_config_destroy(ourcfg);
 		}
-		myrpt->longestnode = MAX(longestnode, rpt_maximum_node_length);
+		myrpt->longestnode = MAX(longestnode, rpt_max_dns_node_length);
 		ast_mutex_unlock(&nodelookuplock);
 	}
 
@@ -1140,7 +1140,7 @@ void load_rpt_vars(int n, int init)
 		vp = vp->next;
 	}
 
-	rpt_vars[n].longestnode = MAX(longestnode, rpt_maximum_node_length);
+	rpt_vars[n].longestnode = MAX(longestnode, rpt_max_dns_node_length);
 
 	/* For this repeater, Determine the length of the longest function */
 	rpt_vars[n].longestfunc = 0;

--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -33,6 +33,7 @@
 
 extern struct rpt rpt_vars[MAXRPTS];
 extern enum rpt_dns_method rpt_node_lookup_method;
+extern int rpt_maximum_node_length;
 
 static struct ast_flags config_flags = { CONFIG_FLAG_WITHCOMMENTS };
 
@@ -615,7 +616,7 @@ int node_lookup(struct rpt *myrpt, char *digitbuf, char *nodedata, size_t nodeda
 			}
 			ast_config_destroy(ourcfg);
 		}
-		myrpt->longestnode = MAX(longestnode, MIN_NODE_LENGTH);
+		myrpt->longestnode = MAX(longestnode, rpt_maximum_node_length);
 		ast_mutex_unlock(&nodelookuplock);
 	}
 
@@ -1139,7 +1140,7 @@ void load_rpt_vars(int n, int init)
 		vp = vp->next;
 	}
 
-	rpt_vars[n].longestnode = MAX(longestnode, MIN_NODE_LENGTH);
+	rpt_vars[n].longestnode = MAX(longestnode, rpt_maximum_node_length);
 
 	/* For this repeater, Determine the length of the longest function */
 	rpt_vars[n].longestfunc = 0;

--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -400,6 +400,7 @@ static int node_lookup_bydns(const char *node, char *nodedata, size_t nodedatale
 			return -1;
 		}
 		if (!result) {
+			ast_debug(4, "No SRV results returned for %s\n", domain);
 			return -1;
 		}
 
@@ -407,6 +408,7 @@ static int node_lookup_bydns(const char *node, char *nodedata, size_t nodedatale
 		record = ast_dns_result_get_records(result);
 	
 		if(!record) {
+			ast_debug(4, "No SRV records returned for %s\n", domain);
 			ast_dns_result_free(result);
 			return -1;
 		}
@@ -423,12 +425,14 @@ static int node_lookup_bydns(const char *node, char *nodedata, size_t nodedatale
 			return -1;
 		}
 		if (!result) {
+			ast_debug(4, "No A results returned for %s\n", hostname);
 			return -1;
 		}
 
 		/* get the response */
 		record = ast_dns_result_get_records(result);
 		if (!record) {
+			ast_debug(4, "No A records returned for %s\n", hostname);
 			ast_dns_result_free(result);
 			return -1;
 		}

--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -615,7 +615,7 @@ int node_lookup(struct rpt *myrpt, char *digitbuf, char *nodedata, size_t nodeda
 			}
 			ast_config_destroy(ourcfg);
 		}
-		myrpt->longestnode = longestnode;
+		myrpt->longestnode = MAX(longestnode, MIN_NODE_LENGTH);
 		ast_mutex_unlock(&nodelookuplock);
 	}
 
@@ -1139,7 +1139,7 @@ void load_rpt_vars(int n, int init)
 		vp = vp->next;
 	}
 
-	rpt_vars[n].longestnode = longestnode;
+	rpt_vars[n].longestnode = MAX(longestnode, MIN_NODE_LENGTH);
 
 	/* For this repeater, Determine the length of the longest function */
 	rpt_vars[n].longestfunc = 0;


### PR DESCRIPTION
This updates app_rpt to address a problem with looking up a 5 or 6 digit node from a 4 digit node. The 4 digit node could not lookup 5 or 6 digit nodes when it did not use an external nodes file. This would happen if you are not using the node updater and depending on DNS only.

The problem was associated with the internal 'longestnode' variable. We did not have an external file to determine the longest node number. In this case, the longest node was set to 4.

A new rpt.conf [general] item, max_dns_node_length, has been added with a default value of 6. The routines that determine the longest nodes will now MAX the value it determines with rpt_max_dns_node_length. The configurable item cannot be less than 4 or more then 63.

By default, this configurable item will not be in rpt_conf. It can be used in the future if we need to support longer node numbers.

Additional level 4 debugging was added to the DNS lookup routine.

Without this change, the problem can be remediated with existing installs, that don't use the node updater, by adding the following to rpt.conf [nodes].

999999 = radio@127.0.0.1:4569/999999,NONE