### PR TITLE
rpt_serial.c: use const char * for txbuf

### DIFF
--- a/apps/app_rpt/rpt_serial.c
+++ b/apps/app_rpt/rpt_serial.c
@@ -141,7 +141,7 @@ int serial_txstring(int fd, char *txstring)
 	return 0;
 }
 
-int serial_io(int fd, char *txbuf, char *rxbuf, int txbytes, int rxmaxbytes, unsigned int timeoutms, char termchr)
+int serial_io(int fd, const char *txbuf, char *rxbuf, int txbytes, int rxmaxbytes, unsigned int timeoutms, char termchr)
 {
 	int i;
 

--- a/apps/app_rpt/rpt_serial.h
+++ b/apps/app_rpt/rpt_serial.h
@@ -39,7 +39,7 @@ int serial_txstring(int fd, char *txstring);
 /*
  * Write some bytes to the serial port, then optionally expect a fixed response
  */
-int serial_io(int fd, char *txbuf, char *rxbuf, int txbytes, int rxmaxbytes, unsigned int timeoutms, char termchr);
+int serial_io(int fd, const char *txbuf, char *rxbuf, int txbytes, int rxmaxbytes, unsigned int timeoutms, char termchr);
 
 /*! \brief Set the Data Terminal Ready (DTR) pin on a serial interface */
 int setdtr(struct rpt *myrpt, int fd, int enable);


### PR DESCRIPTION
`int serial_io(int fd, char *txbuf, char *rxbuf, int txbytes, int rxmaxbytes, unsigned int timeoutms, char termchr)` should be `const char *txbuf`.