### PR TITLE
pre-commit.yml: Use specific version of codespell.

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: codespell-project/actions-codespell@master
+      - uses: codespell-project/actions-codespell@v2.1
         with:
           check_filenames: true
           ignore_words_file: ./.dev/.codespellignore


### PR DESCRIPTION
I should have locked this to a version -> using master is not a good idea.