### PR TITLE
app_rpt.c: Don't keyup link if TOT

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4322,7 +4322,7 @@ static inline int process_link_channels(struct rpt *myrpt, struct ast_channel *w
 			if (myrpt->patchvoxalways)
 				mycalltx = mycalltx && ((!myrpt->voxtostate) && myrpt->wasvox);
 #endif
-			*totx = ((l->isremote) ? (remnomute) : myrpt->localtx || mycalltx) || remrx;
+			*totx = ((l->isremote) ? (remnomute) : (myrpt->localtx && myrpt->totimer) || mycalltx) || remrx;
 
 			/* foop */
 			if ((!l->lastrx) && altlink(myrpt, l))
@@ -6050,7 +6050,12 @@ static inline int exec_rxchannel_read(struct rpt *myrpt, const int reming, const
 		if (myreming || !*remkeyed || (myrpt->remote && myrpt->remotetx) || (myrpt->remmode != REM_MODE_FM && notremming)) {
 			memset(f->data.ptr, 0, f->datalen);
 		}
-		ast_write(myrpt->pchannel, f);
+		if (myrpt->totimer) {
+			if (myrpt->totimer) { /* Don't send local RX voice frames if the local repeater is timedout */
+				ast_write(myrpt->pchannel, f);
+			}
+		}
+		
 	} else if (f->frametype == AST_FRAME_CONTROL) {
 		if (f->subclass.integer == AST_CONTROL_HANGUP) {
 			ast_debug(1, "@@@@ rpt:Hung Up\n");

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -6050,10 +6050,8 @@ static inline int exec_rxchannel_read(struct rpt *myrpt, const int reming, const
 		if (myreming || !*remkeyed || (myrpt->remote && myrpt->remotetx) || (myrpt->remmode != REM_MODE_FM && notremming)) {
 			memset(f->data.ptr, 0, f->datalen);
 		}
-		if (myrpt->totimer) {
-			if (myrpt->totimer) { /* Don't send local RX voice frames if the local repeater is timed out */
-				ast_write(myrpt->pchannel, f);
-			}
+		if (myrpt->totimer) { /* Don't send local RX voice frames if the local repeater is timed out */
+			ast_write(myrpt->pchannel, f);
 		}
 	} else if (f->frametype == AST_FRAME_CONTROL) {
 		if (f->subclass.integer == AST_CONTROL_HANGUP) {

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -6051,11 +6051,10 @@ static inline int exec_rxchannel_read(struct rpt *myrpt, const int reming, const
 			memset(f->data.ptr, 0, f->datalen);
 		}
 		if (myrpt->totimer) {
-			if (myrpt->totimer) { /* Don't send local RX voice frames if the local repeater is timedout */
+			if (myrpt->totimer) { /* Don't send local RX voice frames if the local repeater is timed out */
 				ast_write(myrpt->pchannel, f);
 			}
 		}
-		
 	} else if (f->frametype == AST_FRAME_CONTROL) {
 		if (f->subclass.integer == AST_CONTROL_HANGUP) {
 			ast_debug(1, "@@@@ rpt:Hung Up\n");


### PR DESCRIPTION
Addressing https://github.com/AllStarLink/ASL3/issues/134

When the local repeater times out on TOTIMER, stop transmitting audio and "keyup" to the links from the local inputs.  Link traffic will continue to pass through the node to other connected nodes.

