### PR TITLE
Add RX Audio Statistics and ADC Clip Detection feature. This adds a n…

### DIFF
--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -2105,12 +2105,12 @@ static struct ast_frame *simpleusb_read(struct ast_channel *c)
 					/* enough to fill a frame */
 					memcpy(o->simpleusb_write_buf + o->simpleusb_write_dst, (char *) f1->data.ptr + src, l);
 
-					/* TBR - below appears to be an attempt to match levels to the original CM108
-					 * IC which has been out of production for over 10 years. Scaling audio to 
-					 * 109.375% will result in clipping! Any adjustments for CM1xxx gain differences
-					 * should be made in the mixer settings, not in the audio stream itself.
+					/* TBR - below is an attempt to match levels to the original CM108 IC which has
+					 * been out of production for over 10 years. Scaling audio to 109.375% will
+					 * result in clipping! Any adjustments for CM1xxx gain differences should be
+					 * made in the mixer settings, not in the audio stream.
 					 */
-#if 0
+#if 1
 					/* Adjust the audio level for CM119 A/B devices */
 					if (o->devtype != C108_PRODUCT_ID) {
 						register int v;

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -3517,10 +3517,12 @@ static void tune_menusupport(int fd, struct chan_simpleusb_pvt *o, const char *c
 		}
 		for (;;) {
 			ast_radio_print_rx_audio_stats(fd, &o->rxaudiostats);
-			if (cmd[0] == 'Y')
+			if (cmd[0] == 'Y') {
 				break;
-			if (ast_radio_poll_input(fd, 1000))
+			}
+			if (ast_radio_poll_input(fd, 1000)) {
 				break;
+			}
 		}
 		break;
 	default:

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -602,8 +602,7 @@ static int hidhdwconfig(struct chan_simpleusb_pvt *o)
 		if (o->clipledgpio >= GPIO_PINCOUNT || !(o->valid_gpios & (1 << (o->clipledgpio - 1)))) {
 			ast_log(LOG_ERROR, "Channel %s: clipledgpio = GPIO%d not supported\n", o->name, o->clipledgpio);
 			o->clipledgpio = 0;
-		}
-		else {
+		} else {
 			o->hid_gpio_ctl |= 1 << (o->clipledgpio - 1); /* confirm Clip LED GPIO set to output mode */
 		}
 	}

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -314,7 +314,7 @@ struct chan_simpleusb_pvt {
 	struct timeval tonetime;
 	int toneflag;
 	int duplex3;
-	int checkrxaudio;
+	int checkrxaudio;           /* enables RxAudioStats feature & Clip LED output on specified GPIO# */
 	
 	int32_t discfactor;
 	int32_t discounterl;
@@ -598,15 +598,12 @@ static int hidhdwconfig(struct chan_simpleusb_pvt *o)
 		o->valid_gpios = 1;			/* for GPIO 1 */
 	}
 	/* validate checkrxaudio setting (Clip LED GPIO#) */
-	if (o->checkrxaudio)
-	{
-		if (o->checkrxaudio >= GPIO_PINCOUNT || !(o->valid_gpios & (1 << (o->checkrxaudio - 1))))
-		{
+	if (o->checkrxaudio) {
+		if (o->checkrxaudio >= GPIO_PINCOUNT || !(o->valid_gpios & (1 << (o->checkrxaudio - 1)))) {
 			ast_log(LOG_ERROR, "Channel %s: checkrxaudio = GPIO%d not supported\n", o->name, o->checkrxaudio);
 			o->checkrxaudio = 0;
 		}
-		else
-		{
+		else {
 			o->hid_gpio_ctl |= 1 << (o->checkrxaudio - 1); /* confirm Clip LED GPIO set to output mode */
 		}
 	}
@@ -2298,13 +2295,10 @@ static struct ast_frame *simpleusb_read(struct ast_channel *c)
 	 * extracts the mono 48K channel, checks amplitude and distortion characteristics,
 	 * and returns true if clipping was detected.
 	 */
-	if (o->checkrxaudio)
-	{
-		if (ast_radio_check_rx_audio((short *) o->simpleusb_read_buf, &o->rxaudiostats, 12 * FRAME_SIZE))
-		{
+	if (o->checkrxaudio) {
+		if (ast_radio_check_rx_audio((short *) o->simpleusb_read_buf, &o->rxaudiostats, 12 * FRAME_SIZE)) {
 			/* Set Clip LED GPIO pulsetimer if not already set */
-			if (!o->hid_gpio_pulsetimer[o->checkrxaudio - 1])
-			{
+			if (!o->hid_gpio_pulsetimer[o->checkrxaudio - 1]) {
 				o->hid_gpio_pulsetimer[o->checkrxaudio - 1] = CLIP_LED_HOLD_TIME_MS;
 			}
 		}

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -272,6 +272,7 @@ struct chan_simpleusb_pvt {
 	int hid_io_ctcss;
 	int hid_io_ctcss_loc;
 	int hid_io_ptt;
+	int hid_io_clip_led;			/* indicator to alert user of ADC clipping */
 	int hid_gpio_loc;
 	int32_t hid_gpio_val;
 	int32_t valid_gpios;
@@ -314,6 +315,7 @@ struct chan_simpleusb_pvt {
 	struct timeval tonetime;
 	int toneflag;
 	int duplex3;
+	int rxaudiostats;
 	
 	int32_t discfactor;
 	int32_t discounterl;
@@ -325,6 +327,15 @@ struct chan_simpleusb_pvt {
 	int32_t cur_gpios;
 	char *gpios[GPIO_PINCOUNT];
 	char *pps[32];
+
+	/* Rx audio (ADC) statistics variables. susb tune-menu "R" command displays
+	 * stats data (peak, average, min, max levels and clipped sample count).
+	 */
+#define AUDIO_STATS_LEN 50 			/* number of 20mS frames. 50 => 1 second buf len */
+	unsigned short maxbuf[AUDIO_STATS_LEN];		/* peak sample value per frame */
+	unsigned short clipbuf[AUDIO_STATS_LEN];	/* number of clipped samples per frame */
+	unsigned int pwrbuf[AUDIO_STATS_LEN];		/* total RMS power per frame */
+	short rxaudiostats_index;					/* Index within buffers, updated as frames received */
 	
 	ast_mutex_t usblock;
 };
@@ -344,6 +355,8 @@ static struct chan_simpleusb_pvt simpleusb_default = {
 	.rxondelay = 0,
 	.txoffdelay = 0,
 	.pager = PAGER_NONE,
+	.rxaudiostats = 1,
+	.rxaudiostats_index = 0
 };
 
 /*	DECLARE FUNCTION PROTOTYPES	*/
@@ -367,6 +380,8 @@ static int simpleusb_setoption(struct ast_channel *chan, int option, void *data,
 static void tune_menusupport(int fd, struct chan_simpleusb_pvt *o, const char *cmd);
 static void tune_write(struct chan_simpleusb_pvt *o);
 static int _send_tx_test_tone(int fd, struct chan_simpleusb_pvt *o, int ms, int intflag);
+static void check_rx_audio(struct chan_simpleusb_pvt *o, short len);
+static void print_rx_audio_stats(int fd, struct chan_simpleusb_pvt *o);
 
 static char *simpleusb_active;	/* the active device */
 
@@ -559,6 +574,7 @@ static int hidhdwconfig(struct chan_simpleusb_pvt *o)
 		o->hid_io_ctcss = 2;		/* GPIO 2 is External CTCSS */
 		o->hid_io_ctcss_loc = 1;	/* is GPIO 2 */
 		o->hid_io_ptt = 8;			/* GPIO 4 is PTT */
+		o->hid_io_clip_led = 0;		/* No Clip LED on this HW */
 		o->hid_gpio_loc = 1;		/* For ALL GPIO */
 		o->valid_gpios = 1;			/* for GPIO 1 */
 	} else if (o->hdwtype == 0) {	//dudeusb
@@ -569,6 +585,7 @@ static int hidhdwconfig(struct chan_simpleusb_pvt *o)
 		o->hid_io_ctcss = 1;		/* VOL UP External CTCSS */
 		o->hid_io_ctcss_loc = 0;	/* VOL UP External CTCSS */
 		o->hid_io_ptt = 4;			/* GPIO 3 is PTT */
+		o->hid_io_clip_led = 3;		/* GPIO 4 is Clip LED */
 		o->hid_gpio_loc = 1;		/* For ALL GPIO */
 		o->valid_gpios = 0xfb;		/* for GPIO 1,2,4,5,6,7,8 (5,6,7,8 for CM-119 only) */
 	} else if (o->hdwtype == 2) {	//NHRC (N1KDO) (dudeusb w/o user GPIO)
@@ -579,6 +596,7 @@ static int hidhdwconfig(struct chan_simpleusb_pvt *o)
 		o->hid_io_ctcss = 1;		/* VOL UP is External CTCSS */
 		o->hid_io_ctcss_loc = 0;	/* VOL UP CTCSS */
 		o->hid_io_ptt = 4;			/* GPIO 3 is PTT */
+		o->hid_io_clip_led = 3;		/* GPIO 4 is Clip LED */
 		o->hid_gpio_loc = 1;		/* For ALL GPIO */
 		o->valid_gpios = 0;			/* for GPIO 1,2,4 */
 	} else if (o->hdwtype == 3) {	// custom version
@@ -589,6 +607,7 @@ static int hidhdwconfig(struct chan_simpleusb_pvt *o)
 		o->hid_io_ctcss = 2;		/* GPIO 2 is External CTCSS */
 		o->hid_io_ctcss_loc = 1;	/* is GPIO 2 */
 		o->hid_io_ptt = 4;			/* GPIO 3 is PTT */
+		o->hid_io_clip_led = 3;		/* GPIO 4 is Clip LED */
 		o->hid_gpio_loc = 1;		/* For ALL GPIO */
 		o->valid_gpios = 1;			/* for GPIO 1 */
 	}
@@ -2267,6 +2286,16 @@ static struct ast_frame *simpleusb_read(struct ast_channel *c)
 		}
 	}
 
+	/* Check for ADC clipping and input audio statistics before any filtering is done.
+	 * FRAME_SIZE define refers to 8Ksps mono which is 160 samples per 20mS USB frame.
+	 * check_rx_audio() takes the read buffer as received (48K stereo), extracts the
+	 * mono 48K channel and checks amplitude and distortion characteristics.
+	 */
+	if(o->rxaudiostats)
+	{
+		check_rx_audio(o, 12 * FRAME_SIZE);
+	}
+
 	/* Downsample received audio from 48000 stereo to 8000 mono */
 	sp = (short *) o->simpleusb_read_buf;
 	sp1 = (short *) (o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET);
@@ -3256,6 +3285,7 @@ static void tune_write(struct chan_simpleusb_pvt *o)
  *		1 - get node names that are configured in simpleusb.conf
  *		2 - print parameters
  *		3 - get node names that are configured in simpleusb.conf, except current device
+ *		a - receive audio statistics display
  *		b - receiver tune display
  *		c - receive level
  *		f - txa level
@@ -3316,6 +3346,24 @@ static void tune_menusupport(int fd, struct chan_simpleusb_pvt *o, const char *c
 			x++;
 		}
 		ast_cli(fd, "\n");
+		break;
+	case 'a':					/* display receive audio statistics (interactive) */
+	case 'A':					/* display receive audio statistics (once only) */
+		if (!o->hasusb) {
+			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
+			break;
+		}
+		if (!o->rxaudiostats) {
+			ast_cli(fd, "rxaudiostats is currently Disabled in simpleusb.conf\n");
+			break;
+		}
+		for (;;) {
+			print_rx_audio_stats(fd, o);
+			if (cmd[0] == 'A')
+				break;
+			if (ast_radio_poll_input(fd, 1000))
+				break;
+		}
 		break;
 	case 'b':					/* receiver tune display */
 		if (!o->hasusb) {
@@ -3650,6 +3698,7 @@ static struct chan_simpleusb_pvt *store_config(const struct ast_config *cfg, con
 		CV_BOOL("deemphasis", o->deemphasis);
 		CV_BOOL("preemphasis", o->preemphasis);
 		CV_UINT("duplex3", o->duplex3);
+		CV_BOOL("rxaudiostats", o->rxaudiostats);
 		CV_END;
 		
 		for (i = 0; i < GPIO_PINCOUNT; i++) {
@@ -4010,6 +4059,157 @@ static int unload_module(void)
 	simpleusb_tech.capabilities = NULL;
 
 	return 0;
+}
+
+/*!
+ * \brief Detect ADC clipping, collect Rx audio statistics.
+ *
+ * If enabled by conf settings will set GPIO4 high for 500mS when clipping is
+ * detected. Nodes/URIs/audio interfaces can then light a Clip LED to alert users
+ * of excessive audio input levels. Because CM1xxx USB audio interface ICs have an
+ * internal mixer ahead of the ADC it is not possible within the interface board
+ * analog circuitry to detect clipping at the ADC input point, thus this function
+ * enables the raw ADC data to be checked. Clipping is detected by looking for
+ * large amplitude square waves (min. 3 samples in a row > 99% FS).
+ *
+ * Data collected can be displayed from the simpleusb-tune-menu 'R' option or AMI
+ * "susb tune menu-support a" function. This also shows average power levels which
+ * can be of further use in optimizing audio levels, compression, limiting, etc.
+ * In general, peak levels should be within 6-10dB of full-scale (0dBFS) and
+ * average signal power levels should be 6-12dB below peak levels.
+ *
+ * Should be passed the raw 48Ksps stereo USB frame read buffer before any
+ * filtering or downsampling has been done. Extracts the 48K mono channel and
+ * downsamples to 8Ksps (as is done in simpleusb_read() but without filtering).
+ * Signal power calculation takes the square of each sample to measure RMS power.
+ * For CPU efficiency no scaling is done here. (When stats data is printed the
+ * values are scaled to dBFS.)
+ *
+ * Audio parameters of interest include:
+ * - Peak signal level over a longer time period eg. 1+ seconds (dBFS)
+ *   This defines headroom (dB) and potential for clipping
+ * - Min and max signal power levels averaged within each USB frame (dBFS)
+ *   These define average dynamic range (dB)
+ * - Min and max signal power averaged over a longer time period (dBFS)
+ *   These define total signal power and peak-to-average power ratio
+ *
+ * \author			NR9V
+ * \param o			Channel data structure
+ * \param len		Length of data within o->simpleusb_read_buf
+ * \return 			None
+ */
+#define CLIP_SAMP_THRESH       0x7eb0
+#define CLIP_EVENT_MIN_SAMPLES 3
+#define CLIP_LED_HOLD_TIME_MS  500
+static void check_rx_audio(struct chan_simpleusb_pvt *o, short len)
+{
+	short *sbuf = (short *) o->simpleusb_read_buf;
+	unsigned short i, j, val, max=0, clip_cnt=0, seq_clips=0, last_clip=-1;
+	double pwr=0.0;
+	short buf[FRAME_SIZE];
+
+	if(len > 12 * FRAME_SIZE)
+		len = 12 * FRAME_SIZE;
+	if(o->rxaudiostats_index >= AUDIO_STATS_LEN)
+		o->rxaudiostats_index = 0;
+	/* Downsample from 48000 stereo to 8000 mono */
+	for(i=10, j=0; i < len; i += 12)
+	{
+		buf[j++] = sbuf[i];
+	}
+	len /= 12;
+	/* len should now be 160 */
+	for(i=0; i < len; i++)
+	{
+		val = abs(buf[i]);
+		if(val)
+		{
+			if(val > max)
+				max = val;
+			pwr += (double) (val * val);
+			if(val > CLIP_SAMP_THRESH)
+			{
+				clip_cnt++;
+				if(last_clip >= 0 && last_clip + 1 == i)
+					seq_clips++;
+				last_clip = i;
+			}
+		}
+	}
+	o->maxbuf[o->rxaudiostats_index] = max;
+	o->pwrbuf[o->rxaudiostats_index] = (unsigned int) (pwr / (double)len);
+	o->clipbuf[o->rxaudiostats_index] = seq_clips;
+	/* Set Clip LED if clipping detected and LED not already set */
+	if(seq_clips >= CLIP_EVENT_MIN_SAMPLES && o->hid_io_clip_led &&
+			!o->hid_gpio_pulsetimer[o->hid_io_clip_led])
+	{
+		o->hid_gpio_pulsetimer[o->hid_io_clip_led] = CLIP_LED_HOLD_TIME_MS;
+	}
+	if(++o->rxaudiostats_index >= AUDIO_STATS_LEN)
+	{
+		o->rxaudiostats_index = 0;
+	}
+}
+
+/*!
+ * \brief Display receive audio statistics.
+ *
+ * Display the audio stats buffer data in normalized units. Peak value is the largest
+ * sample value seen in the past AUDIO_STATS_LEN audio frames (1 second default).
+ * Average, min, and max signal power levels are calculated from the total signal
+ * power buffer which contains total RMS power per 20mS frame. Avg Pwr is the average
+ * of the power values in the buffer, min and max are the lowest and highest average
+ * power levels within the buffer. ClipCnt is the count of audio clipping events
+ * detected.
+ *
+ * Example output message:
+ *   RxAudioStats: Pk -2.1  Avg Pwr -32  Min -60  Max -12  dBFS  ClipCnt 0
+ *
+ * Results are scaled to double precision 0.0-1.0 and converted to log (dB)
+ * ie. 10*log10(scaledVal) for power levels.
+ *
+ * \author			NR9V
+ * \param fd		File descriptor to print to, or if 0 print using ast_verbose()
+ * \param o			Channel data structure
+ * \return 			None
+ */
+static void print_rx_audio_stats(int fd, struct chan_simpleusb_pvt *o)
+{
+	unsigned int pk=0, pwr=0, i, minpwr=0x40000000, maxpwr=0, clipcnt=0;
+	double tpwr=0.0, dpk, dmin, dmax, scale;
+	char s1[100];
+
+	/* Peak    = max(maxbuf)^2
+	 * Avg Pwr = avg(pwrbuf)
+	 *     Min = min(pwrbuf)
+	 *     Max = max(pwrbuf)
+	 */
+	for(i=0; i < AUDIO_STATS_LEN; i++)
+	{
+		if(o->maxbuf[i] > pk)
+			pk = o->maxbuf[i];
+		pwr = o->pwrbuf[i];
+		if(pwr < minpwr)
+			minpwr = pwr;
+		if(pwr > maxpwr)
+			maxpwr = pwr;
+		tpwr += pwr;
+		clipcnt += o->clipbuf[i];
+	}
+	tpwr /= AUDIO_STATS_LEN;
+	/* Convert to dBFS / dB */
+	scale = 1.0 / (double) (1 << 30);
+	dpk =  (pk > 0.0) ? 10 * log10(pk * pk * scale) : -96.0;
+	tpwr = (tpwr > 0.0) ? 10 * log10(tpwr * scale) : -96.0;
+	dmin = minpwr ? 10 * log10(minpwr * scale) : -96.0;
+	dmax = maxpwr ? 10 * log10(maxpwr * scale) : -96.0;
+	/* Print stats */
+	sprintf(s1, "RxAudioStats: Pk %5.1f  Avg Pwr %3.0f  Min %3.0f  Max %3.0f  dBFS  ClipCnt %u",
+			dpk, tpwr, dmin, dmax, clipcnt);
+	if(fd)
+		ast_cli(fd, "%s\n", s1);
+	else
+		ast_verbose("%s\n", s1);
 }
 
 AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_DEFAULT, "SimpleUSB Radio Interface Channel Driver",

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -2298,7 +2298,7 @@ static struct ast_frame *simpleusb_read(struct ast_channel *c)
 	 * extracts the mono 48K channel, checks amplitude and distortion characteristics,
 	 * and returns true if clipping was detected.
 	 */
-	if(o->checkrxaudio)
+	if (o->checkrxaudio)
 	{
 		if (ast_radio_check_rx_audio((short *) o->simpleusb_read_buf, &o->rxaudiostats, 12 * FRAME_SIZE))
 		{

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -399,7 +399,7 @@ struct chan_usbradio_pvt {
 	struct timeval tonetime;
 	int toneflag;
 	int duplex3;
-	int checkrxaudio;
+	int checkrxaudio;           /* enables RxAudioStats feature & Clip LED output on specified GPIO# */
 	
 	int fever;
 	int count_rssi_update;
@@ -555,15 +555,12 @@ static int hidhdwconfig(struct chan_usbradio_pvt *o)
 		o->valid_gpios = 1;			/* for GPIO 1 */
 	}
 	/* validate checkrxaudio setting (Clip LED GPIO#) */
-	if (o->checkrxaudio)
-	{
-		if (o->checkrxaudio >= GPIO_PINCOUNT || !(o->valid_gpios & (1 << (o->checkrxaudio - 1))))
-		{
+	if (o->checkrxaudio) {
+		if (o->checkrxaudio >= GPIO_PINCOUNT || !(o->valid_gpios & (1 << (o->checkrxaudio - 1)))) {
 			ast_log(LOG_ERROR, "Channel %s: checkrxaudio = GPIO%d not supported\n", o->name, o->checkrxaudio);
 			o->checkrxaudio = 0;
 		}
-		else
-		{
+		else {
 			o->hid_gpio_ctl |= 1 << (o->checkrxaudio - 1); /* confirm Clip LED GPIO set to output mode */
 		}
 	}
@@ -2104,13 +2101,10 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	 * extracts the mono 48K channel, checks amplitude and distortion characteristics,
 	 * and returns true if clipping was detected.
 	 */
-	if (o->checkrxaudio)
-	{
-		if (ast_radio_check_rx_audio((short *) o->usbradio_read_buf, &o->rxaudiostats, 12 * FRAME_SIZE))
-		{
+	if (o->checkrxaudio) {
+		if (ast_radio_check_rx_audio((short *) o->usbradio_read_buf, &o->rxaudiostats, 12 * FRAME_SIZE)) {
 			/* Set Clip LED GPIO pulsetimer if not already set */
-			if (!o->hid_gpio_pulsetimer[o->checkrxaudio - 1])
-			{
+			if (!o->hid_gpio_pulsetimer[o->checkrxaudio - 1]) {
 				o->hid_gpio_pulsetimer[o->checkrxaudio - 1] = CLIP_LED_HOLD_TIME_MS;
 			}
 		}

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -2104,7 +2104,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	 * extracts the mono 48K channel, checks amplitude and distortion characteristics,
 	 * and returns true if clipping was detected.
 	 */
-	if(o->checkrxaudio)
+	if (o->checkrxaudio)
 	{
 		if (ast_radio_check_rx_audio((short *) o->usbradio_read_buf, &o->rxaudiostats, 12 * FRAME_SIZE))
 		{

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -399,6 +399,7 @@ struct chan_usbradio_pvt {
 	struct timeval tonetime;
 	int toneflag;
 	int duplex3;
+	int checkrxaudio;
 	
 	int fever;
 	int count_rssi_update;
@@ -407,7 +408,9 @@ struct chan_usbradio_pvt {
 	char *gpios[GPIO_PINCOUNT];
 	char *pps[32];
 	int sendvoter;
-	
+
+	struct rxaudiostatistics rxaudiostats;
+
 	ast_mutex_t usblock;
 };
 

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -4200,10 +4200,12 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 		}
 		for (;;) {
 			ast_radio_print_rx_audio_stats(fd, &o->rxaudiostats);
-			if (cmd[0] == 'Y')
+			if (cmd[0] == 'Y') {
 				break;
-			if (ast_radio_poll_input(fd, 1000))
+			}
+			if (ast_radio_poll_input(fd, 1000)) {
 				break;
+			}
 		}
 		break;
 	default:

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -559,8 +559,7 @@ static int hidhdwconfig(struct chan_usbradio_pvt *o)
 		if (o->clipledgpio >= GPIO_PINCOUNT || !(o->valid_gpios & (1 << (o->clipledgpio - 1)))) {
 			ast_log(LOG_ERROR, "Channel %s: clipledgpio = GPIO%d not supported\n", o->name, o->clipledgpio);
 			o->clipledgpio = 0;
-		}
-		else {
+		} else {
 			o->hid_gpio_ctl |= 1 << (o->clipledgpio - 1); /* confirm Clip LED GPIO set to output mode */
 		}
 	}

--- a/configs/rpt/simpleusb.conf
+++ b/configs/rpt/simpleusb.conf
@@ -108,9 +108,10 @@ preemphasis = no                    ; Perform standard 6db/octave pre-emphasis
 
 ; duplex3 = 0                       ; duplex 3 gain setting (0 to disable)
 
-rxaudiostats = yes                  ; Enable receive audio statistics and ADC clip detection (no to disable).
+checkrxaudio = 1                    ; Enable receive audio statistics and ADC clip detection (0 to disable).
                                     ; Enables tune-menu 'R' function. Supports audio interface Clip LED by
-                                    ; setting GPIO4 (if available) high for 500mS when clipping detected.
+                                    ; setting a GPIO (if available) high for 500mS when clipping detected.
+                                    ; parameter value = GPIO# to use, eg. checkrxaudio = 1 will use GPIO1.
 
 ;;; End of node-main template
 

--- a/configs/rpt/simpleusb.conf
+++ b/configs/rpt/simpleusb.conf
@@ -108,6 +108,10 @@ preemphasis = no                    ; Perform standard 6db/octave pre-emphasis
 
 ; duplex3 = 0                       ; duplex 3 gain setting (0 to disable)
 
+rxaudiostats = yes                  ; Enable receive audio statistics and ADC clip detection (no to disable).
+                                    ; Enables tune-menu 'R' function. Supports audio interface Clip LED by
+                                    ; setting GPIO4 (if available) high for 500mS when clipping detected.
+
 ;;; End of node-main template
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/configs/rpt/simpleusb.conf
+++ b/configs/rpt/simpleusb.conf
@@ -108,10 +108,9 @@ preemphasis = no                    ; Perform standard 6db/octave pre-emphasis
 
 ; duplex3 = 0                       ; duplex 3 gain setting (0 to disable)
 
-checkrxaudio = 1                    ; Enable receive audio statistics and ADC clip detection (0 to disable).
-                                    ; Enables tune-menu 'R' function. Supports audio interface Clip LED by
-                                    ; setting a GPIO (if available) high for 500mS when clipping detected.
-                                    ; parameter value = GPIO# to use, eg. checkrxaudio = 1 will use GPIO1.
+clipledgpio = 1                     ; Enable ADC Clip Detect feature to use a GPIO output (0 to disable).
+                                    ; Supports URI Clip LED by setting a GPIO (if available) high for 500mS
+                                    ; when clipping detected. Value = GPIO# to use (GPIO1 recommended)
 
 ;;; End of node-main template
 

--- a/configs/rpt/usbradio.conf
+++ b/configs/rpt/usbradio.conf
@@ -168,6 +168,11 @@ duplex = 0                  ; Duplex 0,1
                             ; 1 - full duplex
 duplex3 = 0                 ; duplex 3 gain setting (0 to disable) ???
 
+checkrxaudio = 1            ; Enable receive audio statistics and ADC clip detection (0 to disable).
+                            ; Enables tune-menu 'R' function. Supports audio interface Clip LED by
+                            ; setting a GPIO (if available) high for 500mS when clipping detected.
+                            ; parameter value = GPIO# to use, eg. checkrxaudio = 1 will use GPIO1.
+
 ;;; End of node-main template
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/configs/rpt/usbradio.conf
+++ b/configs/rpt/usbradio.conf
@@ -168,7 +168,7 @@ duplex = 0                  ; Duplex 0,1
                             ; 1 - full duplex
 duplex3 = 0                 ; duplex 3 gain setting (0 to disable) ???
 
-checkrxaudio = 1            ; Enable receive audio statistics and ADC clip detection (0 to disable).
+checkrxaudio = 0            ; Enable receive audio statistics and ADC clip detection (0 to disable).
                             ; Enables tune-menu 'R' function. Supports audio interface Clip LED by
                             ; setting a GPIO (if available) high for 500mS when clipping detected.
                             ; parameter value = GPIO# to use, eg. checkrxaudio = 1 will use GPIO1.

--- a/configs/rpt/usbradio.conf
+++ b/configs/rpt/usbradio.conf
@@ -168,10 +168,9 @@ duplex = 0                  ; Duplex 0,1
                             ; 1 - full duplex
 duplex3 = 0                 ; duplex 3 gain setting (0 to disable) ???
 
-checkrxaudio = 0            ; Enable receive audio statistics and ADC clip detection (0 to disable).
-                            ; Enables tune-menu 'R' function. Supports audio interface Clip LED by
-                            ; setting a GPIO (if available) high for 500mS when clipping detected.
-                            ; parameter value = GPIO# to use, eg. checkrxaudio = 1 will use GPIO1.
+clipledgpio = 0             ; Enable ADC Clip Detect feature to use a GPIO output (0 to disable).
+                            ; Supports URI Clip LED by setting a GPIO (if available) high for 500mS
+                            ; when clipping detected. Value = GPIO# to use (GPIO1 recommended)
 
 ;;; End of node-main template
 

--- a/configs/samples/simpleusb.conf.sample
+++ b/configs/samples/simpleusb.conf.sample
@@ -90,10 +90,9 @@
 
 ;duplex3 = 0                ; duplex 3 gain setting (0 to disable)
 
-;checkrxaudio = 1           ; Enable receive audio statistics and ADC clip detection (0 to disable).
-                            ; Enables tune-menu 'R' function. Supports audio interface Clip LED by
-                            ; setting a GPIO (if available) high for 500mS when clipping detected.
-                            ; parameter value = GPIO# to use, eg. checkrxaudio = 1 will use GPIO1.
+;clipledgpio = 1            ; Enable ADC Clip Detect feature to use a GPIO output (0 to disable).
+                            ; Supports URI Clip LED by setting a GPIO (if available) high for 500mS
+                            ; when clipping detected. Value = GPIO# to use (GPIO1 recommended)
 
 ;gpioX=in					; define input/output pin GPIO(x) in,out0,out1 (where X {1..8}) (optional)
 

--- a/configs/samples/simpleusb.conf.sample
+++ b/configs/samples/simpleusb.conf.sample
@@ -90,7 +90,7 @@
 
 ;duplex3 = 0                ; duplex 3 gain setting (0 to disable)
 
-;clipledgpio = 1            ; Enable ADC Clip Detect feature to use a GPIO output (0 to disable).
+;clipledgpio = 0            ; Enable ADC Clip Detect feature to use a GPIO output (0 to disable).
                             ; Supports URI Clip LED by setting a GPIO (if available) high for 500mS
                             ; when clipping detected. Value = GPIO# to use (GPIO1 recommended)
 

--- a/configs/samples/simpleusb.conf.sample
+++ b/configs/samples/simpleusb.conf.sample
@@ -90,6 +90,10 @@
 
 ;duplex3 = 0                ; duplex 3 gain setting (0 to disable)
 
+;rxaudiostats = yes         ; Enable receive audio statistics and ADC clip detection (no to disable).
+                            ; Enables tune-menu 'R' function. Supports audio interface Clip LED by
+                            ; setting GPIO4 (if available) high for 500mS when clipping detected.
+
 ;gpioX=in					; define input/output pin GPIO(x) in,out0,out1 (where X {1..8}) (optional)
 
 ;pport=/dev/parport0		; Specify parport device (optional)

--- a/configs/samples/simpleusb.conf.sample
+++ b/configs/samples/simpleusb.conf.sample
@@ -90,9 +90,10 @@
 
 ;duplex3 = 0                ; duplex 3 gain setting (0 to disable)
 
-;rxaudiostats = yes         ; Enable receive audio statistics and ADC clip detection (no to disable).
+;checkrxaudio = 1           ; Enable receive audio statistics and ADC clip detection (0 to disable).
                             ; Enables tune-menu 'R' function. Supports audio interface Clip LED by
-                            ; setting GPIO4 (if available) high for 500mS when clipping detected.
+                            ; setting a GPIO (if available) high for 500mS when clipping detected.
+                            ; parameter value = GPIO# to use, eg. checkrxaudio = 1 will use GPIO1.
 
 ;gpioX=in					; define input/output pin GPIO(x) in,out0,out1 (where X {1..8}) (optional)
 

--- a/configs/samples/usbradio.conf.sample
+++ b/configs/samples/usbradio.conf.sample
@@ -154,7 +154,7 @@
                             ; 1 - full duplex
 ;duplex3 = 0                ; duplex 3 gain setting (0 to disable) ???
 
-;checkrxaudio = 1           ; Enable receive audio statistics and ADC clip detection (0 to disable).
+;checkrxaudio = 0           ; Enable receive audio statistics and ADC clip detection (0 to disable).
                             ; Enables tune-menu 'R' function. Supports audio interface Clip LED by
                             ; setting a GPIO (if available) high for 500mS when clipping detected.
                             ; parameter value = GPIO# to use, eg. checkrxaudio = 1 will use GPIO1.

--- a/configs/samples/usbradio.conf.sample
+++ b/configs/samples/usbradio.conf.sample
@@ -154,6 +154,11 @@
                             ; 1 - full duplex
 ;duplex3 = 0                ; duplex 3 gain setting (0 to disable) ???
 
+;checkrxaudio = 1           ; Enable receive audio statistics and ADC clip detection (0 to disable).
+                            ; Enables tune-menu 'R' function. Supports audio interface Clip LED by
+                            ; setting a GPIO (if available) high for 500mS when clipping detected.
+                            ; parameter value = GPIO# to use, eg. checkrxaudio = 1 will use GPIO1.
+
 ;gpioX=in					; define input/output pin GPIO(x) in,out0,out1 (where X {1..8}) (optional)
 
 ;pport=/dev/parport0		; Specify parport device (optional)

--- a/configs/samples/usbradio.conf.sample
+++ b/configs/samples/usbradio.conf.sample
@@ -154,10 +154,9 @@
                             ; 1 - full duplex
 ;duplex3 = 0                ; duplex 3 gain setting (0 to disable) ???
 
-;checkrxaudio = 0           ; Enable receive audio statistics and ADC clip detection (0 to disable).
-                            ; Enables tune-menu 'R' function. Supports audio interface Clip LED by
-                            ; setting a GPIO (if available) high for 500mS when clipping detected.
-                            ; parameter value = GPIO# to use, eg. checkrxaudio = 1 will use GPIO1.
+;clipledgpio = 0            ; Enable ADC Clip Detect feature to use a GPIO output (0 to disable).
+                            ; Supports URI Clip LED by setting a GPIO (if available) high for 500mS
+                            ; when clipping detected. Value = GPIO# to use (GPIO1 recommended)
 
 ;gpioX=in					; define input/output pin GPIO(x) in,out0,out1 (where X {1..8}) (optional)
 

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -504,7 +504,7 @@ int ast_radio_check_rx_audio(short *sbuf, struct rxaudiostatistics *o, short len
  * ie. 10*log10(scaledVal) for power levels.
  *
  * \author  		NR9V
- * \param fd		File descriptor to print to, or if 0 print using ast_verbose()
+ * \param fd		File descriptor to print to, or if -1 print using ast_verbose()
  * \param o 		Channel data structure
  * \return  		None
  */

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -456,15 +456,15 @@ struct timeval ast_radio_tvnow(void);
  * enables the raw ADC data to be checked. Clipping is detected by looking for
  * large amplitude square waves (min. 3 samples in a row > 99% FS).
  *
- * Data collected can be displayed from the simpleusb-tune-menu 'R' option or AMI
- * "susb tune menu-support a" function. This also shows average power levels which
- * can be of further use in optimizing audio levels, compression, limiting, etc.
- * In general, peak levels should be within 6-10dB of full-scale (0dBFS) and
- * average signal power levels should be 6-12dB below peak levels.
+ * Data collected can be displayed from the tune-menu 'R' option or AMI
+ * "[susb/radio] tune menu-support y" function. This also shows average power levels
+ * which can be useful for optimizing audio levels and compression/limiting.
+ * In general, peak levels should be within 3-10dB of full-scale (0dBFS) and
+ * average signal power levels should be 10-20dB below full-scale.
  *
- * Should be passed the raw 48Ksps stereo USB frame read buffer before any
- * filtering or downsampling has been done. Extracts the 48K mono channel and
- * downsamples to 8Ksps (as is done in simpleusb_read() but without filtering).
+ * Should be passed the raw 48Ksps stereo USB frame read buffer before any filtering
+ * or downsampling has been done. Extracts the 48K mono channel and downsamples to
+ * 8Ksps (as is done in [simpleusb/usbradio]_read() but without filtering).
  * Signal power calculation takes the square of each sample to measure RMS power.
  * For CPU efficiency no scaling is done here. (When stats data is printed the
  * values are scaled to dBFS.)

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -189,12 +189,12 @@ struct usbecho {
 /* Rx audio (ADC) statistics variables. tune-menu "R" command displays
  * stats data (peak, average, min, max levels and clipped sample count).
  */
-#define AUDIO_STATS_LEN 50 			/* number of 20mS frames. 50 => 1 second buf len */
+#define AUDIO_STATS_LEN 50 	                	/* number of 20mS frames. 50 => 1 second buf len */
 struct rxaudiostatistics {
-	unsigned short maxbuf[AUDIO_STATS_LEN];		/* peak sample value per frame */
+	unsigned short maxbuf[AUDIO_STATS_LEN]; 	/* peak sample value per frame */
 	unsigned short clipbuf[AUDIO_STATS_LEN];	/* number of clipped samples per frame */
-	unsigned int pwrbuf[AUDIO_STATS_LEN];		/* total RMS power per frame */
-	short index;								/* Index within buffers, updated as frames received */
+	unsigned int pwrbuf[AUDIO_STATS_LEN];   	/* total RMS power per frame */
+	short index;                            	/* Index within buffers, updated as frames received */
 };
 
 /*
@@ -477,11 +477,11 @@ struct timeval ast_radio_tvnow(void);
  * - Min and max signal power averaged over a longer time period (dBFS)
  *   These define total signal power and peak-to-average power ratio
  *
- * \author			NR9V
+ * \author    		NR9V
  * \param sbuf		Rx audio sample buffer
- * \param o			Rx Audio Stats data structure
- * \param len		Length of data in sbuf
- * \return 			None
+ * \param o	  		Rx Audio Stats data structure
+ * \param len 		Length of data in sbuf
+ * \return 	  		None
  */
 #define CLIP_LED_HOLD_TIME_MS  500
 int ast_radio_check_rx_audio(short *sbuf, struct rxaudiostatistics *o, short len);
@@ -503,9 +503,9 @@ int ast_radio_check_rx_audio(short *sbuf, struct rxaudiostatistics *o, short len
  * Results are scaled to double precision 0.0-1.0 and converted to log (dB)
  * ie. 10*log10(scaledVal) for power levels.
  *
- * \author			NR9V
+ * \author  		NR9V
  * \param fd		File descriptor to print to, or if 0 print using ast_verbose()
- * \param o			Channel data structure
- * \return 			None
+ * \param o 		Channel data structure
+ * \return  		None
  */
 void ast_radio_print_rx_audio_stats(int fd, struct rxaudiostatistics *o);

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -481,7 +481,7 @@ struct timeval ast_radio_tvnow(void);
  * \param sbuf  	Rx audio sample buffer
  * \param o	    	Rx Audio Stats data structure
  * \param len   	Length of data in sbuf
- * \return 	    	None
+ * \return 	    	1 if clipping detected, 0 otherwise
  */
 #define CLIP_LED_HOLD_TIME_MS  500
 int ast_radio_check_rx_audio(short *sbuf, struct rxaudiostatistics *o, short len);

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -504,7 +504,7 @@ int ast_radio_check_rx_audio(short *sbuf, struct rxaudiostatistics *o, short len
  * ie. 10*log10(scaledVal) for power levels.
  *
  * \author  		NR9V
- * \param fd		File descriptor to print to, or if -1 print using ast_verbose()
+ * \param fd		File descriptor to print to, or if < 0 print using ast_verbose()
  * \param o 		Channel data structure
  * \return  		None
  */

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -477,11 +477,11 @@ struct timeval ast_radio_tvnow(void);
  * - Min and max signal power averaged over a longer time period (dBFS)
  *   These define total signal power and peak-to-average power ratio
  *
- * \author    		NR9V
- * \param sbuf		Rx audio sample buffer
- * \param o	  		Rx Audio Stats data structure
- * \param len 		Length of data in sbuf
- * \return 	  		None
+ * \author      	NR9V
+ * \param sbuf  	Rx audio sample buffer
+ * \param o	    	Rx Audio Stats data structure
+ * \param len   	Length of data in sbuf
+ * \return 	    	None
  */
 #define CLIP_LED_HOLD_TIME_MS  500
 int ast_radio_check_rx_audio(short *sbuf, struct rxaudiostatistics *o, short len);

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -741,10 +741,12 @@ int ast_radio_check_rx_audio(short *sbuf, struct rxaudiostatistics *o, short len
 	short buf[FRAME_SIZE], last_clip = -1;
 
 	/* validate len and index */
-	if (len > 12 * FRAME_SIZE)
+	if (len > 12 * FRAME_SIZE) {
 		len = 12 * FRAME_SIZE;
-	if (o->index >= AUDIO_STATS_LEN)
+	}
+	if (o->index >= AUDIO_STATS_LEN) {
 		o->index = 0;
+	}
 	/* Downsample from 48000 stereo to 8000 mono */
 	for (i = 10, j = 0; i < len; i += 12) {
 		buf[j++] = sbuf[i];
@@ -754,12 +756,14 @@ int ast_radio_check_rx_audio(short *sbuf, struct rxaudiostatistics *o, short len
 	for (i = 0; i < len; i++) {
 		val = abs(buf[i]);
 		if (val) {
-			if (val > max)
+			if (val > max) {
 				max = val;
+			}
 			pwr += (double) (val * val);
 			if (val > CLIP_SAMP_THRESH) {
-				if (last_clip >= 0 && last_clip + 1 == i)
+				if (last_clip >= 0 && last_clip + 1 == i) {
 					seq_clips++;
+				}
 				last_clip = i;
 			}
 		}
@@ -786,13 +790,16 @@ void ast_radio_print_rx_audio_stats(int fd, struct rxaudiostatistics *o)
 	 *     Max = max(pwrbuf)
 	 */
 	for (i = 0; i < AUDIO_STATS_LEN; i++) {
-		if (o->maxbuf[i] > pk)
+		if (o->maxbuf[i] > pk) {
 			pk = o->maxbuf[i];
+		}
 		pwr = o->pwrbuf[i];
-		if (pwr < minpwr)
+		if (pwr < minpwr) {
 			minpwr = pwr;
-		if (pwr > maxpwr)
+		}
+		if (pwr > maxpwr) {
 			maxpwr = pwr;
+		}
 		tpwr += pwr;
 		clipcnt += o->clipbuf[i];
 	}
@@ -806,10 +813,12 @@ void ast_radio_print_rx_audio_stats(int fd, struct rxaudiostatistics *o)
 	/* Print stats */
 	sprintf(s1, "RxAudioStats: Pk %5.1f  Avg Pwr %3.0f  Min %3.0f  Max %3.0f  dBFS  ClipCnt %u",
 			dpk, tpwr, dmin, dmax, clipcnt);
-	if (fd)
+	if (fd) {
 		ast_cli(fd, "%s\n", s1);
-	else
+	}
+	else {
 		ast_verbose("%s\n", s1);
+	}
 }
 
 static int load_module(void)

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -736,7 +736,7 @@ struct timeval ast_radio_tvnow(void)
 #define CLIP_EVENT_MIN_SAMPLES 3
 int ast_radio_check_rx_audio(short *sbuf, struct rxaudiostatistics *o, short len)
 {
-	unsigned short i, j, val, max = 0, clip_cnt = 0, seq_clips = 0;
+	unsigned short i, j, val, max = 0, seq_clips = 0;
 	double pwr = 0.0;
 	short buf[FRAME_SIZE], last_clip = -1;
 
@@ -762,7 +762,6 @@ int ast_radio_check_rx_audio(short *sbuf, struct rxaudiostatistics *o, short len
 			pwr += (double) (val * val);
 			if (val > CLIP_SAMP_THRESH)
 			{
-				clip_cnt++;
 				if (last_clip >= 0 && last_clip + 1 == i)
 					seq_clips++;
 				last_clip = i;

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -813,7 +813,7 @@ void ast_radio_print_rx_audio_stats(int fd, struct rxaudiostatistics *o)
 	/* Print stats */
 	sprintf(s1, "RxAudioStats: Pk %5.1f  Avg Pwr %3.0f  Min %3.0f  Max %3.0f  dBFS  ClipCnt %u",
 			dpk, tpwr, dmin, dmax, clipcnt);
-	if (fd) {
+	if (fd >= 0) {
 		ast_cli(fd, "%s\n", s1);
 	} else {
 		ast_verbose("%s\n", s1);

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -815,8 +815,7 @@ void ast_radio_print_rx_audio_stats(int fd, struct rxaudiostatistics *o)
 			dpk, tpwr, dmin, dmax, clipcnt);
 	if (fd) {
 		ast_cli(fd, "%s\n", s1);
-	}
-	else {
+	} else {
 		ast_verbose("%s\n", s1);
 	}
 }

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -746,22 +746,18 @@ int ast_radio_check_rx_audio(short *sbuf, struct rxaudiostatistics *o, short len
 	if (o->index >= AUDIO_STATS_LEN)
 		o->index = 0;
 	/* Downsample from 48000 stereo to 8000 mono */
-	for (i = 10, j = 0; i < len; i += 12)
-	{
+	for (i = 10, j = 0; i < len; i += 12) {
 		buf[j++] = sbuf[i];
 	}
 	len /= 12;
 	/* len should now be 160 */
-	for (i = 0; i < len; i++)
-	{
+	for (i = 0; i < len; i++) {
 		val = abs(buf[i]);
-		if (val)
-		{
+		if (val) {
 			if (val > max)
 				max = val;
 			pwr += (double) (val * val);
-			if (val > CLIP_SAMP_THRESH)
-			{
+			if (val > CLIP_SAMP_THRESH) {
 				if (last_clip >= 0 && last_clip + 1 == i)
 					seq_clips++;
 				last_clip = i;
@@ -771,8 +767,7 @@ int ast_radio_check_rx_audio(short *sbuf, struct rxaudiostatistics *o, short len
 	o->maxbuf[o->index] = max;
 	o->pwrbuf[o->index] = (unsigned int) (pwr / (double)len);
 	o->clipbuf[o->index] = seq_clips;
-	if (++o->index >= AUDIO_STATS_LEN)
-	{
+	if (++o->index >= AUDIO_STATS_LEN) {
 		o->index = 0;
 	}
 	/* return 1 if clipping was detected */
@@ -790,8 +785,7 @@ void ast_radio_print_rx_audio_stats(int fd, struct rxaudiostatistics *o)
 	 *     Min = min(pwrbuf)
 	 *     Max = max(pwrbuf)
 	 */
-	for (i = 0; i < AUDIO_STATS_LEN; i++)
-	{
+	for (i = 0; i < AUDIO_STATS_LEN; i++) {
 		if (o->maxbuf[i] > pk)
 			pk = o->maxbuf[i];
 		pwr = o->pwrbuf[i];

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -736,9 +736,9 @@ struct timeval ast_radio_tvnow(void)
 #define CLIP_EVENT_MIN_SAMPLES 3
 int ast_radio_check_rx_audio(short *sbuf, struct rxaudiostatistics *o, short len)
 {
-	unsigned short i, j, val, max = 0, clip_cnt = 0, seq_clips = 0, last_clip = -1;
+	unsigned short i, j, val, max = 0, clip_cnt = 0, seq_clips = 0;
 	double pwr = 0.0;
-	short buf[FRAME_SIZE];
+	short buf[FRAME_SIZE], last_clip = -1;
 
 	/* validate len and index */
 	if (len > 12 * FRAME_SIZE)
@@ -806,7 +806,7 @@ void ast_radio_print_rx_audio_stats(int fd, struct rxaudiostatistics *o)
 	tpwr /= AUDIO_STATS_LEN;
 	/* Convert to dBFS / dB */
 	scale = 1.0 / (double) (1 << 30);
-	dpk =  (pk > 0.0) ? 10 * log10(pk * pk * scale) : -96.0;
+	dpk = (pk > 0.0) ? 10 * log10(pk * pk * scale) : -96.0;
 	tpwr = (tpwr > 0.0) ? 10 * log10(tpwr * scale) : -96.0;
 	dmin = minpwr ? 10 * log10(minpwr * scale) : -96.0;
 	dmax = maxpwr ? 10 * log10(maxpwr * scale) : -96.0;

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -732,6 +732,93 @@ struct timeval ast_radio_tvnow(void)
 	return tv;
 }
 
+#define CLIP_SAMP_THRESH       0x7eb0
+#define CLIP_EVENT_MIN_SAMPLES 3
+int ast_radio_check_rx_audio(short *sbuf, struct rxaudiostatistics *o, short len)
+{
+	unsigned short i, j, val, max = 0, clip_cnt = 0, seq_clips = 0, last_clip = -1;
+	double pwr = 0.0;
+	short buf[FRAME_SIZE];
+
+	/* validate len and index */
+	if (len > 12 * FRAME_SIZE)
+		len = 12 * FRAME_SIZE;
+	if (o->index >= AUDIO_STATS_LEN)
+		o->index = 0;
+	/* Downsample from 48000 stereo to 8000 mono */
+	for (i = 10, j = 0; i < len; i += 12)
+	{
+		buf[j++] = sbuf[i];
+	}
+	len /= 12;
+	/* len should now be 160 */
+	for (i = 0; i < len; i++)
+	{
+		val = abs(buf[i]);
+		if (val)
+		{
+			if (val > max)
+				max = val;
+			pwr += (double) (val * val);
+			if (val > CLIP_SAMP_THRESH)
+			{
+				clip_cnt++;
+				if (last_clip >= 0 && last_clip + 1 == i)
+					seq_clips++;
+				last_clip = i;
+			}
+		}
+	}
+	o->maxbuf[o->index] = max;
+	o->pwrbuf[o->index] = (unsigned int) (pwr / (double)len);
+	o->clipbuf[o->index] = seq_clips;
+	if (++o->index >= AUDIO_STATS_LEN)
+	{
+		o->index = 0;
+	}
+	/* return 1 if clipping was detected */
+	return (seq_clips >= CLIP_EVENT_MIN_SAMPLES);
+}
+
+void ast_radio_print_rx_audio_stats(int fd, struct rxaudiostatistics *o)
+{
+	unsigned int i, pk = 0, pwr = 0, minpwr = 0x40000000, maxpwr = 0, clipcnt = 0;
+	double dpk, dmin, dmax, scale, tpwr = 0.0;
+	char s1[100];
+
+	/* Peak    = max(maxbuf)^2
+	 * Avg Pwr = avg(pwrbuf)
+	 *     Min = min(pwrbuf)
+	 *     Max = max(pwrbuf)
+	 */
+	for (i = 0; i < AUDIO_STATS_LEN; i++)
+	{
+		if (o->maxbuf[i] > pk)
+			pk = o->maxbuf[i];
+		pwr = o->pwrbuf[i];
+		if (pwr < minpwr)
+			minpwr = pwr;
+		if (pwr > maxpwr)
+			maxpwr = pwr;
+		tpwr += pwr;
+		clipcnt += o->clipbuf[i];
+	}
+	tpwr /= AUDIO_STATS_LEN;
+	/* Convert to dBFS / dB */
+	scale = 1.0 / (double) (1 << 30);
+	dpk =  (pk > 0.0) ? 10 * log10(pk * pk * scale) : -96.0;
+	tpwr = (tpwr > 0.0) ? 10 * log10(tpwr * scale) : -96.0;
+	dmin = minpwr ? 10 * log10(minpwr * scale) : -96.0;
+	dmax = maxpwr ? 10 * log10(maxpwr * scale) : -96.0;
+	/* Print stats */
+	sprintf(s1, "RxAudioStats: Pk %5.1f  Avg Pwr %3.0f  Min %3.0f  Max %3.0f  dBFS  ClipCnt %u",
+			dpk, tpwr, dmin, dmax, clipcnt);
+	if (fd)
+		ast_cli(fd, "%s\n", s1);
+	else
+		ast_verbose("%s\n", s1);
+}
+
 static int load_module(void)
 {
 	return 0;

--- a/utils/radio-tune-menu.c
+++ b/utils/radio-tune-menu.c
@@ -54,6 +54,7 @@
  *		v - view cos, ctcss and ptt status
  *		w - change tx mixer a
  *		x - change tx mixer b
+ *		y - receive audio statistics display
  *
  * Most of these commands take optional parameters to set values.
  *
@@ -1043,6 +1044,7 @@ static void options_menu(void)
 		printf("H) Change CTCSS From (currently '%s')\n", sd_signal_type[ctcssfrom]);
 		printf("P) Print Current Parameter Values\n");
 		printf("O) Options Menu\n");
+		printf("R) View Rx Audio Statistics\n");
 		printf("S) Swap Current USB device with another USB device\n");
 		printf("T) Toggle Transmit Test Tone/Keying (currently '%s')\n", (keying) ? "enabled" : "disabled");
 		printf("V) View COS, CTCSS and PTT Status\n");
@@ -1155,6 +1157,10 @@ static void options_menu(void)
 			if (astgetresp(COMMAND_PREFIX "tune menu-support 2")) {
 				exit(255);
 			}
+			break;
+		case 'r':				/* display receive audio statistics */
+		case 'R':
+			astgetresp(COMMAND_PREFIX "tune menu-support y");
 			break;
 		case 's':				/* swap usb device with another device */
 		case 'S':

--- a/utils/simpleusb-tune-menu.c
+++ b/utils/simpleusb-tune-menu.c
@@ -30,7 +30,6 @@
  *		1 - get node names that are configured in simpleusb.conf
  *		2 - print parameters
  *		3 - get node names that are configured in simpleusb.conf, except current device
- *		a - receive audio statistics display
  *		b - receiver tune display
  *		c - receive level
  *		f - txa level
@@ -48,6 +47,7 @@
  *		t - change rx on delay
  *		u - change tx off delay
  *		v - view cos, ctcss and ptt status
+ *		y - receive audio statistics display
  *
  * Most of these commands take optional parameters to set values.
  *
@@ -945,7 +945,7 @@ static int astgetresp(char *cmd)
 			break;
 		case 'r':				/* display receive audio statistics */
 		case 'R':
-			astgetresp(COMMAND_PREFIX "tune menu-support a");
+			astgetresp(COMMAND_PREFIX "tune menu-support y");
 			break;
 		case 's':				/* swap usb device with another device */
 		case 'S':

--- a/utils/simpleusb-tune-menu.c
+++ b/utils/simpleusb-tune-menu.c
@@ -30,6 +30,7 @@
  *		1 - get node names that are configured in simpleusb.conf
  *		2 - print parameters
  *		3 - get node names that are configured in simpleusb.conf, except current device
+ *		a - receive audio statistics display
  *		b - receiver tune display
  *		c - receive level
  *		f - txa level
@@ -796,6 +797,7 @@ static int astgetresp(char *cmd)
 		printf("K) Change RX On Delay (currently '%d')\n", rxondelay);
 		printf("L) Change TX Off Delay (currently '%d')\n", txoffdelay);
 		printf("P) Print Current Parameter Values\n");
+		printf("R) View Rx Audio Statistics\n");
 		printf("S) Swap Current USB device with another USB device\n");
 		printf("T) Toggle Transmit Test Tone/Keying (currently '%s')\n", keying ? "enabled" : "disabled");
 		printf("V) View COS, CTCSS and PTT Status\n");
@@ -940,6 +942,10 @@ static int astgetresp(char *cmd)
 			if (astgetresp(COMMAND_PREFIX "tune menu-support 2")) {
 				exit(255);
 			}
+			break;
+		case 'r':				/* display receive audio statistics */
+		case 'R':
+			astgetresp(COMMAND_PREFIX "tune menu-support a");
 			break;
 		case 's':				/* swap usb device with another device */
 		case 'S':


### PR DESCRIPTION
Add RX Audio Statistics and ADC Clip Detection feature. This adds a new rxaudiostats parameter to simpleusb.conf, which enables a new function check_rx_audio() in chan_simpleusb.c to be called during processing of received USB audio frames. If ADC clipping is then detected GPIO4 is set for 500mS to support illumination of a Clip LED on the node / audio interface. Statistics collected also include peak and average RMS audio levels, averaged over the previous 1 second, which can be displayed from a new simpleusb-tune-menu 'R' option or AMI 'susb tune menu-support a' function.

The background behind this feature is discussed in this ASL forum post: https://community.allstarlink.org/t/audio-clip-led-feature-addition-to-asl3/21651

I have reviewed the schematics for a wide variety of USB radio interfaces used with ASL including models from Repeater-Builder, Masters Communications, DMK Engineering, Kits-for-Hams, BH7NOR, Digirig, as well as C-Media CM108AH/B sound fobs, and found that GPIO4 is not currently used in any of these interfaces, and thus is ideal for use as an LED clip indicator, to allow future URIs - or in the case of radio-less nodes a USB Communications Interface (UCI) - to provide a simple, low cost means to notify users of audio level issues. As more users get on AllStar, improperly adjusted audio levels are an increasingly important issue, and this addition will make it easier for users to confirm audio levels with a clip LED present on future products as well as with an added simpleusb-tune-menu option that shows more precise statistics than the existing "Set Rx Voice Level" utility.

I have tested this feature on several nodes using various URIs/UCIs with C-Media CM108AH, CM119A, and CM108B ICs. On each of these I added an LED output on GPIO4, and confirmed that the LED only illuminates when actual clipping occurred. See the function header documentation in chan_simpleusb.c for more details. The statistics collected are simple and require essentially zero CPU use, and under 1KB of additional RAM use.  Tests with the feature enabled and disabled resulted in no noticeable difference in asterisk's CPU use as shown by top. In both cases CPU use averages 10% +/- 1% on a Dell Wyse thin-client PC with 1.4GHz Atom CPU, with both the Allmon3 and AllScan dashboard apps running.

Below screenshot shows the operation of the new simpleusb-tune-menu "R" option, which prints once per second the peak and average rx audio stats along with number of clip events detected, until the Enter key is pressed - similar to how other menu options work such as the "2) Set Rx Voice Level" or "V) View COS, CTCSS and PTT Status".

![susb-tune-menu-R](https://github.com/user-attachments/assets/40f5eb96-d4d6-4fe5-95dc-eea56a27d9cb)

To those with experience in audio production, recording, engineering, etc., these basic audio statistics and Clip LED support should be a welcome addition. Audio equipment products such as mixers, mic preamps, dynamics processors, etc. almost always have clip LEDs on the inputs thereby allowing levels to be quickly and easily optimized (with no need to SSH into anything).

For those who use AllStar mainly for repeaters and have high-end communications test equipment, this feature may not be as interesting, but most AllStar users have small inexpensive nodes and limited abilities to optimize audio levels, or may not be able to easily SSH into their node and figure out how to use the tune-menu utility properly. Unfortunately it takes only 1 or 2 users on an AllStar-linked repeater, hub, or net who have audio levels that are too high or too low, and a significant inconvenience then results for everyone else as they have to ride their volume controls up and down as various people key up. Distorted audio is the bane of digital/VOIP modes and with the expanding number of ways that people can get on AllStar I feel it's important as an AllStar user and vendor to make it as easy as possible for users to get their audio levels right.  (This feature could also be extended in the future to support AGC/leveling functionality that could for example smoothly and gradually reduce or increase the rxmix setting when clipping is detected or if signal levels are excessively low.)

I was careful to really thoroughly look at how chan_simpleusb and the tune-menu utilities are set up, how configuration parameters and other variables and structures are managed, and how all this works in various use cases, including in the context of simpleusb supporting multiple nodes and interfaces on one server. I believe my implementation of this feature has closely followed the style and implementation of similar functions in the app_rpt code, while being simple and cleanly partitioned. I believe there should be essentially zero risk of bugs or issues with this feature addition. If I can provide any additional test info let me know. The feature is pretty easy to test since all it's doing is looking at incoming audio and then showing a few basic statistics in a tune-menu command, and setting a CM1xxx GPIO when clipping is detected. (Clipping can easily be induced just by increasing the rxmix setting in the tune-menu.)

I have not added this to the usbradio driver since that tends to be used more in unattended applications such as repeaters rather than in small personal nodes. But it would be very easy to also add to usbradio by moving the 2 new functions to a common file and copying the handful of other lines of code into the corresponding usbradio files.