### PR TITLE
rpt_cli: Fix rpt cmd <node> cmd. 

### DIFF
--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -550,11 +550,11 @@ struct sysstate {
 #define CMD_STATE_EXECUTING 3
 
 struct rpt_cmd_struct {
-    int state;
-    int functionNumber;
-    char param[MAXDTMF];
-    char digits[MAXDTMF];
-    int command_source;
+	int state;
+	int functionNumber;
+	char param[MAXMACRO];
+	char digits[MAXDTMF];
+	int command_source;
 };
 
 enum {TOP_TOP,TOP_WON,WON_BEFREAD,BEFREAD_AFTERREAD};

--- a/apps/app_rpt/rpt_cli.c
+++ b/apps/app_rpt/rpt_cli.c
@@ -1003,8 +1003,8 @@ static int rpt_do_cmd(int fd, int argc, const char *const *argv)
 	if (rpt_vars[thisRpt].cmdAction.state == CMD_STATE_IDLE) {
 		rpt_vars[thisRpt].cmdAction.state = CMD_STATE_BUSY;
 		rpt_vars[thisRpt].cmdAction.functionNumber = thisAction;
-		snprintf(rpt_vars[thisRpt].cmdAction.param, MAXDTMF, "%s,%s", argv[4], argv[5]);
-		ast_copy_string(rpt_vars[thisRpt].cmdAction.digits, argv[5], MAXDTMF);
+		snprintf(rpt_vars[thisRpt].cmdAction.param, sizeof(rpt_vars[thisRpt].cmdAction.param), "%s,%s", argv[4], argv[5]);
+		ast_copy_string(rpt_vars[thisRpt].cmdAction.digits, argv[5], sizeof(rpt_vars[thisRpt].cmdAction.digits));
 		rpt_vars[thisRpt].cmdAction.command_source = SOURCE_RPT;
 		rpt_vars[thisRpt].cmdAction.state = CMD_STATE_READY;
 	}							/* if (rpt_vars[thisRpt].cmdAction.state == CMD_STATE_IDLE */

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -1800,7 +1800,7 @@ int function_cmd(struct rpt *myrpt, char *param, char *digitbuf, int command_sou
 
 	if (param) {
 		if (*param == '#') {	/* to execute asterisk cli command */
-			ast_cli_command(rpt_nullfd(), param + 1);
+			ast_cli_command(rpt_nullfd(), param + 2);
 		} else {
 			cp = ast_malloc(strlen(param) + 10);
 			if (!cp) {


### PR DESCRIPTION
Parameter size is too small for actual command line parameters.
Index was including a `,` producing a malformed command line.