### PR TITLE
Update the permissions of the "archivedir" .WAV files.

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -3861,7 +3861,7 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 						if (blocksleft >= myrpt->p.monminblocks) {
 							myrpt->monstream =
 								ast_writefile(myfname, "wav49", "app_rpt Air Archive", O_CREAT | O_APPEND, 0,
-											  0600);
+											  0644);
 						}
 					}
 				}


### PR DESCRIPTION
When using "archivedir = /var/spool/asterisk/monitor" we create files in the [spool] directory. We are setting the filesystem permissions on the ".txt" files to be 0644.  We should do the same for the ".WAV" files.