### PR TITLE
CI: Don't restart Asterisk in the middle of the build.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,6 @@ jobs:
           ./phreaknet.sh make
           phreaknet update
           phreaknet install --dahdi --lightweight --alsa --fast --devmode
-          /etc/init.d/asterisk restart
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build app_rpt

--- a/rpt_install.sh
+++ b/rpt_install.sh
@@ -164,7 +164,7 @@ fi
 if [ ! -d /var/lib/asterisk/sounds/en/rpt ]; then
 	printf "RPT sounds don't exist yet, adding them now...\n"
 	mkdir /var/lib/asterisk/sounds/en/rpt
-	cd rpt
+	cd /var/lib/asterisk/sounds/en/rpt
 	wget "http://downloads.allstarlink.org/asterisk-asl-sounds-en-ulaw.tar.gz"
 	# Sounds are extracted directly into the dir
 	tar -xvzf asterisk-asl-sounds-en-ulaw.tar.gz


### PR DESCRIPTION
It seems that /etc/init.d/asterisk restart is now returning nonzero, causing the build to abort. This action isn't actually even necessary, so we could remove it, or safely continue the build regardless of its return value.