### PR TITLE
modules.conf: update for Asterisk 22.x.x

### DIFF
--- a/configs/rpt/modules.conf
+++ b/configs/rpt/modules.conf
@@ -1,132 +1,60 @@
 ;
-; Asterisk configuration file
+; Asterisk module loading configuration file
 ;
-; Module Loader configuration file
-;
-; By default DIAL does NOT load every module, only what is needed
 
+;
 ; You can enable or disable any of the asterisk modules
-; All modules are compiled and installed.
+;
+; To enable a module, use  : load = module_name.so
+; To disable a module, use : noload = module_name.so
+;
 
-; To enable a module: load => module_name.so
-; To disable a module: noload => module_name.so
-
-; You will want to enable the channel driver modules you will be using.
-; There are below in the Channel Driver section
-; The most common Channel drivers for app_rpt are:
-; chan_echolink.so   echolink channel driver
-; chan_simpleusb.so  Simple USB Radio Interface Channel Drive
-; chan_usbradio.so   USB Console Channel Driver
-; chan_usrp.so       USRP Channel Module
-; chan_voter.so      radio Voter channel driver
+;
+; For ASL (app_rpt), you need to enable the channel driver modules you will
+; be using. You will find the modules in the "Channel Driver" section, below.
+;
+; The most common ASL (app_rpt) channel drivers are:
+;
+;   chan_dahdi.so      DAHDI Telephony
+;   chan_echolink.so   Echolink Channel Driver
+;   chan_simpleusb.so  Simple USB Radio Interface Channel Driver
+;   chan_usbradio.so   USB Console Channel Driver
+;   chan_usrp.so       USRP Channel Module
+;   chan_voter.so      Voter Radio Channel Driver
+;
 
 [modules]
-autoload=no
+autoload = no
 
-;load => func_frame_trace            ; Debug
+;load = func_frame_trace                ; Debug
 
 ; Applications
-noload => app_adsiprog.so           ; Asterisk ADSI Programming Application
-noload => app_alarmreceiver.so      ; Alarm Receiver for Asterisk
-noload => app_amd.so                ; Answering Machine Detection Application
-load => app_authenticate.so         ; Authentication Application
-noload => app_cdr.so                ; Tell Asterisk to not maintain a CDR for
-noload => app_chanisavail.so        ; Check channel availability
-noload => app_channelredirect.so    ; Channel Redirect
-noload => app_chanspy.so            ; Listen to the audio of an active channel
-noload => app_controlplayback.so    ; Control Playback Application
-noload => app_dahdibarge.so         ; Barge in on channel application
-noload => app_dahdiras.so           ; DAHDI RAS Application
-noload => app_dahdiscan.so          ; Scan Zap channels application
-noload => app_db.so                 ; Database Access Functions
-load => app_dial.so                 ; Dialing Application
-noload => app_dictate.so            ; Virtual Dictation Machine
-noload => app_directed_pickup.so    ; Directed Call Pickup Application
-noload => app_directory.so          ; Extension Directory
-noload => app_disa.so               ; DISA (Direct Inward System Access) Appli
-noload => app_dumpchan.so           ; Dump Info About The Calling Channel
-noload => app_echo.so               ; Simple Echo Application
-load => app_exec.so                 ; Executes dialplan applications
-noload => app_externalivr.so        ; External IVR Interface Application
-noload => app_festival.so           ; Simple Festival Interface
-noload => app_flash.so              ; Flash channel application
-noload => app_followme.so           ; Find-Me/Follow-Me Application
-noload => app_forkcdr.so            ; Fork The CDR into 2 separate entities
-noload => app_getcpeid.so           ; Get ADSI CPE ID
-noload => app_gps.so                ; GPS interface module
-noload => app_hasnewvoicemail.so    ; Indicator for whether a voice mailbox ha
-noload => app_ices.so               ; Encode and Stream via icecast and ices
-noload => app_image.so              ; Image Transmission Application
-noload => app_lookupblacklist.so    ; Look up Caller*ID name/number from black
-noload => app_lookupcidname.so      ; Look up CallerID Name from local database
-noload => app_macro.so              ; Extension Macros
-noload => app_meetme.so             ; MeetMe conference bridge
-noload => app_milliwatt.so          ; Digital Milliwatt (mu-law) Test Applicat
-noload => app_mixmonitor.so         ; Mixed Audio Monitoring Application
-noload => app_morsecode.so          ; Morse code
-noload => app_mp3.so                ; Silly MP3 Application
-noload => app_nbscat.so             ; Silly NBS Stream Application
-noload => app_page.so               ; Page Multiple Phones
-noload => app_parkandannounce.so    ; Call Parking and Announce Application
-load => app_playback.so             ; Sound File Playback Application
-noload => app_privacy.so            ; Require phone number to be entered, if n
-noload => app_queue.so              ; True Call Queueing
-noload => app_radbridge.so          ; Radio Bridging interface module
-noload => app_random.so             ; Random goto
-noload => app_readfile.so           ; Stores output of file into a variable
-noload => app_read.so               ; Read Variable Application
-noload => app_realtime.so           ; Realtime Data Lookup/Rewrite
-noload => app_record.so             ; Trivial Record Application
-load => app_rpt.so                  ; Radio Repeater/Remote Base Application
-noload => app_sayunixtime.so        ; Say time
-noload => app_senddtmf.so           ; Send DTMF digits Application
-load => app_sendtext.so             ; Send Text Applications
-noload => app_setcallerid.so        ; Set CallerID Application
-noload => app_setcdruserfield.so    ; CDR user field apps
-noload => app_settransfercapability.so   ; Set ISDN Transfer Capability
-noload => app_sms.so                ; SMS/PSTN handler
-noload => app_softhangup.so         ; Hangs up the requested channel
-noload => app_speech_utils.so       ; Dialplan Speech Applications
-noload => app_stack.so              ; Stack Routines
-load => app_system.so               ; Generic System() application
-noload => app_talkdetect.so         ; Playback with Talk Detection
-noload => app_test.so               ; Interface Test Application
-load => app_transfer.so             ; Transfer
-noload => app_url.so                ; Send URL Applications
-noload => app_userevent.so          ; Custom User Event Application
-noload => app_verbose.so            ; Send verbose output
-noload => app_voicemail.so          ; Comedian Mail (Voicemail System)
-noload => app_waitforring.so        ; Waits until first ring after time
-noload => app_waitforsilence.so     ; Wait For Silence
-noload => app_while.so              ; While Loops and Conditional Execution
-noload => app_zapateller.so         ; Block Telemarketers with Special Informa
 
-; CDR
-noload => cdr_csv.so                ; Comma Separated Values CDR Backend
-noload => cdr_custom.so             ; Customizable Comma Separated Values CDR
-noload => cdr_manager.so            ; Asterisk Manager Interface CDR Backend
+load    = app_authenticate.so            ; Authentication Application
+load    = app_dial.so                    ; Dialing Application
+load    = app_exec.so                    ; Executes dialplan applications
+noload  = app_gps.so                     ; GPS Interface
+load    = app_playback.so                ; Sound File Playback Application
+require = app_rpt.so                     ; Radio Repeater/Remote Base Application
+load    = app_sendtext.so                ; Send and Receive Text Applications
+load    = app_system.so                  ; Generic System() application
+load    = app_transfer.so                ; Transfers a caller to another extension
 
-; Channels
-noload => chan_agent.so             ; Agent Proxy Channel
-noload => chan_alsa.so              ; ALSA Console Channel Driver
-noload => chan_beagle.so            ; Beagleboard Radio Interface Channel Driver
-load => chan_dahdi.so               ; DAHDI Telephony
-noload => chan_echolink.so          ; echolink Channel Driver
-noload => chan_features.so          ; Feature Proxy Channel
-noload => chan_gtalk.so             ; Gtalk Channel Driver
-load => chan_iax2.so                ; Inter Asterisk eXchange (Ver 2)
-noload => chan_local.so             ; Local Proxy Channel (Note: used internal
-noload => chan_oss.so               ; Channel driver for OSS sound cards
-noload => chan_phone.so             ; Generic Linux Telephony Interface driver
-noload => chan_pi.so                ; DMK Engineering "PITA" Board on Rpi2/3 Channel Driver
-load => chan_simpleusb.so           ; CM1xx USB Cards with Radio Interface Channel Driver (No DSP)
-noload => chan_sip.so               ; Session Initiation Protocol (SIP)
-noload => chan_tlb.so               ; TheLinkBox Channel Driver
-noload => chan_usbradio.so          ; CM1xx USB Cards with Radio Interface Channel Driver (DSP)
-noload => chan_usrp.so              ; GNU Radio interface USRP Channel Driver
-noload => chan_voter.so             ; Radio Voter Channel Driver
+; Channel Drivers
+
+load    = chan_dahdi.so                  ; DAHDI Telephony w/PRI & SS7 & MFC/R2
+noload  = chan_echolink.so               ; Echolink Channel Driver
+require = chan_iax2.so                   ; Inter Asterisk eXchange (Ver 2)
+noload  = chan_mobile.so                 ; Bluetooth Mobile Device Channel Driver
+noload  = chan_ooh323.so                 ; Objective Systems H323 Channel
+load    = chan_simpleusb.so              ; SimpleUSB Radio Interface Channel Driver
+noload  = chan_tlb.so                    ; TheLinkBox Channel Driver
+noload  = chan_usbradio.so               ; USB Console Channel Driver
+noload  = chan_usrp.so                   ; USRP Channel Module
+noload  = chan_voter.so                  ; Voter Radio Channel Driver
 
 ; Codecs
+
 ; CODEC          AUDIO QUALITY   BANDWIDTH (including IP and Ethernet headers)
 ; ULAW           best            87 kilobits per second (kbps)
 ; ADPCM          good            55 kbps
@@ -134,80 +62,125 @@ noload => chan_voter.so             ; Radio Voter Channel Driver
 ; g726aal2
 ; ilbc
 
-load => codec_adpcm.so              ; Adaptive Differential PCM Coder/Decoder
-load => codec_alaw.so               ; A-law Coder/Decoder
-load => codec_a_mu.so               ; A-law and Mulaw direct Coder/Decoder
-noload => codec_dahdi.so            ; Generic DAHDI Transcoder Codec Translato
-load => codec_g726.so               ; ITU G.726-32kbps G726 Transcoder
-load => codec_gsm.so                ; GSM Coder/Decoder
-load => codec_ulaw.so               ; mu-Law Coder/Decoder
-noload => codec_ilbc.so             ; http://en.wikipedia.org/wiki/Internet_Low_Bitrate_Codec
+load    = codec_adpcm.so                 ; Adaptive Differential PCM Coder/Decoder
+load    = codec_alaw.so                  ; A-law Coder/Decoder
+load    = codec_a_mu.so                  ; A-law and Mulaw direct Coder/Decoder
+noload  = codec_dahdi.so                 ; Generic DAHDI Transcoder Codec Translator
+noload  = codec_g722.so                  ; ITU G.722-64kbps G722 Transcoder
+load    = codec_g726.so                  ; ITU G.726-32kbps G726 Transcoder
+load    = codec_gsm.so                   ; GSM Coder/Decoder
+noload  = codec_resample.so              ; SLIN Resampling Codec
+load    = codec_ulaw.so                  ; mu-Law Coder/Decoder
 
 ; Formats
-load => format_g723.so              ; G.723.1 Simple Timestamp File Format
-load => format_g726.so              ; Raw G.726 (16/24/32/40kbps) data
-load => format_g729.so              ; Raw G729 data
-load => format_gsm.so               ; Raw GSM data
-load => format_h263.so              ; Raw H.263 data
-load => format_h264.so              ; Raw H.264 data
-load => format_ilbc.so              ; Raw iLBC data
-noload => format_jpeg.so            ; JPEG (Joint Picture Experts Group) Image
-load => format_pcm.so               ; Raw/Sun uLaw/ALaw 8KHz (PCM,PCMA,AU), G.
-load => format_sln.so               ; Raw Signed Linear Audio support (SLN)
-load => format_vox.so               ; Dialogic VOX (ADPCM) File Format
-load => format_wav_gsm.so           ; Microsoft WAV format (Proprietary GSM)
-load => format_wav.so               ; Microsoft WAV format (8000Hz Signed Line
+
+load    = format_g723.so                 ; G.723.1 Simple Timestamp File Format
+load    = format_g726.so                 ; Raw G.726 (16/24/32/40kbps) data
+noload  = format_g729.so                 ; Raw G.729 data
+load    = format_gsm.so                  ; Raw GSM data
+load    = format_h263.so                 ; Raw H.263 data
+load    = format_h264.so                 ; Raw H.264 data
+load    = format_ilbc.so                 ; Raw iLBC data
+load    = format_mp3.so                  ; MP3 format [Any rate but 8000hz mono is optimal]
+load    = format_pcm.so                  ; Raw/Sun uLaw/ALaw 8KHz (PCM,PCMA,AU), G.722 16Khz
+load    = format_sln.so                  ; Raw Signed Linear Audio support (SLN) 8khz-192khz
+load    = format_vox.so                  ; Dialogic VOX (ADPCM) File Format
+load    = format_wav_gsm.so              ; Microsoft WAV format (Proprietary GSM)
+load    = format_wav.so                  ; Microsoft WAV/WAV16 format (8kHz/16kHz Signed Linear)
 
 ; Functions
-load => func_base64.so              ; base64 encode/decode dialplan functions
-load => func_callerid.so            ; Caller ID related dialplan function
-load => func_cdr.so                 ; CDR dialplan function
-load => func_channel.so             ; Channel information dialplan function
-load => res_curl.so                 ; Required for ASL3
-load => func_curl.so                ; Load external URL
-load => func_cut.so                 ; Cut out information from a string
-load => func_db.so                  ; Database (astdb) related dialplan functi
-load => func_enum.so                ; ENUM related dialplan functions
-load => func_env.so                 ; Environment/filesystem dialplan function
-load => func_global.so              ; Global variable dialplan functions
-load => func_groupcount.so          ; Channel group dialplan functions
-noload => func_language.so          ; Channel language dialplan function
-load => func_logic.so               ; Logical dialplan functions
-load => func_math.so                ; Mathematical dialplan function
-load => func_md5.so                 ; MD5 digest dialplan functions
-noload => func_moh.so               ; Music-on-hold dialplan function
-load => func_rand.so                ; Random number dialplan function
-load => func_realtime.so            ; Read/Write values from a RealTime reposi
-noload => func_sha1.so              ; SHA-1 computation dialplan function
-noload => func_strings.so           ; String handling dialplan functions
-noload => func_timeout.so           ; Channel timeout dialplan functions
-noload => func_uri.so               ; URI encode/decode dialplan functions
 
-; PBX
-noload => pbx_ael.so                ; Asterisk Extension Language Compiler
-load => pbx_config.so               ; Text Extension Configuration
-noload => pbx_dundi.so              ; Distributed Universal Number Discovery (
-noload => pbx_loopback.so           ; Loopback Switch
-noload => pbx_realtime.so           ; Realtime Switch
-noload => pbx_spool.so              ; Outgoing Spool Support
+load    = func_base64.so                 ; base64 encode/decode dialplan functions
+load    = func_callerid.so               ; Party ID related dialplan functions (Caller-ID, Connected-line, Redirecting)
+load    = func_cdr.so                    ; Call Detail Record (CDR) dialplan functions
+load    = func_channel.so                ; Channel information dialplan functions
+load    = func_curl.so                   ; Load external URL
+load    = func_cut.so                    ; Cut out information from a string
+load    = func_db.so                     ; Database (astdb) related dialplan functions
+load    = func_enum.so                   ; ENUM related dialplan functions
+load    = func_env.so                    ; Environment/filesystem dialplan functions
+load    = func_global.so                 ; Variable dialplan functions
+load    = func_groupcount.so             ; Channel group dialplan functions
+load    = func_logic.so                  ; Logical dialplan functions
+load    = func_math.so                   ; Mathematical dialplan function
+load    = func_md5.so                    ; MD5 digest dialplan functions
+load    = func_rand.so                   ; Random number dialplan function
+load    = func_realtime.so               ; Read/Write/Store/Destroy values from a RealTime repository
+noload  = func_sha1.so                   ; SHA-1 computation dialplan function
+load    = func_strings.so                ; String handling dialplan functions
+noload  = func_timeout.so                ; Channel timeout dialplan functions
+noload  = func_uri.so                    ; URI encode/decode dialplan functions
+
+; Core/PBX
+
+load    = pbx_config.so                  ; Text Extension Configuration
 
 ; Resources
-load => res_adsi.so                 ; ADSI Resource
-noload => res_agi.so                ; Asterisk Gateway Interface (AGI)
-noload => res_clioriginate.so       ; Call origination from the CLI
-noload => res_convert.so            ; File format conversion CLI command
-load => res_crypto.so               ; Cryptographic Digital Signatures
-noload => res_features.so           ; Call Features Resource
-load => res_rpt_http_registrations.so   ; ASL3 app_rpt http registrations
-noload => res_indications.so        ; Indications Resource
-noload => res_jabber.so             ; AJI - Asterisk Jabber Interface
-noload => res_monitor.so            ; Call Monitoring Resource
-noload => res_musiconhold.so        ; Music On Hold Resource
-load => res_smdi.so                 ; Simplified Message Desk Interface (SMDI)
-noload => res_snmp.so               ; SNMP [Sub]Agent for Asterisk
-noload => res_speech.so             ; Generic Speech Recognition API
-load => res_timing_dahdi.so         ; DAHDI Timing Interface
-load => res_timing_timerfd.so       ; Timerfd Timing Interface is preferred for ASL3
-load => res_usbradio.so             ; ASL3 required for both simpleusb and usbradio
 
-[global]
+load    = res_crypto.so                  ; Cryptographic Digital Signatures
+require = res_curl.so                    ; cURL Resource Module
+require = res_rpt_http_registrations.so  ; RPT HTTP Periodic Registrations
+load    = res_timing_dahdi.so            ; DAHDI Timing Interface
+load    = res_timing_timerfd.so          ; Timerfd Timing Interface is preferred for ASL3
+require = res_usbradio.so                ; USB Radio Resource
+
+;
+; The following modules are used by configurations that are setup for
+; an "autopatch" or support SIP phones.  If needed, uncomment each of
+; the following lines (by removing the leading ";").
+;
+;load   = bridge_builtin_features.so                  ; Built in bridging features
+;load   = bridge_builtin_interval_features.so         ; Built in bridging interval features
+;load   = bridge_holding.so                           ; Holding bridge module
+;load   = bridge_native_rtp.so                        ; Native RTP bridging module
+;load   = bridge_simple.so                            ; Simple two channel bridging module
+;load   = bridge_softmix.so                           ; Multi-party software based channel mixing
+;load   = chan_bridge_media.so                        ; Bridge Media Channel Driver
+;load   = chan_pjsip.so                               ; PJSIP Channel Driver
+;load   = func_pjsip_endpoint.so                      ; Get information about a PJSIP endpoint
+;load   = func_sorcery.so                             ; Get a field from a sorcery object
+;load   = func_devstate.so                            ; Gets or sets a device state in the dialplan
+;load   = res_pjproject.so                            ; PJPROJECT Log and Utility Support
+;load   = res_pjsip_acl.so                            ; PJSIP ACL Resource
+;load   = res_pjsip_authenticator_digest.so           ; PJSIP authentication resource
+;load   = res_pjsip_caller_id.so                      ; PJSIP Caller ID Support
+;load   = res_pjsip_dialog_info_body_generator.so     ; PJSIP Extension State Dialog Info+XML Provider
+;load   = res_pjsip_diversion.so                      ; PJSIP Add Diversion Header Support
+;load   = res_pjsip_dtmf_info.so                      ; PJSIP DTMF INFO Support
+;load   = res_pjsip_endpoint_identifier_anonymous.so  ; PJSIP Anonymous endpoint identifier
+;load   = res_pjsip_endpoint_identifier_ip.so         ; PJSIP IP endpoint identifier
+;load   = res_pjsip_endpoint_identifier_user.so       ; PJSIP username endpoint identifier
+;load   = res_pjsip_exten_state.so                    ; PJSIP Extension State Notifications
+;load   = res_pjsip_header_funcs.so                   ; PJSIP Header Functions
+;load   = res_pjsip_logger.so                         ; PJSIP Packet Logger
+;load   = res_pjsip_messaging.so                      ; PJSIP Messaging Support
+;load   = res_pjsip_mwi_body_generator.so             ; PJSIP MWI resource
+;load   = res_pjsip_mwi.so                            ; PJSIP MWI resource
+;load   = res_pjsip_nat.so                            ; PJSIP NAT Support
+;load   = res_pjsip_notify.so                         ; CLI/AMI PJSIP NOTIFY Support
+;load   = res_pjsip_one_touch_record_info.so          ; PJSIP INFO One Touch Recording Support
+;load   = res_pjsip_outbound_authenticator_digest.so  ; PJSIP authentication resource
+;load   = res_pjsip_outbound_publish.so               ; PJSIP Outbound Publish Support
+;load   = res_pjsip_outbound_registration.so          ; PJSIP Outbound Registration Support
+;load   = res_pjsip_path.so                           ; PJSIP Path Header Support
+;load   = res_pjsip_pidf_body_generator.so            ; PJSIP Extension State PIDF Provider
+;load   = res_pjsip_pidf_digium_body_supplement.so    ; PJSIP PIDF Sangoma presence supplement
+;load   = res_pjsip_pidf_eyebeam_body_supplement.so   ; PJSIP PIDF Eyebeam supplement
+;load   = res_pjsip_publish_asterisk.so               ; PJSIP Asterisk Event PUBLISH Support
+;load   = res_pjsip_pubsub.so                         ; PJSIP event resource
+;load   = res_pjsip_refer.so                          ; PJSIP Blind and Attended Transfer Support
+;load   = res_pjsip_registrar.so                      ; PJSIP Registrar Support
+;load   = res_pjsip_rfc3326.so                        ; PJSIP RFC3326 Support
+;load   = res_pjsip_sdp_rtp.so                        ; PJSIP SDP RTP/AVP stream handler
+;load   = res_pjsip_send_to_voicemail.so              ; PJSIP REFER Send to Voicemail Support
+;load   = res_pjsip_session.so                        ; PJSIP Session resource
+;load   = res_pjsip.so                                ; Basic SIP resource
+;noload = res_pjsip_t38.so                            ; PJSIP T.38 UDPTL Support
+;noload = res_pjsip_transport_websocket.so            ; PJSIP WebSocket Transport Support
+;load   = res_pjsip_xpidf_body_generator.so           ; PJSIP Extension State PIDF Provider
+;load   = res_rtp_asterisk.so                         ; Asterisk RTP Stack
+;load   = res_sorcery_astdb.so                        ; Sorcery Astdb Object Wizard
+;load   = res_sorcery_config.so                       ; Sorcery Configuration File Object Wizard
+;load   = res_sorcery_memory.so                       ; Sorcery In-Memory Object Wizard
+;load   = res_sorcery_realtime.so                     ; Sorcery Realtime Object Wizard
+


### PR DESCRIPTION
A number of Asterisk modules were deprecated (and removed) in 21.x.x and 22.x.x.  These changes update the ASL3 provided "modules.conf" file to sync with those changes as well as some overdue cleanup.

*** NOTE ***
The file currently includes some added content and a bunch of questions. For those reviewing the changes, your comments and guidance are welcomed.