### PR TITLE
rpt_config.c: Add missing votermode load parameter

### DIFF
--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -1029,8 +1029,8 @@ void load_rpt_vars(int n, int init)
 #endif
 
 	RPT_CONFIG_VAR_INT(votertype, "votertype");
+	RPT_CONFIG_VAR_INT(votermode, "votermode");
 	RPT_CONFIG_VAR_INT_DEFAULT(votermargin, "votermargin", 10);
-	RPT_CONFIG_VAR_INT(votertype, "votertype");
 
 	val = ast_variable_retrieve(cfg, cat, "telemnomdb");
 	rpt_vars[n].p.telemnomgain = pow(10.0, atof(S_OR(val, "0")) / 20.0);


### PR DESCRIPTION
Found another missing initialization. The clue was that we were initializing votertype 2x.
Also, ASL2 inits these with default 0