### PR TITLE
Address channel crashing on rapid connect/disconnect 

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -6751,11 +6751,6 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 			donodelog_fmt(myrpt,"LINK%s,%s", l->phonemode ? "(P)" : "", l->name);
 		}
 		doconpgm(myrpt, l->name);
-		if ((!phone_mode) && (l->name[0] <= '9') && (ast_channel_state(chan) == AST_STATE_UP)) {
-			rpt_mutex_lock(&myrpt->blocklock);
-			send_newkey(chan);
-			rpt_mutex_unlock(&myrpt->blocklock);
-		}
 		if (!strcasecmp(ast_channel_tech(l->chan)->type, "echolink") || !strcasecmp(ast_channel_tech(l->chan)->type, "tlb") || (l->name[0] > '9')) {
 			rpt_telemetry(myrpt, CONNECTED, l);
 		}

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -6742,11 +6742,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 				if (ast_safe_sleep(chan, 500) == -1) {
 					return -1;
 				}
-			} else {
-				if (!phone_mode) {
-					send_newkey(chan);
-				}
-			}
+			} 
 		}
 		rpt_mutex_unlock(&myrpt->blocklock);
 		rpt_mutex_unlock(&myrpt->lock); /* Moved unlock to AFTER the if... answer block above, to prevent ast_waitfor_n assertion due to simultaneous channel access */
@@ -6755,7 +6751,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 			donodelog_fmt(myrpt,"LINK%s,%s", l->phonemode ? "(P)" : "", l->name);
 		}
 		doconpgm(myrpt, l->name);
-		if ((!phone_mode) && (l->name[0] <= '9')) {
+		if ((!phone_mode) && (l->name[0] <= '9') && (ast_channel_state(chan) == AST_STATE_UP)) {
 			rpt_mutex_lock(&myrpt->blocklock);
 			send_newkey(chan);
 			rpt_mutex_unlock(&myrpt->blocklock);

--- a/apps/app_rpt/rpt_channel.c
+++ b/apps/app_rpt/rpt_channel.c
@@ -464,16 +464,20 @@ void send_newkey(struct ast_channel *chan)
 {
 	/* app_sendtext locks the channel before calling ast_sendtext,
 	 * do this to prevent simultaneous channel servicing which can cause an assertion. */
+	ast_channel_lock(chan);
 	if (ast_sendtext(chan, NEWKEY1STR)) {
 		ast_log(LOG_WARNING, "Failed to send text %s on %s\n", ast_channel_name(chan), NEWKEY1STR);
 	}
+	ast_channel_unlock(chan);
 	return;
 }
 
 void send_old_newkey(struct ast_channel *chan)
 {
+	ast_channel_lock(chan);
 	if (ast_sendtext(chan, NEWKEYSTR)) {
 		ast_log(LOG_WARNING, "Failed to send text %s on %s\n", ast_channel_name(chan), NEWKEYSTR);
 	}
+	ast_channel_unlock(chan);
 	return;
 }

--- a/apps/app_rpt/rpt_channel.c
+++ b/apps/app_rpt/rpt_channel.c
@@ -464,20 +464,16 @@ void send_newkey(struct ast_channel *chan)
 {
 	/* app_sendtext locks the channel before calling ast_sendtext,
 	 * do this to prevent simultaneous channel servicing which can cause an assertion. */
-	ast_channel_lock(chan);
 	if (ast_sendtext(chan, NEWKEY1STR)) {
 		ast_log(LOG_WARNING, "Failed to send text %s on %s\n", ast_channel_name(chan), NEWKEY1STR);
 	}
-	ast_channel_unlock(chan);
 	return;
 }
 
 void send_old_newkey(struct ast_channel *chan)
 {
-	ast_channel_lock(chan);
 	if (ast_sendtext(chan, NEWKEYSTR)) {
 		ast_log(LOG_WARNING, "Failed to send text %s on %s\n", ast_channel_name(chan), NEWKEYSTR);
 	}
-	ast_channel_unlock(chan);
 	return;
 }


### PR DESCRIPTION
Addressing https://github.com/AllStarLink/app_rpt/issues/422
There appears to be a race condition between  ```process_link_channels``` https://github.com/AllStarLink/app_rpt/blob/5101b1bb1338144ecd2ea00f7d4c7ffd18104a25/apps/app_rpt.c#L4495-L4497 detecting and closing a channel while  ```rpt_exec``` is still mid setup on the connection. https://github.com/AllStarLink/app_rpt/blob/5101b1bb1338144ecd2ea00f7d4c7ffd18104a25/apps/app_rpt.c#L6154 is still "starting up" the channel.

Simply allowing ```process_link_channels``` to deal with sending the new key will solve this issue, but may introduce other issues that I currently do not observe.

Alternately, we could make sure the channel is not null in the ```send_newkey()``` function, but I'm not sure locking the channel prevents Asterisk from cleaning in up (it just gives us a warning and cleans up anyway from what I can tell).
