### PR TITLE
app_rpt: Shut down repeaters if Asterisk is shutting down.

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4952,7 +4952,7 @@ static void *rpt(void *this)
 			break;
 		}
 
-		if (rpt_any_hangups(myrpt)) {
+		if (ast_shutting_down() || rpt_any_hangups(myrpt)) {
 			break;
 		}
 
@@ -5750,7 +5750,7 @@ static void *rpt_master(void *ignore)
 					rpt_vars[i].name[0] = 0;
 					continue;
 				}
-				if (shutting_down) {
+				if (ast_shutting_down() || shutting_down) {
 					continue; /* Don't restart thread if we're unloading the module */
 				}
 				if (time(NULL) - rpt_vars[i].lastthreadrestarttime <= 5) {


### PR DESCRIPTION
* Abort repeater loop if Asterisk is shutting down.
* Don't try restarting repeaters if Asterisk is shutting down.

This prevents tests from hanging forever and timing out when the test suite attempts to shut Asterisk down.