### PR TITLE
app_rpt: Don't emit warnings about <sys/io.h> being unavailable

### DIFF
--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -22,13 +22,8 @@
 #endif
 
 /*! \note <sys/io.h> is not portable to all architectures, so don't call non-portable functions if we don't have them */
-#if defined(__alpha__) || defined(__x86_64__) || defined(__ia64__)
+#if __has_include(<sys/io.h>)
 #define HAVE_SYS_IO
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wcpp"
-#warning sys.io is not available on this architecture and some functionality will be disabled
-#pragma GCC diagnostic pop
 #endif
 
 /* Un-comment the following to include support for notch filters in the

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -23,13 +23,8 @@
  */
 
 /*! \note <sys/io.h> is not portable to all architectures, so don't call non-portable functions if we don't have them */
-#if defined(__alpha__) || defined(__x86_64__) || defined(__ia64__)
+#if __has_include(<sys/io.h>)
 #define HAVE_SYS_IO
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wcpp"
-#warning sys.io is not available on this architecture and some functionality will be disabled
-#pragma GCC diagnostic pop
 #endif
 
 /*!


### PR DESCRIPTION
While some may argue that a few known/understood compilation warnings are OK we get into trouble when stop looking for "new" warnings in build output that includes a number of "old" ones. The simple solution is to banish ALL warnings from the project and then treat any warnings as errors.

This PR addresses the `sys.io is not available on this architecture` warnings reported on `arm64` builds.