### PR TITLE
Restore missing break in process_link_channels()

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4495,6 +4495,7 @@ static inline int process_link_channels(struct rpt *myrpt, struct ast_channel *w
 				if (f->subclass.integer == AST_CONTROL_HANGUP) {
 					ast_frfree(f);
 					remote_hangup_helper(myrpt, l);
+					break;
 				}
 			}
 			ast_frfree(f);


### PR DESCRIPTION
Addressing issue #447 
Restore in inadvertently removed break 