### PR TITLE
app_rpt.c: fix memory leak around mute_frame_helper()

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -3583,7 +3583,7 @@ static inline void mute_frame_helper(struct rpt *myrpt, struct ast_frame *f, int
 static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 {
 	int ismuted;
-	struct ast_frame *f, *f1;
+	struct ast_frame *f, *lastf2_old;
 	int i, dtmfed = 0;
 
 	rpt_mutex_lock(&myrpt->blocklock);
@@ -3785,18 +3785,18 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 		if (myrpt->p.votertype == 1 && myrpt->voted_link != NULL) {
 			ismuted = 1;
 		}
-		f1 = myrpt->lastf2;
+		lastf2_old = myrpt->lastf2;
 		mute_frame_helper(myrpt, f, ismuted);
-		if (f1) {
-			ast_write(myrpt->localoverride ? myrpt->txpchannel : myrpt->pchannel, f1);
+		if (lastf2_old) {
+			ast_write(myrpt->localoverride ? myrpt->txpchannel : myrpt->pchannel, lastf2_old);
 			if ((myrpt->p.duplex < 2) && myrpt->monstream && (!myrpt->txkeyed) && myrpt->keyed) {
-				ast_writestream(myrpt->monstream, f1);
+				ast_writestream(myrpt->monstream, lastf2_old);
 			}
 			if ((myrpt->p.duplex < 2) && myrpt->keyed && myrpt->p.outstreamcmd &&
 				(myrpt->outstreampipe[1] != -1)) {
-				outstream_write(myrpt, f1);
+				outstream_write(myrpt, lastf2_old);
 			}
-			ast_frfree(f1);
+			ast_frfree(lastf2_old);
 		}
 	} else if (f->frametype == AST_FRAME_DTMF_BEGIN) {
 		if (myrpt->lastf1)
@@ -5911,7 +5911,7 @@ done:
 
 static inline int exec_chan_read(struct rpt *myrpt, struct ast_channel *chan, char *restrict keyed, const int phone_mode, const int phone_vox, char *restrict myfirst, int *restrict dtmfed)
 {
-	struct ast_frame *f = ast_read(chan);
+	struct ast_frame *f = ast_read(chan), *lastf2_old;
 	if (!f) {
 		ast_debug(1, "@@@@ link:Hung Up\n");
 		return -1;
@@ -5970,16 +5970,16 @@ static inline int exec_chan_read(struct rpt *myrpt, struct ast_channel *chan, ch
 		if (*dtmfed && phone_mode)
 			ismuted = 1;
 		*dtmfed = 0;
-		f1 = myrpt->lastf2;
+		lastf2_old = myrpt->lastf2;
 		mute_frame_helper(myrpt, f, ismuted);
-		if (f1) {
+		if (lastf2_old) {
 			if (!myrpt->remstopgen) {
 				if (phone_mode)
-					ast_write(myrpt->txchannel, f1);
+					ast_write(myrpt->txchannel, lastf2_old);
 				else
 					ast_write(myrpt->txchannel, f);
 			}
-			ast_frfree(f1);
+			ast_frfree(lastf2_old);
 		}
 	} else if (f->frametype == AST_FRAME_DTMF_BEGIN) {
 		if (myrpt->lastf1)

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -3583,7 +3583,7 @@ static inline void mute_frame_helper(struct rpt *myrpt, struct ast_frame *f, int
 static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 {
 	int ismuted;
-	struct ast_frame *f, *lastf2_old;
+	struct ast_frame *f, *last_frame;
 	int i, dtmfed = 0;
 
 	rpt_mutex_lock(&myrpt->blocklock);
@@ -3785,18 +3785,18 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 		if (myrpt->p.votertype == 1 && myrpt->voted_link != NULL) {
 			ismuted = 1;
 		}
-		lastf2_old = myrpt->lastf2;
+		last_frame = myrpt->lastf2;
 		mute_frame_helper(myrpt, f, ismuted);
-		if (lastf2_old) {
-			ast_write(myrpt->localoverride ? myrpt->txpchannel : myrpt->pchannel, lastf2_old);
+		if (last_frame) {
+			ast_write(myrpt->localoverride ? myrpt->txpchannel : myrpt->pchannel, last_frame);
 			if ((myrpt->p.duplex < 2) && myrpt->monstream && (!myrpt->txkeyed) && myrpt->keyed) {
-				ast_writestream(myrpt->monstream, lastf2_old);
+				ast_writestream(myrpt->monstream, last_frame);
 			}
 			if ((myrpt->p.duplex < 2) && myrpt->keyed && myrpt->p.outstreamcmd &&
 				(myrpt->outstreampipe[1] != -1)) {
-				outstream_write(myrpt, lastf2_old);
+				outstream_write(myrpt, last_frame);
 			}
-			ast_frfree(lastf2_old);
+			ast_frfree(last_frame);
 		}
 	} else if (f->frametype == AST_FRAME_DTMF_BEGIN) {
 		if (myrpt->lastf1)
@@ -5911,7 +5911,7 @@ done:
 
 static inline int exec_chan_read(struct rpt *myrpt, struct ast_channel *chan, char *restrict keyed, const int phone_mode, const int phone_vox, char *restrict myfirst, int *restrict dtmfed)
 {
-	struct ast_frame *f = ast_read(chan), *lastf2_old;
+	struct ast_frame *f = ast_read(chan), *last_frame;
 	if (!f) {
 		ast_debug(1, "@@@@ link:Hung Up\n");
 		return -1;
@@ -5970,16 +5970,16 @@ static inline int exec_chan_read(struct rpt *myrpt, struct ast_channel *chan, ch
 		if (*dtmfed && phone_mode)
 			ismuted = 1;
 		*dtmfed = 0;
-		lastf2_old = myrpt->lastf2;
+		last_frame = myrpt->lastf2;
 		mute_frame_helper(myrpt, f, ismuted);
-		if (lastf2_old) {
+		if (last_frame) {
 			if (!myrpt->remstopgen) {
 				if (phone_mode)
-					ast_write(myrpt->txchannel, lastf2_old);
+					ast_write(myrpt->txchannel, last_frame);
 				else
 					ast_write(myrpt->txchannel, f);
 			}
-			ast_frfree(lastf2_old);
+			ast_frfree(last_frame);
 		}
 	} else if (f->frametype == AST_FRAME_DTMF_BEGIN) {
 		if (myrpt->lastf1)

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -3551,9 +3551,16 @@ static inline void outstream_write(struct rpt *myrpt, struct ast_frame *f)
 	}
 }
 
-static inline void mute_frame_helper(struct rpt *myrpt, struct ast_frame *f, int ismuted)
+/*! \brief Shifts frames: myrpt->lastf1 -> myrpt->lastf2, f -> myrpt->lastf1.
+ * If muted, old lastf2, lastf1, lastf2 and f are filled with zeros.
+ * \param myrpt - the rpt structure
+ * \param f - the frame to be stored in lastf1
+ * \param ismuted - if true, the frame is muted by filling f, lastf1 and lastf2 with zeros
+ */
+static inline void mute_frame_helper(struct rpt *myrpt, struct ast_frame *f, int ismuted) 
 {
 	struct ast_frame *f2;
+
 	if (ismuted) {
 		memset(f->data.ptr, 0, f->datalen);
 		if (myrpt->lastf1)
@@ -3561,6 +3568,7 @@ static inline void mute_frame_helper(struct rpt *myrpt, struct ast_frame *f, int
 		if (myrpt->lastf2)
 			memset(myrpt->lastf2->data.ptr, 0, myrpt->lastf2->datalen);
 	}
+
 	f2 = f ? ast_frdup(f) : NULL;
 	myrpt->lastf2 = myrpt->lastf1;
 	myrpt->lastf1 = f2;
@@ -3777,8 +3785,8 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 		if (myrpt->p.votertype == 1 && myrpt->voted_link != NULL) {
 			ismuted = 1;
 		}
-		mute_frame_helper(myrpt, f, ismuted);
 		f1 = myrpt->lastf2;
+		mute_frame_helper(myrpt, f, ismuted);
 		if (f1) {
 			ast_write(myrpt->localoverride ? myrpt->txpchannel : myrpt->pchannel, f1);
 			if ((myrpt->p.duplex < 2) && myrpt->monstream && (!myrpt->txkeyed) && myrpt->keyed) {
@@ -3788,7 +3796,6 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 				(myrpt->outstreampipe[1] != -1)) {
 				outstream_write(myrpt, f1);
 			}
-			myrpt->lastf2 = NULL; /* Aliased with f1, so set to NULL since this reference is no longer valid */
 			ast_frfree(f1);
 		}
 	} else if (f->frametype == AST_FRAME_DTMF_BEGIN) {
@@ -5963,8 +5970,8 @@ static inline int exec_chan_read(struct rpt *myrpt, struct ast_channel *chan, ch
 		if (*dtmfed && phone_mode)
 			ismuted = 1;
 		*dtmfed = 0;
-		mute_frame_helper(myrpt, f, ismuted);
 		f1 = myrpt->lastf2;
+		mute_frame_helper(myrpt, f, ismuted);
 		if (f1) {
 			if (!myrpt->remstopgen) {
 				if (phone_mode)
@@ -5972,7 +5979,6 @@ static inline int exec_chan_read(struct rpt *myrpt, struct ast_channel *chan, ch
 				else
 					ast_write(myrpt->txchannel, f);
 			}
-			myrpt->lastf2 = NULL; /* Aliased with f1, so set to NULL since this reference is no longer valid */
 			ast_frfree(f1);
 		}
 	} else if (f->frametype == AST_FRAME_DTMF_BEGIN) {


### PR DESCRIPTION
Add docs to the `mute_frame_helper()`
Copy lastf2 BEFORE shifting frames