### PR TITLE
Address channel crashing on rapid connect/disconnect

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -6742,11 +6742,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 				if (ast_safe_sleep(chan, 500) == -1) {
 					return -1;
 				}
-			} else {
-				if (!phone_mode) {
-					send_newkey(chan);
-				}
-			}
+			} 
 		}
 		rpt_mutex_unlock(&myrpt->blocklock);
 		rpt_mutex_unlock(&myrpt->lock); /* Moved unlock to AFTER the if... answer block above, to prevent ast_waitfor_n assertion due to simultaneous channel access */
@@ -6755,7 +6751,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 			donodelog_fmt(myrpt,"LINK%s,%s", l->phonemode ? "(P)" : "", l->name);
 		}
 		doconpgm(myrpt, l->name);
-		if ((!phone_mode) && (l->name[0] <= '9')) {
+		if ((!phone_mode) && (l->name[0] <= '9') && (ast_channel_state(chan) == AST_STATE_UP)) {
 			rpt_mutex_lock(&myrpt->blocklock);
 			send_newkey(chan);
 			rpt_mutex_unlock(&myrpt->blocklock);

--- a/apps/app_rpt/rpt_channel.c
+++ b/apps/app_rpt/rpt_channel.c
@@ -464,20 +464,16 @@ void send_newkey(struct ast_channel *chan)
 {
 	/* app_sendtext locks the channel before calling ast_sendtext,
 	 * do this to prevent simultaneous channel servicing which can cause an assertion. */
-	ast_channel_lock(chan);
 	if (ast_sendtext(chan, NEWKEY1STR)) {
 		ast_log(LOG_WARNING, "Failed to send text %s on %s\n", ast_channel_name(chan), NEWKEY1STR);
 	}
-	ast_channel_unlock(chan);
 	return;
 }
 
 void send_old_newkey(struct ast_channel *chan)
 {
-	ast_channel_lock(chan);
 	if (ast_sendtext(chan, NEWKEYSTR)) {
 		ast_log(LOG_WARNING, "Failed to send text %s on %s\n", ast_channel_name(chan), NEWKEYSTR);
 	}
-	ast_channel_unlock(chan);
 	return;
 }


### PR DESCRIPTION
Addressing issue #422 
1 - remove channel locks around ```ast_sendtext()```.  This made triggering the crash much more difficult (aka things are executing faster) but did not eliminate it.
2 - remove "extra" send_newkey() -> it's extra, and everything appears to work after removal.
3 - test channel state still up before sending text messages.  I can no longer crash asterisk after this addition.