### PR TITLE
app_rpt: Fix variable typing issue.

### DIFF
--- a/apps/app_rpt/rpt_manager.c
+++ b/apps/app_rpt/rpt_manager.c
@@ -21,7 +21,7 @@ extern struct rpt rpt_vars[MAXRPTS];
 static char *ctime_no_newline(const time_t *clock)
 {
 	static char buf[32];
-	const char *cp;
+	char *cp;
 	size_t len;
 
 	cp = ctime_r(clock, buf);


### PR DESCRIPTION
This function returns char*, but the variable is typed const char* by mistake; this fixes that.

Resolves: #439