### PR TITLE
app_rpt.c: change timers of unnecessary long to int

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2869,7 +2869,7 @@ static inline void dump_rpt(struct rpt *myrpt, const int lasttx, const int laste
 	ast_debug(2, "myrpt->mustid = %d\n", myrpt->mustid);
 	ast_debug(2, "myrpt->tounkeyed = %d\n", myrpt->tounkeyed);
 	ast_debug(2, "myrpt->tonotify = %d\n", myrpt->tonotify);
-	ast_debug(2, "myrpt->retxtimer = %ld\n", myrpt->retxtimer);
+	ast_debug(2, "myrpt->retxtimer = %d\n", myrpt->retxtimer);
 	ast_debug(2, "myrpt->totimer = %d\n", myrpt->totimer);
 	ast_debug(2, "myrpt->tailtimer = %d\n", myrpt->tailtimer);
 	ast_debug(2, "myrpt->tailevent = %d\n", myrpt->tailevent);
@@ -2894,8 +2894,8 @@ static inline void dump_rpt(struct rpt *myrpt, const int lasttx, const int laste
 		ast_debug(2, "        link->outbound %d\n", zl->outbound);
 		ast_debug(2, "        link->disced %d\n", zl->disced);
 		ast_debug(2, "        link->killme %d\n", zl->killme);
-		ast_debug(2, "        link->disctime %ld\n", zl->disctime);
-		ast_debug(2, "        link->retrytimer %ld\n", zl->retrytimer);
+		ast_debug(2, "        link->disctime %d\n", zl->disctime);
+		ast_debug(2, "        link->retrytimer %d\n", zl->retrytimer);
 		ast_debug(2, "        link->retries = %d\n", zl->retries);
 		ast_debug(2, "        link->reconnects = %d\n", zl->reconnects);
 		ast_debug(2, "        link->newkey = %d\n", zl->newkey);

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -394,12 +394,12 @@ struct rpt_link {
 	char	disced;
 	char	killme;
 	long	elaptime;
-	long	disctime;
-	long 	retrytimer;
-	long	retxtimer;
-	long	rerxtimer;
-	long	rxlingertimer;
-	int     rssi;
+	int	disctime;
+	int	retrytimer;
+	int	retxtimer;
+	int	rerxtimer;
+	int	rxlingertimer;
+	int	rssi;
 	int	retries;
 	int	max_retries;
 	int	reconnects;
@@ -408,7 +408,7 @@ struct rpt_link {
 	struct ast_channel *pchan;	
 	char	linklist[MAXLINKLIST];
 	time_t	linklistreceived;
-	long	linklisttimer;
+	int	linklisttimer;
 	int	dtmfed;
 	int linkunkeytocttimer;
 	struct timeval lastlinktv;
@@ -778,8 +778,8 @@ struct rpt {
 	int dtmfidx,rem_dtmfidx;
 	int dailytxtime,dailykerchunks,totalkerchunks,dailykeyups,totalkeyups,timeouts;
 	int totalexecdcommands, dailyexecdcommands;
-	long	retxtimer;
-	long	rerxtimer;
+	int	retxtimer;
+	int	rerxtimer;
 	long long totaltxtime;
 	char mydtmf;
 	char exten[AST_MAX_EXTENSION];
@@ -816,7 +816,7 @@ struct rpt {
 	int tailmessagen;
 	time_t disgorgetime;
 	time_t lastthreadrestarttime;
-	long	macrotimer;
+	int	macrotimer;
 	char	lastnodewhichkeyedusup[MAXNODESTR];
 	int	dtmf_local_timer;
 	char	dtmf_local_str[100];
@@ -843,7 +843,7 @@ struct rpt {
 	char newkey;
 	char iaxkey;
 	char inpadtest;
-	long rxlingertimer;
+	int rxlingertimer;
 	char localoverride;
 	char ready;
 	char lastrxburst;


### PR DESCRIPTION
Not sure how I missed the compiler warnings when I tested https://github.com/AllStarLink/app_rpt/pull/457
The changed timers are unnecessarily `long`.  We could alternately go with `long` for all timers if there is concern about expanding beyond 32767ms for any timer.  Currently all of them appear to fit in an `int`. 