### PR TITLE
app_gps: Code updates and documentation

### DIFF
--- a/apps/app_gps.c
+++ b/apps/app_gps.c
@@ -1821,10 +1821,7 @@ static int load_module(void)
 		ast_log(LOG_ERROR, "Cannot create APRStt sender thread %s", sender_entry->section);
 		return -1;
 	}
-	/* 	if (!sender_entry) {
-		return -1;
-	}
-
+	/* 
 	 * See if we have sections other than general. 
 	 * If present, create aprs processing threads for those sections 
 	 */

--- a/apps/app_gps.c
+++ b/apps/app_gps.c
@@ -348,7 +348,7 @@ static time_t time_monotonic(void)
  *
  * \retval 			Returns number of substrings found.
  */
-static int explode_string(char *str, char *strp[], int limit, char delim, char quote)
+static int explode_string(char *str, char *strp[], int limit, const char delim, const char quote)
 {
 	int i, l, inquo;
 
@@ -598,7 +598,7 @@ static void *aprs_connection_thread(void *data)
  * \retval 0		Success
  * \retval -1		Failure
  */
-static int report_aprs(char *ctg, char *lat, char *lon, char *elev)
+static int report_aprs(const char *ctg, const char *lat, const char *lon, const char *elev)
 {
 	struct ast_config *cfg = NULL;
 	char *call, *comment, icon, icon_table;
@@ -760,7 +760,7 @@ static int report_aprs(char *ctg, char *lat, char *lon, char *elev)
  * \retval -1		Failure
  */
 
-static int report_aprstt(char *ctg, char *lat, char *lon, char *theircall, char overlay)
+static int report_aprstt(const char *ctg, const char *lat, const char *lon, const char *theircall, const char overlay)
 {
 	struct ast_config *cfg = NULL;
 	char *call, *comment;

--- a/apps/app_gps.c
+++ b/apps/app_gps.c
@@ -1616,7 +1616,7 @@ static char *handle_cli_status(struct ast_cli_entry *e, int cmd, struct ast_cli_
 		return NULL;
 	}
 
-	if (a->argc > 2) {
+	if (a->argc > 3) {
 		return CLI_SHOWUSAGE;
 	}
 

--- a/apps/app_gps.c
+++ b/apps/app_gps.c
@@ -30,212 +30,307 @@
 	<support_level>extended</support_level>
  ***/
 
+/*
+ * app_gps is responsible for posting APRS (Automated Packet Reporting System) 
+ * information to APRS-IS Internet servers. APRS is a registered trademark of 
+ * Bob Bruninga, WB4APR (SK).
+ *
+ * The APRS-IS server requires a password to post status messages.  The password
+ * is constructed as a hash on the call sign. This website can be used to 
+ * to generate the password: https://n5dux.com/ham/aprs-passcode/ 
+ *
+ * app_gps can connect to a serial GPS receiver to get position information.  
+ * If a GPS receiver is not configured, it can provide default position information 
+ * entered in the gps.conf file.  It decodes the NEMA-0183 $GPGGA sentence.
+ *
+ * The $GPGGA sentence looks like the following:
+ * $GPGGA,011530.00,3255.21780,N,08556.91695,W,2,06,3.45,217.4,M,-30.3,M,,0000*63
+ *
+ * Name	                  Example Data        Description
+ * Sentence Identifier	  $GPGGA              Global Positioning System Fix Data
+ * Time                   011530.00           01:15:30 UTC
+ * Latitude               3255.21780          32.920297°N or 32° 55' 13.0692"N
+ * Latitude direction	  N                   N = North or S = South
+ * Longitude              08556.91695         85.948616°W or 85° 56' 55.0176"W
+ * Longitude direction    W                   W = West or E = East
+ * Fix Quality            2                   0 = Invalid (no fix), 1 = GPS fix, 2 = DGPS fix
+ * Number of Satellites   06                  6 Satellites in view
+ * Horizontal Precision   3.45                Relative accuracy of horizontal position
+ * Altitude               217.4               217.4 meters above mean sea level
+ * Altitude Unit		  M                   M = meters
+ * Height of geoid        -30.3               -30.3 meters
+ * Height Unit            M                   M = meters
+ * Time since last update blank               No last update
+ * DGPS reference         0000                No station id
+ * Checksum               *63                 Checksum 
+ * Terminator             [CR][LF]            Line terminator
+ *
+ * apps_gps supports standard APRS position updates, along with support for APRS Touchtone.
+ * Standard updates are posted to 'APRS'.  APRStt updates are posted to 'APSTAR'.
+ *
+ * APRStt allows analog users to use DTMF to update the APRS system.  app_rpt can 
+ * receive specially crafted DTMF strings, send those to app_gps through a named pipe,
+ * for app_gps to post to the APRS-IS server.
+ *
+ * The recommended status message is:
+ *
+ * APRStt information - http://www.aprs.org/aprstt.html, http://www.aprs.org/aprstt/aprstt-user.txt
+ *
+ * The reporting interval (beacon rate) can be configured based on your needs.  
+ * Beacon rates should be set as if the station was on a busy RF frequency.
+ * Never faster than 1 minute for mobile, 5 minutes for weather, 10 minutes for local 
+ * infrastructure , and 20 minutes for fixed stations).
+ */
+
 /* The following are the recognized APRS icon codes: 
-
-NOTE: Since the semicolon (';') is recognized by the
-Asterisk config subsystem as a comment, we use the
-question-mark ('?') instead when we want to specify
-a 'portable tent'.
-
-! - 3 vert bars (EMERGENCY)
-" - RAIN
-# - DIGI
-
-$ - SUN (always yellow)
-% - DX CLUSTER
-& - HF GATEway
-' - AIRCRAFT (small)
-( - CLOUDY
-) - Hump
-* - SNOW
-+ - Cross
-, - reverse L shape
-
-- - QTH
-. - X
-/ - Dot
-0-9 Numerial Boxes
-: - FIRE
-? - Portable tent (note different then standard ';')
-< - Advisory flag
-= - RAILROAD ENGINE
-> - CAR (SSID-9)
-
-@ - HURRICANE or tropical storm
-A - reserved
-B - Blowing Snow  (also BBS)
-C - reserved
-D - Drizzle
-E - Smoke
-F - Freezing rain
-G - Snow Shower
-H - Haze
-
-I - Rain Shower   (Also TCP-IP)
-J - Lightening
-K - School
-L - Lighthouse
-M - MacAPRS
-N - Navigation Buoy
-O - BALLOON
-P - Police
-Q - QUAKE
-
-R - RECREATIONAL VEHICLE
-S - Space/Satellite
-T - THUNDERSTORM
-U - BUS
-V - VORTAC Nav Aid
-W - National WX Service Site
-X - HELO  (SSID-5)
-Y - YACHT (sail SSID-6)
-Z - UNIX X-APRS
-
-[ - RUNNER
-\ - TRIANGLE   (DF)
-] - BOX with X (PBBS's)
-^ - LARGE AIRCRAFT
-_ - WEATHER SURFACE CONDITIONS (always blue)
-` - Satellite Ground Station
-a - AMBULANCE
-b - BIKE
-c - DX spot by callsign
-
-d - Dual Garage (Fire dept)
-e - SLEET
-f - FIRE TRUCK
-g - GALE FLAGS
-h - HOSPITAL
-i - IOTA (islands on the air)
-j - JEEP (SSID-12)
-k - TRUCK (SSID-14)
-l - AREAS (box,circle,line,triangle) See below
-
-m - MILEPOST (box displays 2 letters if in {35})
-n - small triangle
-o - small circle
-p - PARTLY CLOUDY
-q - GRID SQUARE (4 digit.  Not shown below 128 miles)
-r - ANTENNA
-s - SHIP (pwr boat SSID-8)
-t - TORNADO
-u - TRUCK (18 wheeler)
-
-v - VAN (SSID-15)
-w - FLOODING(water)
-x - diamond (NODE)
-y - YAGI @ QTH
-z - WinAPRS
-{ - FOG
-| - reserved (Stream Switch)
-} - diamond 
-~ - reserved (Stream Switch)
-
-*/
+ *
+ * NOTE: Since the semicolon (';') is recognized by the Asterisk config 
+ * subsystem as a comment, we use the question-mark ('?') instead when 
+ * we want to specify a 'portable tent'.
+ *
+ * NOTE: The configuration setting icontable can be changed to select the alternate table.
+ *
+ * Code  Primary Table '/'  Alternate Table '\'
+ * !     Police, Sheriff    EMERGENCY
+ * "     Reserve            Reserved
+ * #     DIGI               Numbered Star
+ * $     Phone              Bank or ATM
+ * %     DX Cluster
+ * &     HF GATEway         Numbered Diamond
+ * '     AIRCRAFT (small)   Crash site
+ * (     CLOUDY             Cloudy
+ * )     was Mic-Rptr
+ * *     Snow               Snow
+ * +     Red Cross          Church  
+ * ,     reverse L shape
+ * -     House QTH
+ * .     X
+ * /     Dot
+ * 0-8   Numeral Circle     Numbered Circle
+ * 9     Numeral Circle     Gas Station
+ * :     FIRE               Hail
+ * ?     Campground         Park/Picnic area (note different then standard ';' * )
+ * <     Motorcycle         Advisory 
+ * =     Railroad Engine
+ * >     CAR (SSID * -9)    Numbered Car
+ * 
+ * @     HURRICANE or tropical storm Hurricane
+ * A     Aid Station        Numbered Box
+ * B     BBS                Blowing Snow
+ * C     Canoe              Coast Guard
+ * D                        Drizzle
+ * E                        Smoke
+ * F                        Freezing rain
+ * G     Grid Square        Snow Shower
+ * H     Hotel              Haze
+ * I     TCP-IP             Rain Shower
+ * J                        Lightning
+ * K     School
+ * L     avail              Lighthouse
+ * M     MacAPRS
+ * N     NTS Station        Navigation Buoy
+ * O     BALLOON
+ * P     Police             Parking
+ * Q     TBD                Quake
+ * R     RECREATIONAL VEHICLE   Restaurant
+ * S     Space/Satellite    Satellite/Pacsat
+ * T     Thunderstorm       Thunderstorm
+ * U     BUS                Sunny
+ * V     TBD                VORTAC Nav Aid
+ * W     National WX Service Site  NWS Site W-R DIGI
+ * X     HELO (SSID-6)      Pharmacy Rx
+ * Y     YACHT (sail SSID-5)
+ * Z     WinAPRS
+ * 
+ * [     RUNNER             Wall Cloud
+ * \     TRIANGLE (DF)
+ * ]     PBBS
+ * ^     LARGE AIRCRAFT     Numbered Aircraft
+ * _     WEATHER SURFACE CONDITIONS WX and W-R DIGI
+ * `     Dish Antenna       Rain
+ * a     AMBULANCE
+ * b     BIKE               Blowing Dust/Sand
+ * c     TBD
+ * d     Dual Garage (Fire dept)  DX spot by callsign
+ * e     Horse              Sleet
+ * f     FIRE TRUCK         Funnel Cloud
+ * g     Glider             GALE FLAGS
+ * h     HOSPITAL           HAM Store
+ * i     IOTA (islands on the air)
+ * j     JEEP (SSID-12)     Workzone (Steam Shovel)
+ * k     TRUCK (SSID-14)
+ * l     Area Locations     Area Locations (box,circle,line,triangle) 
+ * m     Mic-Repeater       MILEPOST (box displays 2 letters )
+ * n     Node               Numbered Triangle
+ * o     EOC                small circle
+ * p     Rover Puppy        PARTLY CLOUDY
+ * q     GRID SQUARE 
+ * r     ANTENNA            Restrooms
+ * s     SHIP (pwr boat SSID-8)  Numbered Ship
+ * t     Truck Stop         TORNADO
+ * u     TRUCK (18 wheeler) Numbered Truck
+ * v     VAN (SSID-15)      Numbered Van
+ * w     Water Station      FLOODING
+ * x     xAPRS (Unix)
+ * y     YAGI @ QTH
+ * z 
+ * {                        FOG
+ * |     reserved (Stream Switch)
+ * }     diamond 
+ * ~     reserved (Stream Switch)
+ * 
+ */
+ 
+ /* Power, Height, Gain, Dir (direction) codes (PHG)
+  *   DIGITS   0   1   2    3    4    5    6     7     8     9  Units       
+  *   -------------------------------------------------------------------
+  *   POWER    0,  1,  4,   9,  16,  25,  36,   49,   64,   81  watts  
+  *   HEIGHT  10, 20, 40,  80, 160, 320, 640, 1280, 2560, 5120  feet   
+  *   GAIN     0,  1,  2,   3,   4,   5,   6,    7,    8,    9  dB
+  *   DIR   omni, 45, 90, 135, 180, 225, 270,  315,  360,    .  deg   
+  */  
 
 #include "asterisk.h"
 
-#include <stdio.h>
-#include <string.h>
-#include <sys/socket.h>
-#include <sys/time.h>
-#include <errno.h>
-#include <unistd.h>
-#include <sys/stat.h>
-#include <stdlib.h>
-#include <arpa/inet.h>
-#include <fcntl.h>
 #include <sys/ioctl.h>
-#include <ctype.h>
-#include <search.h>
-#include <arpa/inet.h>
-#include <netinet/in.h>
-#include <netdb.h>
-#include <pthread.h>
-#include <signal.h>
 #include <termios.h>
-#include <math.h>
 #include <sys/mman.h>
 
-#include "asterisk/lock.h"
 #include "asterisk/channel.h"
 #include "asterisk/config.h"
-#include "asterisk/logger.h"
 #include "asterisk/module.h"
 #include "asterisk/pbx.h"
-#include "asterisk/options.h"
-#include "asterisk/utils.h"
 #include "asterisk/app.h"
-#include "asterisk/translate.h"
 #include "asterisk/cli.h"
 
-#ifdef OLD_ASTERISK
-#define ast_free free
-#define ast_malloc malloc
-#endif
+/*** DOCUMENTATION
+	<function name="GPS_READ" language="en_US">
+		<synopsis>
+			Read GPS position.
+		</synopsis>
+		<description>
+			<para>Read current or default GPS position.
+			Returns a string in the format epoch, space, latitude, spaces,
+			longitude, spaces, and elevation.</para>
+		</description>
+	</function>
+	<function name="APRS_SENDTT" language="en_US">
+		<synopsis>
+			Report a callsign to APRS.
+		</synopsis>
+		<syntax>
+			<parameter name="stanza" required="true">
+				<para>Stanza to use.</para>
+			</parameter>
+			<parameter name="overlay" required="true">
+				<para>Overlay to report. Number 1 to 9.</para>
+			</parameter>
+		</syntax>
+		<description>
+			<para>Nothing is returned.</para>
+		    <example title="Sending a report.">
+				exten => s,1,APRS_SENDTT(general,1)=WB6NIL
+ 		    </example>
+		</description>
+	</function>
+ ***/
 
-#define	GPS_DEFAULT_SERVER "second.aprs.net"
-#define	GPS_DEFAULT_PORT "10151"
-#define	GPS_DEFAULT_COMMENT "Asterisk app_rpt server"
-#define	TT_DEFAULT_COMMENT "Asterisk app_rpt user"
-#define	TT_DEFAULT_OVERLAY '0'
+/*! Defines */
+#define	APRS_DEFAULT_SERVER "rotate.aprs.net"
+#define	APRS_DEFAULT_PORT "14580"
+#define	APRS_DEFAULT_COMMENT "AllStar Link Node"
+#define	APRSTT_DEFAULT_COMMENT "AllStar Link TT Report"
+#define	APRSTT_DEFAULT_OVERLAY '0'
+#define APRS_DEFAULT_ICON_TABLE '/'		/* primary table */
+#define	APRS_DEFAULT_ICON '-'			/* house */
 #define	DEFAULT_TTLIST 10
 #define	DEFAULT_TTOFFSET 10
 #define	TT_LIST_TIMEOUT 3600
-#define	GPS_DEFAULT_BAUDRATE B4800
-#define	GPS_DEFAULT_ICON '>'	/* car */
-#define	GPS_WORK_FILE "/tmp/gps.tmp"
-#define	GPS_DATA_FILE "/tmp/gps.dat"
-#define	GPS_SUB_FILE "/tmp/gps_%s.dat"
-#define	TT_PIPE "/tmp/aprs_ttfifo"
-#define	TT_SUB_PIPE "/tmp/aprs_ttfifo_%s"
 #define	TT_COMMON "/tmp/aprs_ttcommon"
 #define	TT_SUB_COMMON "/tmp/aprs_ttcommon_%s"
-#define	GPS_UPDATE_SECS 30
+#define	GPS_DEFAULT_BAUDRATE B4800
+#define	GPS_UPDATE_SECS 60
 #define	GPS_VALID_SECS 60
 #define	SERIAL_MAXMS 10000
 
+/*!
+ * \brief APRS TT entry.
+ */
 struct ttentry {
 	char call[20];
-	time_t t;
+	time_t last_updated;
 };
 
-AST_MUTEX_DEFINE_STATIC(gps_lock);
+AST_MUTEX_DEFINE_STATIC(aprs_socket_lock);
+AST_MUTEX_DEFINE_STATIC(position_update_lock);
 
 static char *config = "gps.conf";
 
-static char *app = "GPS";
-
-static char *synopsis = "GPS Device Interface Module";
-
-static char *descrip = "Interfaces app_rpt to a NMEA 0183 (GGA records) compliant GPS device\n";
-
-static pthread_t gps_thread = 0;
-static pthread_t gps_section_thread = 0;
-static pthread_t gps_subthread = 0;
-static pthread_t gps_ttthread = 0;
-static pthread_t aprs_thread = 0;
+/* Thread information */
+static pthread_t gps_reader_thread_id = 0;
+static pthread_t aprs_connection_thread_id = 0;
 static int run_forever = 1;
+
+/* Global configuration information */
 static char *comport, *server, *port;
-static char *general_deflat, *general_deflon, *general_defelev;
 static int baudrate;
-static int debug = 0;
 static int sockfd = -1;
 
-/*
-* Break up a delimited string into a table of substrings
-*
-* str - delimited string ( will be modified )
-* strp- list of pointers to substrings (this is built by this function), NULL will be placed at end of list
-* limit- maximum number of substrings to process
-* delim- user specified delimeter
-* quote- user specified quote for escaping a substring. Set to zero to escape nothing.
-*
-* Note: This modifies the string str, be suer to save an intact copy if you need it later.
-*
-* Returns number of substrings found.
-*/
+/* Message flags */
+static int gps_unlock_shown = 0;
 
+/*!
+ * \brief Position information structure
+ */
+struct position_info {
+	int is_valid:1;			/* contains valid values indicator */
+	char latitude[25];		/* latitude format DDMM.SSS */
+	char longitude[25];		/* longitude format DDDMM.SSS */
+	char elevation[25];		/* elevation format VVVV.V */
+	time_t last_updated;	/* the time these values were last updated */
+};
+
+static struct position_info current_gps_position;
+static struct position_info general_def_position;
+
+/*!
+ *\brief Enum for aprs sender info type.
+ */
+enum Sender_Type {
+	APRS,
+	APRSTT
+};
+
+/*!		
+ * \brief Structure to track APRS and APRStt sender threads.
+ */
+struct aprs_sender_info {
+	AST_LIST_ENTRY(aprs_sender_info) list;
+	enum Sender_Type type;					/* sender type enum */
+	char stanza[50]; 						/* stanza associated with this aprs thread */
+	pthread_t thread_id;					/* thread id for this sender */
+	ast_cond_t condition;					/* condition indicator for this sender */
+	ast_mutex_t lock;						/* lock for condition */
+	char their_call[50];					/* their callsign for processing */
+	char overlay;							/* the overlay to use with the callsign */
+};
+
+AST_LIST_HEAD_NOLOCK_STATIC(aprs_sender_list, aprs_sender_info);
+
+
+/*!
+ * \brief Break up a delimited string into a table of substrings
+ *
+ * \note This modifies the string str, be sure to save an intact copy if you need it later.
+ *
+ * \param str		Pointer to string to process (it will be modified).
+ * \param strp		Pointer to a list of substrings created, NULL will be placed at the end of the list.
+ * \param limit		Maximum number of substrings to process.
+ * \param delim		Specified delimiter
+ * \param quote		User specified quote for escaping a substring. Set to zero to escape nothing.
+ *
+ * \retval 			Returns number of substrings found.
+ */
 static int explode_string(char *str, char *strp[], int limit, char delim, char quote)
 {
 	int i, l, inquo;
@@ -245,7 +340,7 @@ static int explode_string(char *str, char *strp[], int limit, char delim, char q
 	strp[i++] = str;
 	if (!*str) {
 		strp[0] = 0;
-		return (0);
+		return 0;
 	}
 	for (l = 0; *str && (l < limit); str++) {
 		if (quote) {
@@ -266,19 +361,18 @@ static int explode_string(char *str, char *strp[], int limit, char delim, char q
 		}
 	}
 	strp[i] = 0;
-	return (i);
-
+	return i;
 }
 
-static void strupr(char *str)
-{
-	while (*str) {
-		*str = toupper(*str);
-		str++;
-	}
-	return;
-}
-
+/*!
+ * \brief Read one character from serial device.
+ *
+ * Read one character from the serial device.  Timeout after SERIAL_MAXMS.
+ *
+ * \param fd		File descriptor to read.
+ *
+ * \retval 			Character read, 0 if timed out, or -1 on select error.
+ */
 static int getserialchar(int fd)
 {
 	int res;
@@ -293,194 +387,305 @@ static int getserialchar(int fd)
 		FD_ZERO(&fds);
 		FD_SET(fd, &fds);
 		res = ast_select(fd + 1, &fds, NULL, NULL, &tv);
-		if (res < 0)
+		if (res < 0) {
 			return -1;
+		}
 		if (res) {
-			if (read(fd, &c, 1) < 1)
+			if (read(fd, &c, 1) < 1) {
+				ast_debug(1, "Read error: %s", strerror(errno));
 				return -1;
-			return (c);
+			}
+			return c;
 		}
 	}
-	return (0);
+	return 0;
 }
 
-static int getserial(int fd, char *str, int max)
+/*!
+ * \brief Get a line of characters from serial device.
+ *
+ * Get one line of characters from the serial device.  Timeout after SERIAL_MAXMS.
+ *
+ * \param fd		File descriptor to read.
+ * \param str		Pointer to string buffer.
+ * \param max		Maximum characters to read.
+ *
+ * \retval 			Number of characters read, 0 for time out or -1 for error.
+ */
+
+static int getserialline(int fd, char *str, int max)
 {
 	int i;
 	char c;
 
 	for (i = 0; (i < max) && run_forever; i++) {
 		c = getserialchar(fd);
-		if (c < 1)
-			return (c);
+		/* See if we timed out or received an error */
+		if (c < 1) {
+			return c;
+		}
 		if ((i == 0) && (c < ' ')) {
 			i--;
 			continue;
 		}
-		if (c < ' ')
+		/* Any character < ' ' indicates the end of line */
+		if (c < ' ') {
 			break;
+		}
 		str[i] = c;
 	}
 	str[i] = 0;
-	return (i);
+	
+	return i;
 }
 
-static void *aprsthread(void *data)
+/*!
+ * \brief APRS connection thread.
+ * This thread opens and maintains a TCP/IP connection to the APRS-IS server.
+ * It logs into the server using the call sign and password specified 
+ * in the configuration.
+ *
+ * Data sent from the APRS-IS server is read and discarded.
+ *
+ * In the event that the connection is lost, the routine
+ * will automatically attempt to reconnect.
+ *
+ * \param data		Pointer to data (nothing passed)
+ */
+static void *aprs_connection_thread(void *data)
 {
 	char *call, *password, *val, buf[300];
 	struct ast_config *cfg = NULL;
-	struct ast_hostent ahp;
-	struct hostent *hp;
-	struct sockaddr_in servaddr;
 	struct ast_flags zeroflag = { 0 };
-
-	call = NULL;
-	password = NULL;
+	struct ast_sockaddr addr = { {0,} };
+	struct pollfd fds[1];
+	int res;
+	
 	if (!(cfg = ast_config_load(config, zeroflag))) {
 		ast_log(LOG_NOTICE, "Unable to load config %s\n", config);
 		pthread_exit(NULL);
 		return NULL;
 	}
 	val = (char *) ast_variable_retrieve(cfg, "general", "call");
-	if (val)
-		call = ast_strdup(val);
-	else
+	if (val) {
+		call = ast_strdupa(val);
+	} else {
 		call = NULL;
+	}
 	val = (char *) ast_variable_retrieve(cfg, "general", "password");
-	if (val)
-		password = ast_strdup(val);
-	else
+	if (val) {
+		password = ast_strdupa(val);
+	} else {
 		password = NULL;
+	}
+	/* Verify that we have a callsign and password */
 	if ((!call) || (!password)) {
 		ast_log(LOG_ERROR, "You must specify call and password\n");
-		if (call)
-			ast_free(call);
-		if (password)
-			ast_free(password);
 		pthread_exit(NULL);
 		return NULL;
 	}
 	ast_config_destroy(cfg);
 	cfg = NULL;
+	
 	while (run_forever) {
-		ast_mutex_lock(&gps_lock);
-		if (sockfd < 0) {
+		ast_mutex_lock(&aprs_socket_lock);
+		/* See the socket is open.  Close it so that it can be reopened. */
+		if (sockfd > -1) {
 			close(sockfd);
+			sockfd = -1;
 		}
 		sockfd = socket(AF_INET, SOCK_STREAM, 0);
-		pthread_testcancel();
 		if (sockfd < 0) {
-			ast_log(LOG_ERROR, "Error opening socket\n");
-			sockfd = -1;
-			ast_mutex_unlock(&gps_lock);
+			ast_log(LOG_ERROR, "Error opening socket. Error: %s\n", strerror(errno));
+			ast_mutex_unlock(&aprs_socket_lock);
+			/* Wait 500ms before trying again. */
 			usleep(500000);
 			continue;
 		}
-		bzero(&servaddr, sizeof(servaddr));
-		servaddr.sin_family = AF_INET;
-		servaddr.sin_port = htons(atoi(port));
-		hp = ast_gethostbyname(server, &ahp);
-		if (!hp) {
-			ast_log(LOG_WARNING, "server %s cannot be found!!\n", server);
-			close(sockfd);
-			sockfd = -1;
-			ast_mutex_unlock(&gps_lock);
+		
+		if (ast_sockaddr_resolve_first_af(&addr, server, PARSE_PORT_IGNORE, AST_AF_INET)) {
+			ast_log(LOG_WARNING, "Server %s cannot be found!\n", server);
+			ast_mutex_unlock(&aprs_socket_lock);
+			/* Wait 500ms before trying again. */
 			usleep(500000);
 			continue;
 		}
-		memcpy(&servaddr.sin_addr, hp->h_addr, sizeof(in_addr_t));
-		if (connect(sockfd, (struct sockaddr *) &servaddr, sizeof(servaddr)) < 0) {
-			ast_log(LOG_WARNING, "server %s cannot be found!!\n", server);
-			close(sockfd);
-			sockfd = -1;
-			ast_mutex_unlock(&gps_lock);
+		ast_sockaddr_set_port(&addr, atoi(port));
+		
+		if (ast_connect(sockfd, &addr) < 0) {
+			ast_log(LOG_WARNING, "Cannot connect to server %s. Error: %s\n", server, strerror(errno));
+			ast_mutex_unlock(&aprs_socket_lock);
+			/* Wait 500ms before trying again. */
 			usleep(500000);
 			continue;
 		}
-		sprintf(buf, "user %s pass %s vers \"Asterisk app_gps\"\n", call, password);
+
+		/* Log into the APRS-IS server */
+		sprintf(buf, "user %s pass %s vers Asterisk app_gps_V3\n", call, password);
+		
 		if (send(sockfd, buf, strlen(buf), 0) < 0) {
-			ast_log(LOG_WARNING, "Can not send signon to server\n");
+			ast_log(LOG_WARNING, "Can not send sign on to server. Error: %s\n", strerror(errno));
 			close(sockfd);
 			sockfd = -1;
-			ast_mutex_unlock(&gps_lock);
+			ast_mutex_unlock(&aprs_socket_lock);
 			continue;
 		}
-		if (debug)
-			ast_log(LOG_NOTICE, "sent packet(login): %s", buf);
-		ast_mutex_unlock(&gps_lock);
-		while (recv(sockfd, buf, sizeof(buf) - 1, 0) > 0);
+		ast_debug(1, "Sent packet(login): %s", buf);
+		ast_mutex_unlock(&aprs_socket_lock);
+		
+		memset(&fds, 0, sizeof(fds));
+		fds[0].fd = sockfd;
+		fds[0].events = POLLIN;
+		
+		/* Consume the received data from the APRS-IS server.
+		 * We do not use the returned information at this time.
+		 */
+		 while (run_forever) {
+			/*
+			 * poll for activity
+			 * time out after 500ms
+			 */
+			res = ast_poll(fds, 1, 500);
+			if (res == 0) {
+				continue;
+			}
+			if (res < 0 || fds[0].revents & POLLHUP) {
+				break;
+			}
+			if (fds[0].revents & POLLIN) {
+				memset(buf, 0, sizeof(buf));
+				if (recv(sockfd, buf, sizeof(buf) - 1, 0) > 0) {
+					ast_debug(4, "APRS-IS: %s\n", buf);
+				}
+			}
+		 }
 	}
+	
+	close(sockfd);
+	sockfd = -1;
+	
 	ast_debug(2, "%s has exited\n", __FUNCTION__);
 	return NULL;
 }
 
-static int report_aprs(char *ctg, char *lat, char *lon)
+/*!
+ * \brief Report APRS information.
+ * This routine send an APRS position report to the APRS-IS server.
+ *
+ * Message type 'position without timestamp'.
+ * Data extension PHG 'Station Power and Effective Antenna Height/Gain/Directivity'
+ * Optionally includes elevation.
+ *
+ * \param ctg		Pointer to configuration stanza to process
+ * \param lat		Pointer to latitude to report
+ * \param lon		Pointer to longitude to report
+ * \param elev		Pointer to elevation to report
+ *
+ * \retval 0		Success
+ * \retval -1		Failure
+ */
+static int report_aprs(char *ctg, char *lat, char *lon, char *elev)
 {
 	struct ast_config *cfg = NULL;
-	char *call, *comment, icon;
-	char power, height, gain, dir, *val, basecall[300], buf[350], *cp;
-	time_t t;
+	char *call, *comment, icon, icon_table;
+	char power, height, gain, dir, *val, servercall[200], buf[350], *cp;
 	struct ast_flags zeroflag = { 0 };
+	char elev_str[25];
+	float elev_f;
 
 	call = NULL;
 	comment = NULL;
+	
+	/* Load the configuration settings for the stanza requested */
 	if (!(cfg = ast_config_load(config, zeroflag))) {
 		ast_log(LOG_NOTICE, "Unable to load config %s\n", config);
 		return -1;
 	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "call");
-	if (val)
-		call = ast_strdup(val);
-	else
+	if (val) {
+		call = ast_strdupa(val);
+	} else {
 		call = NULL;
+	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "comment");
-	if (val)
-		comment = ast_strdup(val);
-	else
-		comment = ast_strdup(GPS_DEFAULT_COMMENT);
+	if (val) {
+		comment = ast_strdupa(val);
+	} else {
+		comment = ast_strdupa(APRS_DEFAULT_COMMENT);
+	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "power");
-	if (val)
+	if (val) {
 		power = (char) strtol(val, NULL, 0);
-	else
+	} else {
 		power = 0;
+	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "height");
-	if (val)
+	if (val) {
 		height = (char) strtol(val, NULL, 0);
-	else
+	} else {
 		height = 0;
+	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "gain");
-	if (val)
+	if (val) {
 		gain = (char) strtol(val, NULL, 0);
-	else
+	} else {
 		gain = 0;
+	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "dir");
-	if (val)
+	if (val) {
 		dir = (char) strtol(val, NULL, 0);
-	else
+	} else {
 		dir = 0;
+	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "icon");
-	if (val && *val)
+	if (val && *val) {
 		icon = *val;
-	else
-		icon = GPS_DEFAULT_ICON;
-	if (icon == '?')
-		icon = ';';				/* allow for entry of portable tent */
-
-	if (!call) {
-		ast_log(LOG_ERROR, "You must specify call\n");
-		if (call)
-			ast_free(call);
-		if (comment)
-			ast_free(comment);
-		return -1;
+	} else {
+		icon = APRS_DEFAULT_ICON;
+	}
+	val = (char *) ast_variable_retrieve(cfg, ctg, "icontable");
+	if (val && *val) {
+		icon_table = *val;
+	} else {
+		icon_table = APRS_DEFAULT_ICON_TABLE;
 	}
 	ast_config_destroy(cfg);
 	cfg = NULL;
+	
+	/* Remap '?' to ';' due to Asterisk config limitation on using ';' (; = portable tent) */
+	if (icon == '?') {
+		icon = ';';	
+	}
 
-	ast_copy_string(basecall, call, sizeof(basecall));
-	cp = strchr(basecall, '-');
-	if (cp)
-		*cp = 0;
+	/* We must have a callsign to report information */
+	if (!call) {
+		ast_log(LOG_ERROR, "You must configure a callsign\n");
+		return -1;
+	}
+
+    /* Setup the server call sign 
+	 * If the SID is a single character, append 'S' 
+	 * If there is no SID, append '-VS'
+	 */
+	ast_copy_string(servercall, call, sizeof(servercall));
+	cp = strchr(servercall, '-');
+	if (cp) {
+		if (strlen(cp) == 2) {
+			strcat(servercall, "S");
+		}
+	} else {
+		strcat(servercall, "-VS");
+	}
+	
+	/* Reduce the precision of latitude and longitude
+	 *
+	 * Latitude is expressed as a fixed 8-character field, in degrees and decimal
+     * minutes (to two decimal places), followed by the letter N for north or 
+     * S for south.
+	 * Longitude is expressed as a fixed 9-character field, in degrees and decimal
+	 * minutes (to two decimal places), followed by the letter E for east or 
+	 * W for west.
+	 */
 	cp = strchr(lat, '.');
 	if (cp && (strlen(cp) >= 3)) {
 		*(cp + 3) = lat[strlen(lat) - 1];
@@ -491,34 +696,57 @@ static int report_aprs(char *ctg, char *lat, char *lon)
 		*(cp + 3) = lon[strlen(lon) - 1];
 		*(cp + 4) = 0;
 	}
+	
+	/* Setup optional elevation */
+	memset(elev_str, 0, sizeof(elev_str));
+	elev_f = 0;
+	sscanf(elev, "%f", &elev_f);
+	if (elev_f > 0) {
+		snprintf(elev_str, sizeof(elev_str), "/A=%06.0f", elev_f * 3.28);
+	}
 
-	sprintf(buf, "%s>APRS,qAR,%s-VS:=%s/%s%cPHG%d%d%d%d/%s\n",
-			call, basecall, lat, lon, icon, power, height, gain, dir, comment);
-	time(&t);
-	ast_mutex_lock(&gps_lock);
+	snprintf(buf, sizeof(buf), "%s>APSTAR,TCPIP*,qAC,%s:!%s%c%s%cPHG%d%d%d%d%s%s\r\n",
+			call, servercall, lat, icon_table, lon, icon, power, height, gain, dir, elev_str, comment);
+
+	ast_mutex_lock(&aprs_socket_lock);
+	
 	if (sockfd == -1) {
-		ast_log(LOG_WARNING, "Attempt to send APRS data with no connection open!!\n");
-		ast_mutex_unlock(&gps_lock);
+		ast_log(LOG_WARNING, "Attempt to send APRS data with no connection open!\n");
+		ast_mutex_unlock(&aprs_socket_lock);
 		return -1;
 	}
 	if (send(sockfd, buf, strlen(buf), 0) < 0) {
-		ast_log(LOG_WARNING, "Can not send APRS (GPS) data\n");
-		ast_mutex_unlock(&gps_lock);
+		ast_log(LOG_WARNING, "Can not send APRS (GPS) data. Error: %s\n", strerror(errno));
+		ast_mutex_unlock(&aprs_socket_lock);
 		return -1;
 	}
-	if (debug)
-		ast_log(LOG_NOTICE, "sent packet(%s): %s", ctg, buf);
-	ast_mutex_unlock(&gps_lock);
-	if (call)
-		ast_free(call);
-	if (comment)
-		ast_free(comment);
+	
+	ast_debug(1, "Sent packet(%s): %s", ctg, buf);
+	ast_mutex_unlock(&aprs_socket_lock);
+	
 	return 0;
 }
 
+/*!
+ * \brief Report APRStt information.
+ * This routine send an APRStt position report to the APRS-IS server.
+ *
+ * Message type 'object'
+ * The call sign being reported is shown in APRS as an object with
+ * a SSID of '-12'.
+ *
+ * \param ctg		Pointer to configuration stanza to process
+ * \param lat		Pointer to latitude to report
+ * \param lon		Pointer to longitude to report
+ * \param theircall	Pointer to the received callsign to report
+ * \param overlay	The overlay character to use
+ *
+ * \retval 0		Success
+ * \retval -1		Failure
+ */
+
 static int report_aprstt(char *ctg, char *lat, char *lon, char *theircall, char overlay)
 {
-
 	struct ast_config *cfg = NULL;
 	char *call, *comment;
 	char *val, basecall[300], buf[300], buf1[100], *cp;
@@ -528,36 +756,49 @@ static int report_aprstt(char *ctg, char *lat, char *lon, char *theircall, char 
 
 	call = NULL;
 	comment = NULL;
+	
+	/* Load the configuration settings for the stanza requested */
 	if (!(cfg = ast_config_load(config, zeroflag))) {
 		ast_log(LOG_NOTICE, "Unable to load config %s\n", config);
 		return -1;
 	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "call");
-	if (val)
-		call = ast_strdup(val);
-	else
+	if (val) {
+		call = ast_strdupa(val);
+	} else {
 		call = NULL;
+	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "ttcomment");
-	if (val)
-		comment = ast_strdup(val);
-	else
-		comment = ast_strdup(TT_DEFAULT_COMMENT);
-
-	if (!call) {
-		ast_log(LOG_ERROR, "You must specify call\n");
-		if (call)
-			ast_free(call);
-		if (comment)
-			ast_free(comment);
-		return -1;
+	if (val) {
+		comment = ast_strdupa(val);
+	} else {
+		comment = ast_strdupa(APRSTT_DEFAULT_COMMENT);
 	}
 	ast_config_destroy(cfg);
 	cfg = NULL;
 
+	/* We must have a callsign to report information */
+	if (!call) {
+		ast_log(LOG_ERROR, "You must configure a callsign\n");
+		return -1;
+	}
+
+	/* Get the base callsign - everything before the '-' */
 	ast_copy_string(basecall, call, sizeof(basecall));
 	cp = strchr(basecall, '-');
-	if (cp)
+	if (cp) {
 		*cp = 0;
+	}
+	
+	/* Reduce the precision of latitude and longitude
+	 *
+	 * Latitude is expressed as a fixed 8-character field, in degrees and decimal
+     * minutes (to two decimal places), followed by the letter N for north or 
+     * S for south.
+	 * Longitude is expressed as a fixed 9-character field, in degrees and decimal
+	 * minutes (to two decimal places), followed by the letter E for east or 
+	 * W for west.
+	 */
 	cp = strchr(lat, '.');
 	if (cp && (strlen(cp) >= 3)) {
 		*(cp + 3) = lat[strlen(lat) - 1];
@@ -568,56 +809,104 @@ static int report_aprstt(char *ctg, char *lat, char *lon, char *theircall, char 
 		*(cp + 3) = lon[strlen(lon) - 1];
 		*(cp + 4) = 0;
 	}
+	
 	time(&t);
 	tm = gmtime(&t);
+	
 	sprintf(buf1, "%s-12", theircall);
-	sprintf(buf, "%s>APSTAR:;%-9s*%02d%02d%02dz%s%c%sA%s\n",
+	sprintf(buf, "%s>APSTAR:;%-9s*%02d%02d%02dz%s%c%sA%s\r\n",
 			call, buf1, tm->tm_hour, tm->tm_min, tm->tm_sec, lat, overlay, lon, comment);
-	if (send(sockfd, buf, strlen(buf), 0) < 0) {
-		ast_log(LOG_WARNING, "Can not send APRS (APSTAR) data\n");
-		ast_mutex_unlock(&gps_lock);
-		if (call)
-			ast_free(call);
-		if (comment)
-			ast_free(comment);
+	
+	ast_mutex_lock(&aprs_socket_lock);
+		
+	if (sockfd == -1) {
+		ast_log(LOG_WARNING, "Attempt to send APRS (APSTAR) data with no connection open!\n");
+		ast_mutex_unlock(&aprs_socket_lock);
 		return -1;
 	}
-	if (debug)
-		ast_log(LOG_NOTICE, "sent packet(%s): %s", ctg, buf);
-	ast_mutex_unlock(&gps_lock);
-	if (call)
-		ast_free(call);
-	if (comment)
-		ast_free(comment);
+	
+	if (send(sockfd, buf, strlen(buf), 0) < 0) {
+		ast_log(LOG_WARNING, "Can not send APRS (APSTAR) data. Error: %s\n", strerror(errno));
+		ast_mutex_unlock(&aprs_socket_lock);
+		return -1;
+	}
+	
+	ast_debug(1, "Sent packet(%s): %s", ctg, buf);
+	ast_mutex_unlock(&aprs_socket_lock);
+	
 	return 0;
 }
-
-static void *gpsthread(void *data)
+/*!
+ * \brief Convert latitude in decimal to DMS string.
+ *
+ * \param dec		Latitude in decimal
+ * \param value		Pointer to buffer to receive the value
+ * \param len		Length of the value buffer
+ */
+static void lat_decimal_to_DMS(float dec, char *value, int len)
 {
-	char buf[300], c, *strs[100], lat[100], lon[100];
-	char latc, lonc, astr[50];
+	char direction;
+	float lata, latb, latd;
+
+	direction = (dec >= 0.0) ? 'N' : 'S';
+	lata = fabs(dec);
+	latb = (lata - floor(lata)) * 60;
+	latd = (latb - floor(latb)) * 100 + 0.5;
+	snprintf(value, len, "%02d%02d.%02d%c", (int) lata, (int) latb, (int) latd, direction);
+}
+/*!
+ * \brief Convert longitude in decimal to DMS string.
+ *
+ * \param dec		Longitude in decimal
+ * \param value		Pointer to buffer to receive the value
+ * \param len		Length of the value buffer
+ */
+static void lon_decimal_to_DMS(float dec, char *value, int len)
+{
+	char direction;
+	float lona, lonb, lond;
+
+	direction = (dec >= 0.0) ? 'E' : 'W';
+	lona = fabs(dec);
+	lonb = (lona - floor(lona)) * 60;
+	lond = (lonb - floor(lonb)) * 100 + 0.5;
+	snprintf(value, len, "%03d%02d.%02d%c", (int) lona, (int) lonb, (int) lond, direction);
+}
+
+/*!
+ * \brief GPS device processing thread.
+ * This routine continously reads and parses the serial GPS data.
+ *
+ * The position information is made available through the global 
+ * current_gps_position structure.
+ *
+ * \param data		Pointer to data (nothing passed)
+ */
+static void *gps_reader(void *data)
+{
+	char buf[300], c, *strs[100];
 	int res, i, n, fd, has_comport = 0;
-	float mylat, lata, latb, latd;
-	float mylon, lona, lonb, lond;
-	FILE *fp;
-	time_t t;
 	struct termios mode;
+	struct position_info *selected_info;
+	time_t now;
 
-	if (comport)
+	if (comport) {
 		has_comport = 1;
-	else
+	} else {
 		comport = "/dev/null";
+	}
 
+	/* Open the serial port configured for the GPS device */
 	fd = open(comport, O_RDWR);
 	if (fd == -1) {
-		ast_log(LOG_WARNING, "Cannot open serial port %s\n", comport);
+		ast_log(LOG_WARNING, "Cannot open serial port %s: Error %s\n", comport, strerror(errno));
 		goto err;
 	}
 
 	if (has_comport) {
 		memset(&mode, 0, sizeof(mode));
 		if (tcgetattr(fd, &mode)) {
-			ast_log(LOG_WARNING, "Unable to get serial parameters on %s: %s\n", comport, strerror(errno));
+			ast_log(LOG_WARNING, "Unable to get serial parameters on %s: Error %s\n", comport, strerror(errno));
 			close(fd);
 			goto err;
 		}
@@ -635,51 +924,57 @@ static void *gpsthread(void *data)
 		cfsetispeed(&mode, baudrate);
 		cfsetospeed(&mode, baudrate);
 		if (tcsetattr(fd, TCSANOW, &mode)) {
-			ast_log(LOG_WARNING, "Unable to set serial parameters on %s: %s\n", comport, strerror(errno));
+			ast_log(LOG_WARNING, "Unable to set serial parameters on %s: Error %s\n", comport, strerror(errno));
 			close(fd);
 			goto err;
 		}
 	}
+	
+	/* Give the device a few milliseconds to come on-line */
 	usleep(100000);
 
+	/*! \todo we need to detail with someone unplugging the device */
+	
 	while (run_forever) {
-		res = getserial(fd, buf, sizeof(buf) - 1);
+		
+		/* Read a line from the serial port */
+		res = getserialline(fd, buf, sizeof(buf) - 1);
 		if (res < 0) {
-			ast_log(LOG_ERROR, "GPS fatal error!!\n");
+			ast_log(LOG_ERROR, "GPS fatal error!\n");
 			continue;
 		}
 		if (!res) {
-			if ((!general_deflat) || (!general_deflon)) {
-				ast_log(LOG_WARNING, "GPS timeout!!\n");
+			ast_mutex_lock(&position_update_lock);
+			current_gps_position.is_valid = 0;
+			ast_mutex_unlock(&position_update_lock);
+			/* 
+			 * A timeout has occurred.  No data received from the GPS device.
+			 * If we don't have default position information, report the timeout.
+			 */
+			if (!general_def_position.is_valid) {
+				ast_log(LOG_WARNING, "GPS timeout!\n");
 				continue;
 			}
+			
 			ast_log(LOG_WARNING, "GPS timeout -- Using default (fixed location) parameters instead\n");
-			mylat = strtof(general_deflat, NULL);
-			mylon = strtof(general_deflon, NULL);
-			latc = (mylat >= 0.0) ? 'N' : 'S';
-			lonc = (mylon >= 0.0) ? 'E' : 'W';
-			lata = fabs(mylat);
-			lona = fabs(mylon);
-			latb = (lata - floor(lata)) * 60;
-			latd = (latb - floor(latb)) * 100 + 0.5;
-			lonb = (lona - floor(lona)) * 60;
-			lond = (lonb - floor(lonb)) * 100 + 0.5;
-			sprintf(lat, "%02d%02d.%02d%c", (int) lata, (int) latb, (int) latd, latc);
-			sprintf(lon, "%03d%02d.%02d%c", (int) lona, (int) lonb, (int) lond, lonc);
-			if (general_defelev) {
-				mylat = strtof(general_defelev, NULL);
-				lata = (mylat - floor(mylat)) * 10 + 0.5;
-				sprintf(astr, "%03d.%1d", (int) mylat, (int) lata);
-				strs[9] = astr;
-			} else
-				strs[9] = "000.0";
-			strs[10] = "M";
+			
+			selected_info = &general_def_position;
+			
 		} else {
-			c = 0;
+			time(&now);
+			/* Check for no data receiption */
+			if (current_gps_position.last_updated + GPS_VALID_SECS < now) {
+				ast_mutex_lock(&position_update_lock);
+				current_gps_position.is_valid = 0;
+				ast_mutex_unlock(&position_update_lock);
+			}
+			/* Validate the GPS data */
 			if (buf[0] != '$') {
 				ast_log(LOG_WARNING, "GPS Invalid data format (no '$' at beginning)\n");
 				continue;
 			}
+			/* Calculate the check sum */
+			c = 0;
 			for (i = 1; buf[i]; i++) {
 				if (buf[i] == '*')
 					break;
@@ -693,57 +988,86 @@ static void *gpsthread(void *data)
 				ast_log(LOG_WARNING, "GPS Invalid checksum\n");
 				continue;
 			}
+			
 			n = explode_string(buf, strs, 100, ',', '\"');
 			if (!n) {
 				ast_log(LOG_WARNING, "GPS Invalid data format (no data)\n");
 				continue;
 			}
-			if (strcasecmp(strs[0], "$GPGGA"))
+			/* We only process the $GPGGA sentence */
+			if (strcasecmp(strs[0], "$GPGGA")) {
 				continue;
+			}
 			if (n != 15) {
 				ast_log(LOG_WARNING, "GPS Invalid data format (invalid format for GGA record)\n");
 				continue;
 			}
+			/* See if the GPS is locked */
 			if (*strs[6] < '1') {
-				ast_log(LOG_WARNING, "GPS data not available\n");
+				if (!gps_unlock_shown) {
+					ast_log(LOG_WARNING, "GPS data not available (signal not locked)\n");
+					gps_unlock_shown = 1;
+				}
 				continue;
 			}
-			snprintf(lat, sizeof(lat) - 1, "%s%s", strs[2], strs[3]);
-			snprintf(lon, sizeof(lon) - 1, "%s%s", strs[4], strs[5]);
+			
+			/* If we have been unlocked, let them know that we are locked */
+			if (gps_unlock_shown) {
+				ast_log(LOG_NOTICE, "GPS locked\n");
+				gps_unlock_shown = 0;
+			}
+			
+			ast_mutex_lock(&position_update_lock);
+			current_gps_position.is_valid = 1;
+			snprintf(current_gps_position.latitude, sizeof(current_gps_position.latitude) - 1, "%s%s", strs[2], strs[3]);
+			snprintf(current_gps_position.longitude, sizeof(current_gps_position.longitude) - 1, "%s%s", strs[4], strs[5]);
+			snprintf(current_gps_position.elevation, sizeof(current_gps_position.elevation) - 1, "%s%s", strs[9], strs[10]);
+			time(&current_gps_position.last_updated);
+			ast_mutex_unlock(&position_update_lock);
+			
+			selected_info = & current_gps_position;
 		}
-		if (debug)
-			ast_log(LOG_NOTICE, "got lat: %s, long: %s, elev: %s%s\n", lat, lon, strs[9], strs[10]);
-		fp = fopen(GPS_WORK_FILE, "w");
-		if (!fp) {
-			ast_log(LOG_ERROR, "Unable to open GPS work file!!\n");
-			continue;
-		}
-		time(&t);
-		fprintf(fp, "%u %s %s %s%s\n", (unsigned int) t, lat, lon, strs[9], strs[10]);
-		fclose(fp);
-		sprintf(buf, "/bin/mv %s %s > /dev/null 2>&1", GPS_WORK_FILE, GPS_DATA_FILE);
-		ast_safe_system(buf);
+		
+		ast_debug(5, "Got latitude: %s, longitude: %s, elevation: %s from: %s\n", 
+			selected_info->latitude, selected_info->longitude, selected_info->elevation,
+			(selected_info == &current_gps_position) ? "GPS" : "Default");
 	}
-	close(fd);
+	
+	if (fd) {
+		close(fd);
+	}
+	
 err:
 	ast_debug(2, "%s has exited\n", __FUNCTION__);
 	return NULL;
 }
 
-static void *gps_sub_thread(void *data)
+/*!
+ * \brief APRS sender thread.
+ * The routine sends the packet report based on the configured
+ * interval (beacon time).
+ *
+ * This thread is setup initially for the [general] stanza.
+ * If other stanzas are present in the configuration file,
+ * additional threads will be created passing in the name
+ * of the respective stanza.
+ *
+ * \param data		Pointer to aprs_sender_info struct.
+ */
+static void *aprs_sender_thread(void *data)
 {
 	struct ast_config *cfg = NULL;
-	char *ctg = (char *) data, gotfiledata;
-	char *val, *deflat, *deflon, latc, lonc;
-	char fname[200], lat[300], lon[300];
-	FILE *fp;
-	unsigned int u;
+	char *ctg;
+	char *val, *deflat, *deflon, *defelev;
 	int interval, my_update_secs, ehlert;
-	float mylat, lata, latb, latd;
-	float mylon, lona, lonb, lond;
-	struct stat mystat;
-	time_t now, was, lastupdate;
+	time_t now, lastupdate;
 	struct ast_flags zeroflag = { 0 };
+	struct position_info this_def_position, selected_position;
+	struct aprs_sender_info *sender_entry = (struct aprs_sender_info *) data;
+	
+	ctg = ast_strdupa(sender_entry->stanza);
+	
+	ast_debug(2, "Starting aprs sender thread: %s\n", ctg);
 
 	if (!(cfg = ast_config_load(config, zeroflag))) {
 		ast_log(LOG_NOTICE, "Unable to load config %s\n", config);
@@ -751,258 +1075,361 @@ static void *gps_sub_thread(void *data)
 		return NULL;
 	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "lat");
-	if (val)
-		deflat = ast_strdup(val);
-	else
+	if (val) {
+		deflat = ast_strdupa(val);
+	} else {
 		deflat = NULL;
+	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "lon");
-	if (val)
-		deflon = ast_strdup(val);
-	else
+	if (val) {
+		deflon = ast_strdupa(val);
+	} else {
 		deflon = NULL;
+	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "elev");
+	if (val) {
+		defelev = ast_strdupa(val);
+	} else {
+		defelev = NULL;
+	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "interval");
-	if (val)
+	if (val) {
 		interval = atoi(val);
-	else
+	} else {
 		interval = GPS_UPDATE_SECS;
+	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "ehlert");
-	if (val)
+	if (val) {
 		ehlert = ast_true(val);
-	else
+	} else {
 		ehlert = 0;
+	}
 	ast_config_destroy(cfg);
 	cfg = NULL;
+	/*
+	 * Set the default position for this stanza
+	 * If it is [general], we already have the defaults
+	 * otherwise, we need to build the specific defaults
+	 * for this stanza.
+	 */
+	 if (!strcmp(ctg, "general") || (!deflat && !deflon)) {
+		 this_def_position = general_def_position;
+	 } else {
+		this_def_position.is_valid = 1;
+		lat_decimal_to_DMS(strtof(deflat, NULL), this_def_position.latitude, sizeof(this_def_position.latitude));
+		lon_decimal_to_DMS(strtof(deflon, NULL), this_def_position.longitude, sizeof(this_def_position.longitude));
+		/* See if we have a default elevation */
+		if (defelev) {
+			float eleva, elevd;
+			eleva = strtof(defelev, NULL);
+			elevd = (eleva - floor(eleva)) * 10 + 0.5;
+			snprintf(this_def_position.elevation, sizeof(this_def_position.elevation), "%03d.%1d", (int) eleva, (int) elevd);
+		} else {
+			strcpy(this_def_position.elevation, "000.0");
+		}
+	 }
+	
+	memset(&selected_position, 0, sizeof(selected_position));
 	time(&lastupdate);
 	my_update_secs = GPS_UPDATE_SECS;
+	
 	while (run_forever) {
-		gotfiledata = 0;
-		if (!strcmp(ctg, "general"))
-			strcpy(fname, GPS_DATA_FILE);
-		else
-			snprintf(fname, sizeof(fname) - 1, GPS_SUB_FILE, ctg);
 		time(&now);
-		fp = fopen(fname, "r");
-		if (fp && (fstat(fileno(fp), &mystat) != -1) && (mystat.st_size < 100)) {
-			if (fscanf(fp, "%u %s %s", &u, lat, lon) == 3) {
-				was = (time_t) u;
-				if ((was + GPS_VALID_SECS) >= now) {
-					gotfiledata = 1;
-					if (now >= (lastupdate + my_update_secs)) {
-						report_aprs(ctg, lat, lon);
-						lastupdate = now;
-						my_update_secs = interval;
-					}
-				}
+		
+		ast_mutex_lock(&position_update_lock);
+		selected_position.is_valid = 0;
+		/* See if we need to send live GPS or the default */
+		if (current_gps_position.is_valid) {
+			selected_position = current_gps_position;
+		} else {
+			if (this_def_position.is_valid && !ehlert) {
+				selected_position = this_def_position;
+				selected_position.last_updated = now;
 			}
 		}
-		if ((!gotfiledata) && (!ehlert) && deflat && deflon) {
+		ast_mutex_unlock(&position_update_lock);
+		/* 
+		 * See if it is time to send the position report
+		 * The last_updated time must be current so that
+		 * we know we are getting good GPS information.
+		 */
+		if (selected_position.is_valid && (selected_position.last_updated + GPS_VALID_SECS) >= now) {
 			if (now >= (lastupdate + my_update_secs)) {
-				mylat = strtof(deflat, NULL);
-				mylon = strtof(deflon, NULL);
-				latc = (mylat >= 0.0) ? 'N' : 'S';
-				lonc = (mylon >= 0.0) ? 'E' : 'W';
-				lata = fabs(mylat);
-				lona = fabs(mylon);
-				latb = (lata - floor(lata)) * 60;
-				latd = (latb - floor(latb)) * 100 + 0.5;
-				lonb = (lona - floor(lona)) * 60;
-				lond = (lonb - floor(lonb)) * 100 + 0.5;
-				sprintf(lat, "%02d%02d.%02d%c", (int) lata, (int) latb, (int) latd, latc);
-				sprintf(lon, "%03d%02d.%02d%c", (int) lona, (int) lonb, (int) lond, lonc);
-				report_aprs(ctg, lat, lon);
+				report_aprs(ctg, selected_position.latitude, selected_position.longitude, selected_position.elevation);
 				lastupdate = now;
 				my_update_secs = interval;
 			}
-
 		}
-		if (fp)
-			fclose(fp);
-		sleep(10);
+		/* wait 1 second */
+		sleep(1);
 	}
 	ast_debug(2, "%s has exited\n", __FUNCTION__);
 	return NULL;
 }
 
-static void *gps_tt_thread(void *data)
+/*!
+ * \brief APRStt (touch tone) processing thread.
+ * The routine sends the touch tone packet report.
+ *
+ * This thread is setup initially for the [general] stanza.
+ * If other stanzas are present in the configuration file,
+ * additional threads will be created passing in the name
+ * of the respective stanza.
+ *
+ * \param data		Pointer to aprs_sender_info struct.
+ */
+static void *aprstt_sender_thread(void *data)
 {
 	struct ast_config *cfg = NULL;
-	int i, j, ttlist, ttoffset, ttslot, myoffset;
-	char *ctg = (char *) data, gotfiledata, c;
-	char *val, *deflat, *deflon, latc, lonc, ttsplit, *ttlat, *ttlon;
-	char fname[200], lat[300], lon[300], buf[100], theircall[100], overlay;
-	FILE *fp, *fp1, *mfp;
-	unsigned int u;
-	float mylat, lata, latb, latd;
-	float mylon, lona, lonb, lond;
-	struct stat mystat;
-	time_t now, was, lastupdate;
-	struct ttentry *ttentries, ttempty;
 	struct ast_flags zeroflag = { 0 };
+	int i, j, ttlist, ttoffset, ttslot, myoffset;
+	char *ctg, c;
+	char *val, *deflat, *deflon, *defelev, ttsplit, *ttlat, *ttlon;
+	char fname[200], lat[100], theircall[100], overlay;
+	FILE *mfp;
+	struct stat mystat;
+	time_t now, lastupdate;
+	struct ttentry *ttentries, ttempty;
+	struct position_info this_def_position, selected_position;
+	struct timeval tv;
+	struct timespec ts = {0};
+	struct aprs_sender_info *sender_entry = (struct aprs_sender_info *) data;
+	
+	ctg = ast_strdupa(sender_entry->stanza);
+	
+	ast_debug(2, "Starting aprstt sender thread: %s\n", ctg);
 
+	/* Load our configuration */
 	if (!(cfg = ast_config_load(config, zeroflag))) {
 		ast_log(LOG_NOTICE, "Unable to load config %s\n", config);
 		pthread_exit(NULL);
 		return NULL;
 	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "lat");
-	if (val)
-		deflat = ast_strdup(val);
-	else
+	if (val) {
+		deflat = ast_strdupa(val);
+	} else {
 		deflat = NULL;
+	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "lon");
-	if (val)
-		deflon = ast_strdup(val);
-	else
+	if (val) {
+		deflon = ast_strdupa(val);
+	} else {
 		deflon = NULL;
+	}
+	val = (char *) ast_variable_retrieve(cfg, ctg, "elev");
+	if (val) {
+		defelev = ast_strdupa(val);
+	} else {
+		defelev = NULL;
+	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "ttlat");
-	if (val)
-		ttlat = ast_strdup(val);
-	else
+	if (val) {
+		ttlat = ast_strdupa(val);
+	} else {
 		ttlat = NULL;
+	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "ttlon");
-	if (val)
-		ttlon = ast_strdup(val);
-	else
+	if (val) {
+		ttlon = ast_strdupa(val);
+	} else {
 		ttlon = NULL;
+	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "ttlist");
-	if (val)
+	if (val) {
 		ttlist = atoi(val);
-	else
+	} else {
 		ttlist = DEFAULT_TTLIST;
+	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "ttoffset");
-	if (val)
+	if (val) {
 		ttoffset = atoi(val);
-	else
+	} else {
 		ttoffset = DEFAULT_TTOFFSET;
+	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "ttsplit");
-	if (val)
+	if (val) {
 		ttsplit = ast_true(val);
-	else
+	} else {
 		ttsplit = 0;
+	}
+	ast_config_destroy(cfg);
+	cfg = NULL;
 
+	/*
+	 * Set the default position for this stanza
+	 * If it is [general], we already have the defaults
+	 * otherwise, we need to build the specific defaults
+	 * for this stanza.
+	 */
+	 if (!strcmp(ctg, "general") || (!deflat && !deflon)) {
+		 this_def_position = general_def_position;
+	 } else {
+		this_def_position.is_valid = 1;
+		lat_decimal_to_DMS(strtof((ttlat ? ttlat : deflat), NULL), this_def_position.latitude, sizeof(this_def_position.latitude));
+		lon_decimal_to_DMS(strtof((ttlon? ttlon : deflon), NULL), this_def_position.longitude, sizeof(this_def_position.longitude));
+		/* See if we have a default elevation */
+		if (defelev) {
+			float eleva, elevd;
+			eleva = strtof(defelev, NULL);
+			elevd = (eleva - floor(eleva)) * 10 + 0.5;
+			snprintf(this_def_position.elevation, sizeof(this_def_position.elevation), "%03d.%1d", (int) eleva, (int) elevd);
+		} else {
+			strcpy(this_def_position.elevation, "000.0");
+		}
+	 }
+
+	/*
+	 * Open the common block file for this stanza.
+	 * We will store the callsign and last update time.
+	 */
 	mfp = NULL;
-	if (!strcmp(ctg, "general"))
+	if (!strcmp(sender_entry->stanza, "general")) {
 		strcpy(fname, TT_COMMON);
-	else
-		snprintf(fname, sizeof(fname) - 1, TT_SUB_COMMON, ctg);
+	} else { 
+		snprintf(fname, sizeof(fname) - 1, TT_SUB_COMMON, sender_entry->stanza);
+	}
 	if (stat(fname, &mystat) == -1) {
 		mfp = fopen(fname, "w");
 		if (!mfp) {
-			ast_log(LOG_ERROR, "Can not create aprstt common block file %s\n", fname);
+			ast_log(LOG_ERROR, "Can not create aprstt common block file %s. Error: %s\n", fname, strerror(errno));
 			pthread_exit(NULL);
 		}
 		memset(&ttempty, 0, sizeof(ttempty));
 		for (i = 0; i < ttlist; i++) {
 			if (fwrite(&ttempty, 1, sizeof(ttempty), mfp) != sizeof(ttempty)) {
-				ast_log(LOG_ERROR, "Error initializing aprtss common block file %s\n", fname);
+				ast_log(LOG_ERROR, "Error initializing aprtss common block file %s. Error: %s\n", fname, strerror(errno));
 				fclose(mfp);
 				pthread_exit(NULL);
 			}
 		}
 		fclose(mfp);
 		if (stat(fname, &mystat) == -1) {
-			ast_log(LOG_ERROR, "Unable to stat new aprstt common block file %s\n", fname);
+			ast_log(LOG_ERROR, "Unable to stat new aprstt common block file %s: Error: %s\n", fname, strerror(errno));
 			pthread_exit(NULL);
 		}
 	}
 	if (mystat.st_size < (sizeof(struct ttentry) * ttlist)) {
 		mfp = fopen(fname, "r+");
 		if (!mfp) {
-			ast_log(LOG_ERROR, "Can not open aprstt common block file %s\n", fname);
+			ast_log(LOG_ERROR, "Can not open aprstt common block file %s. Error: %s\n", fname, strerror(errno));
 			pthread_exit(NULL);
 		}
 		memset(&ttempty, 0, sizeof(ttempty));
 		if (fseek(mfp, 0, SEEK_END)) {
-			ast_log(LOG_ERROR, "Can not seek aprstt common block file %s\n", fname);
+			ast_log(LOG_ERROR, "Can not seek aprstt common block file %s. Error: %s\n", fname, strerror(errno));
 			pthread_exit(NULL);
 		}
 		for (i = mystat.st_size; i < (sizeof(struct ttentry) * ttlist); i += sizeof(struct ttentry)) {
 			if (fwrite(&ttempty, 1, sizeof(ttempty), mfp) != sizeof(ttempty)) {
-				ast_log(LOG_ERROR, "Error growing aprtss common block file %s\n", fname);
+				ast_log(LOG_ERROR, "Error growing aprtss common block file %s. Error: %s\n", fname, strerror(errno));
 				fclose(mfp);
 				pthread_exit(NULL);
 			}
 		}
 		fclose(mfp);
 		if (stat(fname, &mystat) == -1) {
-			ast_log(LOG_ERROR, "Unable to stat updated aprstt common block file %s\n", fname);
+			ast_log(LOG_ERROR, "Unable to stat updated aprstt common block file %s. Error: %s\n", fname, strerror(errno));
 			pthread_exit(NULL);
 		}
 	}
 	mfp = fopen(fname, "r+");
 	if (!mfp) {
-		ast_log(LOG_ERROR, "Can not open aprstt common block file %s\n", fname);
+		ast_log(LOG_ERROR, "Can not open aprstt common block file %s. Error: %s\n", fname, strerror(errno));
 		pthread_exit(NULL);
 	}
 	ttentries = mmap(NULL, mystat.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, fileno(mfp), 0);
 	if (ttentries == NULL) {
-		ast_log(LOG_ERROR, "Cannot map aprtss common file %s!!\n", fname);
+		ast_log(LOG_ERROR, "Cannot map aprtss common file %s. Error: %s\n", fname, strerror(errno));
 		pthread_exit(NULL);
 	}
-	ast_config_destroy(cfg);
-	cfg = NULL;
+	
 	time(&lastupdate);
-	if (!strcmp(ctg, "general"))
-		strcpy(fname, TT_PIPE);
-	else
-		snprintf(fname, sizeof(fname) - 1, TT_SUB_PIPE, ctg);
-	mkfifo(fname, 0666);
-	fp1 = fopen(fname, "r");
-	while (fp1 && run_forever) {
-		if (fgets(buf, sizeof(buf) - 1, fp1) == NULL) {
-			usleep(500000);
+	
+	while (run_forever) {
+		/* Wait for the aprs_sendtt function to give us data or time out after 500ms */
+		ast_mutex_lock(&sender_entry->lock);
+		
+		tv = ast_tvadd(ast_tvnow(), ast_samp2tv(500,1000));	/* Setup the time value for 500ms from now */
+		ts.tv_sec = tv.tv_sec;
+		ts.tv_nsec = tv.tv_usec * 1000;
+		ast_cond_timedwait(&sender_entry->condition, &sender_entry->lock, &ts);
+
+		ast_mutex_unlock(&sender_entry->lock);
+
+		/* Make sure we have some data to process - if we did not get anything we could have timedout */
+		if (ast_strlen_zero(sender_entry->their_call)) {
 			continue;
 		}
-		strupr(buf);
-		i = sscanf(buf, "%s %c", theircall, &overlay);
-		if (i < 1) {
-			usleep(500000);
-			continue;
+		
+		ast_copy_string(theircall, sender_entry->their_call, sizeof(theircall));
+		sender_entry->their_call[0] = '\0';
+		overlay = sender_entry->overlay;
+
+		ast_str_to_upper(theircall);
+		if (overlay < '0') {
+			overlay = APRSTT_DEFAULT_OVERLAY;
 		}
-		if (i < 2)
-			overlay = TT_DEFAULT_OVERLAY;
+		
 		time(&now);
+		
 		/* if we already have it, just update time */
 		for (ttslot = 0; ttslot < ttlist; ttslot++) {
-			if (!strcmp(theircall, ttentries[ttslot].call))
+			if (!strcmp(theircall, ttentries[ttslot].call)) {
 				break;
+			}
 		}
 		if (ttslot < ttlist) {
-			time(&ttentries[ttslot].t);
-		} else {				/* otherwise, look for empty or timed-out */
+			time(&ttentries[ttslot].last_updated);
+		} else {				
+			/* otherwise, look for empty or timed-out */
 			for (ttslot = 0; ttslot < ttlist; ttslot++) {
 				/* if empty */
-				if (!ttentries[ttslot].call[0])
+				if (!ttentries[ttslot].call[0]) {
 					break;
+				}
 				/* if timed-out */
-				if ((ttentries[ttslot].t + TT_LIST_TIMEOUT) < now)
+				if ((ttentries[ttslot].last_updated + TT_LIST_TIMEOUT) < now) {
 					break;
+				}
 			}
 			if (ttslot < ttlist) {
 				ast_copy_string(ttentries[ttslot].call, theircall, sizeof(ttentries[ttslot].call) - 1);
-				time(&ttentries[ttslot].t);
+				time(&ttentries[ttslot].last_updated);
 			} else {
-				ast_log(LOG_WARNING, "APRSTT attempting to add call %s to full list (%d items)\n", theircall, ttlist);
+				ast_log(LOG_WARNING, "APRStt attempting to add call %s to full list (%d items)\n", theircall, ttlist);
 				continue;
 			}
 		}
+		/* Sync the entries to the file */
 		msync(ttentries, mystat.st_size, MS_SYNC);
+		
+		/* Center tt reports around the origin */
 		if (ttsplit) {
 			myoffset = ttoffset * ((ttslot >> 1) + 1);
-			if (!(ttslot & 1))
+			if (!(ttslot & 1)) {
 				myoffset = -myoffset;
+			}
 		} else {
 			myoffset = ttoffset * (ttslot + 1);
 		}
-		gotfiledata = 0;
-		if (!strcmp(ctg, "general"))
-			strcpy(fname, GPS_DATA_FILE);
-		else
-			snprintf(fname, sizeof(fname) - 1, GPS_SUB_FILE, ctg);
-		fp = fopen(fname, "r");
-		if (fp && (fstat(fileno(fp), &mystat) != -1) && (mystat.st_size < 100)) {
-			if (fscanf(fp, "%u %d.%d%c %s", &u, &i, &j, &c, lon) == 5) {
+						
+		ast_mutex_lock(&position_update_lock);
+		selected_position.is_valid = 0;
+		/* See if we need to send live GPS or the default */
+		if (current_gps_position.is_valid) {
+			selected_position = current_gps_position;
+		} else {
+			if (this_def_position.is_valid) {
+				selected_position = this_def_position;
+				selected_position.last_updated = now;
+			}
+		}
+		ast_mutex_unlock(&position_update_lock);
+
+		if (selected_position.is_valid) {
+			if (sscanf(selected_position.latitude, "%d.%d%c", &i, &j, &c) == 3) {
+				/* Adjust the latitude for the offset */
 				if (c == 'S') {
 					i = -i;
 				}
@@ -1012,78 +1439,256 @@ static void *gps_tt_thread(void *data)
 					j += myoffset;
 				}
 				i += (j / 60);
-				if (j < 0)
+				if (j < 0){
 					sprintf(lat, "%04d.%02d%c", (i >= 0) ? i : -i, -j % 60, (i >= 0) ? 'N' : 'S');
-				else
+				} else {
 					sprintf(lat, "%04d.%02d%c", (i >= 0) ? i : -i, j % 60, (i >= 0) ? 'N' : 'S');
-				was = (time_t) u;
-				if ((was + GPS_VALID_SECS) >= now) {
-					gotfiledata = 1;
-					report_aprstt(ctg, lat, lon, theircall, overlay);
+				}
+				/* If our last position update is good, send an update */
+				if ((selected_position.last_updated + GPS_VALID_SECS) >= now) {
+					report_aprstt(ctg, lat, selected_position.longitude, theircall, overlay);
 				}
 			}
 		}
-		if ((!gotfiledata) && deflat && deflon) {
-			mylat = strtof((ttlat) ? ttlat : deflat, NULL);
-			mylon = strtof((ttlon) ? ttlon : deflon, NULL);
-			if (mylat >= 0.0) {
-				mylat -= ((float) myoffset) * 0.00016666666666666666666666666666667;
-			} else {
-				mylat += ((float) myoffset) * 0.00016666666666666666666666666666667;
-			}
-			latc = (mylat >= 0.0) ? 'N' : 'S';
-			lonc = (mylon >= 0.0) ? 'E' : 'W';
-			lata = fabs(mylat);
-			lona = fabs(mylon);
-			latb = (lata - floor(lata)) * 60;
-			latd = (latb - floor(latb)) * 100 + 0.5;
-			lonb = (lona - floor(lona)) * 60;
-			lond = (lonb - floor(lonb)) * 100 + 0.5;
-			sprintf(lat, "%02d%02d.%02d%c", (int) lata, (int) latb, (int) latd, latc);
-			sprintf(lon, "%03d%02d.%02d%c", (int) lona, (int) lonb, (int) lond, lonc);
-			report_aprstt(ctg, lat, lon, theircall, overlay);
-			lastupdate = now;
-
-		}
-		if (fp)
-			fclose(fp);
 	}
 	munmap(ttentries, mystat.st_size);
-	if (mfp)
+	if (mfp) {
 		fclose(mfp);
+	}
+	
 	ast_debug(2, "%s has exited\n", __FUNCTION__);
 	return NULL;
 }
 
-static int gps_exec(struct ast_channel *chan, const char *data)
+/*!
+ * \brief GPS read helper function.
+ * The function "GPS_READ" responds with current GPS information.
+ *
+ * The response is in the format, with each element delimited by a space:
+ *	unix time (EPOCH) format %llu
+ *  latitude DDMM.SSX		(degrees, minutes, seconds, direction)
+ *  longitude DDMM.SSX		(degrees, minutes, seconds, direction)
+ *  elevation NNNN.NU		(value, unit - default is "M" meters)
+ *
+ * \param	chan	Pointer to the asterisk channel struct.
+ * \param	cmd		Pointer to the command passed to the function.
+ * \param	data	Pointer to the data passed to the function.
+ * \param	buf		Pointer to the buffer to receive the returned data.
+ * \param	len		Length of the buffer.
+ *
+ * \retval	0		Success
+ * \retval	-1		Failure
+ */
+static int gps_read_helper(struct ast_channel *chan, const char *cmd, char *data, char *buf, size_t len)
 {
-	/*! \todo ??? Why does this even exist? */
+	struct position_info selected_position;
+	
+	memset(buf, 0, len);
+	
+	ast_mutex_lock(&position_update_lock);
+	selected_position.is_valid = 0;
+	/* See if we need to send live GPS or the default */
+	if (current_gps_position.is_valid) {
+		selected_position = current_gps_position;
+	} else {
+		if (general_def_position.is_valid) {
+			selected_position = general_def_position;
+			time(&selected_position.last_updated);
+		}
+	}
+	ast_mutex_unlock(&position_update_lock);
+	/* 
+	 * Format the response if we have a valid position
+	 */
+	if (selected_position.is_valid ) {
+		snprintf(buf, len, "%llu %s %s %s", (unsigned long long) selected_position.last_updated, 
+			selected_position.latitude, selected_position.longitude, selected_position.elevation);
+		return 0;
+	}
+
+	return -1;
+}
+/*!
+ * \brief Send APRStt (touch tone) position report function.
+ * The write function "APRS_SENDTT" sends an APRS position report
+ * for the specified stanza, overlay and callsign.
+ *
+ * APRS_SENDTT(stanza, overlay) = callsign
+ *
+ * \param	chan	Pointer to the asterisk channel struct.
+ * \param	cmd		Pointer to the command passed to the function.
+ * \param	data	Pointer to the data passed to the function.
+ * \param	value	Pointer to value that represents the callsign.
+ *
+ * \retval	0		Success
+ * \retval	-1		Failure
+ */
+static int aprs_sendtt_helper(struct ast_channel *chan, const char *function, char *data, const char *value)
+{
+		char *parse;
+		struct aprs_sender_info *sender_entry;
+		
+		AST_DECLARE_APP_ARGS(args,
+			AST_APP_ARG(stanza);
+			AST_APP_ARG(overlay);
+	);
+	if (ast_strlen_zero(data)) {
+		ast_log(LOG_ERROR, "APRS_SENDTT requires arguments\n");
+		return -1;
+	}
+
+	parse = ast_strdupa(data);
+	AST_STANDARD_APP_ARGS(args, parse);
+
+	if (ast_strlen_zero(args.stanza)) {
+		ast_log(LOG_ERROR, "APRS_SENDTT requires a stanza\n");
+		return -1;
+	}
+	if (ast_strlen_zero(args.overlay)) {
+		ast_log(LOG_ERROR, "APRS_SENDTT requires an overlay\n");
+		return -1;
+	}
+	if (ast_strlen_zero(value)) {
+		ast_log(LOG_ERROR, "APRS_SENDTT requires a callsign\n");
+		return -1;
+	}
+	/* Find the stanza */
+	AST_LIST_TRAVERSE(&aprs_sender_list, sender_entry, list) {
+		if (!strcasecmp(sender_entry->stanza, args.stanza) && sender_entry->type == APRSTT) {
+			break;
+		}
+	}
+	if (!sender_entry) {
+		ast_log(LOG_WARNING, "APRS_SENDTT cannot find associated stanza: %s\n", args.stanza);
+		return -1;
+	}
+
+	ast_mutex_lock(&sender_entry->lock);
+	
+	sender_entry->overlay = args.overlay[0];
+	ast_copy_string(sender_entry->their_call, value, sizeof(sender_entry->their_call));
+	ast_cond_signal(&sender_entry->condition);	/* Signal the thread to start working */
+	
+	ast_mutex_unlock(&sender_entry->lock);
+
 	return 0;
 }
 
+/*!
+ * \brief Asterisk function setup struct for gps_read_helper
+ */
+static struct ast_custom_function gps_read_function = {
+	.name = "GPS_READ",
+	.synopsis = "Read GPS position",
+	.desc = "Read current or default GPS position.",
+	.read = gps_read_helper,
+};
+
+/*!
+ * \brief Asterisk function setup struct for aprstt_send_helper
+ */
+static struct ast_custom_function aprs_sendtt_function = {
+	.name = "APRS_SENDTT",
+	.synopsis = "Send APRStt",
+	.desc = "Sends an APRStt position report.",
+	.write = aprs_sendtt_helper,
+};
+
+/*!
+ * \brief Handle asterisk cli request for status
+ * \param e				Asterisk cli entry.
+ * \param cmd			Cli command type.
+ * \param a				Pointer to asterisk cli arguments.
+ * \return	Cli success or failure.
+ */
+static char *handle_cli_status(struct ast_cli_entry *e, int cmd, struct ast_cli_args *a)
+{
+	switch (cmd) {
+	case CLI_INIT:
+		e->command = "gps status";
+		e->usage =
+			"Usage: gps status\n"
+			"       Displays the GPS status.\n";
+		return NULL;
+	case CLI_GENERATE:
+		return NULL;
+	}
+
+	if (a->argc > 2) {
+		return CLI_SHOWUSAGE;
+	}
+
+	ast_mutex_lock(&position_update_lock);
+	ast_cli(a->fd, "GPS: %s, Signal: %s \n", 
+		ast_strlen_zero(comport) ? "Disconnected" : "Connected",
+		current_gps_position.is_valid ? "Locked" : "Unlocked");
+	if (current_gps_position.is_valid) {
+		ast_cli(a->fd, "Position: %s %s Elevation: %s\n", 
+			current_gps_position.latitude, current_gps_position.longitude,
+			current_gps_position.elevation);
+	}
+	if (general_def_position.is_valid) {
+		ast_cli(a->fd, "Default Position: %s %s Elevation: %s\n", 
+			general_def_position.latitude, general_def_position.longitude,
+			general_def_position.elevation);
+	}
+	ast_mutex_unlock(&position_update_lock);
+	
+	return CLI_SUCCESS;
+}
+
+/*!
+ * \brief Define cli entries for this module
+ */
+static struct ast_cli_entry cli_status = AST_CLI_DEFINE(handle_cli_status, "Display the GPS status");
+
+
 static int unload_module(void)
 {
+	struct aprs_sender_info *sender_entry;
 	int res;
 
 	run_forever = 0;
-	ast_debug(2, "Waiting for general threads to exit\n");
+	ast_debug(2, "Waiting for threads to exit\n");
 	if (sockfd != -1) {
 		shutdown(sockfd, SHUT_RDWR);
 	}
-	pthread_cancel(aprs_thread);
-	ast_debug(2, "Waiting for aprs_thread to exit\n");
-	pthread_join(aprs_thread, NULL);
+	ast_debug(2, "Waiting for aprs_connection_thread to exit\n");
+	pthread_join(aprs_connection_thread_id, NULL);
+	
 	if (comport) {
-		ast_debug(2, "Waiting for gps_thread to exit\n");
-		pthread_join(gps_thread, NULL);
+		ast_debug(2, "Waiting for gps_reader_thread to exit\n");
+		pthread_join(gps_reader_thread_id, NULL);
+		ast_free(comport);
 	}
-	ast_debug(2, "Waiting for gps_subthread to exit\n");
-	pthread_join(gps_subthread, NULL);
-	pthread_cancel(gps_ttthread);
-	ast_debug(2, "Waiting for gps_ttthread to exit\n");
-	pthread_join(gps_ttthread, NULL);
-	ast_debug(1, "General threads have exited\n");
-	res = ast_unregister_application(app);
+	
+	/* Shutdown and clean up sender threads */
+	AST_LIST_TRAVERSE_SAFE_BEGIN(&aprs_sender_list, sender_entry, list) {
+		AST_LIST_REMOVE_CURRENT(list);
+		ast_debug(2, "Waiting for %s sender thread %s to exit\n", sender_entry->type == APRS ? "aprs" : "aprstt", sender_entry->stanza);
+		pthread_join(sender_entry->thread_id, NULL);
+		ast_mutex_destroy(&sender_entry->lock);
+		ast_cond_destroy(&sender_entry->condition);
+		ast_free(sender_entry);
+	}
+	AST_LIST_TRAVERSE_SAFE_END;
+
+	ast_debug(1, "Threads have exited\n");
+	
+	if (server) {
+		ast_free(server);
+	}
+	if (port) {
+		ast_free(port);
+	}
+	
+	/* Unregister our functions */
+	res = ast_custom_function_unregister(&gps_read_function);
+	res |= ast_custom_function_unregister(&aprs_sendtt_function);
+	
+	/* Unregister cli */
+	ast_cli_unregister(&cli_status);
+	
 	return res;
 }
 
@@ -1091,6 +1696,8 @@ static int load_module(void)
 {
 	struct ast_config *cfg = NULL;
 	char *ctg = "general", *val;
+	char *def_lat, *def_lon, *def_elev;
+	struct aprs_sender_info *sender_entry;
 	int res;
 
 	struct ast_flags zeroflag = { 0 };
@@ -1100,35 +1707,41 @@ static int load_module(void)
 		return AST_MODULE_LOAD_DECLINE;
 	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "comport");
-	if (val)
+	if (val) {
 		comport = ast_strdup(val);
-	else
+	} else {
 		comport = NULL;
+	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "lat");
-	if (val)
-		general_deflat = ast_strdup(val);
-	else
-		general_deflat = NULL;
+	if (val) {
+		def_lat = ast_strdupa(val);
+	} else {
+		def_lat = NULL;
+	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "lon");
-	if (val)
-		general_deflon = ast_strdup(val);
-	else
-		general_deflon = NULL;
+	if (val) {
+		def_lon = ast_strdupa(val);
+	} else {
+		def_lon = NULL;
+	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "elev");
-	if (val)
-		general_defelev = ast_strdup(val);
-	else
-		general_defelev = NULL;
+	if (val) {
+		def_elev = ast_strdupa(val);
+	} else {
+		def_elev = NULL;
+	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "server");
-	if (val)
+	if (val) {
 		server = ast_strdup(val);
-	else
-		server = ast_strdup(GPS_DEFAULT_SERVER);
+	} else {
+		server = ast_strdup(APRS_DEFAULT_SERVER);
+	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "port");
-	if (val)
+	if (val) {
 		port = ast_strdup(val);
-	else
-		port = ast_strdup(GPS_DEFAULT_PORT);
+	} else {
+		port = ast_strdup(APRS_DEFAULT_PORT);
+	}
 	val = (char *) ast_variable_retrieve(cfg, ctg, "baudrate");
 	if (val) {
 		switch (atoi(val)) {
@@ -1137,6 +1750,9 @@ static int load_module(void)
 			break;
 		case 4800:
 			baudrate = B4800;
+			break;
+		case 9600:
+			baudrate = B9600;
 			break;
 		case 19200:
 			baudrate = B19200;
@@ -1151,27 +1767,90 @@ static int load_module(void)
 			ast_log(LOG_ERROR, "%s is not valid baud rate for iospeed\n", val);
 			break;
 		}
-	} else
+	} else {
 		baudrate = GPS_DEFAULT_BAUDRATE;
-	val = (char *) ast_variable_retrieve(cfg, ctg, "debug");
-	if (val)
-		debug = ast_true(val);
+	}
+	
+	memset(&current_gps_position, 0, sizeof(current_gps_position));
+	memset(&general_def_position, 0, sizeof(general_def_position));
+	/* 
+	 * Setup the general default position.
+	 * This is used when the GPS device is not available.
+	 */
+	if (def_lat && def_lon) {
+		general_def_position.is_valid = 1;
+		lat_decimal_to_DMS(strtof(def_lat, NULL), general_def_position.latitude, sizeof(general_def_position.latitude));
+		lon_decimal_to_DMS(strtof(def_lon, NULL), general_def_position.longitude, sizeof(general_def_position.longitude));
+		/* See if we have a default elevation */
+		if (def_elev) {
+			float eleva, elevd;
+			eleva = strtof(def_elev, NULL);
+			elevd = (eleva - floor(eleva)) * 10 + 0.5;
+			snprintf(general_def_position.elevation, sizeof(general_def_position.elevation), "%03d.%1dM", (int) eleva, (int) elevd);
+		} else {
+			strcpy(general_def_position.elevation, "000.0M");
+		}
+	}
 
-	ast_pthread_create(&aprs_thread, NULL, aprsthread, NULL);
-	if (comport)
-		ast_pthread_create(&gps_thread, NULL, gpsthread, NULL);
-	ast_pthread_create(&gps_subthread, NULL, gps_sub_thread, ast_strdup("general"));
-	ast_pthread_create(&gps_ttthread, NULL, gps_tt_thread, ast_strdup("general"));
+	/* Create the aprs connection thread */
+	ast_pthread_create(&aprs_connection_thread_id, NULL, aprs_connection_thread, NULL);
+	/* If we have a comport specified, start the GPS processing thread */
+	if (comport) {
+		ast_pthread_create(&gps_reader_thread_id, NULL, gps_reader, NULL);
+	}
+	/* Create the aprs sender thread for 'general' */
+	sender_entry = ast_calloc(1, sizeof(*sender_entry));
+	sender_entry->type = APRS;
+	strcpy(sender_entry->stanza, "general");
+	ast_mutex_init(&sender_entry->lock);
+	ast_cond_init(&sender_entry->condition, 0);
+	AST_LIST_INSERT_TAIL(&aprs_sender_list, sender_entry, list);
+	ast_pthread_create(&sender_entry->thread_id, NULL, aprs_sender_thread, sender_entry);
+	
+	/* Create the aprs tt sender thread for 'general' */
+	sender_entry = ast_calloc(1, sizeof(*sender_entry));
+	sender_entry->type = APRSTT;
+	strcpy(sender_entry->stanza, "general");
+	ast_mutex_init(&sender_entry->lock);
+	ast_cond_init(&sender_entry->condition, 0);
+	AST_LIST_INSERT_TAIL(&aprs_sender_list, sender_entry, list);
+	ast_pthread_create(&sender_entry->thread_id, NULL, aprstt_sender_thread, sender_entry);
+	/* 
+	 * See if we have stanzas other than general. 
+	 * If present, create aprs processing threads for those stanzas 
+	 */
 	while ((ctg = ast_category_browse(cfg, ctg)) != NULL) {
-		if (ctg == NULL)
+		if (ctg == NULL) {
 			continue;
-		/* Don't clobber gps_thread */
-		ast_pthread_create_detached(&gps_section_thread, NULL, gps_sub_thread, ast_strdup(ctg));
-		ast_pthread_create_detached(&gps_section_thread, NULL, gps_tt_thread, ast_strdup(ctg));
+		}
+		/* Create the aprs sender thread for this category */
+		sender_entry = ast_calloc(1, sizeof(*sender_entry));
+		sender_entry->type = APRS;
+		ast_copy_string(sender_entry->stanza, ctg, sizeof(sender_entry->stanza));
+		ast_mutex_init(&sender_entry->lock);
+		ast_cond_init(&sender_entry->condition, 0);
+		AST_LIST_INSERT_TAIL(&aprs_sender_list, sender_entry, list);
+		ast_pthread_create(&sender_entry->thread_id, NULL, aprs_sender_thread, sender_entry);
+		
+		/* Create the aprs tt sender thread for this category */
+		sender_entry = ast_calloc(1, sizeof(*sender_entry));
+		sender_entry->type = APRSTT;
+		ast_copy_string(sender_entry->stanza, ctg, sizeof(sender_entry));
+		ast_mutex_init(&sender_entry->lock);
+		ast_cond_init(&sender_entry->condition, 0);
+		AST_LIST_INSERT_TAIL(&aprs_sender_list, sender_entry, list);
+		ast_pthread_create_detached(&sender_entry->thread_id, NULL, aprstt_sender_thread, sender_entry->stanza);
 	}
 	ast_config_destroy(cfg);
 	cfg = NULL;
-	res = ast_register_application(app, gps_exec, synopsis, descrip);
+	
+	/* Register our functions */
+	res = ast_custom_function_register(&gps_read_function);
+	res |= ast_custom_function_register(&aprs_sendtt_function);
+	
+	/* Register cli */
+	ast_cli_register(&cli_status);
+	
 	return res;
 }
 

--- a/apps/app_gps.c
+++ b/apps/app_gps.c
@@ -318,6 +318,7 @@ struct aprs_sender_info {
 };
 
 AST_LIST_HEAD_NOLOCK_STATIC(aprs_sender_list, aprs_sender_info);
+AST_MUTEX_DEFINE_STATIC(aprs_sender_list_lock);
 
 
 /*!
@@ -1566,11 +1567,13 @@ static int aprs_sendtt_helper(struct ast_channel *chan, const char *function, ch
 		return -1;
 	}
 	/* Find the section */
+	ast_mutex_lock(&aprs_sender_list_lock);
 	AST_LIST_TRAVERSE(&aprs_sender_list, sender_entry, list) {
 		if (!strcasecmp(sender_entry->section, args.section) && sender_entry->type == APRSTT) {
 			break;
 		}
 	}
+	ast_mutex_unlock(&aprs_sender_list_lock);
 	if (!sender_entry) {
 		ast_log(LOG_WARNING, "APRS_SENDTT cannot find associated section: %s\n", args.section);
 		return -1;

--- a/apps/app_gps.c
+++ b/apps/app_gps.c
@@ -1822,7 +1822,9 @@ static int load_module(void)
 	strcpy(sender_entry->section, "general");
 	ast_mutex_init(&sender_entry->lock);
 	ast_cond_init(&sender_entry->condition, 0);
+	AST_RWLIST_RDLOCK(&aprs_sender_list);
 	AST_LIST_INSERT_TAIL(&aprs_sender_list, sender_entry, list);
+	AST_RWLIST_UNLOCK(&aprs_sender_list);
 	if (ast_pthread_create(&sender_entry->thread_id, NULL, aprs_sender_thread, sender_entry)) {
 		ast_log(LOG_ERROR, "Cannot create APRS sender thread %s", sender_entry->section);
 		return -1;
@@ -1837,7 +1839,9 @@ static int load_module(void)
 	strcpy(sender_entry->section, "general");
 	ast_mutex_init(&sender_entry->lock);
 	ast_cond_init(&sender_entry->condition, 0);
+	AST_RWLIST_RDLOCK(&aprs_sender_list);
 	AST_LIST_INSERT_TAIL(&aprs_sender_list, sender_entry, list);
+	AST_RWLIST_UNLOCK(&aprs_sender_list);
 	if (ast_pthread_create(&sender_entry->thread_id, NULL, aprstt_sender_thread, sender_entry)) {
 		ast_log(LOG_ERROR, "Cannot create APRStt sender thread %s", sender_entry->section);
 		return -1;
@@ -1859,7 +1863,9 @@ static int load_module(void)
 		ast_copy_string(sender_entry->section, ctg, sizeof(sender_entry->section));
 		ast_mutex_init(&sender_entry->lock);
 		ast_cond_init(&sender_entry->condition, 0);
+		AST_RWLIST_RDLOCK(&aprs_sender_list);
 		AST_LIST_INSERT_TAIL(&aprs_sender_list, sender_entry, list);
+		AST_RWLIST_UNLOCK(&aprs_sender_list);
 		if (ast_pthread_create(&sender_entry->thread_id, NULL, aprs_sender_thread, sender_entry)) {
 			ast_log(LOG_ERROR, "Cannot create APRS sender thread %s", sender_entry->section);
 			return -1;
@@ -1874,7 +1880,9 @@ static int load_module(void)
 		ast_copy_string(sender_entry->section, ctg, sizeof(sender_entry));
 		ast_mutex_init(&sender_entry->lock);
 		ast_cond_init(&sender_entry->condition, 0);
+		AST_RWLIST_RDLOCK(&aprs_sender_list);
 		AST_LIST_INSERT_TAIL(&aprs_sender_list, sender_entry, list);
+		AST_RWLIST_UNLOCK(&aprs_sender_list);
 		if (ast_pthread_create_detached(&sender_entry->thread_id, NULL, aprstt_sender_thread, sender_entry->section)) {
 			ast_log(LOG_ERROR, "Cannot create APRStt sender thread %s", sender_entry->section);
 			return -1;

--- a/apps/app_gps.c
+++ b/apps/app_gps.c
@@ -325,7 +325,7 @@ AST_LIST_HEAD_NOLOCK_STATIC(aprs_sender_list, aprs_sender_info);
  * This returns the CLOCK_MONOTONIC time
  * \retval		Monotonic seconds.
  */
-static int time_monotonic(void)
+static time_t time_monotonic(void)
 {
 	struct timespec ts;
 	

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4982,7 +4982,7 @@ static void *rpt(void *this)
 
 		time(&t);
 		while (t >= (myrpt->lastgpstime + GPS_UPDATE_SECS)) {
-			unsigned long long u;
+			unsigned long long u_mono, u_epoch;
 			char gps_data[100];
 			char lat[25], lon[25], elev[25];
 
@@ -4996,10 +4996,10 @@ static void *rpt(void *this)
 				break;
 			}
 
-			if (sscanf(gps_data, "%llu %s %s %s", &u, lat, lon, elev) != 4) {
+			if (sscanf(gps_data, "%llu %llu %s %s %s", &u_mono, &u_epoch, lat, lon, elev) != 5) {
 				break;
 			}
-			was = (time_t) u;
+			was = (time_t) u_epoch;
 			if ((was + GPS_VALID_SECS) < t) {
 				break;
 			}

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -1565,13 +1565,12 @@ static void do_aprstt(struct rpt *myrpt)
 	 */
 	overlay = aprstt_xlat(cmd, aprscall);
 	if (overlay) {
-		ast_log(LOG_NOTICE, "APRStt got string %s callsign %s overlay %c\n", cmd, aprscall, overlay);
+		ast_debug(1, "APRStt got string %s callsign %s overlay %c\n", cmd, aprscall, overlay);
 		
 		if (!ast_custom_function_find("APRS_SENDTT")) {
 			ast_log(LOG_WARNING, "app_gps is not loaded.  APRSTT failed\n");
 		} else {
-			memset(func, 0, sizeof(func));
-			snprintf(func, sizeof(func) -1, "APRS_SENDTT(%s,%c)", !myrpt->p.aprstt[0] ? "general" : myrpt->p.aprstt, overlay);
+			snprintf(func, sizeof(func), "APRS_SENDTT(%s,%c)", !myrpt->p.aprstt[0] ? "general" : myrpt->p.aprstt, overlay);
 			/* execute the APRS_SENDTT function in app_gps*/
 			if (!ast_func_write(NULL, func, aprscall)) {
 				rpt_telemetry(myrpt, ARB_ALPHA, (void *) aprscall);

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -1552,7 +1552,7 @@ static inline void collect_function_digits_post(struct rpt *myrpt, int res, cons
  * sent to app_gps using the APRS_SENDTT function for 
  * processing and posting to the APRS-IS server.
  *
- * \param rpt		pointer to repeater struct.
+ * \param myrpt		pointer to repeater struct.
  */
 static void do_aprstt(struct rpt *myrpt)
 {

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -1568,7 +1568,7 @@ static void do_aprstt(struct rpt *myrpt)
 		ast_debug(1, "APRStt got string %s callsign %s overlay %c\n", cmd, aprscall, overlay);
 		
 		if (!ast_custom_function_find("APRS_SENDTT")) {
-			ast_log(LOG_WARNING, "app_gps is not loaded.  APRSTT failed\n");
+			ast_log(LOG_WARNING, "app_gps is not loaded.  APRStt failed\n");
 		} else {
 			snprintf(func, sizeof(func), "APRS_SENDTT(%s,%c)", !myrpt->p.aprstt[0] ? "general" : myrpt->p.aprstt, overlay);
 			/* execute the APRS_SENDTT function in app_gps*/
@@ -4984,7 +4984,7 @@ static void *rpt(void *this)
 		while (t >= (myrpt->lastgpstime + GPS_UPDATE_SECS)) {
 			unsigned long long u;
 			char gps_data[100];
-			char lat[100], lon[100], elev[100];
+			char lat[25], lon[25], elev[25];
 
 			myrpt->lastgpstime = t;
 			

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -101,9 +101,6 @@ typedef struct {
 #define	MAX_RETRIES 5
 #define	MAX_RETRIES_PERM 1000000000
 
-#define	APRSTT_PIPE "/tmp/aprs_ttfifo"
-#define	APRSTT_SUB_PIPE "/tmp/aprs_ttfifo_%s"
-
 #define	REDUNDANT_TX_TIME 2000
 
 #define	RETRY_TIMER_MS 5000
@@ -161,7 +158,6 @@ typedef struct {
 #define	EXTNODEFILE "/var/lib/asterisk/rpt_extnodes"
 #define	NODENAMES "rpt/nodenames"
 #define	PARROTFILE "/tmp/parrot_%s_%u"
-#define	GPSFILE "/tmp/gps.dat"
 
 #define	GPS_VALID_SECS 60
 #define	GPS_UPDATE_SECS 30

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -860,7 +860,7 @@ struct rpt {
 	char lastdtmfuser[MAXNODESTR];
 	char curdtmfuser[MAXNODESTR];
 	int  sleeptimer;
-	time_t lastgpstime;
+	time_t lastgpstime;			/* monotonic time */
 	int outstreampipe[2];
 	int outstreampid;
 	time_t outstreamlasterror;	/*!< \brief set when there is an outstream error and is reset when error cleared */

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -1722,17 +1722,17 @@ int function_cop(struct rpt *myrpt, char *param, char *digitbuf, int command_sou
 		
 		if (!ast_custom_function_find("APRS_SENDTT")) {
 			ast_log(LOG_WARNING, "app_gps is not loaded.  APRSTT failed\n");
-		} else {
-			memset(func, 0, sizeof(func));
-			snprintf(func, sizeof(func) -1, "APRS_SENDTT(%s,%c)", !myrpt->p.aprstt ? "general" : myrpt->p.aprstt, 
-				argc > 2 ? argv[2][0] : ' ');
-			/* execute the APRS_SENDTT function in app_gps*/
-			if (!ast_func_write(NULL, func, argv[1])) {
-				if (myatoi(argv[0]) == 63) {
-					rpt_telemetry(myrpt, ARB_ALPHA, (void *) argv[1]);
-				}
+			return DC_COMPLETE;
+		}
+		memset(func, 0, sizeof(func));
+		snprintf(func, sizeof(func) -1, "APRS_SENDTT(%s,%c)", !myrpt->p.aprstt ? "general" : myrpt->p.aprstt, 
+			argc > 2 ? argv[3][0] : ' ');
+		/* execute the APRS_SENDTT function in app_gps*/
+		if (!ast_func_write(NULL, func, argv[1])) {
+			if (myatoi(argv[0]) == 63) {
+				rpt_telemetry(myrpt, ARB_ALPHA, (void *) argv[1]);
 			}
-		} 
+		}
 		return DC_COMPLETE;
 	case 65:					/* send POCSAG page */
 		if (argc < 3)

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -10,6 +10,7 @@
 #include "asterisk/channel.h"
 #include "asterisk/file.h"
 #include "asterisk/cli.h"
+#include "asterisk/pbx.h" /* functions */
 
 #include "app_rpt.h"
 #include "rpt_lock.h"
@@ -1157,10 +1158,9 @@ int function_localplay(struct rpt *myrpt, char *param, char *digitbuf, int comma
 
 int function_cop(struct rpt *myrpt, char *param, char *digitbuf, int command_source, struct rpt_link *mylink)
 {
-	char string[50], fname[50];
+	char string[50], func[100];
 	char paramcopy[500];
 	int argc;
-	FILE *fp;
 	char *argv[101], *cp;
 	int i, j, k, r, src;
 	struct rpt_tele *telem;
@@ -1714,28 +1714,25 @@ int function_cop(struct rpt *myrpt, char *param, char *digitbuf, int command_sou
 			rpt_telemetry(myrpt, COMPLETE, NULL);
 		}
 		return DC_COMPLETE;
-	case 63:					/* send pre-configured APRSTT notification */
-	case 64:
-		if (argc < 2)
-			break;
-		if (!myrpt->p.aprstt)
-			break;
-		if (!myrpt->p.aprstt[0])
-			ast_copy_string(fname, APRSTT_PIPE, sizeof(fname) - 1);
-		else
-			snprintf(fname, sizeof(fname) - 1, APRSTT_SUB_PIPE, myrpt->p.aprstt);
-		fp = fopen(fname, "w");
-		if (!fp) {
-			ast_log(LOG_WARNING, "Can not open APRSTT pipe %s\n", fname);
+	case 63:					/* send pre-configured APRStt notification */
+	case 64:					/* same, but quiet */
+		if (argc < 2) {
 			break;
 		}
-		if (argc > 2)
-			fprintf(fp, "%s %c\n", argv[1], *argv[2]);
-		else
-			fprintf(fp, "%s\n", argv[1]);
-		fclose(fp);
-		if (myatoi(argv[0]) == 63)
-			rpt_telemetry(myrpt, ARB_ALPHA, (void *) argv[1]);
+		
+		if (!ast_custom_function_find("APRS_SENDTT")) {
+			ast_log(LOG_WARNING, "app_gps is not loaded.  APRSTT failed\n");
+		} else {
+			memset(func, 0, sizeof(func));
+			snprintf(func, sizeof(func) -1, "APRS_SENDTT(%s,%c)", !myrpt->p.aprstt ? "general" : myrpt->p.aprstt, 
+				argc > 2 ? argv[2][0] : ' ');
+			/* execute the APRS_SENDTT function in app_gps*/
+			if (!ast_func_write(NULL, func, argv[1])) {
+				if (myatoi(argv[0]) == 63) {
+					rpt_telemetry(myrpt, ARB_ALPHA, (void *) argv[1]);
+				}
+			}
+		} 
 		return DC_COMPLETE;
 	case 65:					/* send POCSAG page */
 		if (argc < 3)

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -1724,7 +1724,6 @@ int function_cop(struct rpt *myrpt, char *param, char *digitbuf, int command_sou
 			ast_log(LOG_WARNING, "app_gps is not loaded.  APRSTT failed\n");
 			return DC_COMPLETE;
 		}
-		memset(func, 0, sizeof(func));
 		snprintf(func, sizeof(func) -1, "APRS_SENDTT(%s,%c)", !myrpt->p.aprstt ? "general" : myrpt->p.aprstt, 
 			argc > 2 ? argv[2][0] : ' ');
 		/* execute the APRS_SENDTT function in app_gps*/

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -1721,7 +1721,7 @@ int function_cop(struct rpt *myrpt, char *param, char *digitbuf, int command_sou
 		}
 		
 		if (!ast_custom_function_find("APRS_SENDTT")) {
-			ast_log(LOG_WARNING, "app_gps is not loaded.  APRSTT failed\n");
+			ast_log(LOG_WARNING, "app_gps is not loaded.  APRStt failed\n");
 			return DC_COMPLETE;
 		}
 		snprintf(func, sizeof(func) -1, "APRS_SENDTT(%s,%c)", !myrpt->p.aprstt ? "general" : myrpt->p.aprstt, 

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -1726,7 +1726,7 @@ int function_cop(struct rpt *myrpt, char *param, char *digitbuf, int command_sou
 		}
 		memset(func, 0, sizeof(func));
 		snprintf(func, sizeof(func) -1, "APRS_SENDTT(%s,%c)", !myrpt->p.aprstt ? "general" : myrpt->p.aprstt, 
-			argc > 2 ? argv[3][0] : ' ');
+			argc > 2 ? argv[2][0] : ' ');
 		/* execute the APRS_SENDTT function in app_gps*/
 		if (!ast_func_write(NULL, func, argv[1])) {
 			if (myatoi(argv[0]) == 63) {

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -2341,7 +2341,7 @@ treataslocal:
 		/* If the app_gps custom function GPS_READ exists, read the GPS position */
 		if (!ast_custom_function_find("GPS_READ")) {
 			break;
-		}				
+		}
 		if (ast_func_read(NULL, "GPS_READ()", gps_data, sizeof(gps_data))) {
 			break;
 		}

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -975,7 +975,7 @@ void *rpt_tele_thread(void *this)
 	int i, j, k, ns, rbimode;
 	char mhz[MAXREMSTR], decimals[MAXREMSTR], mystr[200];
 	float f;
-	unsigned long long u;
+	unsigned long long u_mono, u_epoch;
 	char gps_data[100], lat[25], lon[25], elev[25], c;
 #ifdef	_MDC_ENCODE_H_
 	struct mdcparams *mdcp;
@@ -2347,11 +2347,11 @@ treataslocal:
 			break;
 		}
 
-		if (sscanf(gps_data, "%llu %s %s %s", &u, lat, lon, elev) != 4) {
+		if (sscanf(gps_data, "%llu %llu %s %s %s", &u_mono, &u_epoch, lat, lon, elev) != 5) {
 			break;
 		}
 		
-		was = (time_t) u;
+		was = (time_t) u_epoch;
 		time(&t);
 		if ((was + GPS_VALID_SECS) < t) {
 			break;
@@ -2605,7 +2605,7 @@ void rpt_telemetry(struct rpt *myrpt, int mode, void *data)
 	char lbuf[MAXLINKLIST], *strs[MAXLINKLIST];
 	struct rpt_link *l;
 	time_t t, was;
-	unsigned long long u;
+	unsigned long long u_mono, u_epoch;
 	char gps_data[100], lat[25], lon[25], elev[25];
 	
 	ast_debug(6, "Tracepoint rpt_telemetry() entered mode=%i\n", mode);
@@ -2774,11 +2774,11 @@ void rpt_telemetry(struct rpt *myrpt, int mode, void *data)
 				break;
 			}
 
-			if (sscanf(gps_data, "%llu %s %s %s", &u, lat, lon, elev) != 4) {
+			if (sscanf(gps_data, "%llu %llu %s %s %s", &u_mono, &u_epoch, lat, lon, elev) != 5) {
 				break;
 			}
 
-			was = (time_t) u;
+			was = (time_t) u_epoch;
 			time(&t);
 			if ((was + GPS_VALID_SECS) < t) {
 				break;

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -976,8 +976,7 @@ void *rpt_tele_thread(void *this)
 	char mhz[MAXREMSTR], decimals[MAXREMSTR], mystr[200];
 	float f;
 	unsigned long long u;
-	char gps_data[100];
-	char lat[100], lon[100], elev[100], c;
+	char gps_data[100], lat[25], lon[25], elev[25], c;
 #ifdef	_MDC_ENCODE_H_
 	struct mdcparams *mdcp;
 #endif
@@ -2338,8 +2337,10 @@ treataslocal:
 	case STATS_GPS:
 	case STATS_GPS_LEGACY:
 		
-		/* If the app_gps custom function GPS_READ exists, read the GPS position */
+		/* If the app_gps custom function GPS_READ does not exist, let them know */
 		if (!ast_custom_function_find("GPS_READ")) {
+			saycharstr(mychannel, "GPS");
+			sayfile(mychannel, "rpt/off");
 			break;
 		}
 		if (ast_func_read(NULL, "GPS_READ()", gps_data, sizeof(gps_data))) {
@@ -2605,7 +2606,7 @@ void rpt_telemetry(struct rpt *myrpt, int mode, void *data)
 	struct rpt_link *l;
 	time_t t, was;
 	unsigned long long u;
-	char gps_data[100], lat[100], lon[100], elev[100];
+	char gps_data[100], lat[25], lon[25], elev[25];
 	
 	ast_debug(6, "Tracepoint rpt_telemetry() entered mode=%i\n", mode);
 

--- a/apps/app_rpt/rpt_translate.h
+++ b/apps/app_rpt/rpt_translate.h
@@ -2,5 +2,5 @@
 /*! \brief Translate function */
 char func_xlat(struct rpt *myrpt, char c, struct rpt_xlat *xlat);
 
-/*! \brief Translate characters to APRSTT data */
+/*! \brief Translate APRStt DTMF to a callsign */
 char aprstt_xlat(const char *instr, char *outstr);

--- a/apps/app_rpt/rpt_utils.c
+++ b/apps/app_rpt/rpt_utils.c
@@ -220,3 +220,12 @@ time_t rpt_mktime(struct ast_tm *tm, const char *zone)
 	now = ast_mktime(tm, zone);
 	return now.tv_sec;
 }
+
+time_t rpt_time_monotonic(void)
+{
+	struct timespec ts;
+	
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	
+	return ts.tv_sec;
+}

--- a/apps/app_rpt/rpt_utils.h
+++ b/apps/app_rpt/rpt_utils.h
@@ -66,3 +66,10 @@ long diskavail(struct rpt *myrpt);
 void rpt_localtime(time_t * t, struct ast_tm *lt, const char *tz);
 
 time_t rpt_mktime(struct ast_tm *tm, const char *zone);
+
+/*!
+ * \brief Get system monotonic 
+ * This returns the CLOCK_MONOTONIC time
+ * \retval		Monotonic seconds.
+ */
+time_t rpt_time_monotonic(void);

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -3340,7 +3340,7 @@ static void *el_reader(void *data)
 			if (sin_aprs.sin_port) {	/* a zero port indicates that we never resolved the host name */
 				char aprsstr[512], aprscall[256], gps_data[100], latc, lonc;
 				unsigned char sdes_packet[256];
-				unsigned long long u;
+				unsigned long long u_mono, u_epoch;
 				float lata, lona, latb, lonb, latd, lond, lat, lon, mylat, mylon;
 				int sdes_length, from_GPS = 0;
 				struct el_node_count count;
@@ -3364,8 +3364,8 @@ static void *el_reader(void *data)
 				mylat = instp->lat;
 				mylon = instp->lon;
 				if (ast_custom_function_find("GPS_READ") && !ast_func_read(NULL, "GPS_READ()", gps_data, sizeof(gps_data))) {
-					if (sscanf(gps_data, "%llu %f%c %f%c", &u, &lat, &latc, &lon, &lonc) == 5) {
-						was = (time_t) u;
+					if (sscanf(gps_data, "%llu %llu %f%c %f%c", &u_mono, &u_epoch, &lat, &latc, &lon, &lonc) == 6) {
+						was = (time_t) u_epoch;
 						if ((was + GPS_VALID_SECS) >= now) {
 							mylat = floor(lat / 100.0);
 							mylat += (lat - (mylat * 100)) / 60.0;

--- a/configs/rpt/gps.conf
+++ b/configs/rpt/gps.conf
@@ -1,35 +1,90 @@
+;
 ; Configuration for app_gps
 ;
 [general]
-; See https://wiki.allstarlink.org/wiki/Gps.conf
-call = W1AW-1               ; callsign (including SSID) for APRS purposes
+call = W1AW-1               ; callsign (including SSID) for APRS 
+							; SSID can be 2 characters.  1 to 15 org
+							; combinations of alpha-numeric characters.
 password = 12345            ; Password for APRS-IS server for above callsign
-comment = AllStar Node 1999 ; Text to be displayed associated with this station
-server = rotate.aprs2.net   ; APRS-IS server to report information to
-port = 14580                ; port on server to send data
+                            ; Generate at https://n5dux.com/ham/aprs-passcode/ 
+comment = AllStar Node 1999 ; Text to be displayed for this station
+							; To include frequency, tone and offset - use the following format for comment
+							; 145.000MHz T146 -060, AllStar Node 1999
+server = rotate.aprs2.net   ; APRS-IS server to report information
+                            ;  Worldwide: rotate.aprs2.net  (this the default server if not specified)
+                            ;  North America: noam.aprs2.net
+                            ;  South America: soam.aprs2.net
+                            ;  Europe/Africa: euro.aprs2.net
+                            ;  Asia: asia.aprs2.net
+                            ;  Oceania: aunz.aprs2.net
+							;  Global Hamnet: aprs.hc.r1.ampr.org
+port = 14580                ; port on APRS-IS server to send data
 interval = 600              ; Beacon interval in seconds
-icon = r                    ; A CAR (default) Icon to be displayed for station on APRS display
+                            ;  Mobile 60 to 120, infrastructure 1200, fixed base 1800
+icontable = /				; The icon table to use '/' (primary) or '\' (alternate).  See the below symbol link.
+icon = -                    ; A House (default) Icon to be displayed for station on APRS 
+                            ;  See http://www.aprs.org/symbols.html
 comport = /dev/ttyS0        ; Serial port for GPS receiver (specify this only if using GPS receiver)
-baudrate = 4800             ; Baud rate for GPS receiver (specify this only if using GPS receiver)
-debug = n                   ; set this for debug output
+baudrate = 4800             ; Baud rate for GPS receiver (specify this only if using GPS receiver), default 4800
 freq = 145.000              ; Display Frequency of station
-tone = 100.0                ; CTCSS tone of station (0.0 for none)
-lat = 12.3456               ; Fixed (default) latitude in decimal degrees
-lon = -123.4567             ; Fixed (default) longitude in decimal degrees
+tone = 100.0                ; CTCSS tone of station (0.0 for none) 
+lat = 12.3456               ; Fixed latitude in decimal degrees (positive for North, negative for South)
+lon = -123.4567             ; Fixed longitude in decimal degrees (positive for East, negative for West)
 elev = 123.4                ; Elevation of Antenna in Meters (*NOT* HAAT)
-power = 1                   ; Power level
-height = 2                  ; Antenna Height in HAAT
-gain = 3                    ; Antenna Gain
-dir = 0                     ; Antenna Direction
+power = 1                   ; Power level 0 to 9 - see http://www.aprs.org/aprsdos-pix/phg.txt for power, height, gain, and dir settings
+height = 2                  ; Antenna Height in HAAT 0 to 9
+gain = 3                    ; Antenna Gain 0 to 9
+dir = 0                     ; Antenna Direction 0 to 9
 
-; ehlert =
-; interval =
-; ttcomment =
-; ttlat =
-; ttlist =
-; ttlon =
-; ttoffset =
-; ttsplit =
+; ehlert =                    ; Set this to true to disable the use of the default latitude/longitude
+;
+; These settings are for APRStt (touch tone) mode.  APRStt must be enabled in rpt.conf
+;
+; ttcomment =                 ; Text to be displayed associated with this TT station
+; ttlat =                     ; Fixed latitude in decimal degrees - if not specified 'lat' is used for the default
+; ttlon =                     ; Fixed longitude in decimal degrees - if not specified 'lon' is used for the default
+; ttelev =                    ; Elevation of Antenna in Meters (*NOT* HAAT) - if not specified 'elev' is used for the default
+; ttlist =                    ; Number of touch tone entries to maintain.  Default is 10.
+; ttoffset =                  ; TT Offset from main lat/lon value. Default is 10.
+; ttsplit =                   ; yes = center reports around lat/lon origin, no = (default) only use ttoffset
+
+;
+;add additional stanzas for nodes that are not located at the same position as [general]
+;app_rpt's aprstt setting can also use these additional stanzas
+;
+;[1999]
+;call = W1AW-1              ; callsign (including SSID) for APRS 
+ 							; SSID can be 2 characters.  1 to 15 org
+							; combinations of alpha-numeric characters.
+;password = 12345           ; Password for APRS-IS server for above callsign
+                            ; Generate at https://n5dux.com/ham/aprs-passcode/ 
+;comment = AllStar Node 1999 ; Text to be displayed for this station
+;interval = 600             ; Beacon interval in seconds
+                            ;  Mobile 60 to 120, infrastructure 1200, fixed base 1800
+;icontable = /				; The icon table to use '/' (primary) or '\' (alternate).  See the below symbol link.
+;icon = -                   ; A House (default) Icon to be displayed for station on APRS 
+                            ;  See http://www.aprs.org/symbols.html
+;freq = 145.000             ; Display Frequency of station
+;tone = 100.0               ; CTCSS tone of station (0.0 for none) 
+;lat = 12.3456              ; Fixed latitude in decimal degrees (positive for North, negative for South)
+;lon = -123.4567            ; Fixed longitude in decimal degrees (positive for East, negative for West)
+;elev = 123.4               ; Elevation of Antenna in Meters (*NOT* HAAT)
+;power = 1                  ; Power level 0 to 9 - see http://www.aprs.org/aprsdos-pix/phg.txt for power, height, gain, and dir settings
+;height = 2                 ; Antenna Height in HAAT 0 to 9
+;gain = 3                   ; Antenna Gain 0 to 9
+;dir = 0                    ; Antenna Direction 0 to 9
+
+; ehlert =                    ; Set this to true to disable the use of the default latitude/longitude
+;
+; These settings are for APRStt (touch tone) mode.  APRStt must be enabled in rpt.conf
+;
+; ttcomment =                 ; Text to be displayed associated with this TT station
+; ttlat =                     ; Fixed latitude in decimal degrees - if not specified 'lat' is used for the default
+; ttlon =                     ; Fixed longitude in decimal degrees - if not specified 'lon' is used for the default
+; ttelev =                    ; Elevation of Antenna in Meters (*NOT* HAAT) - if not specified 'elev' is used for the default
+; ttlist =                    ; Number of touch tone entries to maintain.  Default is 10.
+; ttoffset =                  ; TT Offset from main lat/lon value. Default is 10.
+; ttsplit =                   ; yes = center reports around lat/lon origin, no = (default) only use ttoffset
 
 #tryinclude custom/gps.conf
 

--- a/configs/rpt/gps.conf
+++ b/configs/rpt/gps.conf
@@ -37,13 +37,18 @@ icon = -                    ; A House (default) Icon to be displayed for station
                             ;  See http://www.aprs.org/symbols.html
 freq = 145.000              ; Display Frequency of station
 tone = 100.0                ; CTCSS tone of station (0.0 for none) 
-lat = 12.3456               ; Fixed latitude in decimal degrees (positive for North, negative for South)
-lon = -123.4567             ; Fixed longitude in decimal degrees (positive for East, negative for West)
-elev = 123.4                ; Elevation of Antenna in Meters (*NOT* HAAT)
 power = 1                   ; Power level 0 to 9 - see http://www.aprs.org/aprsdos-pix/phg.txt for power, height, gain, and dir settings
 height = 2                  ; Antenna Height in HAAT 0 to 9
 gain = 3                    ; Antenna Gain 0 to 9
 dir = 0                     ; Antenna Direction 0 to 9
+;
+;lat, lon, elev should be populated if you are not using a GPS device.
+;When you use a GPS device, these defaults are used when the GPS cannot lock to a satellite.
+;In the event that you do not want to use these defaults when using GPS, set the ehlert option to yes or true.
+;
+lat = 12.3456               ; Fixed latitude in decimal degrees (positive for North, negative for South)
+lon = -123.4567             ; Fixed longitude in decimal degrees (positive for East, negative for West)
+elev = 123.4                ; Elevation of Antenna in Meters (*NOT* HAAT)
 
 ; ehlert =                    ; Set this to true to disable the use of the default latitude/longitude
 ;
@@ -78,13 +83,18 @@ dir = 0                     ; Antenna Direction 0 to 9
                             ;  See http://www.aprs.org/symbols.html
 ;freq = 145.000             ; Display Frequency of station
 ;tone = 100.0               ; CTCSS tone of station (0.0 for none) 
-;lat = 12.3456              ; Fixed latitude in decimal degrees (positive for North, negative for South)
-;lon = -123.4567            ; Fixed longitude in decimal degrees (positive for East, negative for West)
-;elev = 123.4               ; Elevation of Antenna in Meters (*NOT* HAAT)
 ;power = 1                  ; Power level 0 to 9 - see http://www.aprs.org/aprsdos-pix/phg.txt for power, height, gain, and dir settings
 ;height = 2                 ; Antenna Height in HAAT 0 to 9
 ;gain = 3                   ; Antenna Gain 0 to 9
 ;dir = 0                    ; Antenna Direction 0 to 9
+;
+;lat, lon, elev should be populated if you are not using a GPS device.
+;When you use a GPS device, these defaults are used when the GPS cannot lock to a satellite.
+;In the event that you do not want to use these defaults when using GPS, set the ehlert option to yes or true.
+;
+;lat = 12.3456              ; Fixed latitude in decimal degrees (positive for North, negative for South)
+;lon = -123.4567            ; Fixed longitude in decimal degrees (positive for East, negative for West)
+;elev = 123.4               ; Elevation of Antenna in Meters (*NOT* HAAT)
 
 ; ehlert =                    ; Set this to true to disable the use of the default latitude/longitude
 ;

--- a/configs/rpt/gps.conf
+++ b/configs/rpt/gps.conf
@@ -2,14 +2,11 @@
 ; Configuration for app_gps
 ;
 [general]
-call = W1AW-1               ; callsign (including SSID) for APRS 
+call = INVALID-1            ; callsign (including SSID) for APRS - Change this!
 							; SSID can be 2 characters.  1 to 15 org
 							; combinations of alpha-numeric characters.
 password = 12345            ; Password for APRS-IS server for above callsign
                             ; Generate at https://n5dux.com/ham/aprs-passcode/ 
-comment = AllStar Node 1999 ; Text to be displayed for this station
-							; To include frequency, tone and offset - use the following format for comment
-							; 145.000MHz T146 -060, AllStar Node 1999
 server = rotate.aprs2.net   ; APRS-IS server to report information
                             ;  Worldwide: rotate.aprs2.net  (this the default server if not specified)
                             ;  North America: noam.aprs2.net
@@ -21,6 +18,9 @@ server = rotate.aprs2.net   ; APRS-IS server to report information
 port = 14580                ; port on APRS-IS server to send data
 interval = 600              ; Beacon interval in seconds
                             ;  Mobile 60 to 120, infrastructure 1200, fixed base 1800
+comment = AllStar Node 1999 ; Text to be displayed for this station
+							; To include frequency, tone and offset - use the following format for comment
+							; 145.000MHz T146 -060, AllStar Node 1999
 icontable = /				; The icon table to use '/' (primary) or '\' (alternate).  See the below symbol link.
 icon = -                    ; A House (default) Icon to be displayed for station on APRS 
                             ;  See http://www.aprs.org/symbols.html
@@ -53,14 +53,16 @@ dir = 0                     ; Antenna Direction 0 to 9
 ;app_rpt's aprstt setting can also use these additional stanzas
 ;
 ;[1999]
-;call = W1AW-1              ; callsign (including SSID) for APRS 
+;call = INVALID-1           ; callsign (including SSID) for APRS - Change this!
  							; SSID can be 2 characters.  1 to 15 org
 							; combinations of alpha-numeric characters.
 ;password = 12345           ; Password for APRS-IS server for above callsign
                             ; Generate at https://n5dux.com/ham/aprs-passcode/ 
-;comment = AllStar Node 1999 ; Text to be displayed for this station
 ;interval = 600             ; Beacon interval in seconds
                             ;  Mobile 60 to 120, infrastructure 1200, fixed base 1800
+;comment = AllStar Node 1999 ; Text to be displayed for this station
+							; To include frequency, tone and offset - use the following format for comment
+							; 145.000MHz T146 -060, AllStar Node 1999
 ;icontable = /				; The icon table to use '/' (primary) or '\' (alternate).  See the below symbol link.
 ;icon = -                   ; A House (default) Icon to be displayed for station on APRS 
                             ;  See http://www.aprs.org/symbols.html

--- a/configs/rpt/gps.conf
+++ b/configs/rpt/gps.conf
@@ -1,112 +1,111 @@
 ;
 ; Configuration for app_gps
 ;
-[general]
+[general](!)
+
 ;
-;settings for the GPS device
+; settings for the GPS device
 ;
 comport = /dev/ttyS0        ; Serial port for GPS receiver (specify this only if using GPS receiver)
 baudrate = 4800             ; Baud rate for GPS receiver (specify this only if using GPS receiver), default 4800
+
 ;
-;settings for the APRS-IS server
+; settings for the APRS-IS server
 ;
-call = INVALID-1            ; callsign (including SSID) for APRS - Change this!
-							; SSID can be 2 characters.  1 to 15 org
-							; combinations of alpha-numeric characters.
-password = 12345            ; Password for APRS-IS server for above callsign
-                            ; Generate at https://n5dux.com/ham/aprs-passcode/ 
-server = rotate.aprs2.net   ; APRS-IS server to report information
-                            ;  Worldwide: rotate.aprs2.net  (this the default server if not specified)
-                            ;  North America: noam.aprs2.net
-                            ;  South America: soam.aprs2.net
-                            ;  Europe/Africa: euro.aprs2.net
-                            ;  Asia: asia.aprs2.net
-                            ;  Oceania: aunz.aprs2.net
-							;  Global Hamnet: aprs.hc.r1.ampr.org
-port = 14580                ; port on APRS-IS server to send data
-interval = 600              ; Beacon interval in seconds
-                            ;  Mobile 60 to 120, infrastructure 1200, fixed base 1800
+
+; The APRS-IS callsign (including SSID) for APRS. Additional
+; information on the callsign/SSID format can be found at
+; https://www.aprs-is.net/Connecting.aspx
+call = INVALID              ; Change this!
+
+; The computed APRS-IS password for the above callsign.  You can
+; generate the password at https://n5dux.com/ham/aprs-passcode
 ;
-;settings for the APRS position report
+password = INVALID          ; Change this!
+
+; The APRS-IS server to report information
+;   Worldwide: rotate.aprs2.net  (this the default server if not specified)
+;   North America: noam.aprs2.net
+;   South America: soam.aprs2.net
+;   Europe/Africa: euro.aprs2.net
+;   Asia: asia.aprs2.net
+;   Oceania: aunz.aprs2.net
+;   Global Hamnet: aprs.hc.r1.ampr.org
+server = rotate.aprs2.net
+
+; The APRS-IS port on server to send data
+port = 14580
+
+; Beacon interval in seconds
+;   Mobile 60 to 120, infrastructure 1200, fixed base 1800
+interval = 600
+
 ;
-comment = AllStar Node 1999 ; Text to be displayed for this station
-							; To include frequency, tone and offset - use the following format for comment
-							; 145.000MHz T146 -060, AllStar Node 1999
-icontable = /				; The icon table to use '/' (primary) or '\' (alternate).  See the below symbol link.
-icon = -                    ; A House (default) Icon to be displayed for station on APRS 
+; settings for the APRS position report
+;
+comment = AllStar Node      ; Text to be displayed for this station
+                            ; To include frequency, tone and offset, the comment should use the following format:
+                            ;   145.000MHz T146 -060, AllStar Node 1999
+icontable = /               ; The icon table to use '/' (primary) or '\' (alternate).  See the below symbol link.
+icon = -                    ; A House (default) Icon to be displayed for station on APRS
                             ;  See http://www.aprs.org/symbols.html
-freq = 145.000              ; Display Frequency of station
-tone = 100.0                ; CTCSS tone of station (0.0 for none) 
-power = 1                   ; Power level 0 to 9 - see http://www.aprs.org/aprsdos-pix/phg.txt for power, height, gain, and dir settings
+
+;
+; station information
+;   see http://www.aprs.org/aprsdos-pix/phg.txt for power, height, gain, and dir settings
+;
+freq = 145.000              ; Display frequency of station
+tone = 100.0                ; CTCSS tone of station (0.0 for none)
+power = 1                   ; Power level 0 to 9
 height = 2                  ; Antenna Height in HAAT 0 to 9
 gain = 3                    ; Antenna Gain 0 to 9
 dir = 0                     ; Antenna Direction 0 to 9
+
 ;
-;lat, lon, elev should be populated if you are not using a GPS device.
-;When you use a GPS device, these defaults are used when the GPS cannot lock to a satellite.
-;In the event that you do not want to use these defaults when using GPS, set the ehlert option to yes or true.
+; station location information
+;   lat, lon, elev should be populated if you are not using a GPS device.
+;
+;   Note: when you use a GPS device, these values will be used when
+;         the GPS cannot lock to a satellite.  Set "ehlert = yes" if
+;         you do not want to use these defaults when using GPS.
 ;
 lat = 12.3456               ; Fixed latitude in decimal degrees (positive for North, negative for South)
 lon = -123.4567             ; Fixed longitude in decimal degrees (positive for East, negative for West)
 elev = 123.4                ; Elevation of Antenna in Meters (*NOT* HAAT)
-
-; ehlert =                    ; Set this to true to disable the use of the default latitude/longitude
-;
-; These settings are for APRStt (touch tone) mode.  APRStt must be enabled in rpt.conf
-;
-; ttcomment =                 ; Text to be displayed associated with this TT station
-; ttlat =                     ; Fixed latitude in decimal degrees - if not specified 'lat' is used for the default
-; ttlon =                     ; Fixed longitude in decimal degrees - if not specified 'lon' is used for the default
-; ttelev =                    ; Elevation of Antenna in Meters (*NOT* HAAT) - if not specified 'elev' is used for the default
-; ttlist =                    ; Number of touch tone entries to maintain.  Default is 10.
-; ttoffset =                  ; TT Offset from main lat/lon value. Default is 10.
-; ttsplit =                   ; yes = center reports around lat/lon origin, no = (default) only use ttoffset
+;ehlert = yes               ; Set this to true to disable the use of the default latitude/longitude
 
 ;
-;add additional stanzas for nodes that are not located at the same position as [general]
-;app_rpt's aprstt setting can also use these additional stanzas
+; settings are for APRStt (touch tone) mode.  APRStt must be enabled in rpt.conf
 ;
-;[1999]
-;call = INVALID-1           ; callsign (including SSID) for APRS - Change this!
- 							; SSID can be 2 characters.  1 to 15 org
-							; combinations of alpha-numeric characters.
-;interval = 600             ; Beacon interval in seconds
-                            ;  Mobile 60 to 120, infrastructure 1200, fixed base 1800
-;
-;settings for the APRS position report
-;
-;comment = AllStar Node 1999 ; Text to be displayed for this station
-							; To include frequency, tone and offset - use the following format for comment
-							; 145.000MHz T146 -060, AllStar Node 1999
-;icontable = /				; The icon table to use '/' (primary) or '\' (alternate).  See the below symbol link.
-;icon = -                   ; A House (default) Icon to be displayed for station on APRS 
-                            ;  See http://www.aprs.org/symbols.html
-;freq = 145.000             ; Display Frequency of station
-;tone = 100.0               ; CTCSS tone of station (0.0 for none) 
-;power = 1                  ; Power level 0 to 9 - see http://www.aprs.org/aprsdos-pix/phg.txt for power, height, gain, and dir settings
-;height = 2                 ; Antenna Height in HAAT 0 to 9
-;gain = 3                   ; Antenna Gain 0 to 9
-;dir = 0                    ; Antenna Direction 0 to 9
-;
-;lat, lon, elev should be populated if you are not using a GPS device.
-;When you use a GPS device, these defaults are used when the GPS cannot lock to a satellite.
-;In the event that you do not want to use these defaults when using GPS, set the ehlert option to yes or true.
-;
-;lat = 12.3456              ; Fixed latitude in decimal degrees (positive for North, negative for South)
-;lon = -123.4567            ; Fixed longitude in decimal degrees (positive for East, negative for West)
-;elev = 123.4               ; Elevation of Antenna in Meters (*NOT* HAAT)
+;ttcomment =                 ; Text to be displayed associated with this TT station
+;ttlat =                     ; Fixed latitude in decimal degrees - if not specified 'lat' is used for the default
+;ttlon =                     ; Fixed longitude in decimal degrees - if not specified 'lon' is used for the default
+;ttelev =                    ; Elevation of Antenna in Meters (*NOT* HAAT) - if not specified 'elev' is used for the default
+;ttlist =                    ; Number of touch tone entries to maintain.  Default is 10.
+;ttoffset =                  ; TT Offset from main lat/lon value. Default is 10.
+;ttsplit =                   ; yes = center reports around lat/lon origin, no = (default) only use ttoffset
 
-; ehlert =                    ; Set this to true to disable the use of the default latitude/longitude
 ;
-; These settings are for APRStt (touch tone) mode.  APRStt must be enabled in rpt.conf
+; If you need per-node APRS customizations you can use a template-based
+; configuration.  The steps are simple.
 ;
-; ttcomment =                 ; Text to be displayed associated with this TT station
-; ttlat =                     ; Fixed latitude in decimal degrees - if not specified 'lat' is used for the default
-; ttlon =                     ; Fixed longitude in decimal degrees - if not specified 'lon' is used for the default
-; ttelev =                    ; Elevation of Antenna in Meters (*NOT* HAAT) - if not specified 'elev' is used for the default
-; ttlist =                    ; Number of touch tone entries to maintain.  Default is 10.
-; ttoffset =                  ; TT Offset from main lat/lon value. Default is 10.
-; ttsplit =                   ; yes = center reports around lat/lon origin, no = (default) only use ttoffset
+; 1. in your "rpt.conf" file you would update the per-node configuration
+;    to look like :
+;
+;    [1999](node-main)
+;    aprstt = 1999            <--- Add this line to "rpt.conf"
+;    ...
+;
+; 2. Uncomment and customize the following section in this file with
+;    the per-node changes.
+;
+; Note: the per-node section below starts off with (inherits) all of the
+;       settings from the "general" section and then adds/updates settings
+;       with new/updated values.
+;
+;[1999](general)
+;comment = AllStar Node 1999 ; per-node setting
+;freq = 432.100              ; per-node-setting
 
 #tryinclude custom/gps.conf
 

--- a/configs/rpt/gps.conf
+++ b/configs/rpt/gps.conf
@@ -2,6 +2,14 @@
 ; Configuration for app_gps
 ;
 [general]
+;
+;settings for the GPS device
+;
+comport = /dev/ttyS0        ; Serial port for GPS receiver (specify this only if using GPS receiver)
+baudrate = 4800             ; Baud rate for GPS receiver (specify this only if using GPS receiver), default 4800
+;
+;settings for the APRS-IS server
+;
 call = INVALID-1            ; callsign (including SSID) for APRS - Change this!
 							; SSID can be 2 characters.  1 to 15 org
 							; combinations of alpha-numeric characters.
@@ -18,14 +26,15 @@ server = rotate.aprs2.net   ; APRS-IS server to report information
 port = 14580                ; port on APRS-IS server to send data
 interval = 600              ; Beacon interval in seconds
                             ;  Mobile 60 to 120, infrastructure 1200, fixed base 1800
+;
+;settings for the APRS position report
+;
 comment = AllStar Node 1999 ; Text to be displayed for this station
 							; To include frequency, tone and offset - use the following format for comment
 							; 145.000MHz T146 -060, AllStar Node 1999
 icontable = /				; The icon table to use '/' (primary) or '\' (alternate).  See the below symbol link.
 icon = -                    ; A House (default) Icon to be displayed for station on APRS 
                             ;  See http://www.aprs.org/symbols.html
-comport = /dev/ttyS0        ; Serial port for GPS receiver (specify this only if using GPS receiver)
-baudrate = 4800             ; Baud rate for GPS receiver (specify this only if using GPS receiver), default 4800
 freq = 145.000              ; Display Frequency of station
 tone = 100.0                ; CTCSS tone of station (0.0 for none) 
 lat = 12.3456               ; Fixed latitude in decimal degrees (positive for North, negative for South)
@@ -56,10 +65,11 @@ dir = 0                     ; Antenna Direction 0 to 9
 ;call = INVALID-1           ; callsign (including SSID) for APRS - Change this!
  							; SSID can be 2 characters.  1 to 15 org
 							; combinations of alpha-numeric characters.
-;password = 12345           ; Password for APRS-IS server for above callsign
-                            ; Generate at https://n5dux.com/ham/aprs-passcode/ 
 ;interval = 600             ; Beacon interval in seconds
                             ;  Mobile 60 to 120, infrastructure 1200, fixed base 1800
+;
+;settings for the APRS position report
+;
 ;comment = AllStar Node 1999 ; Text to be displayed for this station
 							; To include frequency, tone and offset - use the following format for comment
 							; 145.000MHz T146 -060, AllStar Node 1999

--- a/configs/rpt/rpt.conf
+++ b/configs/rpt/rpt.conf
@@ -180,6 +180,9 @@ parrottime = 1000                   ; Set the amount of time in milliseconds
 
 ;nodenames = /var/lib/asterisk/sounds/rpt/nodenames.callsign  ; Point to alternate nodename sound directory
 
+;aprstt = general					; To enable APRStt, set this value to the stanza to use in gps.conf
+									; module app_gps.so will need to be enabled
+
 ; *** Status Reporting ***
 ; Uncomment the statpost line to report the status of your node to stats.allstarlink.org
 ;statpost_url = http://stats.allstarlink.org/uhandler ; Status updates
@@ -391,8 +394,8 @@ rxchannel = SimpleUSB/1999      ; SimpleUSB
 ; 961 = cop,61                      ; Send Message to USB to control GPIO pins (cop,61,GPIO1=0[,GPIO4=1].....)
 ; 962 = cop,62                      ; Send Message to USB to control GPIO pins, quietly (cop,62,GPIO1=0[,GPIO4=1].....)
 
-; 963 = cop,63                      ; Send pre-configred APRSTT notification (cop,63,CALL[,OVERLAYCHR])
-; 964 = cop,64                      ; Send pre-configred APRSTT notification, quietly (cop,64,CALL[,OVERLAYCHR])
+; 963 = cop,63                      ; Send pre-configred APRStt notification (cop,63,CALL[,OVERLAYCHR])
+; 964 = cop,64                      ; Send pre-configred APRStt notification, quietly (cop,64,CALL[,OVERLAYCHR])
 ; 965 = cop,65                      ; Send POCSAG page (equipped channel types only)
 
 ; [functions-remote]


### PR DESCRIPTION
This updates app_gps with the following changes:

Update the code to use the asterisk coding guidelines. Added documentation to all functions.
Added documentation to gps.conf.
Added functions: GPS_READ and APRS_SENDTT.
Added the cli command gps status.
Added the ability to select the primary or alternate symbol table. Replaced depreciated ast_gethostbyname.
Addressed issues with module unload not completing timely.

GPS_READ() function replaces the need to create the gps.dat file stored in the /tmp directory.  The application previously wrote to the disk once per second, which included a system call to rename a temporary file.

app_rpt and chan_echolink have been updated to use GPS_READ to retrieve the gps data, instead of reading a data file.

APRS_SENDTT(stanza, overlay) = callsign, function replaces the pipe that was used by app_rpt to send APRStt requests to app_gps.

APSTAR is now used as the tocall for both APRS an APRStt posts.  This is being registered as the tocall for AllStar Link.

If elevation is available, it is included in the APRS post.

The cli command 'gps status' will allow the user to check the status of the attached GPS device.  It tells the user if the GPS device is connected, if it is locked to the satellites, and the current and default position.

The unlocked warning message is now only printed when it first occurs. The message is turned back on when we receive a lock on the satellite.

The gps.conf file now has an entry for icontable.  The default is '\' primary or '/' for the alternate symbol table.

For APRStt to work, the aprstt entry in app_rpt needs to be enabled.  That option has been added to rtp.conf and commented out.

There were a number of refinements to the code, along with fixes for memory leaks.