### PR TITLE
Properly kill stuff started with startoutstream()

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -7507,6 +7507,11 @@ static int stop_repeaters(void)
 			ast_channel_lock(myrpt->rxchannel);
 			ast_softhangup(myrpt->rxchannel, AST_SOFTHANGUP_EXPLICIT); /* Hanging up one channel will signal the thread to abort */
 			ast_channel_unlock(myrpt->rxchannel);
+
+			/* Also kill any outstreamcmd fork()s */
+			ast_debug(1,"trying to stopoutstream %s", rpt_vars[i].name);
+			stopoutstream(&rpt_vars[i]);
+
 			myrpt->rxchannel = NULL; /* If we aborted the repeater but haven't unloaded, this channel handle is not valid anymore in a future call to stop_repeaters() */
 		}
 	}
@@ -7545,9 +7550,7 @@ static int unload_module(void)
 		ast_mutex_unlock(&rpt_vars[i].blocklock);
 		ast_mutex_destroy(&rpt_vars[i].blocklock);
 
-		/* Also kill any outstreamcmd fork()s */
-		stopoutstream(&rpt_vars[i]);
-	}
+			}
 
 	res = ast_unregister_application(app);
 #ifdef	_MDC_ENCODE_H_

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -1129,7 +1129,7 @@ static void killpidtree(const int pid_int){
         char *child_pid_str = strtok_r(buffer, " ");
         while (child_pid_str != NULL) {
             int child_pid_int = atoi(child_pid_str);
-            kill_process_and_children(child_pid_int);
+            killpidtree(child_pid_int);
             child_pid_str = strtok_r(NULL, " ");
         }
     }

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -1146,7 +1146,7 @@ static void killpidtree(const int pid_int){
 
 static void stopoutstream(struct rpt *myrpt)
 {
-	if (myrpt->outstreampid != -1) {
+	if (myrpt->p.outstreamcmd && myrpt->outstreampid >= 2) {
 		killpidtree(myrpt->outstreampid);
 	}
 }

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -1126,11 +1126,12 @@ static void killpidtree(const int pid_int){
     }
 
     if (fgets(buffer, sizeof(buffer), file) != NULL) {
-        char *child_pid_str = strtok_r(buffer, " ");
+		char *saveptr;
+        char *child_pid_str = strtok_r(buffer, " ", &saveptr);
         while (child_pid_str != NULL) {
             int child_pid_int = atoi(child_pid_str);
             killpidtree(child_pid_int);
-            child_pid_str = strtok_r(NULL, " ");
+            child_pid_str = strtok_r(NULL, " ", &saveptr);
         }
     }
     fclose(file);
@@ -7520,7 +7521,6 @@ static int unload_module(void)
 
 	daq_uninit();
 
-	stopoutstream(&rpt_vars[i]);
 
 	stop_repeaters();
 
@@ -7544,6 +7544,9 @@ static int unload_module(void)
 		ast_mutex_lock(&rpt_vars[i].blocklock);
 		ast_mutex_unlock(&rpt_vars[i].blocklock);
 		ast_mutex_destroy(&rpt_vars[i].blocklock);
+
+		/* Also kill any outstreamcmd fork()s */
+		stopoutstream(&rpt_vars[i]);
 	}
 
 	res = ast_unregister_application(app);

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -1112,24 +1112,25 @@ static void startoutstream(struct rpt *myrpt)
  * terminate things started in startoutstream()
  */
 static void killpidtree(const int pid_int){
-	pid_t pid = (pid_t)pid_int; // Convert integer to pid_t
-
+	pid_t pid;
     char path[256];
-    snprintf(path, sizeof(path), "/proc/%d/task/%d/children", pid, pid);
+    char buffer[1024];
+	FILE *file;
 
-    FILE *file = fopen(path, "r");
+	pid = (pid_t)pid_int; // Convert integer to pid_t
+    snprintf(path, sizeof(path), "/proc/%d/task/%d/children", pid, pid);
+    file = fopen(path, "r");
     if (file == NULL) {
 		ast_log(LOG_ERROR, "killpidtree failed to read /proc/%d/task/%d/children", pid, pid);
         return;
     }
 
-    char buffer[1024];
     if (fgets(buffer, sizeof(buffer), file) != NULL) {
-        char *child_pid_str = strtok(buffer, " ");
+        char *child_pid_str = strtok_r(buffer, " ");
         while (child_pid_str != NULL) {
             int child_pid_int = atoi(child_pid_str);
             kill_process_and_children(child_pid_int);
-            child_pid_str = strtok(NULL, " ");
+            child_pid_str = strtok_r(NULL, " ");
         }
     }
     fclose(file);
@@ -1145,7 +1146,7 @@ static void killpidtree(const int pid_int){
 static void stopoutstream(struct rpt *myrpt)
 {
 	if (myrpt->outstreampid != -1) {
-		killpidtree(rpt->outstreampid);
+		killpidtree(myrpt->outstreampid);
 	}
 }
 


### PR DESCRIPTION
NOTE: I'm just staging this for testing/review -- this is NOT ready for merge

This is to address #338 