### PR TITLE
app_rpt.c: Refactor handle_link_data() and handle_remote_data()

### DIFF
--- a/apps/app_rpt/rpt_cli.c
+++ b/apps/app_rpt/rpt_cli.c
@@ -525,10 +525,11 @@ static int rpt_do_xnode(int fd, int argc, const char *const *argv)
 				tel_mode = "3";
 			}
 
-//### GET CONNECTED NODE INFO ####################
-			// Traverse the list of connected nodes 
+			/* ### GET CONNECTED NODE INFO ####################
+			 * Traverse the list of connected nodes
+			 */
 
-			__mklinklist(myrpt, NULL, lbuf, 0);
+			__mklinklist(myrpt, NULL, lbuf, sizeof(lbuf), 0);
 
 			j = 0;
 			l = myrpt->links.next;
@@ -590,7 +591,7 @@ static int rpt_do_xnode(int fd, int argc, const char *const *argv)
 
 //### GET ALL LINKED NODES INFO ####################
 			/* parse em */
-			ns = finddelim(lbuf, strs, MAXLINKLIST);
+			ns = finddelim(lbuf, strs, ARRAY_LEN(strs));
 			/* sort em */
 			if (ns)
 				qsort((void *) strs, ns, sizeof(char *), mycompar);
@@ -657,10 +658,10 @@ static int rpt_do_nodes(int fd, int argc, const char *const *argv)
 			/* Make a copy of all stat variables while locked */
 			myrpt = &rpt_vars[i];
 			rpt_mutex_lock(&myrpt->lock);	/* LOCK */
-			__mklinklist(myrpt, NULL, lbuf, 0);
+			__mklinklist(myrpt, NULL, lbuf, sizeof(lbuf), 0);
 			rpt_mutex_unlock(&myrpt->lock);	/* UNLOCK */
 			/* parse em */
-			ns = finddelim(lbuf, strs, MAXLINKLIST);
+			ns = finddelim(lbuf, strs, ARRAY_LEN(strs));
 			/* sort em */
 			if (ns)
 				qsort((void *) strs, ns, sizeof(char *), mycompar);

--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -14,6 +14,7 @@
 #include "asterisk/dns_srv.h"	/* use for srv dns lookup */
 #include "asterisk/dns_txt.h" /* user for dns lookup */
 #include "asterisk/vector.h" /* required for dns */
+#include "asterisk/utils.h" /* required for ARRAY_LEN */
 
 #include "app_rpt.h"
 #include <arpa/nameser.h> /* needed for dns - must be after app_rpt.h */
@@ -23,7 +24,7 @@
 #include "rpt_utils.h" /* use myatoi */
 #include "rpt_rig.h" /* use setrem */
 
-/*! \brief Echolink queryoption for retrieving call sign */ 
+/*! \brief Echolink queryoption for retrieving call sign */
 #define ECHOLINK_QUERY_CALLSIGN 2
 
 /*! \brief The Link Box queryoptions */
@@ -292,7 +293,7 @@ int elink_query_callsign(char *node, char *callsign, int callsignlen)
 		ast_log(LOG_WARNING, "chan_echolink not loaded.  Cannot query callsign.\n");
 		return res;
 	}
-	
+
 	/* data is passed to and from the query option using the callsign field */
 	ast_copy_string(callsign, node, callsignlen);
 
@@ -312,11 +313,11 @@ int tlb_query_node_exists(const char *node)
 		ast_debug(5, "chan_tlb not loaded.\n");
 		return res;
 	}
-	
+
 	if (!chan_tech->queryoption(NULL, TLB_QUERY_NODE_EXISTS, (void *) node, 0)) {
 		res = 1;
 	}
-	
+
 	return res;
 }
 
@@ -331,7 +332,7 @@ int tlb_query_callsign(const char *node, char *callsign, int callsignlen)
 		ast_debug(5, "chan_tlb not loaded. Cannot query callsign.\n");
 		return res;
 	}
-	
+
 	/* data is passed to and from the query option using the callsign field */
 	ast_copy_string(callsign, node, callsignlen);
 
@@ -343,12 +344,12 @@ int tlb_query_callsign(const char *node, char *callsign, int callsignlen)
 /*!
  * \brief AllStar Network node lookup by dns.
  * Calling routine should pass a buffer for nodedata and nodedatalength
- * of sufficient length. A typical response is 
+ * of sufficient length. A typical response is
  * "radio@123.123.123.123:4569/50000,123.123.123.123
  * This routine uses the SRV or TXT records provided by AllStarLink
  *
- * \note This routine can be called by app_rpt multiple times as 
- * it constructs the node number.  The routine will only perform a 
+ * \note This routine can be called by app_rpt multiple times as
+ * it constructs the node number.  The routine will only perform a
  * lookup after it receives 4 digits.  The actual node number may be
  * longer than 4 digits.
  *
@@ -385,7 +386,7 @@ static int node_lookup_bydns(const char *node, char *nodedata, size_t nodedatale
 		char *hostname;
 		const char *ipaddress;
 		unsigned short iaxport;
-		
+
 		/* setup the domain to lookup */
 		memset(domain,0, sizeof(domain));
 		res = snprintf(domain, sizeof(domain), "_iax._udp.%s.nodes.allstarlink.org", node);
@@ -406,7 +407,7 @@ static int node_lookup_bydns(const char *node, char *nodedata, size_t nodedatale
 
 		/* get the response */
 		record = ast_dns_result_get_records(result);
-	
+
 		if(!record) {
 			ast_debug(4, "No SRV records returned for %s\n", domain);
 			ast_dns_result_free(result);
@@ -464,7 +465,7 @@ static int node_lookup_bydns(const char *node, char *nodedata, size_t nodedatale
 		}
 
 		ast_debug(4, "Resolving DNS TXT records for: %s\n", domain);
-	
+
 		/* resolve the domain name */
 		if (ast_dns_resolve(domain, T_TXT, C_IN, &result)) {
 			ast_log(LOG_ERROR, "DNS request failed\n");
@@ -476,14 +477,14 @@ static int node_lookup_bydns(const char *node, char *nodedata, size_t nodedatale
 
 		/* get the response */
 		record = ast_dns_result_get_records(result);
-	
+
 		if(!record) {
 			ast_dns_result_free(result);
 			return -1;
 		}
 
-		/* process the text records 
-		text records are in the format 
+		/* process the text records
+		text records are in the format
 		"NN=2530" "RT=2023-02-21 17:33:07" "RB=0" "IP=104.153.109.212" "PIP=0" "PT=4569" "RH=register-west"
 		*/
 		txtrecords = ast_dns_txt_get_strings( record);
@@ -500,7 +501,7 @@ static int node_lookup_bydns(const char *node, char *nodedata, size_t nodedatale
 				ast_copy_string(iaxport,tmp + 3, sizeof(iaxport));
 			}
 		}
-	
+
 		/* format the response */
 		memset(nodedata, 0, nodedatalength);
 		snprintf(nodedata, nodedatalength, "radio@%s:%s/%s,%s", ipaddress, iaxport, actualnode, ipaddress);
@@ -558,7 +559,7 @@ int node_lookup(struct rpt *myrpt, char *digitbuf, char *nodedata, size_t nodeda
 
 	/* try to lookup using the external file(s) */
 	if(rpt_node_lookup_method == LOOKUP_BOTH || rpt_node_lookup_method == LOOKUP_FILE) {
-		
+
 		/* lock the node lookup */
 		ast_mutex_lock(&nodelookuplock);
 		if (!myrpt->p.extnodefilesn) {
@@ -668,7 +669,7 @@ int forward_node_lookup(char *digitbuf, struct ast_config *cfg, char *nodedata, 
 		}
 
 		/* parse the external node file name(s) - we allow for multiple files */
-		n = finddelim(efil, strs, 100);
+		n = finddelim(efil, strs, ARRAY_LEN(strs));
 		if (n < 1) {
 			ast_free(efil);
 			ast_mutex_unlock(&nodelookuplock);
@@ -908,22 +909,22 @@ void load_rpt_vars(int n, int init)
 	RPT_CONFIG_VAR_DEFAULT(extnodes, "extnodes", EXTNODES);
 
 	val = ast_variable_retrieve(cfg, cat, "extnodefile");
-	rpt_vars[n].p.extnodefilesn = explode_string((char*) S_OR(val, EXTNODEFILE), (char**) rpt_vars[n].p.extnodefiles, MAX_EXTNODEFILES, ',', 0); /*! \todo Illegal cast */
+	rpt_vars[n].p.extnodefilesn = explode_string((char*) S_OR(val, EXTNODEFILE), (char**) rpt_vars[n].p.extnodefiles, ARRAY_LEN(rpt_vars[n].p.extnodefiles), ',', 0); /*! \todo Illegal cast */
 
 	/*! \todo Is this memory properly freed? */
 	val = ast_variable_retrieve(cfg, cat, "locallinknodes");
 	if (val) {
-		rpt_vars[n].p.locallinknodesn = explode_string(ast_strdup(val), (char**) rpt_vars[n].p.locallinknodes, MAX_LOCALLINKNODES, ',', 0);
+		rpt_vars[n].p.locallinknodesn = explode_string(ast_strdup(val), (char**) rpt_vars[n].p.locallinknodes, ARRAY_LEN(rpt_vars[n].p.locallinknodes), ',', 0);
 	}
 
 	val = ast_variable_retrieve(cfg, cat, "lconn");
 	if (val) {
-		rpt_vars[n].p.nlconn = explode_string(strupr(ast_strdup(val)), (char**) rpt_vars[n].p.lconn, MAX_LSTUFF, ',', 0);
+		rpt_vars[n].p.nlconn = explode_string(strupr(ast_strdup(val)), (char**) rpt_vars[n].p.lconn, ARRAY_LEN(rpt_vars[n].p.lconn), ',', 0);
 	}
 
 	val = ast_variable_retrieve(cfg, cat, "ldisc");
 	if (val) {
-		rpt_vars[n].p.nldisc = explode_string(strupr(ast_strdup(val)), (char**) rpt_vars[n].p.ldisc, MAX_LSTUFF, ',', 0);
+		rpt_vars[n].p.nldisc = explode_string(strupr(ast_strdup(val)), (char**) rpt_vars[n].p.ldisc, ARRAY_LEN(rpt_vars[n].p.ldisc), ',', 0);
 	}
 
 	RPT_CONFIG_VAR(patchconnect, "patchconnect");
@@ -1073,7 +1074,7 @@ void load_rpt_vars(int n, int init)
 	val = ast_variable_retrieve(cfg, cat, "inxlat");
 	if (val) {
 		memset(&rpt_vars[n].p.inxlat, 0, sizeof(struct rpt_xlat));
-		i = finddelim((char*) val, strs, 3); /*! \todo Illegal cast */
+		i = finddelim((char *) val, strs, ARRAY_LEN(strs)); /*! \todo Illegal cast */
 		if (i > 3) {
 			rpt_vars[n].p.dopfxtone = ast_true(strs[3]);
 		} else if (i > 2) {
@@ -1088,7 +1089,7 @@ void load_rpt_vars(int n, int init)
 	val = ast_variable_retrieve(cfg, cat, "outxlat");
 	if (val) {
 		memset(&rpt_vars[n].p.outxlat, 0, sizeof(struct rpt_xlat));
-		i = finddelim((char*) val, strs, 3); /*! \todo Illegal cast */
+		i = finddelim((char *) val, strs, ARRAY_LEN(strs)); /*! \todo Illegal cast */
 		if (i > 2) {
 			ast_copy_string(rpt_vars[n].p.outxlat.passchars, strs[2], sizeof(rpt_vars[n].p.outxlat.passchars));
 		} else if (i > 1) {
@@ -1226,7 +1227,7 @@ void load_rpt_vars(int n, int init)
 		int k, nukw, statenum;
 		statenum = atoi(vp->name);
 		ast_copy_string(s1, vp->value, sizeof(s1));
-		nukw = finddelim(s1, strs, 32);
+		nukw = finddelim(s1, strs, ARRAY_LEN(strs));
 
 		for (k = 0; k < nukw; k++) {	/* for each user specified keyword */
 			for (j = 0; cs_keywords[j] != NULL; j++) {	/* try to match to one in our internal table */

--- a/apps/app_rpt/rpt_daq.c
+++ b/apps/app_rpt/rpt_daq.c
@@ -230,7 +230,7 @@ int handle_userout_tele(struct rpt *myrpt, struct ast_channel *mychannel, char *
 
 	ast_debug(3, "String: %s\n", myargs);
 
-	argc = explode_string(myargs, argv, 10, ',', 0);
+	argc = explode_string(myargs, argv, ARRAY_LEN(argv), ',', 0);
 	if (argc < 4) {				/* Must have at least 4 arguments */
 		ast_log(LOG_WARNING, "Incorrect number of arguments for USEROUT function");
 		ast_free(myargs);

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -362,7 +362,7 @@ int function_ilink(struct rpt *myrpt, char *param, char *digits, int command_sou
 
 	case 16:					/* Restore links disconnected with "disconnect all links" command */
 		strcpy(tmp, myrpt->savednodes);	/* Make a copy */
-		finddelim(tmp, strs, MAXLINKLIST);	/* convert into substrings */
+		finddelim(tmp, strs, ARRAY_LEN(strs));	/* convert into substrings */
 		for (i = 0; tmp[0] && strs[i] != NULL && i < MAXLINKLIST; i++) {
 			s1 = strs[i];
 			if (s1[0] == 'X')
@@ -921,7 +921,7 @@ int function_autopatchup(struct rpt *myrpt, char *param, char *digitbuf, int com
 		if (!lparam) {
 			return DC_ERROR;
 		}
-		paramlength = finddelim(lparam, paramlist, 20);
+		paramlength = finddelim(lparam, paramlist, ARRAY_LEN(paramlist));
 		for (i = 0; i < paramlength; i++) {
 			index = matchkeyword(paramlist[i], &value, keywords);
 			if (value)
@@ -1172,7 +1172,7 @@ int function_cop(struct rpt *myrpt, char *param, char *digitbuf, int command_sou
 		return DC_ERROR;
 
 	ast_copy_string(paramcopy, param, sizeof(paramcopy));
-	argc = explode_string(paramcopy, argv, 100, ',', 0);
+	argc = explode_string(paramcopy, argv, ARRAY_LEN(argv), ',', 0);
 
 	if (!argc)
 		return DC_ERROR;

--- a/apps/app_rpt/rpt_link.h
+++ b/apps/app_rpt/rpt_link.h
@@ -59,7 +59,10 @@ void rpt_link_add(struct rpt *myrpt, struct rpt_link *l);
 void rpt_link_remove(struct rpt *myrpt, struct rpt_link *l);
 
 /*! \brief must be called locked */
-void __mklinklist(struct rpt *myrpt, struct rpt_link *mylink, char *buf, int flag);
+int __mklinklist(struct rpt *myrpt, struct rpt_link *mylink, char *buf, size_t bufsize, int flag);
+
+/*! \brief must be called locked */
+int __get_nodelist_size (struct rpt *myrpt);
 
 /*! \brief must be called locked */
 void __kickshort(struct rpt *myrpt);

--- a/apps/app_rpt/rpt_manager.c
+++ b/apps/app_rpt/rpt_manager.c
@@ -207,7 +207,7 @@ static int rpt_manager_do_xstat(struct mansession *ses, const struct message *m,
 			/* Get connected node info */
 			/* Traverse the list of connected nodes */
 
-			__mklinklist(myrpt, NULL, lbuf, 0);
+			__mklinklist(myrpt, NULL, lbuf, sizeof(lbuf), 0);
 
 			j = 0;
 			l = myrpt->links.next;
@@ -271,7 +271,7 @@ static int rpt_manager_do_xstat(struct mansession *ses, const struct message *m,
 			/* Get all linked nodes info */
 
 			/* parse em */
-			ns = finddelim(lbuf, strs, MAXLINKLIST);
+			ns = finddelim(lbuf, strs, ARRAY_LEN(strs));
 			/* sort em */
 			if (ns) {
 				qsort((void *) strs, ns, sizeof(char *), mycompar);

--- a/apps/app_rpt/rpt_rig.c
+++ b/apps/app_rpt/rpt_rig.c
@@ -2444,7 +2444,7 @@ char check_tx_freq(struct rpt *myrpt)
 	/* Parse the limits */
 
 	ast_copy_string(limits, limitlist->value, sizeof(limits));
-	finddelim(limits, limit_ranges, 40);
+	finddelim(limits, limit_ranges, ARRAY_LEN(limit_ranges));
 	for (i = 0; i < 40 && limit_ranges[i]; i++) {
 		char range[40];
 		char *r, *s;

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -93,7 +93,7 @@ int handle_meter_tele(struct rpt *myrpt, struct ast_channel *mychannel, char *ar
 		return -1;
 	}
 
-	i = explode_string(myargs, argv, 4, ',', 0);
+	i = explode_string(myargs, argv, ARRAY_LEN(argv), ',', 0);
 	if ((i != 4) && (i != 3)) {	/* Must have 3 or 4 substrings, no more, no less */
 		ast_log(LOG_WARNING, "Wrong number of arguments for meter telemetry function is: %d s/b 3 or 4", i);
 		ast_free(myargs);
@@ -197,7 +197,7 @@ int handle_meter_tele(struct rpt *myrpt, struct ast_channel *mychannel, char *ar
 		/*
 		 * Parse range entries
 		 */
-		if ((numranges = explode_string(start, range_strings, MAX_DAQ_RANGES, ',', 0)) < 2) {
+		if ((numranges = explode_string(start, range_strings, ARRAY_LEN(range_strings), ',', 0)) < 2) {
 			ast_log(LOG_WARNING, "At least 2 ranges required for range() in meter face %s\n", argv[2]);
 			ast_free(myargs);
 			ast_free(meter_face);
@@ -215,7 +215,7 @@ int handle_meter_tele(struct rpt *myrpt, struct ast_channel *mychannel, char *ar
 		*start++ = 0;
 		*end = 0;
 		sounds = end + 2;
-		if (2 != explode_string(start, bitphrases, 2, ',', 0)) {
+		if (2 != explode_string(start, bitphrases, ARRAY_LEN(bitphrases), ',', 0)) {
 			ast_log(LOG_WARNING, "2 phrases required for bit() in meter face %s\n", argv[2]);
 			ast_free(myargs);
 			ast_free(meter_face);
@@ -293,7 +293,7 @@ int handle_meter_tele(struct rpt *myrpt, struct ast_channel *mychannel, char *ar
 	}
 
 	/* Split up the sounds string */
-	files = explode_string(sounds, sound_files, MAX_METER_FILES, ',', 0);
+	files = explode_string(sounds, sound_files, ARRAY_LEN(sound_files), ',', 0);
 	if (files == 0) {
 		ast_log(LOG_WARNING, "No sound files to say for meter %s\n", argv[2]);
 		ast_free(myargs);
@@ -545,7 +545,7 @@ void handle_varcmd_tele(struct rpt *myrpt, struct ast_channel *mychannel, char *
 	unsigned int t1;
 	struct ast_tm localtm;
 
-	n = finddelim(varcmd, strs, 100);
+	n = finddelim(varcmd, strs, ARRAY_LEN(strs));
 	if (n < 1) {
 		return;
 	}
@@ -1248,10 +1248,10 @@ treataslocal:
 
 		rpt_mutex_lock(&myrpt->lock);
 		/* get all the nodes */
-		__mklinklist(myrpt, NULL, lbuf, 0);
+		__mklinklist(myrpt, NULL, lbuf, sizeof(lbuf), 0);
 		rpt_mutex_unlock(&myrpt->lock);
 		/* parse em */
-		ns = finddelim(lbuf, strs, MAXLINKLIST);
+		ns = finddelim(lbuf, strs, ARRAY_LEN(strs));
 		haslink = 0;
 		for (i = 0; i < ns; i++) {
 			char *cpr = strs[i] + 1;
@@ -2142,10 +2142,10 @@ treataslocal:
 	case FULLSTATUS:
 		rpt_mutex_lock(&myrpt->lock);
 		/* get all the nodes */
-		__mklinklist(myrpt, NULL, lbuf, 0);
+		__mklinklist(myrpt, NULL, lbuf, sizeof(lbuf), 0);
 		rpt_mutex_unlock(&myrpt->lock);
 		/* parse em */
-		ns = finddelim(lbuf, strs, MAXLINKLIST);
+		ns = finddelim(lbuf, strs, ARRAY_LEN(strs));
 		/* sort em */
 		if (ns)
 			qsort((void *) strs, ns, sizeof(char *), mycompar);
@@ -2857,10 +2857,10 @@ void rpt_telemetry(struct rpt *myrpt, int mode, void *data)
 			rpt_mutex_lock(&myrpt->lock);
 			sprintf(mystr, "STATUS,%s,%d", myrpt->name, myrpt->callmode);
 			/* get all the nodes */
-			__mklinklist(myrpt, NULL, lbuf, 0);
+			__mklinklist(myrpt, NULL, lbuf, sizeof(lbuf), 0);
 			rpt_mutex_unlock(&myrpt->lock);
 			/* parse em */
-			ns = finddelim(lbuf, strs, MAXLINKLIST);
+			ns = finddelim(lbuf, strs, ARRAY_LEN(strs));
 			/* sort em */
 			if (ns)
 				qsort((void *) strs, ns, sizeof(char *), mycompar);

--- a/apps/app_rpt/rpt_uchameleon.c
+++ b/apps/app_rpt/rpt_uchameleon.c
@@ -97,7 +97,7 @@ void uchameleon_alarm_handler(struct daq_pin_entry_tag *p)
 		return;
 	}
 
-	argc = explode_string(valuecopy, argv, 6, ',', 0);
+	argc = explode_string(valuecopy, argv, ARRAY_LEN(argv), ',', 0);
 
 	ast_debug(3, "Alarm event on device %s, pin %d, state = %d\n", argv[0], p->num, p->value);
 
@@ -188,7 +188,7 @@ int uchameleon_pin_init(struct daq_entry_tag *t)
 
 		ast_copy_string(s, var->value, sizeof(s) - 1);
 
-		if (explode_string(s, argv, 6, ',', 0) != 6) {
+		if (explode_string(s, argv, ARRAY_LEN(argv), ',', 0) != 6) {
 			ast_log(LOG_WARNING, "Alarm arguments must be 6 for %s\n", var->name);
 			var = var->next;
 			continue;
@@ -574,7 +574,7 @@ void *uchameleon_monitor_thread(void *this)
 			ast_debug(5, "Received: %s\n", rxbuff);
 			valid = 0;
 			/* Parse return string */
-			i = explode_string(rxbuff, rxargs, 3, ' ', 0);
+			i = explode_string(rxbuff, rxargs, ARRAY_LEN(rxargs), ' ', 0);
 			if (i == 3) {
 				if (!strcmp(rxargs[0], "pin")) {
 					valid = 1;

--- a/apps/app_rpt/rpt_utils.c
+++ b/apps/app_rpt/rpt_utils.c
@@ -30,9 +30,9 @@ int matchkeyword(char *string, char **param, char *keywords[])
 	return 0;
 }
 
-int explode_string(char *str, char *strp[], int limit, char delim, char quote)
+int explode_string(char *str, char *strp[], size_t limit, char delim, char quote)
 {
-	int i, l, inquo;
+	int i, inquo;
 
 	inquo = 0;
 	i = 0;
@@ -41,7 +41,7 @@ int explode_string(char *str, char *strp[], int limit, char delim, char quote)
 		strp[0] = 0;
 		return (0);
 	}
-	for (l = 0; *str && (l < limit); str++) {
+	for (; *str && (i < (limit - 1)); str++) {
 		if (quote) {
 			if (*str == quote) {
 				if (inquo) {
@@ -55,12 +55,11 @@ int explode_string(char *str, char *strp[], int limit, char delim, char quote)
 		}
 		if ((*str == delim) && (!inquo)) {
 			*str = 0;
-			l++;
 			strp[i++] = str + 1;
 		}
 	}
 	strp[i] = 0;
-	return (i);
+	return i;
 
 }
 
@@ -86,7 +85,7 @@ char *string_toupper(char *str)
 	return str;
 }
 
-int finddelim(char *str, char *strp[], int limit)
+int finddelim(char *str, char *strp[], size_t limit)
 {
 	return explode_string(str, strp, limit, DELIMCHR, QUOTECHR);
 }

--- a/apps/app_rpt/rpt_utils.h
+++ b/apps/app_rpt/rpt_utils.h
@@ -23,7 +23,7 @@ int matchkeyword(char *string, char **param, char *keywords[]);
 * Returns number of substrings found.
 */
 
-int explode_string(char *str, char *strp[], int limit, char delim, char quote);
+int explode_string(char *str, char *strp[], size_t limit, char delim, char quote);
 
 char *strupr(char *instr);
 
@@ -36,7 +36,7 @@ char *string_toupper(char *str);
 * strp- list of pointers to substrings (this is built by this function), NULL will be placed at end of list
 * limit- maximum number of substrings to process
 */
-int finddelim(char *str, char *strp[], int limit);
+int finddelim(char *str, char *strp[], size_t limit);
 
 /*
 * Skip characters in string which are in charlist, and return a pointer to the


### PR DESCRIPTION
This is a follow on to PR https://github.com/AllStarLink/app_rpt/pull/470 which should not be delayed.  Intent is to clean up the stuff I notice while hunting down the truncated message.

Eliminate copy of malloc `char*` to fixed length `char*`
update `sprintf()` to `snprintf()`
rpt_link.c: Calculate buffer size and malloc buffers. add function __get_buffer_size() to calculate buffer size required. add node count to __mklinklist()
add macro for OBUFSIZE and BUFSIZE calculation
eliminate `finddelim()` call as `__mklinklist()` now counts links.

