### PR TITLE
[ASL2 PATCH] Update morse code character timing

### DIFF
--- a/apps/app_rpt/rpt_channel.c
+++ b/apps/app_rpt/rpt_channel.c
@@ -341,9 +341,9 @@ int send_morse(struct ast_channel *chan, char *string, int speed, int freq, int 
 
 	/* Establish timing releationships */
 
-	dashtime = 3 * dottime;
+	dashtime = dottime * 3;
 	intralettertime = dottime;
-	interlettertime = dottime * 4;
+	interlettertime = dottime * 3;
 	interwordtime = dottime * 7;
 
 	for (; (*string) && (!res); string++) {


### PR DESCRIPTION
An ASL2 change (from https://github.com/AllStarLink/ASL-Asterisk/pull/19) was not fully merged into the ASL3 source base.  That PR included an correction to the morse code character timing, specifically the inter character delay.  This change updates the timing to match what's commonly understood (the space between two letters is equal to three dots).