### PR TITLE
rpt_channel.c: Remove noisy dtmf_local_timer debug message.

### DIFF
--- a/apps/app_rpt/rpt_channel.c
+++ b/apps/app_rpt/rpt_channel.c
@@ -177,8 +177,6 @@ void do_dtmf_local(struct rpt *myrpt, char c)
 	}
 	/* if at timeout */
 	if (myrpt->dtmf_local_timer == 1) {
-		ast_debug(7, "time out dtmf_local_timer=%i\n", myrpt->dtmf_local_timer);
-
 		/* if anything in the string */
 		if (myrpt->dtmf_local_str[0]) {
 			digit = myrpt->dtmf_local_str[0];


### PR DESCRIPTION
Remove debug message about dtmf_local_timer reaching 1. This is obvious from the code structure and is incredibly noisy during test executions.