### PR TITLE
Do not default to inverted PTT

### DIFF
--- a/configs/rpt/usbradio.conf
+++ b/configs/rpt/usbradio.conf
@@ -167,7 +167,7 @@ txhpf = 0                   ; Transmitter Audio High Pass Filter 0,1,2
                             ; 2 - 120 Hz cutoff for special applications requiring additional bass response in transmitted audio.
                             ; Not recommended due to the increased possibility of voice energy interfering with sub-audible signaling
 
-invertptt = yes             ; Invert PTT: no,yes
+invertptt = no              ; Invert PTT: no,yes
                             ; no  - ground to transmit
                             ; yes - open to transmit
 

--- a/configs/samples/usbradio.conf.sample
+++ b/configs/samples/usbradio.conf.sample
@@ -153,7 +153,7 @@
                             ; 2 - 120 Hz cutoff for special applications requiring additional bass response in transmitted audio.
                             ; Not recommended due to the increased possibility of voice energy interfering with sub-audible signaling
 
-;invertptt = yes            ; Invert PTT: no,yes
+;invertptt = no             ; Invert PTT: no,yes
                             ; no  - ground to transmit
                             ; yes - open to transmit
 


### PR DESCRIPTION
Should this really be inverted? Unless I missed it, I see no way in radio-tune-menu to swap the PTT logic