### PR TITLE
tests: Add initial test suite test for fast disconnect.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     container: debian:12
     steps:
-      - name: Build Asterisk
+      - name: Build DAHDI and Asterisk
         run: |
           cd /usr/src
           apt-get update -y
@@ -25,16 +25,15 @@ jobs:
           wget https://docs.phreaknet.org/script/phreaknet.sh
           chmod +x phreaknet.sh
           ./phreaknet.sh make
-          phreaknet update
-          phreaknet install --dahdi --lightweight --alsa --fast --devmode
+          phreaknet install --dahdi --lightweight --alsa --fast --devmode --testsuite
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build app_rpt
         run: |
-          pwd
-          ls -la ..
-          ls -la
           cp -r ../app_rpt /usr/src
-          ls -la /usr/src
           cd /usr/src/app_rpt
           ./rpt_install.sh
+      - name: Run tests
+        run: |
+          cd /usr/src/testsuite
+          phreaknet runtest apps/rpt

--- a/README.md
+++ b/README.md
@@ -37,18 +37,37 @@ Updated instructions are in the ASL3-Manual repo at https://github.com/AllStarLi
 
 Step 1: Install DAHDI and Asterisk
 
+**For users:**
+
 ```
 cd /usr/src && wget https://docs.phreaknet.org/script/phreaknet.sh && chmod +x phreaknet.sh && ./phreaknet.sh make
-phreaknet install --alsa -d -b -v 20` # install in developer mode (for backtraces and assertions),  add -s for chan_sip (if you need it still) and DAHDI (required)
+phreaknet install --alsa -d -b -v 20 # -d for DAHDI, add -s for chan_sip (if you need it still)
 ```
 
 The critical flags here are `--alsa`, which adds ALSA support to the build system (required for `chan_simpleusb` and `chan_usbradio` to build) and `-d`, to install DAHDI.
+
+**For developers:**
+
+Developers should build Asterisk with DEVMODE enabled (for backtraces and assertions) and also install the test suite:
+
+```
+cd /usr/src && wget https://docs.phreaknet.org/script/phreaknet.sh && chmod +x phreaknet.sh && ./phreaknet.sh make
+phreaknet install --alsa --dahdi --devmode --testsuite
+```
 
 Step 2: Install app_rpt modules
 
 - Clone this repo into `/usr/src` on your system: `cd /usr/src; git clone https://github.com/AllStarLink/app_rpt.git`
 
-- Then, run: `./rpt_install.sh`
+- If you would like to also install the test suite, also clone the test suite now: `cd /usr/src; git clone https://github.com/asterisk/testsuite.git`
+
+- Finally, run: `./rpt_install.sh`. This compiles Asterisk with the radio modules and adds the radio tests to the test suite, if it was present.
+
+### Running the tests
+
+If you installed the test suite, you can run the `app_rpt` tests by running `cd /usr/src/testsuite; ./runInVenv.sh python3 runtests.py --test=tests/apps/rpt`
+
+You can also use the `phreaknet runtest` command during development (e.g. `phreaknet runtest apps/rpt`), as it has some helpful tooling and wrappers to help with debugging when tests fails.
 
 ## Manual Installation (not recommended)
 

--- a/rpt_install.sh
+++ b/rpt_install.sh
@@ -175,3 +175,10 @@ if [ ! -d /var/lib/asterisk/sounds/en/rpt ]; then
 	tar -xvzf asterisk-asl-sounds-en-ulaw.tar.gz
 	rm asterisk-asl-sounds-en-ulaw.tar.gz
 fi
+
+# Add tests to the test suite, if it exists
+if [ -d /usr/src/testsuite ]; then
+	cd /usr/src/testsuite
+	git apply ../$MYDIR/tests/apps/tests_apps.diff
+	cp -r ../$MYDIR/tests/apps/rpt tests/apps
+fi

--- a/tests/apps/rpt/fast_connect_disconnect/configs/ast1/extensions.conf
+++ b/tests/apps/rpt/fast_connect_disconnect/configs/ast1/extensions.conf
@@ -1,0 +1,22 @@
+
+[default]
+
+[wait]
+exten => s,1,Answer(,i)
+	same => n,Wait(999)
+	same => n,Hangup()
+
+; Manually launch test using 'channel originate Local/s@wait extension ilink@timer'
+[timer]
+exten => ilink,1,Answer(,i)
+	same => n,Wait(0.1) ; Rpt() currently rejects calls until 2 seconds after module load
+	;same => n,System(asterisk -rx "rpt cmd 456 ilink 13 123")
+	same => n,UserEvent(TimerExpired,TimerEvent:nodestart) ; this will trigger a call to 123@repeaters
+	same => n,Wait(0.01)
+	;same => n,System(asterisk -rx "rpt cmd 456 ilink 11 123")
+	same => n,UserEvent(TimerExpired,TimerEvent:ilink) ; trigger disconnect right after connect
+	same => n,Hangup()
+
+[repeaters]
+exten => 123,1,Set(CALLERID(num)=456)
+	same => n,Rpt(${EXTEN})

--- a/tests/apps/rpt/fast_connect_disconnect/configs/ast1/iax.conf
+++ b/tests/apps/rpt/fast_connect_disconnect/configs/ast1/iax.conf
@@ -1,0 +1,9 @@
+[general]
+bandwidth=high
+debug=yes
+authdebug=yes
+
+[radio]
+type=user
+username=radio
+context=repeaters

--- a/tests/apps/rpt/fast_connect_disconnect/configs/ast1/logger.general.conf.inc
+++ b/tests/apps/rpt/fast_connect_disconnect/configs/ast1/logger.general.conf.inc
@@ -1,0 +1,1 @@
+dateformat=%F %T.%3q   ; with milliseconds

--- a/tests/apps/rpt/fast_connect_disconnect/configs/ast1/modules.conf
+++ b/tests/apps/rpt/fast_connect_disconnect/configs/ast1/modules.conf
@@ -1,0 +1,12 @@
+[modules]
+autoload=no
+
+require => app_dial
+require => app_rpt
+require => app_userevent
+require => chan_dahdi
+require => chan_iax2
+require => codec_ulaw
+require => func_callerid
+require => pbx_config
+require => res_curl

--- a/tests/apps/rpt/fast_connect_disconnect/configs/ast1/rpt.conf
+++ b/tests/apps/rpt/fast_connect_disconnect/configs/ast1/rpt.conf
@@ -1,0 +1,12 @@
+[general]
+node_lookup_method = file
+
+[nodes]
+123 = radio@127.0.0.1/123,NONE ; server
+456 = radio@127.0.0.1/456,NONE ; client
+
+[123]
+rxchannel = DAHDI/pseudo
+
+[456]
+rxchannel = DAHDI/pseudo

--- a/tests/apps/rpt/fast_connect_disconnect/test-config.yaml
+++ b/tests/apps/rpt/fast_connect_disconnect/test-config.yaml
@@ -1,0 +1,92 @@
+testinfo:
+    summary: 'Test fast connect/disconnect'
+    description: |
+        'See app_rpt issue #459'
+
+test-modules:
+    test-object:
+        config-section: test-object-config
+        typename: 'test_case.TestCaseModule'
+    modules:
+        -
+            config-section: timer-originator
+            typename: 'pluggable_modules.Originator'
+        -
+            config-section: hangup-monitor
+            typename: 'pluggable_modules.HangupMonitor'
+        -
+            config-section: ami-config-1
+            typename: 'pluggable_modules.EventActionModule'
+        -
+            config-section: ami-config-2
+            typename: 'pluggable_modules.EventActionModule'
+        -
+            config-section: ami-config-3
+            typename: 'pluggable_modules.EventActionModule'
+
+test-object-config:
+    connect-ami: True
+    reactor-timeout: 10
+    stop-after-scenarios: False
+
+timer-originator:
+    channel: 'Local/s@wait'
+    context: 'timer'
+    exten: 'ilink'
+    priority: '1'
+    trigger: 'ami_connect'
+
+hangup-monitor:
+    ids: '0'
+
+ami-config-1:
+    -
+        ami-events:
+            conditions:
+                match:
+                    Event: 'UserEvent'
+                    UserEvent: 'TimerExpired'
+                    TimerEvent: nodestart
+        ami-actions:
+            action:
+                Action: 'Command'
+                Command: 'rpt cmd 456 ilink 13 123'
+
+ami-config-2:
+    -
+        ami-events:
+            conditions:
+                match:
+                    Event: 'UserEvent'
+                    UserEvent: 'TimerExpired'
+                    TimerEvent: ilink
+        ami-actions:
+            action:
+                Action: 'Command'
+                Command: 'rpt cmd 456 ilink 11 123'
+
+# Something that allows us to detect that everything's gone as expected,
+# we haven't crashed, and we can stop the test after the connect/disconnect
+ami-config-3:
+    -
+        ami-events:
+            conditions:
+                match:
+                    Event: 'RPT_ALINKS'
+                    EventValue: '0'
+                count: 5
+        stop_test:
+
+properties:
+    tags:
+        - dial
+        - apps
+    dependencies:
+        - python: 'twisted'
+        - python: 'starpy'
+        - asterisk: 'app_dial'
+        - asterisk: 'app_userevent'
+        - asterisk: 'app_originate'
+        - asterisk: 'app_rpt'
+        - asterisk: 'chan_iax2'
+        - asterisk: 'pbx_config'

--- a/tests/apps/rpt/tests.yaml
+++ b/tests/apps/rpt/tests.yaml
@@ -1,0 +1,3 @@
+# Enter tests here in the order they should be considered for execution:
+tests:
+    - test: 'fast_connect_disconnect'

--- a/tests/apps/tests_apps.diff
+++ b/tests/apps/tests_apps.diff
@@ -1,0 +1,12 @@
+diff --git a/tests/apps/tests.yaml b/tests/apps/tests.yaml
+index 4c8261c..9124368 100644
+--- a/tests/apps/tests.yaml
++++ b/tests/apps/tests.yaml
+@@ -4,6 +4,7 @@ tests:
+     - dir: 'directory'
+     - dir: 'bridge'
+     - dir: 'dial'
++    - dir: 'rpt'
+     - test: 'originate'
+     - dir: 'voicemail'
+     - dir: 'confbridge'


### PR DESCRIPTION
As part of work on troubleshooting the issues raised in #459 and #460, add a test to try to capture this condition. The test doesn't reliably capture that issue (it passes most of the time), but it should continue to pass if there is a fix.

Since this is our first test, some changes have been made to rpt_install.sh to allow patching the tests in if the Asterisk test suite is present. The CI also runs the tests now.

Note: This is a test suite (black box) test. Currently, there aren't any unit tests (white box) tests.

Part of #20