### PR TITLE
app_rpt:  Channel initialization for PTT

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2695,14 +2695,6 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 		myrpt->txchannel = myrpt->rxchannel;
 		myrpt->dahditxchannel = IS_DAHDI_CHAN_NAME(myrpt->rxchanname) && !IS_PSEUDO_NAME(myrpt->rxchanname) ? myrpt->txchannel : NULL;
 	}
-	/* If the TX channel is not a pseudo channel, toggle the PTT line */
-	if (!IS_PSEUDO(myrpt->txchannel)) {
-		/* Wait for the driver to finish initialization */
-		usleep(250000);
-		ast_indicate(myrpt->txchannel, AST_CONTROL_RADIO_KEY);
-		usleep(50000);
-		ast_indicate(myrpt->txchannel, AST_CONTROL_RADIO_UNKEY);
-	}
 
 	if (rpt_request_pseudo(myrpt, cap, RPT_PCHAN)) {
 		rpt_hangup_rx_tx(myrpt);

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2695,8 +2695,12 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 		myrpt->txchannel = myrpt->rxchannel;
 		myrpt->dahditxchannel = IS_DAHDI_CHAN_NAME(myrpt->rxchanname) && !IS_PSEUDO_NAME(myrpt->rxchanname) ? myrpt->txchannel : NULL;
 	}
+	/* If the TX channel is not a pseudo channel, toggle the PTT line */
 	if (!IS_PSEUDO(myrpt->txchannel)) {
+		/* Wait for the driver to finish initialization */
+		usleep(250000);
 		ast_indicate(myrpt->txchannel, AST_CONTROL_RADIO_KEY);
+		usleep(50000);
 		ast_indicate(myrpt->txchannel, AST_CONTROL_RADIO_UNKEY);
 	}
 

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1171,18 +1171,20 @@ static void *hidthread(void *arg)
 			ast_mutex_unlock(&o->txqlock);
 			txreq = txreq || o->txkeyed || o->txtestkey || o->echoing;
 			if (txreq && (!o->lasttx)) {
-				buf[o->hid_gpio_loc] = o->hid_gpio_val |= o->hid_io_ptt;
+				o->hid_gpio_val |= o->hid_io_ptt;
 				if (o->invertptt) {
-					buf[o->hid_gpio_loc] = o->hid_gpio_val &= ~o->hid_io_ptt;
+					o->hid_gpio_val &= ~o->hid_io_ptt;
 				}
+				buf[o->hid_gpio_loc] = o->hid_gpio_val;
 				buf[o->hid_gpio_ctl_loc] = o->hid_gpio_ctl;
 				ast_radio_hid_set_outputs(usb_handle, buf);
 				ast_debug(2, "Channel %s: update PTT = %d on channel.\n", o->name, txreq);
 			} else if ((!txreq) && o->lasttx) {
-				buf[o->hid_gpio_loc] = o->hid_gpio_val &= ~o->hid_io_ptt;
+				o->hid_gpio_val &= ~o->hid_io_ptt;
 				if (o->invertptt) {
-					buf[o->hid_gpio_loc] = o->hid_gpio_val |= o->hid_io_ptt;
+					o->hid_gpio_val |= o->hid_io_ptt;
 				}
+				buf[o->hid_gpio_loc] = o->hid_gpio_val;
 				buf[o->hid_gpio_ctl_loc] = o->hid_gpio_ctl;
 				ast_radio_hid_set_outputs(usb_handle, buf);
 				ast_debug(2, "Channel %s: update PTT = %d.\n", o->name, txreq);
@@ -1358,14 +1360,14 @@ static void *hidthread(void *arg)
 				}
 				if (!o->invertptt) {
 					if (o->lasttx) {
-						buf[o->hid_gpio_loc] = o->hid_gpio_val |= o->hid_io_ptt;
+						o->hid_gpio_val |= o->hid_io_ptt;
 						if (k) {
 							pp_val |= k;
 						}
 					}
 				} else {
 					if (!o->lasttx) {
-						buf[o->hid_gpio_loc] = o->hid_gpio_val |= o->hid_io_ptt;
+						o->hid_gpio_val |= o->hid_io_ptt;
 						if (k) {
 							pp_val |= k;
 						}

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -1416,14 +1416,14 @@ static void *hidthread(void *arg)
 				}
 				if (!o->invertptt) {
 					if (lasttxtmp) {
-						buf[o->hid_gpio_loc] = o->hid_gpio_val |= o->hid_io_ptt;
+						o->hid_gpio_val |= o->hid_io_ptt;
 						if (k) {
 							pp_val |= k;
 						}
 					}
 				} else {
 					if (!lasttxtmp) {
-						buf[o->hid_gpio_loc] = o->hid_gpio_val |= o->hid_io_ptt;
+						o->hid_gpio_val |= o->hid_io_ptt;
 						if (k) {
 							pp_val |= k;
 						}

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -588,6 +588,9 @@ static int hidhdwconfig(struct chan_usbradio_pvt *o)
 			o->hid_gpio_val |= (1 << i);
 		}
 	}
+	if (o->invertptt) {
+		o->hid_gpio_val |= o->hid_io_ptt;
+	}
 	return 0;
 }
 
@@ -1441,7 +1444,7 @@ static void *hidthread(void *arg)
 		lasttxtmp = o->pmrChan->txPttOut = 0;
 		o->lasttx = 0;
 		ast_mutex_lock(&o->usblock);
-		o->hid_gpio_val = ~o->hid_io_ptt;
+		o->hid_gpio_val &= ~o->hid_io_ptt;
 		if (o->invertptt) {
 			o->hid_gpio_val |= o->hid_io_ptt;
 		}
@@ -1455,7 +1458,7 @@ static void *hidthread(void *arg)
 	o->lasttx = 0;
 	if (usb_handle) {
 		ast_mutex_lock(&o->usblock);
-		o->hid_gpio_val = ~o->hid_io_ptt;
+		o->hid_gpio_val &= ~o->hid_io_ptt;
 		if (o->invertptt) {
 			o->hid_gpio_val |= o->hid_io_ptt;
 		}


### PR DESCRIPTION
app_rpt is not waiting long enough in rpt_setup_channels for chan_simpleusb to initialize the usb device before asserting PTT on/off.

This change adds a 250ms delay before asserting PTT on and another 50ms delay before asserting PTT off.

I believe the intention of the original code was to insure that the PTT was toggled immediately after the channel driver was created by app_rpt.

Testing by the effected users is needed. This may close #421 and #424.