### PR TITLE
REPO: Add devcontainer configuration

### DIFF
--- a/.dev/pre-commit
+++ b/.dev/pre-commit
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+# An example hook script to verify what is about to be committed.
+# Called by "git commit" with no arguments.  The hook should
+# exit with non-zero status after issuing an appropriate message if
+# it wants to stop the commit.
+#
+# To enable this hook, rename this file to "pre-commit".
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=$(git hash-object -t tree /dev/null)
+fi
+
+# Test clang-format
+clangformatout=$(git clang-format --style=file:./.dev/.clang-format --staged -q)
+
+# Redirect output to stderr.
+exec 1>&2
+
+if [ "$clangformatout" != "" ]
+then
+    echo "Format error!"
+    echo "Use git clang-format"
+    exit 1
+fi
+
+codespell=$(codespell --skip "./.git" --ignore-words ./.dev/.codespellignore --write-changes)
+
+exec 1>&2
+
+if [ "$codespell" != "" ]
+then
+   echo "Spelling errors!"
+   echo "Run codespell"
+   echo $codespell
+   exit 1
+fi
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,14 +3,17 @@
   "image": "mcr.microsoft.com/devcontainers/cpp:dev-debian12",
   "remoteUser": "root",
   "postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
-  "postStartCommand": "git config --global core.hooksPath ${containerWorkspaceFolder}/.dev/ && git clone https://github.com/AllStarLink/asl3-asterisk.git ${containerWorkspaceFolder}/asl3-asterisk && cd ${containerWorkspaceFolder} && ./asl3-asterisk/build-asl3 -l -a 22 -v 3.3.0 -r 1 -d ${containerWorkspaceFolder} source ",
+  "postStartCommand": "git config --global core.hooksPath ${containerWorkspaceFolder}/.dev/ && \
+        git clone https://github.com/AllStarLink/asl3-asterisk.git ${containerWorkspaceFolder}/asl3-asterisk && \
+        cd ${containerWorkspaceFolder} && \
+        ./asl3-asterisk/build-asl3 -l -a 22 -v 3.3.0 -r 1 -d ${containerWorkspaceFolder} source ",
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
       "packages": "codespell,clang-format,libedit-dev,uuid-dev,libjansson-dev,libsqlite3-dev,libusb-dev"
     }
   },
-  "customizations": {
+  git "customizations": {
     "vscode": {
       "extensions": [
         "redhat.vscode-yaml",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,8 @@
 {
   "name": "allStarLink Dev",
-  "image": "ghcr.io/allstarlink/asl3-asterisk-ci",
+  "image": "ghcr.io/allstarlink/asl3-asterisk-ci:latest",
   "remoteUser": "root",
-  "postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
+  "postCreateCommand": "git config --global --add safe.directory '*'",
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+{
+  "name": "allStarLink Dev",
+  "image": "mcr.microsoft.com/devcontainers/cpp:dev-debian12",
+  "remoteUser": "root",
+  "postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
+  "postStartCommand": "git config --global core.hooksPath ${containerWorkspaceFolder}/.dev/ && git clone https://github.com/AllStarLink/asl3-asterisk.git ${containerWorkspaceFolder}/asl3-asterisk && cd ${containerWorkspaceFolder} && ./asl3-asterisk/build-asl3 -l -a 22 -v 3.3.0 -r 1 -d ${containerWorkspaceFolder} source ",
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+      "packages": "codespell,clang-format,libedit-dev,uuid-dev,libjansson-dev,libsqlite3-dev,libusb-dev"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "redhat.vscode-yaml",
+        "esbenp.prettier-vscode",
+        "ms-vscode.cpptools-extension-pack",
+        "GitHub.vscode-pull-request-github",
+        "GitHub.copilot",
+        "GitHub.copilot-chat",
+        "github.vscode-github-actions"
+      ],
+      "settings": {
+        "editor.formatOnPaste": false,
+        "editor.formatOnSave": true,
+        "editor.formatOnType": true,
+        "files.trimTrailingWhitespace": true,
+        "C_Cpp.default.includePath": [
+          "/workspaces/asterisk/include"
+        ],
+        "terminal.integrated.profiles.linux": {
+          "zsh": {
+            "path": "/usr/bin/zsh"
+          }
+        },
+        "terminal.integrated.defaultProfile.linux": "zsh"
+      }
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,19 +1,15 @@
 {
   "name": "allStarLink Dev",
-  "image": "mcr.microsoft.com/devcontainers/cpp:dev-debian12",
+  "image": "ghcr.io/allstarlink/asl3-asterisk-ci",
   "remoteUser": "root",
   "postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
-  "postStartCommand": "git config --global core.hooksPath ${containerWorkspaceFolder}/.dev/ && \
-        git clone https://github.com/AllStarLink/asl3-asterisk.git ${containerWorkspaceFolder}/asl3-asterisk && \
-        cd ${containerWorkspaceFolder} && \
-        ./asl3-asterisk/build-asl3 -l -a 22 -v 3.3.0 -r 1 -d ${containerWorkspaceFolder} source ",
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
       "packages": "codespell,clang-format,libedit-dev,uuid-dev,libjansson-dev,libsqlite3-dev,libusb-dev"
     }
   },
-  git "customizations": {
+  "customizations": {
     "vscode": {
       "extensions": [
         "redhat.vscode-yaml",


### PR DESCRIPTION
This commit allows for a codespace to be created with pre-configured commit hooks as well as installing codespell, and clang-format in the container.  
We will need https://github.com/AllStarLink/app_rpt/pull/463 and https://github.com/AllStarLink/app_rpt/pull/466 merged before the pre-commit hook will work properly.