### PR TITLE
Tune menus will not always save settings

### DIFF
--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -3203,29 +3203,30 @@ static void _menu_txb(int fd, struct chan_simpleusb_pvt *o, const char *str)
  * \param category	The category being updated (e.g. "12345").
  * \param variable	The variable being updated (e.g. "rxboost").
  * \param value		The value being updated (e.g. "yes").
+ * \retval 0		If successful.
+ * \retval -1		If unsuccessful.
  */
 static int tune_variable_update(const char *filename, struct ast_category *category,
 								const char *variable, const char *value)
 {
 	int	res;
+	struct ast_variable *var;
 
 	res = ast_variable_update(category, variable, value, NULL, 0);
-	if (res != 0) {
-		struct ast_variable *var;
+	if (res == 0) {
+		return 0;
+	}
 
 		/* if we could not find/update the variable, create new */
 		var = ast_variable_new(variable, value, filename);
-		if (var != NULL) {
+	if (var == NULL) {
+		return -1;
+	}
+
 			/* and append */
 			ast_variable_append(category, var);
 			return 0;
 		}
-
-		return -1;
-	}
-
-	return 0;
-}
 
 /*!
  * \brief Write tune settings to the configuration file. If the device EEPROM is enabled, the settings are  saved to EEPROM.
@@ -3288,7 +3289,7 @@ static void tune_write(struct chan_simpleusb_pvt *o)
 		CONFIG_UPDATE_INT(rxondelay);
 		CONFIG_UPDATE_INT(txoffdelay);
 		if (ast_config_text_file_save2(CONFIG, cfg, "chan_simpleusb", 0)) {
-			ast_log(LOG_WARNING, "Failed to save config %s.\n", CONFIG);
+			ast_log(LOG_WARNING, "Failed to save config %s\n", CONFIG);
 		}
 	}
 

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -3209,7 +3209,7 @@ static void _menu_txb(int fd, struct chan_simpleusb_pvt *o, const char *str)
 static int tune_variable_update(const char *filename, struct ast_category *category,
 								const char *variable, const char *value)
 {
-	int	res;
+	int res;
 	struct ast_variable *var;
 
 	res = ast_variable_update(category, variable, value, NULL, 0);
@@ -3217,16 +3217,16 @@ static int tune_variable_update(const char *filename, struct ast_category *categ
 		return 0;
 	}
 
-		/* if we could not find/update the variable, create new */
-		var = ast_variable_new(variable, value, filename);
+	/* if we could not find/update the variable, create new */
+	var = ast_variable_new(variable, value, filename);
 	if (var == NULL) {
 		return -1;
 	}
 
-			/* and append */
-			ast_variable_append(category, var);
-			return 0;
-		}
+	/* and append */
+	ast_variable_append(category, var);
+	return 0;
+}
 
 /*!
  * \brief Write tune settings to the configuration file. If the device EEPROM is enabled, the settings are  saved to EEPROM.

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -4389,6 +4389,36 @@ static void tune_rxctcss(int fd, struct chan_usbradio_pvt *o, int intflag)
 }
 
 /*!
+ * \brief Update the tune settings to the configuration file.
+ * \param filename	The configuration file being updated (e.g. "usbradio.conf").
+ * \param category	The category being updated (e.g. "12345").
+ * \param variable	The variable being updated (e.g. "rxboost").
+ * \param value		The value being updated (e.g. "yes").
+ */
+static int tune_variable_update(const char *filename, struct ast_category *category,
+								const char *variable, const char *value)
+{
+	int	res;
+
+	res = ast_variable_update(category, variable, value, NULL, 0);
+	if (res != 0) {
+		struct ast_variable *var;
+
+		/* if we could not find/update the variable, create new */
+		var = ast_variable_new(variable, value, filename);
+		if (var != NULL) {
+			/* and append */
+			ast_variable_append(category, var);
+			return 0;
+		}
+
+		return -1;
+	}
+
+	return 0;
+}
+
+/*!
  * \brief Write tune settings to the configuration file. If the device EEPROM is enabled, the settings are  saved to EEPROM.
  * \param o Channel private.
  */
@@ -4407,33 +4437,33 @@ static void tune_write(struct chan_usbradio_pvt *o)
 	}
 
 #define CONFIG_UPDATE_STR(field) \
-	if (ast_variable_update(category, #field, o->field, NULL, 0)) { \
+	if (tune_variable_update(CONFIG, category, #field, o->field)) { \
 		ast_log(LOG_WARNING, "Failed to update %s\n", #field); \
 	}
 
 #define CONFIG_UPDATE_INT(field) { \
 	char _buf[15]; \
 	snprintf(_buf, sizeof(_buf), "%d", o->field); \
-	if (ast_variable_update(category, #field, _buf, NULL, 0)) { \
+	if (tune_variable_update(CONFIG, category, #field, _buf)) { \
 		ast_log(LOG_WARNING, "Failed to update %s\n", #field); \
 	} \
 }
 
 #define CONFIG_UPDATE_BOOL(field) \
-	if (ast_variable_update(category, #field, o->field ? "yes" : "no", NULL, 0)) { \
+	if (tune_variable_update(CONFIG, category, #field, o->field ? "yes" : "no")) { \
 		ast_log(LOG_WARNING, "Failed to update %s\n", #field); \
 	}
 
 #define CONFIG_UPDATE_FLOAT(field) { \
 	char _buf[15]; \
 	snprintf(_buf, sizeof(_buf), "%f", o->field); \
-	if (ast_variable_update(category, #field, _buf, NULL, 0)) { \
+	if (tune_variable_update(CONFIG, category, #field, _buf)) { \
 		ast_log(LOG_WARNING, "Failed to update %s\n", #field); \
 	} \
 }
 	
 #define CONFIG_UPDATE_SIGNAL(key, field, signal_type) \
-	if (ast_variable_update(category, #key, signal_type[o->field], NULL, 0)) { \
+	if (tune_variable_update(CONFIG, category, #key, signal_type[o->field])) { \
 		ast_log(LOG_WARNING, "Failed to update %s\n", #field); \
 	}
 
@@ -4463,7 +4493,7 @@ static void tune_write(struct chan_usbradio_pvt *o)
 		CONFIG_UPDATE_SIGNAL(txmixa, txmixa, mixer_type);
 		CONFIG_UPDATE_SIGNAL(txmixb, txmixb, mixer_type);
 		if (ast_config_text_file_save2(CONFIG, cfg, "chan_usbradio", 0)) {
-			ast_log(LOG_WARNING, "Failed to save config\n");
+			ast_log(LOG_WARNING, "Failed to save config %s.\n", CONFIG);
 		}
 	}
 

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -4400,7 +4400,7 @@ static void tune_rxctcss(int fd, struct chan_usbradio_pvt *o, int intflag)
 static int tune_variable_update(const char *filename, struct ast_category *category,
 								const char *variable, const char *value)
 {
-	int	res;
+	int res;
 	struct ast_variable *var;
 
 	res = ast_variable_update(category, variable, value, NULL, 0);
@@ -4408,16 +4408,16 @@ static int tune_variable_update(const char *filename, struct ast_category *categ
 		return 0;
 	}
 
-		/* if we could not find/update the variable, create new */
-		var = ast_variable_new(variable, value, filename);
+	/* if we could not find/update the variable, create new */
+	var = ast_variable_new(variable, value, filename);
 	if (var == NULL) {
 		return -1;
 	}
 
-			/* and append */
-			ast_variable_append(category, var);
-			return 0;
-		}
+	/* and append */
+	ast_variable_append(category, var);
+	return 0;
+}
 
 /*!
  * \brief Write tune settings to the configuration file. If the device EEPROM is enabled, the settings are  saved to EEPROM.

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -4394,29 +4394,30 @@ static void tune_rxctcss(int fd, struct chan_usbradio_pvt *o, int intflag)
  * \param category	The category being updated (e.g. "12345").
  * \param variable	The variable being updated (e.g. "rxboost").
  * \param value		The value being updated (e.g. "yes").
+ * \retval 0		If successful.
+ * \retval -1		If unsuccessful.
  */
 static int tune_variable_update(const char *filename, struct ast_category *category,
 								const char *variable, const char *value)
 {
 	int	res;
+	struct ast_variable *var;
 
 	res = ast_variable_update(category, variable, value, NULL, 0);
-	if (res != 0) {
-		struct ast_variable *var;
+	if (res == 0) {
+		return 0;
+	}
 
 		/* if we could not find/update the variable, create new */
 		var = ast_variable_new(variable, value, filename);
-		if (var != NULL) {
+	if (var == NULL) {
+		return -1;
+	}
+
 			/* and append */
 			ast_variable_append(category, var);
 			return 0;
 		}
-
-		return -1;
-	}
-
-	return 0;
-}
 
 /*!
  * \brief Write tune settings to the configuration file. If the device EEPROM is enabled, the settings are  saved to EEPROM.
@@ -4493,7 +4494,7 @@ static void tune_write(struct chan_usbradio_pvt *o)
 		CONFIG_UPDATE_SIGNAL(txmixa, txmixa, mixer_type);
 		CONFIG_UPDATE_SIGNAL(txmixb, txmixb, mixer_type);
 		if (ast_config_text_file_save2(CONFIG, cfg, "chan_usbradio", 0)) {
-			ast_log(LOG_WARNING, "Failed to save config %s.\n", CONFIG);
+			ast_log(LOG_WARNING, "Failed to save config %s\n", CONFIG);
 		}
 	}
 


### PR DESCRIPTION
When the tune menus request that the current configuration settings be saved there is an assumption that each variable will be represented in the .conf file.  There is no reason that any variables missing from the .conf files cannot be added.