### PR TITLE
rpt_link.c: Avoid allocations of size 0.

### DIFF
--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -579,6 +579,9 @@ void rpt_update_links(struct rpt *myrpt)
 	 */
 	ast_mutex_lock(&myrpt->lock);
 	buffer_size = __get_nodelist_size(myrpt);
+	if (!buffer_size) {
+		return; /* Avoid high fence violation by trying to allocate when size is 0 */
+	}
 	buf = ast_calloc(1, BUFSIZE(buffer_size));
 	if (!buf) {
 		ast_mutex_unlock(&myrpt->lock);


### PR DESCRIPTION
Abort early if the allocation size will be 0. This is possibly due to changes in commit 7b926425281203552b48840f9c5092af669263e9. Apart from being pointless, such an allocation also triggers a high fence violation in astmm, which can cause a crash.

Resolves: #527