### PR TITLE
Support URIx eeprom Serial Numbers

### DIFF
--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -897,6 +897,7 @@ static void *hidthread(void *arg)
 				index_devstr = ast_radio_usb_get_devstr(index);
 				if (ast_strlen_zero(index_devstr)) {
 					/* No more devices, so break out of the loop */
+					ast_log(LOG_NOTICE, "USB Device with serial %s not found.\n", o->serial);
 					break;
 				}
 				/* Go through the list of usb devices, and get the serial numbers */
@@ -911,6 +912,7 @@ static void *hidthread(void *arg)
 					ast_copy_string(o->devstr, index_devstr, sizeof(o->devstr));
 					break;
 				}
+				index++;
 			}
 		}
 		/* Automatically assign a devstr if one was not specified in the configuration. */

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -942,6 +942,10 @@ static void *hidthread(void *arg)
 				/* We found an unused device assign it to our node */
 				ast_copy_string(o->devstr, index_devstr, sizeof(o->devstr));
 				ast_log(LOG_NOTICE, "Channel %s: Automatically assigned USB device %s to USBRadio channel\n", o->name, o->devstr);
+				/* Check if the device has a serial number, and add it to the config file */
+				if (get_usb_serial(o->devstr, serial) > 0) {
+					ast_copy_string(o->serial, serial, sizeof(o->serial));
+				}
 				break;
 			}
 			if (ast_strlen_zero(o->devstr)) {
@@ -984,11 +988,6 @@ static void *hidthread(void *arg)
 				continue;
 			}
 			ast_log(LOG_NOTICE, "Channel %s: Assigned USB device %s to usbradio channel\n", o->name, s);
-			/* Check if the device has a serial number, and add it to the config file */
-			if (get_usb_serial(s, serial) > 0) 
-			{
-				ast_copy_string(o->serial, serial, sizeof(o->serial));
-			}
 			ast_copy_string(o->devstr, s, sizeof(o->devstr));
 		}
 		/* Double check to see if the device string is assigned to another usb channel */

--- a/configs/rpt/usbradio.conf
+++ b/configs/rpt/usbradio.conf
@@ -187,6 +187,7 @@ duplex3 = 0                 ; duplex 3 gain setting (0 to disable) ???
 
 ;;;;; ASL3 Tune settings ;;;;;
 devstr=
+serial=
 rxmixerset=500
 txmixaset=500
 txmixbset=500

--- a/configs/samples/usbradio.conf.sample
+++ b/configs/samples/usbradio.conf.sample
@@ -167,6 +167,7 @@
 
 ;;;;; Tune settings ;;;;;
 ;devstr=
+;serial=
 ;rxmixerset=500
 ;txmixaset=500
 ;txmixbset=500


### PR DESCRIPTION
When using a URIx with an eeprom, the eeprom supports setting a serial number for the device. The serial number is exposed as in the device descriptor as iSerialNumber. 

This PR allows the use of a serial number to identify which device to load in chan_usbradio. 

On channel hidthread startup, the PR will loop through the AST radio device strings looking for a matching configured serial number. If a match is found, the devstr is updated to match the one found in the search loop. 

Should a usb device match not be found, chan_usbradio continues as normal by using the configured devstr, and finally searching for any available device. 

At this time, I only have very terrible python code to modify device serial numbers, and it is not clean enough to include in this PR. 

I've been using a version of this for the old apt_rpt for a while, and it's worked great. This is an attempt to port to the new V3 version.

```
[2024-08-28 14:37:10.221] NOTICE[11380] chan_usbradio.c: Checking for USB device with serial 1000
[2024-08-28 14:37:10.310] NOTICE[11380] chan_usbradio.c: Device Serial 1234 vs 1000
[2024-08-28 14:37:10.398] NOTICE[11380] chan_usbradio.c: Device Serial 1000 vs 1000
[2024-08-28 14:37:10.398] NOTICE[11380] chan_usbradio.c: Found device serial 1000 at 2-1:1.0 for 1999

```
