### PR TITLE
[ASL2 PATCH] Replace xpmr.c '#define XPMR_VOX_HANGTIME' with a new conf var

### DIFF
--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -261,6 +261,7 @@ struct chan_usbradio_pvt {
 	int rxdemod;
 	float rxgain;
 	int rxcdtype;
+	int voxhangtime;			/* if rxcdtype=vox, ms to wait detecting RX audio before setting CD=0 */
 	int rxsdtype;
 	int rxsquelchadj;			/* this copy needs to be here for initialization */
 	int rxsqhyst;
@@ -423,6 +424,7 @@ static struct chan_usbradio_pvt usbradio_default = {
 	.usedtmf = 1,
 	.rxondelay = 0,
 	.txoffdelay = 0,
+	.voxhangtime = 2000,
 	.area = 0,
 	.rptnum = 0,
 	.clipledgpio = 0,
@@ -1057,6 +1059,7 @@ static void *hidthread(void *arg)
 
 			tChan.rxDemod = o->rxdemod;
 			tChan.rxCdType = o->rxcdtype;
+			tChan.voxHangTime = o->voxhangtime;
 			tChan.rxSqVoxAdj = o->rxsqvoxadj;
 
 			if (o->txlimonly) {
@@ -4712,6 +4715,9 @@ static void pmrdump(struct chan_usbradio_pvt *o)
 
 	pd(o->rxdemod);
 	pd(o->rxcdtype);
+	if (o->rxcdtype == CD_XPMR_VOX) {
+		pd(o->voxhangtime);
+	}
 	pd(o->rxsdtype);
 	pd(o->txtoctype);
 
@@ -4932,6 +4938,7 @@ static struct chan_usbradio_pvt *store_config(const struct ast_config *cfg, cons
 		CV_F("txmixa", store_txmixa(o, (char *) v->value));
 		CV_F("txmixb", store_txmixb(o, (char *) v->value));
 		CV_F("carrierfrom", store_rxcdtype(o, (char *) v->value));
+		CV_UINT("voxhangtime", o->voxhangtime);
 		CV_F("ctcssfrom", store_rxsdtype(o, (char *) v->value));
 		CV_UINT("rxsqvox", o->rxsqvoxadj);
 		CV_UINT("rxsqhyst", o->rxsqhyst);
@@ -5068,6 +5075,7 @@ static struct chan_usbradio_pvt *store_config(const struct ast_config *cfg, cons
 
 		tChan.rxDemod = o->rxdemod;
 		tChan.rxCdType = o->rxcdtype;
+		tChan.voxHangTime = o->voxhangtime;
 		tChan.rxCarrierHyst = o->rxsqhyst;
 		tChan.rxSqVoxAdj = o->rxsqvoxadj;
 		tChan.rxSquelchDelay = o->rxsquelchdelay;

--- a/channels/xpmr/xpmr.c
+++ b/channels/xpmr/xpmr.c
@@ -1716,6 +1716,7 @@ t_pmr_chan	*createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 	{
 		pChan->rxDemod=tChan->rxDemod;
 		pChan->rxCdType=tChan->rxCdType;
+		pChan->voxHangTime=tChan->voxHangTime;
 		pChan->rxSquelchPoint = tChan->rxSquelchPoint;
 		pChan->rxCarrierHyst = tChan->rxCarrierHyst;
 		pChan->rxSqVoxAdj=tChan->rxSqVoxAdj;
@@ -2756,13 +2757,11 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 		//pmr_sps=NULL;	// sph maw
 	}
 
-	#define XPMR_VOX_HANGTIME	2000
-
 	if(pChan->rxCdType==CD_XPMR_VOX)
 	{
 		if(pChan->spsRxVox->compOut)
 		{
-			pChan->rxVoxTimer=XPMR_VOX_HANGTIME;    //VOX HangTime in ms
+			pChan->rxVoxTimer=pChan->voxHangTime;	/* VOX HangTime in ms */
 		}
 		if(pChan->rxVoxTimer>0)
 		{

--- a/channels/xpmr/xpmr.h
+++ b/channels/xpmr/xpmr.h
@@ -615,6 +615,7 @@ typedef struct	t_pmr_chan
 	i16 rxQuality;			// signal quality metric
 	i16 rxCarrierDetect;    // carrier detect
 	i16 rxCdType;
+	i16 voxHangTime;		// if rxCdType=CD_XPMR_VOX, time to wait for RX audio before setting CD=0
 	i16 rxSqVoxAdj;
 	i16 rxExtCarrierDetect; 
 	i32 inputBlanking;  	// Tx pulse eliminator

--- a/configs/rpt/usbradio.conf
+++ b/configs/rpt/usbradio.conf
@@ -83,6 +83,10 @@ carrierfrom = dsp           ; no,usb,usbinvert,dsp,vox
                             ; pp - from parallel port (Active high)
                             ; ppinvert - from the inverted parallel port (Active low)
 
+voxhangtime = 2000          ; If carrierfrom=vox, mS to wait detecting RX audio before setting rxcarrierdetect=0
+                            ; 2000 is the default but results in 2 seconds of silence added after RX unkey.
+                            ; 500 seems more optimal. Lower values may result in unintended drops in RX CD.
+
 ctcssfrom = dsp             ; no,usb,usbinvert,dsp
                             ; no - no CTCSS decoding, system will be carrier squelch
                             ; usb - from the CTCSS line on the USB sound fob (Active high)

--- a/configs/samples/usbradio.conf.sample
+++ b/configs/samples/usbradio.conf.sample
@@ -69,6 +69,10 @@
                             ; pp - from parallel port (Active high)
                             ; ppinvert - from the inverted parallel port (Active low)
 
+;voxhangtime = 2000         ; If carrierfrom=vox, mS to wait detecting RX audio before setting rxcarrierdetect=0
+                            ; 2000 is the default but results in 2 seconds of silence added after RX unkey.
+                            ; 500 seems more optimal. Lower values may result in unintended drops in RX CD.
+
 ;ctcssfrom = dsp            ; no,usb,usbinvert,dsp
                             ; no - no CTCSS decoding, system will be carrier squelch
                             ; usb - from the CTCSS line on the USB sound fob (Active high)


### PR DESCRIPTION
The ASL2 change (from https://github.com/AllStarLink/ASL-Asterisk/pull/34) did not get merged into the ASL3 source base. This commit effectivly pulls in those changes.

From: David Gleason <david@allscan.info>

Replace xpmr.c '#define XPMR_VOX_HANGTIME' with a new 'voxhangtime' cfg parameter set in usbradio.conf. When using usbradio in carrierfrom=vox mode this is the value the vox hang timer pChan->rxVoxTimer is set to in xpmr.c each time RX audio is detected. Making it configurable allows the default value of 2000mS to be reduced to a shorter time thereby preventing 2 seconds of silence being added to all node user transmissions. A value of 500mS seems to be much more optimal, and in my testing resulted in no false RX CD drops even when not talking. (xpmr.c's vox mode detects even quiet background noise and thereby supports reliable COS detection for radios that do not have a hardware COS line output.)

Add the new voxhangtime parm to chan_usbradio.c chan_usbradio_pvt struct, store_config(), xpmr.c createPmrChannel(), xpmr.h t_pmr_chan struct, and to configs/rpt/usbradio.conf and configs/samples/usbradio.conf.sample.