### PR TITLE
app_rpt.c: Move link list addition in rpt_exec()

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -6816,7 +6816,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 
 		/* insert at end of queue */
 		rpt_mutex_lock(&myrpt->lock);
-		rpt_link_add(myrpt, l);
+		rpt_link_add(myrpt, l); /* After putting the link on the linked list, ast_waitfor_n can and will start referencing it */
 		__kickshort(myrpt);
 		gettimeofday(&myrpt->lastlinktime, NULL);
 		rpt_mutex_unlock(&myrpt->lock);

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -6808,7 +6808,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 		}
 
 		/* In theory, both these conditions should be true if one is, since the node thread will queue a soft hangup on this channel and then set l->chan to NULL */
-		if (!l->chan || ast_check_hangup(chan)) {
+		if (ast_check_hangup(chan)) {
 			/* This connection is already toast, just return -1 as normal and let the core kill the channel off */
 			ast_debug(3, "Channel %s is a dead link\n", ast_channel_name(chan));
 			return -1;
@@ -6826,7 +6826,6 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 		 * This goes hand in hand with mirroring the old "KEEPALIVE" behavior. Past this point, there is no PBX for this channel.
 		 * We don't do this until the very end, because the node thread will check if this channel has a PBX to determine
 		 * if it's still "owned" by the PBX thread, as opposed to by an app_rpt thread. */
-
 		rpt_mutex_lock(&myrpt->lock);
 		ast_debug(1, "Stopping PBX on %s\n", ast_channel_name(chan));
 		ast_channel_pbx_set(chan, NULL);


### PR DESCRIPTION
Moving the addition of the link to the linked list prevents `ast_waitfor_n` from adding an unfinished link to the list.  If we `return -1` in `rpt_exec()` AFTER adding a link to the `ast_waitfor_n`, the channel pointer is dumped causing a crash.

The main repeater thread is essentially checking every 20ms (max), rebuilding the list of channels and restarting `ast_waitfor_n`.  This can happen much faster if there are messages on the channels.
