### PR TITLE
app_rpt.c, rpt_cli.c, rpt_manager.c: Add missing mutex_lock()

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -3214,7 +3214,9 @@ static inline void periodic_process_links(struct rpt *myrpt, const int elap)
 			lf.samples = 0;
 			l->linklisttimer = LINKLISTTIME;
 			strcpy(lstr, "L ");
+			rpt_mutex_lock(&myrpt->lock);
 			__mklinklist(myrpt, l, lstr + 2, sizeof(lstr) - 2, 0);
+			rpt_mutex_unlock(&myrpt->lock);
 			if (l->chan) {
 				lf.datalen = strlen(lstr) + 1;
 				lf.data.ptr = lstr;

--- a/apps/app_rpt/rpt_cli.c
+++ b/apps/app_rpt/rpt_cli.c
@@ -529,8 +529,9 @@ static int rpt_do_xnode(int fd, int argc, const char *const *argv)
 			 * Traverse the list of connected nodes
 			 */
 
+			rpt_mutex_lock(&myrpt->lock);
 			__mklinklist(myrpt, NULL, lbuf, sizeof(lbuf), 0);
-
+			rpt_mutex_unlock(&myrpt->lock);
 			j = 0;
 			l = myrpt->links.next;
 			while (l && (l != &myrpt->links)) {


### PR DESCRIPTION
It appears these calls should be mutex_locked.
