### PR TITLE
app_rpt.c: add rpt_frame_helper and refactor mute_frame_helper

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4441,11 +4441,7 @@ static inline int process_link_channels(struct rpt *myrpt, struct ast_channel *w
 					}
 				} else {
 					/* if a voting rx link and not the winner, mute audio */
-					if (myrpt->p.votertype == 1 && l->voterlink && myrpt->voted_link != l)
-						ismuted = 1;
-					else
-						ismuted = 0;
-
+					ismuted = (myrpt->p.votertype == 1) && l->voterlink && (myrpt->voted_link != l);
 					if (!l->lastrx || ismuted)
 						RPT_MUTE_FRAME(f);
 					ast_write(l->pchan, f);

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -3790,8 +3790,8 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 		if (myrpt->p.votertype == 1 && myrpt->voted_link != NULL) {
 			ismuted = 1;
 		}
-		mute_frame_helper(myrpt, f, ismuted);
 		f1 = myrpt->lastf2;
+		mute_frame_helper(myrpt, f, ismuted);
 		if (f1) {
 			ast_write(myrpt->localoverride ? myrpt->txpchannel : myrpt->pchannel, f1);
 			if ((myrpt->p.duplex < 2) && myrpt->monstream && (!myrpt->txkeyed) && myrpt->keyed) {
@@ -3801,7 +3801,6 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 				(myrpt->outstreampipe[1] != -1)) {
 				outstream_write(myrpt, f1);
 			}
-			myrpt->lastf2 = NULL; /* Aliased with f1, so set to NULL since this reference is no longer valid */
 			ast_frfree(f1);
 		}
 	} else if (f->frametype == AST_FRAME_DTMF_BEGIN) {
@@ -5970,8 +5969,8 @@ static inline int exec_chan_read(struct rpt *myrpt, struct ast_channel *chan, ch
 		if (*dtmfed && phone_mode)
 			ismuted = 1;
 		*dtmfed = 0;
-		mute_frame_helper(myrpt, f, ismuted);
 		f1 = myrpt->lastf2;
+		mute_frame_helper(myrpt, f, ismuted);
 		if (f1) {
 			if (!myrpt->remstopgen) {
 				if (phone_mode)
@@ -5979,7 +5978,6 @@ static inline int exec_chan_read(struct rpt *myrpt, struct ast_channel *chan, ch
 				else
 					ast_write(myrpt->txchannel, f);
 			}
-			myrpt->lastf2 = NULL; /* Aliased with f1, so set to NULL since this reference is no longer valid */
 			ast_frfree(f1);
 		}
 	} else if (f->frametype == AST_FRAME_DTMF_BEGIN) {

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -3570,7 +3570,7 @@ static inline void dtmf_mute_frame_helper(struct rpt *myrpt)
  * \param f - the frame to be stored in lastf1
  * \param ismuted - if true, the frame is muted by filling f, lastf1 and lastf2 with zeros
  */
-static inline ast_frame *rpt_mute_frame_helper(struct rpt *myrpt, struct ast_frame *f, int ismuted)
+static inline struct ast_frame *rpt_frame_helper(struct rpt *myrpt, struct ast_frame *f, int ismuted)
 {
 	struct ast_frame *f2, *last_frame;
 
@@ -3791,7 +3791,7 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 		if (myrpt->p.votertype == 1 && myrpt->voted_link != NULL) {
 			ismuted = 1;
 		}
-		f1 = rpt_mute_frame_helper(myrpt, f, ismuted);
+		f1 = rpt_frame_helper(myrpt, f, ismuted);
 		if (f1) {
 			ast_write(myrpt->localoverride ? myrpt->txpchannel : myrpt->pchannel, f1);
 			if ((myrpt->p.duplex < 2) && myrpt->monstream && (!myrpt->txkeyed) && myrpt->keyed) {
@@ -5969,7 +5969,7 @@ static inline int exec_chan_read(struct rpt *myrpt, struct ast_channel *chan, ch
 		if (*dtmfed && phone_mode)
 			ismuted = 1;
 		*dtmfed = 0;
-		f1 = rpt_mute_frame_helper(myrpt, f, ismuted);
+		f1 = rpt_frame_helper(myrpt, f, ismuted);
 		if (f1) {
 			if (!myrpt->remstopgen) {
 				if (phone_mode)

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -3564,13 +3564,13 @@ static inline void mute_frame_helper(struct rpt *myrpt)
  * If muted, old lastf2, lastf1, lastf2 and f are filled with zeros.
  * \param myrpt - the rpt structure
  * \param f - the frame to be stored in lastf1
- * \param ismuted - if true, the frame is muted by filling f, lastf1 and lastf2 with zeros
+ * \param mute - if true, the frame is muted by filling last_frame, f, lastf1 and lastf2 with zeros
  */
-static inline struct ast_frame *rpt_frame_helper(struct rpt *myrpt, struct ast_frame *f, int ismuted)
+static inline struct ast_frame *rpt_frame_helper(struct rpt *myrpt, struct ast_frame *f, int mute)
 {
 	struct ast_frame *f2, *last_frame;
 
-	if (ismuted) {
+	if (mute) {
 		RPT_MUTE_FRAME_IE(f);
 		mute_frame_helper(myrpt);
 	}

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -5939,15 +5939,14 @@ static inline int exec_chan_read(struct rpt *myrpt, struct ast_channel *chan, ch
 			ismuted = 1;
 		*dtmfed = 0;
 		f1 = rpt_frame_helper(myrpt, f, ismuted);
-		if (f1) {
-			if (!myrpt->remstopgen) {
-				if (phone_mode)
-					ast_write(myrpt->txchannel, f1);
-				else
-					ast_write(myrpt->txchannel, f);
+		if (!myrpt->remstopgen) {
+			if (phone_mode && f1) {
+				ast_write(myrpt->txchannel, f1);
+			} else if (!phone_mode) {
+				ast_write(myrpt->txchannel, f);
 			}
-			ast_frfree(f1);
 		}
+		ast_frfree(f1);
 	} else if (f->frametype == AST_FRAME_DTMF_BEGIN) {
 		mute_frame_helper(myrpt);
 		*dtmfed = 1;

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -3564,27 +3564,27 @@ static inline void dtmf_mute_frame_helper(struct rpt *myrpt)
 	}
 }
 
+/*! \brief Shifts frames: myrpt->lastf1 -> myrpt->lastf2, f -> myrpt->lastf1.
+ * If muted, old lastf2, lastf1, lastf2 and f are filled with zeros.
+ * \param myrpt - the rpt structure
+ * \param f - the frame to be stored in lastf1
+ * \param ismuted - if true, the frame is muted by filling f, lastf1 and lastf2 with zeros
+ */
 static inline void mute_frame_helper(struct rpt *myrpt, struct ast_frame *f, int ismuted)
 {
 	struct ast_frame *f2;
+
 	if (ismuted) {
-		memset(f->data.ptr, 0, f->datalen);
-		if (myrpt->lastf1)
-			memset(myrpt->lastf1->data.ptr, 0, myrpt->lastf1->datalen);
-		if (myrpt->lastf2)
-			memset(myrpt->lastf2->data.ptr, 0, myrpt->lastf2->datalen);
+		if (f) {
+			memset(f->data.ptr, 0, f->datalen);
+		}
+		dtmf_mute_frame_helper(myrpt);
 	}
+
 	f2 = f ? ast_frdup(f) : NULL;
 	myrpt->lastf2 = myrpt->lastf1;
 	myrpt->lastf1 = f2;
-	if (ismuted) {
-		if (myrpt->lastf1)
-			memset(myrpt->lastf1->data.ptr, 0, myrpt->lastf1->datalen);
-		if (myrpt->lastf2)
-			memset(myrpt->lastf2->data.ptr, 0, myrpt->lastf2->datalen);
-	}
 }
-
 static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 {
 	int ismuted;

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -3560,11 +3560,11 @@ static inline void mute_frame_helper(struct rpt *myrpt)
 	RPT_MUTE_FRAME(myrpt->lastf2);
 }
 
-/*! \brief Shifts frames: myrpt->lastf1 -> myrpt->lastf2, f -> myrpt->lastf1.
- * If muted, lastf1, lastf2 and f are filled with zeros before shifting the frames.
+/*! \brief Shifts frames: myrpt->lastf2 -> return value, myrpt->lastf1 -> myrpt->lastf2, f -> myrpt->lastf1.
  * \param myrpt - the rpt structure
  * \param f - the frame to be stored in lastf1
- * \param mute - if true, the frame is muted by filling last_frame, f, lastf1 and lastf2 with zeros
+ * \param mute - if true, the frame is muted by filling f, lastf1 and lastf2 with zeros
+ * \note If muted, lastf1, lastf2 and f are filled with zeros before shifting the frames, resulting in a muted return frame.
  */
 static inline struct ast_frame *rpt_frame_helper(struct rpt *myrpt, struct ast_frame *f, int mute)
 {

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -3556,12 +3556,12 @@ static inline void outstream_write(struct rpt *myrpt, struct ast_frame *f)
  */
 static inline void mute_frame_helper(struct rpt *myrpt)
 {
-	RPT_MUTE_FRAME_IE(myrpt->lastf1);
-	RPT_MUTE_FRAME_IE(myrpt->lastf2);
+	RPT_MUTE_FRAME(myrpt->lastf1);
+	RPT_MUTE_FRAME(myrpt->lastf2);
 }
 
 /*! \brief Shifts frames: myrpt->lastf1 -> myrpt->lastf2, f -> myrpt->lastf1.
- * If muted, old lastf2, lastf1, lastf2 and f are filled with zeros.
+ * If muted, lastf1, lastf2 and f are filled with zeros before shifting the frames.
  * \param myrpt - the rpt structure
  * \param f - the frame to be stored in lastf1
  * \param mute - if true, the frame is muted by filling last_frame, f, lastf1 and lastf2 with zeros
@@ -3571,7 +3571,7 @@ static inline struct ast_frame *rpt_frame_helper(struct rpt *myrpt, struct ast_f
 	struct ast_frame *f2, *last_frame;
 
 	if (mute) {
-		RPT_MUTE_FRAME_IE(f);
+		RPT_MUTE_FRAME(f);
 		mute_frame_helper(myrpt);
 	}
 	f2 = f ? ast_frdup(f) : NULL;

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -3551,6 +3551,19 @@ static inline void outstream_write(struct rpt *myrpt, struct ast_frame *f)
 	}
 }
 
+/*! \brief Zero data in myrpt->lastf1 and lastf2 registers (muting audio)
+ * \param myrpt The rpt structure to mute
+ */
+static inline void dtmf_mute_frame_helper(struct rpt *myrpt)
+{
+	if (myrpt->lastf1) {
+		memset(myrpt->lastf1->data.ptr, 0, myrpt->lastf1->datalen);
+	}
+	if (myrpt->lastf2) {
+		memset(myrpt->lastf2->data.ptr, 0, myrpt->lastf2->datalen);
+	}
+}
+
 static inline void mute_frame_helper(struct rpt *myrpt, struct ast_frame *f, int ismuted)
 {
 	struct ast_frame *f2;
@@ -3792,10 +3805,7 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 			ast_frfree(f1);
 		}
 	} else if (f->frametype == AST_FRAME_DTMF_BEGIN) {
-		if (myrpt->lastf1)
-			memset(myrpt->lastf1->data.ptr, 0, myrpt->lastf1->datalen);
-		if (myrpt->lastf2)
-			memset(myrpt->lastf2->data.ptr, 0, myrpt->lastf2->datalen);
+		dtmf_mute_frame_helper(myrpt);
 		dtmfed = 1;
 		myrpt->lastdtmftime = ast_tvnow();
 	} else if (f->frametype == AST_FRAME_DTMF) {
@@ -3816,10 +3826,7 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 
 			return 0;
 		}
-		if (myrpt->lastf1)
-			memset(myrpt->lastf1->data.ptr, 0, myrpt->lastf1->datalen);
-		if (myrpt->lastf2)
-			memset(myrpt->lastf2->data.ptr, 0, myrpt->lastf2->datalen);
+		dtmf_mute_frame_helper(myrpt);
 		dtmfed = 1;
 		if ((!myrpt->lastkeytimer) && (!myrpt->localoverride)) {
 			if (myrpt->p.dtmfkey)
@@ -5976,17 +5983,11 @@ static inline int exec_chan_read(struct rpt *myrpt, struct ast_channel *chan, ch
 			ast_frfree(f1);
 		}
 	} else if (f->frametype == AST_FRAME_DTMF_BEGIN) {
-		if (myrpt->lastf1)
-			memset(myrpt->lastf1->data.ptr, 0, myrpt->lastf1->datalen);
-		if (myrpt->lastf2)
-			memset(myrpt->lastf2->data.ptr, 0, myrpt->lastf2->datalen);
+		dtmf_mute_frame_helper(myrpt);
 		*dtmfed = 1;
 	}
 	if (f->frametype == AST_FRAME_DTMF) {
-		if (myrpt->lastf1)
-			memset(myrpt->lastf1->data.ptr, 0, myrpt->lastf1->datalen);
-		if (myrpt->lastf2)
-			memset(myrpt->lastf2->data.ptr, 0, myrpt->lastf2->datalen);
+		dtmf_mute_frame_helper(myrpt);
 		*dtmfed = 1;
 		if (handle_remote_phone_dtmf(myrpt, f->subclass.integer, keyed, phone_mode) == -1) {
 			ast_debug(1, "@@@@ rpt:Hung Up\n");

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -929,4 +929,4 @@ void __donodelog_fmt(struct rpt *myrpt, const char *file, int lineno, const char
 void rpt_event_process(struct rpt *myrpt);
 void *rpt_call(void *this);
 
-#define RPT_MUTE_FRAME_IE(f) if (f) memset(f->data.ptr, 0, f->datalen)
+#define RPT_MUTE_FRAME(f) if (f) memset(f->data.ptr, 0, f->datalen)

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -929,4 +929,6 @@ void __donodelog_fmt(struct rpt *myrpt, const char *file, int lineno, const char
 void rpt_event_process(struct rpt *myrpt);
 void *rpt_call(void *this);
 
-#define RPT_MUTE_FRAME(f) if (f) memset(f->data.ptr, 0, f->datalen)
+#define RPT_MUTE_FRAME(f) \
+	if (f) \
+	ast_frame_clear(f)

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -928,3 +928,5 @@ void __donodelog_fmt(struct rpt *myrpt, const char *file, int lineno, const char
 
 void rpt_event_process(struct rpt *myrpt);
 void *rpt_call(void *this);
+
+#define RPT_MUTE_FRAME_IE(f) if (f) memset(f->data.ptr, 0, f->datalen)


### PR DESCRIPTION
Noticed this chunk of code reused a few times.
Add a new `mute_frame_helper()`
Remove unnecessary `memset()` from `mute_frame_helper()`
Rename original `mute_frame_helper()` to `rpt_frame_helper()`
Add macro for muting frames.

