### PR TITLE
app_rpt: Correct VOX operation for autopatch

### DIFF
--- a/apps/app_rpt/rpt_bridging.c
+++ b/apps/app_rpt/rpt_bridging.c
@@ -417,23 +417,20 @@ static int *dahdi_confno(struct rpt *myrpt, enum rpt_conf_type type)
 }
 
 /*!
- * \brief Get the conference number of a DAHDI channel
- * This actually gets the internal DAHDI channel number.
- * The channel number is used by the DAHDI monitor functions
- * to create a monitor only conference.
+ * \brief Get the channel number of a DAHDI channel
  * \param chan DAHDI channel
  * \retval -1 on failure, conference number on success
  */
-static int dahdi_conf_fd_confno(struct ast_channel *chan)
+static int dahdi_conf_get_channo(struct ast_channel *chan)
 {
 	struct dahdi_confinfo ci = {0};
 
-	if (ioctl(ast_channel_fd(chan, 0), DAHDI_CHANNO, &ci.confno)) {
+	if (ioctl(ast_channel_fd(chan, 0), DAHDI_CHANNO, &ci.chan)) {
 		ast_log(LOG_WARNING, "DAHDI_CHANNO failed: %s\n", strerror(errno));
 		return -1;
 	}
 
-	return ci.confno;
+	return ci.chan;
 }
 
 int __rpt_conf_create(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_type type, enum rpt_conf_flags flags, const char *file, int line)
@@ -488,7 +485,7 @@ int rpt_call_bridge_setup(struct rpt *myrpt, struct ast_channel *mychannel, stru
 	}
 
 	/* get its conference number */
-	res = dahdi_conf_fd_confno(mychannel);
+	res = dahdi_conf_get_channo(mychannel);
 	if (res < 0) {
 		ast_log(LOG_WARNING, "Unable to get autopatch channel number\n");
 		ast_hangup(mychannel);
@@ -498,10 +495,13 @@ int rpt_call_bridge_setup(struct rpt *myrpt, struct ast_channel *mychannel, stru
 	/* put vox channel monitoring on the channel  
 	 *
 	 * This uses the internal DAHDI channel number to create the 
-	 * monitor conference.  It requires a patched version of DAHDI
-	 * that contains changes for this to work properly.  
-	 * Without the patch, this code will hang here when trying to 
-	 * join the conference.
+	 * monitor conference.  This code will hang here when trying to 
+	 * join the conference when the underlying version of DAHDI in use
+	 * is missing a patch that allows the DAHDI_CONF_MONITOR option
+	 * to monitor a pseudo channel.  This patch prevents the hardware
+	 * pre-echo routines from acting on a pseudo channel.  It also
+	 * prevents the DAHDI check conference routine from acting
+	 * on a channel number being used as a conference.
 	 */
 	if (dahdi_conf_add(myrpt->voxchannel, res, DAHDI_CONF_MONITOR)) {
 		ast_hangup(mychannel);
@@ -515,7 +515,7 @@ int rpt_mon_setup(struct rpt *myrpt)
 	int res;
 
 	if (!IS_PSEUDO(myrpt->txchannel) && myrpt->dahditxchannel == myrpt->txchannel) {
-		int confno = dahdi_conf_fd_confno(myrpt->txchannel); /* get tx channel's port number */
+		int confno = dahdi_conf_get_channo(myrpt->txchannel); /* get tx channel's port number */
 		if (confno < 0) {
 			return -1;
 		}

--- a/apps/app_rpt/rpt_bridging.c
+++ b/apps/app_rpt/rpt_bridging.c
@@ -431,7 +431,7 @@ static int dahdi_conf_fd_confno(struct ast_channel *chan)
 	ci.confno = 0;
 	ci.confmode = 0;
 
-	if (ioctl(ast_channel_fd(chan, 0), DAHDI_CHANNO, &ci)) {
+	if (ioctl(ast_channel_fd(chan, 0), DAHDI_CHANNO, &ci.confno)) {
 		ast_log(LOG_WARNING, "DAHDI_GETCONF failed: %s\n", strerror(errno));
 		return -1;
 	}

--- a/apps/app_rpt/rpt_bridging.c
+++ b/apps/app_rpt/rpt_bridging.c
@@ -426,13 +426,10 @@ static int *dahdi_confno(struct rpt *myrpt, enum rpt_conf_type type)
  */
 static int dahdi_conf_fd_confno(struct ast_channel *chan)
 {
-	struct dahdi_confinfo ci;
-	ci.chan = 0;
-	ci.confno = 0;
-	ci.confmode = 0;
+	struct dahdi_confinfo ci = {0};
 
 	if (ioctl(ast_channel_fd(chan, 0), DAHDI_CHANNO, &ci.confno)) {
-		ast_log(LOG_WARNING, "DAHDI_GETCONF failed: %s\n", strerror(errno));
+		ast_log(LOG_WARNING, "DAHDI_CHANNO failed: %s\n", strerror(errno));
 		return -1;
 	}
 
@@ -501,10 +498,10 @@ int rpt_call_bridge_setup(struct rpt *myrpt, struct ast_channel *mychannel, stru
 	/* put vox channel monitoring on the channel  
 	 *
 	 * This uses the internal DAHDI channel number to create the 
-	 * monitor conference.  It requires the ASL version of DAHDI
+	 * monitor conference.  It requires a patched version of DAHDI
 	 * that contains changes for this to work properly.  
-	 * If the standard Asterisk DAHDI driver is used, this
-	 * code will hang here when trying to join the conference.
+	 * Without the patch, this code will hang here when trying to 
+	 * join the conference.
 	 */
 	if (dahdi_conf_add(myrpt->voxchannel, res, DAHDI_CONF_MONITOR)) {
 		ast_hangup(mychannel);


### PR DESCRIPTION
This change restores the operation of the autopatch VOX function.

Changes were made in #363 to get the autopatch working.  Part of those changes did not correctly address the operation of the vox channel.  This change removes some of those changes and restores the operation of the vox channel.

For the vox channel to work properly, this change along with changes to the DAHDI driver are required.  The changes to the DAHDI driver are located at https://github.com/KB4MDD/dahdi-linux

We will be attempting to get these changes into the main DAHDI channel.

This closes #388