### PR TITLE
radio-tune-menu.c: need include "asterisk.h"

### DIFF
--- a/utils/radio-tune-menu.c
+++ b/utils/radio-tune-menu.c
@@ -59,6 +59,7 @@
  * Most of these commands take optional parameters to set values.
  *
  */
+#include "asterisk.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/utils/simpleusb-tune-menu.c
+++ b/utils/simpleusb-tune-menu.c
@@ -52,6 +52,8 @@
  * Most of these commands take optional parameters to set values.
  *
  */
+#include "asterisk.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>


### PR DESCRIPTION
simpleusb-tune-menu.c: need include "asterisk.h"

As asterisk developer site says, you need to start with #include "asterisk.h" for the others to work.