### PR TITLE
app_gps.c: Add missing include

### DIFF
--- a/apps/app_gps.c
+++ b/apps/app_gps.c
@@ -156,6 +156,7 @@ z - WinAPRS
 #include <termios.h>
 #include <math.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
 
 #include "asterisk/lock.h"
 #include "asterisk/channel.h"


### PR DESCRIPTION
This updates app_gps to add an include for sys/stat.h.

My compiles worked properly, but others are having a problem.