### PR TITLE
app_rpt.c: Fix update_timer logic to stop timing when timer = 0

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -3090,7 +3090,7 @@ static inline void rxunkey_helper(struct rpt *myrpt, struct rpt_link *l)
 /*! \brief Do timer value update, limit to end_val */
 static inline void update_timer(int *timer_ptr, int elap, int end_val)
 {
-	if (!timer_ptr){
+	if (!timer_ptr || !*timer_ptr) { /* if the timer value = 0 or we have a null pointer, do not update */
 		return;
 	}
 	if (*timer_ptr > end_val) {


### PR DESCRIPTION
The DTMF timer is using the timer value as a one-shot.  If the timer = 1, we stop counting, then the DTMF logic is supposed to execute 1 time and set the timer value to 0.  
Our timer logic was only checking for a NULL pointer, it should also be checking for a value of 0.
Eliminates the need for https://github.com/AllStarLink/app_rpt/pull/529