### PR TITLE
res_usbradio: Add ability to specify allowed vid:pid

### DIFF
--- a/configs/rpt/res_usbradio.conf
+++ b/configs/rpt/res_usbradio.conf
@@ -1,0 +1,7 @@
+[general]
+;usb_devices = 1209:7388	;comma delimited list of usb
+							;descriptors to allow.
+							;format vvvv:pppp in hexadecimal
+							;vvvv=vendor id, pppp=product id
+							;
+							;1209:7388 = AIOC (all in one cable)

--- a/configs/rpt/res_usbradio.conf
+++ b/configs/rpt/res_usbradio.conf
@@ -1,7 +1,7 @@
 [general]
-;usb_devices = 1209:7388	;comma delimited list of usb
-							;descriptors to allow.
-							;format vvvv:pppp in hexadecimal
-							;vvvv=vendor id, pppp=product id
-							;
-							;1209:7388 = AIOC (all in one cable)
+;usb_devices = 1209:7388    ;comma delimited list of usb
+                            ;descriptors to allow.
+                            ;format vvvv:pppp in hexadecimal
+                            ;vvvv=vendor id, pppp=product id
+                            ;
+                            ;1209:7388 = AIOC (all in one cable)

--- a/configs/samples/res_usbradio.conf.sample
+++ b/configs/samples/res_usbradio.conf.sample
@@ -1,0 +1,7 @@
+[general]
+;usb_devices = 1209:7388	;comma delimited list of usb
+							;descriptors to allow.
+							;format vvvv:pppp in hexadecimal
+							;vvvv=vendor id, pppp=product id
+							;
+							;1209:7388 = AIOC (all in one cable)

--- a/configs/samples/res_usbradio.conf.sample
+++ b/configs/samples/res_usbradio.conf.sample
@@ -1,7 +1,7 @@
 [general]
-;usb_devices = 1209:7388	;comma delimited list of usb
-							;descriptors to allow.
-							;format vvvv:pppp in hexadecimal
-							;vvvv=vendor id, pppp=product id
-							;
-							;1209:7388 = AIOC (all in one cable)
+;usb_devices = 1209:7388    ;comma delimited list of usb
+                            ;descriptors to allow.
+                            ;format vvvv:pppp in hexadecimal
+                            ;vvvv=vendor id, pppp=product id
+                            ;
+                            ;1209:7388 = AIOC (all in one cable)

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -939,7 +939,7 @@ static int load_config(int reload)
 				}
 				device->idVendor = idVendor;
 				device->idProduct = idProduct;
-				device->idMask = 0xfff;
+				device->idMask = 0xffff;
 				/* Add it to our list */
 				AST_RWLIST_WRLOCK(&user_devices);
 				AST_LIST_INSERT_HEAD(&user_devices, device, entry);

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -47,7 +47,6 @@
 #include <linux/parport.h>
 #include <linux/version.h>
 #include <alsa/asoundlib.h>
-#include "asterisk/config.h"
 
 #include "asterisk/res_usbradio.h"
 
@@ -68,6 +67,7 @@
 #include "asterisk/module.h"
 #include "asterisk/cli.h"			
 #include "asterisk/poll-compat.h" 	/* Used for polling */
+#include "asterisk/config.h"
 
 #define CONFIG_FILE "res_usbradio.conf"
 
@@ -85,9 +85,9 @@ static int usb_device_list_size = 0;
  * \brief Structure for defined usb devices.
  */
 struct usb_device_entry {
-	ushort idVendor;
-	ushort idProduct;
-	ushort idMask;
+	unsigned short idVendor;
+	unsigned short idProduct;
+	unsigned short idMask;
 	AST_LIST_ENTRY(usb_device_entry) entry;
 };
 
@@ -335,10 +335,9 @@ void ast_radio_put_eeprom(struct usb_dev_handle *handle, unsigned short *buf)
 static int is_known_device(struct usb_device *dev)
 {
 	int index;
-	int max_entries = sizeof(known_devices) / sizeof(known_devices[0]);
 	int matched_entry = 0;
 	
-	for (index = 0; index < max_entries; index++) {
+	for (index = 0; index < ARRAY_LEN(known_devices); index++) {
 		if (dev->descriptor.idVendor == known_devices[index].idVendor && 
 			dev->descriptor.idProduct == (known_devices[index].idProduct & known_devices[index].idMask)) {
 			matched_entry = 1;


### PR DESCRIPTION
This updates res_usbradio to allow users to specify USB device descriptor(s) that can be used for interface devices. There are compatible chips that are not supported in the code. This will allow users to easily add the compatible chip(s).

This adds res_usbradio.conf for configuration. A sample configuration file was added.

Reworked the supported/known USB devices lookup.  The supported devices are now in an array.

This closes #359.