### PR TITLE
app_rpt: Use ast_str for l->linklist

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -3274,7 +3274,7 @@ static inline void periodic_process_links(struct rpt *myrpt, const int elap)
 			}
 			/* hang-up on call to device */
 			ast_hangup(l->pchan);
-			rpt_free_link_helper(l);
+			rpt_link_free(l);
 			rpt_mutex_lock(&myrpt->lock);
 			break;
 		}
@@ -3297,7 +3297,7 @@ static inline void periodic_process_links(struct rpt *myrpt, const int elap)
 			dodispgm(myrpt, l->name);
 			/* hang-up on call to device */
 			ast_hangup(l->pchan);
-			rpt_free_link_helper(l);
+			rpt_link_free(l);
 
 			rpt_mutex_lock(&myrpt->lock);
 			break;
@@ -4178,7 +4178,7 @@ static void remote_hangup_helper(struct rpt *myrpt, struct rpt_link *l)
 	rpt_mutex_unlock(&myrpt->lock);
 
 	ast_hangup(l->pchan);
-	rpt_free_link_helper(l);
+	rpt_link_free(l);
 }
 
 static inline void fac_frame(struct ast_frame *restrict f, float fac)
@@ -5225,7 +5225,7 @@ static void *rpt(void *this)
 				if (l->chan)
 					ast_hangup(l->chan);
 				ast_hangup(l->pchan);
-				rpt_free_link_helper(l);
+				rpt_link_free(l);
 				rpt_mutex_lock(&myrpt->lock);
 				/* re-start link traversal */
 				l = myrpt->links.next;
@@ -5434,7 +5434,7 @@ static void *rpt(void *this)
 			ast_hangup(l->chan);
 		ast_hangup(l->pchan);
 		l = l->next;
-		rpt_free_link_helper(ll);
+		rpt_link_free(ll);
 	}
 	if (myrpt->xlink == 1)
 		myrpt->xlink = 2;

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -1,4 +1,3 @@
-
 #define VERSION_MAJOR 3
 #define VERSION_MINOR 3
 #define VERSION_PATCH 0
@@ -69,24 +68,25 @@ typedef struct {
 #endif
 
 /* maximum digits in DTMF buffer, and seconds after * for DTMF command timeout */
-#define MAXDTMF 32
-#define MAXMACRO 512
-#define MAXLINKLIST 5120
-#define LINKLISTTIME 10000
-#define LINKLISTSHORTTIME 200
-#define LINKPOSTTIME 30000
-#define LINKPOSTSHORTTIME 200
-#define KEYPOSTTIME 30000
-#define KEYPOSTSHORTTIME 200
-#define KEYTIMERTIME 250
-#define MACROTIME 100
-#define MACROPTIME 500
-#define DTMF_TIMEOUT 3
-#define KENWOOD_RETRIES 5
-#define TOPKEYN 32
-#define TOPKEYWAIT 3
-#define TOPKEYMAXSTR 30
-#define NEWKEYTIME 2000
+#define	MAXDTMF 32
+#define	MAXMACRO 2048
+#define	MAXNODES 500			  /* Maximum number of nodes allowed in the link list */
+#define	RPT_AST_STR_INIT_SIZE 500 /* initial guess for ast_str size */
+#define	LINKLISTTIME 10000
+#define	LINKLISTSHORTTIME 200
+#define	LINKPOSTTIME 30000
+#define	LINKPOSTSHORTTIME 200
+#define	KEYPOSTTIME 30000
+#define	KEYPOSTSHORTTIME 200
+#define	KEYTIMERTIME 250
+#define	MACROTIME 100
+#define	MACROPTIME 500
+#define	DTMF_TIMEOUT 3
+#define	KENWOOD_RETRIES 5
+#define	TOPKEYN 32
+#define	TOPKEYWAIT 3
+#define	TOPKEYMAXSTR 30
+#define	NEWKEYTIME 2000
 
 #define	AUTHTELLTIME 7000
 #define	AUTHTXTIME 1000
@@ -412,8 +412,8 @@ struct rpt_link {
 	int	reconnects;
 	long long connecttime;
 	struct ast_channel *chan;	
-	struct ast_channel *pchan;	
-	char	linklist[MAXLINKLIST];
+	struct ast_channel *pchan;
+	struct ast_str *linklist;
 	time_t	linklistreceived;
 	int	linklisttimer;
 	int	dtmfed;

--- a/apps/app_rpt/rpt_cli.c
+++ b/apps/app_rpt/rpt_cli.c
@@ -531,9 +531,7 @@ static int rpt_do_xnode(int fd, int argc, const char *const *argv)
 			/* ### GET CONNECTED NODE INFO ####################
 			 * Traverse the list of connected nodes
 			 */
-			rpt_mutex_lock(&myrpt->lock); /* LOCK */
 			__mklinklist(myrpt, NULL, &lbuf, 0);
-			rpt_mutex_unlock(&myrpt->lock); /* LOCK */
 
 			j = 0;
 			l = myrpt->links.next;

--- a/apps/app_rpt/rpt_cli.c
+++ b/apps/app_rpt/rpt_cli.c
@@ -408,7 +408,7 @@ static int rpt_do_xnode(int fd, int argc, const char *const *argv)
 {
 	int i, j;
 	unsigned int ns;
-	char lbuf[MAXLINKLIST], *strs[MAXLINKLIST];
+	char *strs[MAXNODES];
 	struct rpt *myrpt;
 	struct ast_var_t *newvariable;
 	char *connstate;
@@ -416,14 +416,18 @@ static int rpt_do_xnode(int fd, int argc, const char *const *argv)
 	struct rpt_lstat *s, *t;
 	struct rpt_lstat s_head;
 	int nrpts = rpt_num_rpts();
+	struct ast_str *lbuf = ast_str_create(RPT_AST_STR_INIT_SIZE);
 
 	char *parrot_ena, *sys_ena, *tot_ena, *link_ena, *patch_ena, *patch_state;
 	char *sch_ena, *user_funs, *tail_type, *iconns, *tot_state, *ider_state, *tel_mode;
 
+	if (!lbuf) {
+		return RESULT_FAILURE;
+	}
 	if (argc != 3) {
+		ast_free(lbuf);
 		return RESULT_SHOWUSAGE;
 	}
-
 	s = NULL;
 	s_head.next = &s_head;
 	s_head.prev = &s_head;
@@ -527,10 +531,10 @@ static int rpt_do_xnode(int fd, int argc, const char *const *argv)
 			/* ### GET CONNECTED NODE INFO ####################
 			 * Traverse the list of connected nodes
 			 */
+			rpt_mutex_lock(&myrpt->lock); /* LOCK */
+			__mklinklist(myrpt, NULL, &lbuf, 0);
+			rpt_mutex_unlock(&myrpt->lock); /* LOCK */
 
-			rpt_mutex_lock(&myrpt->lock);
-			__mklinklist(myrpt, NULL, lbuf, sizeof(lbuf), 0);
-			rpt_mutex_unlock(&myrpt->lock);
 			j = 0;
 			l = myrpt->links.next;
 			while (l && (l != &myrpt->links)) {
@@ -590,7 +594,7 @@ static int rpt_do_xnode(int fd, int argc, const char *const *argv)
 
 //### GET ALL LINKED NODES INFO ####################
 			/* parse em */
-			ns = finddelim(lbuf, strs, ARRAY_LEN(strs));
+			ns = finddelim(ast_str_buffer(lbuf), strs, ARRAY_LEN(strs));
 			/* sort em */
 			if (ns)
 				qsort((void *) strs, ns, sizeof(char *), mycompar);
@@ -633,9 +637,11 @@ static int rpt_do_xnode(int fd, int argc, const char *const *argv)
 			ast_cli(fd, "ider_state=%s\n", ider_state);
 			ast_cli(fd, "tel_mode=%s\n\n", tel_mode);
 
+			ast_free(lbuf);
 			return RESULT_SUCCESS;
 		}
 	}
+	ast_free(lbuf);
 	return RESULT_FAILURE;
 }
 
@@ -644,23 +650,30 @@ static int rpt_do_nodes(int fd, int argc, const char *const *argv)
 {
 	int i, j;
 	unsigned int ns;
-	char lbuf[MAXLINKLIST], *strs[MAXLINKLIST];
+	char *strs[MAXNODES];
 	struct rpt *myrpt;
 	int nrpts = rpt_num_rpts();
+	struct ast_str *lbuf = ast_str_create(RPT_AST_STR_INIT_SIZE);
+
+	if (!lbuf) {
+		return RESULT_FAILURE;
+	}
 
 	if (argc != 3) {
+		ast_free(lbuf);
 		return RESULT_SHOWUSAGE;
 	}
+
 
 	for (i = 0; i < nrpts; i++) {
 		if (!strcmp(argv[2], rpt_vars[i].name)) {
 			/* Make a copy of all stat variables while locked */
 			myrpt = &rpt_vars[i];
 			rpt_mutex_lock(&myrpt->lock);	/* LOCK */
-			__mklinklist(myrpt, NULL, lbuf, sizeof(lbuf), 0);
+			__mklinklist(myrpt, NULL, &lbuf, 0);
 			rpt_mutex_unlock(&myrpt->lock);	/* UNLOCK */
 			/* parse em */
-			ns = finddelim(lbuf, strs, ARRAY_LEN(strs));
+			ns = finddelim(ast_str_buffer(lbuf), strs, ARRAY_LEN(strs));
 			/* sort em */
 			if (ns)
 				qsort((void *) strs, ns, sizeof(char *), mycompar);
@@ -682,9 +695,11 @@ static int rpt_do_nodes(int fd, int argc, const char *const *argv)
 				}
 			}
 			ast_cli(fd, "\n\n");
+			ast_free(lbuf);
 			return RESULT_SUCCESS;
 		}
 	}
+	ast_free(lbuf);
 	return RESULT_FAILURE;
 }
 

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -363,7 +363,7 @@ int function_ilink(struct rpt *myrpt, char *param, char *digits, int command_sou
 	case 16:					/* Restore links disconnected with "disconnect all links" command */
 		strcpy(tmp, myrpt->savednodes);	/* Make a copy */
 		finddelim(tmp, strs, ARRAY_LEN(strs));	/* convert into substrings */
-		for (i = 0; tmp[0] && strs[i] != NULL && i < ARRAY_LEN(strs); i++) {
+		for (i = 0; tmp[0] && i < ARRAY_LEN(strs) && strs[i]; i++) {
 			s1 = strs[i];
 			if (s1[0] == 'X')
 				mode = 1;

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -53,8 +53,8 @@ static char remdtmfstr[] = "0123456789*#ABCD";
 
 int function_ilink(struct rpt *myrpt, char *param, char *digits, int command_source, struct rpt_link *mylink)
 {
-	char *s1, *s2, tmp[300];
-	char digitbuf[MAXNODESTR], *strs[MAXLINKLIST];
+	char *s1, *s2, tmp[MAXNODESTR];
+	char digitbuf[MAXNODESTR], *strs[MAXNODES];
 	char mode, perma;
 	struct rpt_link *l;
 	int i, r;
@@ -363,7 +363,7 @@ int function_ilink(struct rpt *myrpt, char *param, char *digits, int command_sou
 	case 16:					/* Restore links disconnected with "disconnect all links" command */
 		strcpy(tmp, myrpt->savednodes);	/* Make a copy */
 		finddelim(tmp, strs, ARRAY_LEN(strs));	/* convert into substrings */
-		for (i = 0; tmp[0] && strs[i] != NULL && i < MAXLINKLIST; i++) {
+		for (i = 0; tmp[0] && strs[i] != NULL && i < ARRAY_LEN(strs); i++) {
 			s1 = strs[i];
 			if (s1[0] == 'X')
 				mode = 1;

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -121,7 +121,7 @@ static void check_tlink_list(struct rpt *myrpt)
 /*! \brief free a link structure and it's ast_str linklist if it exists
  *  \param link the link to free
  */
-void rpt_free_link_helper(struct rpt_link *link)
+void rpt_link_free(struct rpt_link *link)
 {
 	if (link->linklist) {
 		ast_free(link->linklist);
@@ -485,7 +485,7 @@ int __mklinklist(struct rpt *myrpt, struct rpt_link *mylink, struct ast_str **bu
 			mode = 'C';			/* indicate connecting */
 		spos = ast_str_strlen(*buf); /* current buf size (b4 we add our stuff) */
 		if (spos > 2) {
-			ast_str_append(buf, 1, "%s", ",");
+			ast_str_append(buf, 0, "%s", ",");
 		}
 	    one_link = 1;
 		if (alink_format) { /* RPT_ALINK format - only show adjacent nodes*/
@@ -739,7 +739,7 @@ int connect_link(struct rpt *myrpt, char *node, int mode, int perma)
 	tele = strchr(deststr, '/');
 	if (!tele) {
 		ast_log(LOG_WARNING, "link3:Dial number (%s) must be in format tech/number\n", deststr);
-		rpt_free_link_helper(l);
+		rpt_link_free(l);
 		return -1;
 	}
 	*tele++ = 0;
@@ -747,7 +747,7 @@ int connect_link(struct rpt *myrpt, char *node, int mode, int perma)
 	cap = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
 	if (!cap) {
 		ast_log(LOG_ERROR, "Failed to alloc cap\n");
-		rpt_free_link_helper(l);
+		rpt_link_free(l);
 		return -1;
 	}
 
@@ -773,7 +773,7 @@ int connect_link(struct rpt *myrpt, char *node, int mode, int perma)
 		if (myrpt->p.archivedir) {
 			donodelog_fmt(myrpt, "LINKFAIL,%s/%s", deststr, tele);
 		}
-		rpt_free_link_helper(l);
+		rpt_link_free(l);
 		ao2_ref(cap, -1);
 		return -1;
 	}
@@ -783,7 +783,7 @@ int connect_link(struct rpt *myrpt, char *node, int mode, int perma)
 	if (__rpt_request_pseudo(l, cap, RPT_PCHAN, RPT_LINK_CHAN)) {
 		ao2_ref(cap, -1);
 		ast_hangup(l->chan);
-		rpt_free_link_helper(l);
+		rpt_link_free(l);
 		return -1;
 	}
 
@@ -793,7 +793,7 @@ int connect_link(struct rpt *myrpt, char *node, int mode, int perma)
 	if (rpt_conf_add_speaker(l->pchan, myrpt)) {
 		ast_hangup(l->chan);
 		ast_hangup(l->pchan);
-		rpt_free_link_helper(l);
+		rpt_link_free(l);
 		return -1;
 	}
 	rpt_mutex_lock(&myrpt->lock);

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -118,6 +118,18 @@ static void check_tlink_list(struct rpt *myrpt)
 	}
 }
 
+/*! \brief free a link structure and it's ast_str linklist if it exists
+ *  \param link the link to free
+ */
+void rpt_free_link_helper(struct rpt_link *link)
+{
+	if (link->linklist) {
+		ast_free(link->linklist);
+		link->linklist = NULL;
+	}
+	ast_free(link);
+}
+
 void tele_link_add(struct rpt *myrpt, struct rpt_tele *t)
 {
 	ast_assert(t != NULL);
@@ -447,50 +459,10 @@ void rpt_link_remove(struct rpt *myrpt, struct rpt_link *l)
 	check_link_list(myrpt);
 }
 
-/*!
- * \brief Get required buffer size for link message. 
- * \retval		buffer size.
- */
-
-int __get_nodelist_size (struct rpt *myrpt)
-{
+int __mklinklist(struct rpt *myrpt, struct rpt_link *mylink, struct ast_str **buf, int alink_format) {
 	struct rpt_link *l;
-	/* minimum size for empty string is 1 byte */
-	int buffer_size_links = 1, buffer_size_alinks = 1, link_size;
-
-	for (l = myrpt->links.next; l != &myrpt->links; l = l->next) {
-		/* if is not a real link, ignore it */
-		if (l->name[0] == '0') {
-			continue;
-		}
-		if (l->mode > 1) {
-			continue;			/* Don't report local modes */
-		}
-		/* Calculate size of buffer required to build the list of linked repeaters.
-		 * RPT_ALINKS format = <count>,1234TU,4321TK,2233RU
-		 * RPT_LINKS format = <count>,T1234,R4321,T2233
-		 * Buffer size ALINKS = LINKS with additional U/K characters for each.
-		 */
-		if (l->linklist[0]) {
-			buffer_size_links += (strlen(l->linklist) + 1); /* +1: 1 for comma */
-		}
-		link_size = strlen(l->name);
-		buffer_size_links += (link_size + 2);  /* +2: 1 for comma, 1 form mode (T/R) */
-		buffer_size_alinks += (link_size + 3); /* +3: 1 for comma, 2 for mode (TU/TK/etc) */
-	}
-
-	return (buffer_size_links > buffer_size_alinks) ? buffer_size_links : buffer_size_alinks;
-}
-
-int __mklinklist(struct rpt *myrpt, struct rpt_link *mylink, char *buf, size_t bufsize, int flag)
-{
-	struct rpt_link *l;
-	char mode;
-	int i, spos, link_count, one_link;
-
-	buf[0] = 0;					/* clear output buffer */
-	link_count = 0;
-	one_link = 0;
+	char mode, *links_buf;
+	int i, spos, len, links_count = 0, one_link = 0;
 	if (myrpt->remote)
 		return 0;
 	/* go thru all links */
@@ -511,42 +483,49 @@ int __mklinklist(struct rpt *myrpt, struct rpt_link *mylink, char *buf, size_t b
 			mode = 'R';			/* indicate RX for our mode */
 		if (!l->thisconnected)
 			mode = 'C';			/* indicate connecting */
-		spos = strlen(buf);		/* current buf size (b4 we add our stuff) */
-		if (spos) {
-			strcat(buf, ",");
-			spos++;
+		spos = ast_str_strlen(*buf); /* current buf size (b4 we add our stuff) */
+		if (spos > 2) {
+			ast_str_append(buf, 1, "%s", ",");
 		}
 	    one_link = 1;
-		if (flag) { /* RPT_ALINK format - only show adjacent nodes*/
-			snprintf(buf + spos, bufsize - spos, "%s%c%c", l->name, mode, (l->lastrx1) ? 'K' : 'U');
+		if (alink_format) { /* RPT_ALINK format - only show adjacent nodes*/
+			ast_str_append(buf, 0, "%s%c%c", l->name, mode, (l->lastrx1) ? 'K' : 'U');
 		} else { /* RPT_LINK format - show all nodes*/
 			/* add nodes into buffer */
-			if (l->linklist[0]) {
-				snprintf(buf + spos, bufsize - spos, "%c%s,%s", mode, l->name, l->linklist);
-			} else {			/* if no nodes, add this node into buffer */
-				snprintf(buf + spos, bufsize - spos, "%c%s", mode, l->name);
+			if (ast_str_strlen(l->linklist)) {
+				ast_str_append(buf, 0, "%c%s,%s", mode, l->name, ast_str_buffer(l->linklist));
+			} else { /* if no nodes, add this node into buffer */
+				ast_str_append(buf, 0, "%c%s", mode, l->name);
 			}
 		}
 		/* if we are in tranceive mode, let all modes stand */
 		if (mode == 'T')
 			continue;
 		/* downgrade everyone on this node if appropriate */
-		for (i = spos; buf[i]; i++) {
-			if (buf[i] == 'T')
-				buf[i] = mode;
-			if ((buf[i] == 'R') && (mode == 'C'))
-				buf[i] = mode;
+		links_buf = ast_str_buffer(*buf);
+		len = ast_str_strlen(*buf);
+		for (i = spos; i < len; i++) {
+			if (links_buf[i] == 'T')
+				links_buf[i] = mode;
+			if ((links_buf[i] == 'R') && (mode == 'C'))
+				links_buf[i] = mode;
 		}
 	}
 	/* After building the string, count number of nodes (commas) in buffer string. The first
 	 * node doesn't have a comma, so we need to add 1 if there is at least one_link.  
 	 */
-	for (link_count = 0; buf[link_count]; buf[link_count]==',' ? link_count++: *buf++);
+	links_count = 0;
+	links_buf = ast_str_buffer(*buf);
+	for (i = 0; i < ast_str_strlen(*buf); i++) {
+		if (links_buf[i] == ',') {
+			links_count++;
+		}
+	}
 	if (one_link) { /* The first link in the list has no comma but we have 1 link */
-		link_count++;
+		links_count++;
 	}
 
-	return link_count;
+	return links_count;
 }
 
 void __kickshort(struct rpt *myrpt)
@@ -565,49 +544,46 @@ void __kickshort(struct rpt *myrpt)
 
 void rpt_update_links(struct rpt *myrpt)
 {
-	char *buf, *obuf;
-	int buffer_size, n;
-	/* figure out the RPT_LINK string size - this will be the largest size
-	 * RPT_ALINK is always a subset of RPT_LINK
-	 */
-	ast_mutex_lock(&myrpt->lock);
-	buffer_size = __get_nodelist_size(myrpt);
-	buf = ast_calloc(1, BUFSIZE(buffer_size));
+	struct ast_str *buf, *obuf;
+	int n;
+
+	buf = ast_str_create(RPT_AST_STR_INIT_SIZE);
 	if (!buf) {
 		ast_mutex_unlock(&myrpt->lock);
 		return;
 	}
-	obuf = ast_calloc(1, OBUFSIZE(buffer_size));
+	obuf = ast_str_create(RPT_AST_STR_INIT_SIZE);
 	if (!obuf) {
 		ast_mutex_unlock(&myrpt->lock);
 		ast_free(buf);
 		return;
 	}
-	n = __mklinklist(myrpt, NULL, buf, BUFSIZE(buffer_size), 1);
+
+	ast_mutex_lock(&myrpt->lock);
+	n = __mklinklist(myrpt, NULL, &buf, 1);
+	ast_mutex_unlock(&myrpt->lock);
 	/* parse em */
 	if (n) {
-		snprintf(obuf, OBUFSIZE(buffer_size), "%d,%s", n, buf);
-	} else {
-		strcpy(obuf, "0");
+		ast_str_set(&obuf, 0, "%d,%s", n, ast_str_buffer(buf));
 	}
-	pbx_builtin_setvar_helper(myrpt->rxchannel, "RPT_ALINKS", obuf);
-	rpt_manager_trigger(myrpt, "RPT_ALINKS", obuf);
-	snprintf(obuf, OBUFSIZE(buffer_size), "%d", n);
-	pbx_builtin_setvar_helper(myrpt->rxchannel, "RPT_NUMALINKS", obuf);
-	rpt_manager_trigger(myrpt, "RPT_NUMALINKS", obuf);
-	n = __mklinklist(myrpt, NULL, buf, BUFSIZE(buffer_size), 0);
+	pbx_builtin_setvar_helper(myrpt->rxchannel, "RPT_ALINKS", ast_str_buffer(obuf));
+	rpt_manager_trigger(myrpt, "RPT_ALINKS", ast_str_buffer(obuf));
+	ast_str_set(&obuf, 0, "%d", n);
+	pbx_builtin_setvar_helper(myrpt->rxchannel, "RPT_NUMALINKS", ast_str_buffer(obuf));
+	rpt_manager_trigger(myrpt, "RPT_NUMALINKS", ast_str_buffer(obuf));
 
+	ast_str_reset(buf);
+	ast_mutex_lock(&myrpt->lock);
+	n = __mklinklist(myrpt, NULL, &buf, 0);
 	ast_mutex_unlock(&myrpt->lock);
 	if (n) {
-		snprintf(obuf, OBUFSIZE(buffer_size), "%d,%s", n, buf);
-	} else {
-		strcpy(obuf, "0");
+		ast_str_set(&obuf, 0, "%d,%s", n, ast_str_buffer(buf));
 	}
-	pbx_builtin_setvar_helper(myrpt->rxchannel, "RPT_LINKS", obuf);
-	rpt_manager_trigger(myrpt, "RPT_LINKS", obuf);
-	snprintf(obuf, OBUFSIZE(buffer_size), "%d", n);
-	pbx_builtin_setvar_helper(myrpt->rxchannel, "RPT_NUMLINKS", obuf);
-	rpt_manager_trigger(myrpt, "RPT_NUMLINKS", obuf);
+	pbx_builtin_setvar_helper(myrpt->rxchannel, "RPT_LINKS", ast_str_buffer(obuf));
+	rpt_manager_trigger(myrpt, "RPT_LINKS", ast_str_buffer(obuf));
+	ast_str_set(&obuf, 0, "%d", n);
+	pbx_builtin_setvar_helper(myrpt->rxchannel, "RPT_NUMLINKS", ast_str_buffer(obuf));
+	rpt_manager_trigger(myrpt, "RPT_NUMLINKS", ast_str_buffer(obuf));
 	rpt_event_process(myrpt);
 
 	ast_free(buf);
@@ -617,10 +593,11 @@ void rpt_update_links(struct rpt *myrpt)
 int connect_link(struct rpt *myrpt, char *node, int mode, int perma)
 {
 	char *s, *s1, *tele, *cp;
-	char lstr[MAXLINKLIST], *strs[MAXLINKLIST];
 	char tmp[300], deststr[325] = "", modechange = 0;
 	char sx[320], *sy;
+	char *strs[MAXNODES]; /* List of pointers to links in link list string */
 	struct rpt_link *l;
+	struct ast_str *lstr;
 	int reconnects = 0;
 	int i, n;
 	int voterlink = 0;
@@ -634,8 +611,9 @@ int connect_link(struct rpt *myrpt, char *node, int mode, int perma)
 	} else {
 		if (node[0] != '3') {
 			if (node_lookup(myrpt, node, tmp, sizeof(tmp) - 1, 1)) {
-				if (strlen(node) >= myrpt->longestnode)
+				if (strlen(node) >= myrpt->longestnode) {
 					return -1;	/* No such node */
+				}
 				return 1;		/* No match yet */
 			}
 		} else {
@@ -646,7 +624,7 @@ int connect_link(struct rpt *myrpt, char *node, int mode, int perma)
 		}
 	}
 
-	if (!strcmp(myrpt->name, node)) {	/* Do not allow connections to self */
+	if (!strcmp(myrpt->name, node)) { /* Do not allow connections to self */
 		return -2;
 	}
 
@@ -703,22 +681,34 @@ int connect_link(struct rpt *myrpt, char *node, int mode, int perma)
 		l->retries = l->max_retries + 1;
 		l->disced = 2;
 		modechange = 1;
-	} else {
-		__mklinklist(myrpt, NULL, lstr, sizeof(lstr), 0);
+	} else { /* Check to see if this node is already linked */
+		lstr = ast_str_create(RPT_AST_STR_INIT_SIZE);
+		if (!lstr) {
+			rpt_mutex_unlock(&myrpt->lock);
+			return -1;
+		}
+		__mklinklist(myrpt, NULL, &lstr, 0);
 		rpt_mutex_unlock(&myrpt->lock);
-		n = finddelim(lstr, strs, ARRAY_LEN(strs));
+		n = finddelim(ast_str_buffer(lstr), strs, ARRAY_LEN(strs));
 		for (i = 0; i < n; i++) {
 			if ((*strs[i] < '0') || (*strs[i] > '9'))
 				strs[i]++;
 			if (!strcmp(strs[i], node)) {
-				return 2;		/* Already linked */
+				ast_free(lstr);
+				return 2; /* Already linked */
 			}
 		}
+		ast_free(lstr);
 	}
 	ast_copy_string(myrpt->lastlinknode, node, sizeof(myrpt->lastlinknode));
 	/* establish call */
 	l = ast_calloc(1, sizeof(struct rpt_link));
 	if (!l) {
+		return -1;
+	}
+	l->linklist = ast_str_create(RPT_AST_STR_INIT_SIZE);
+	if (!l->linklist) {
+		ast_free(l);
 		return -1;
 	}
 	l->mode = mode;
@@ -749,7 +739,7 @@ int connect_link(struct rpt *myrpt, char *node, int mode, int perma)
 	tele = strchr(deststr, '/');
 	if (!tele) {
 		ast_log(LOG_WARNING, "link3:Dial number (%s) must be in format tech/number\n", deststr);
-		ast_free(l);
+		rpt_free_link_helper(l);
 		return -1;
 	}
 	*tele++ = 0;
@@ -757,7 +747,7 @@ int connect_link(struct rpt *myrpt, char *node, int mode, int perma)
 	cap = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
 	if (!cap) {
 		ast_log(LOG_ERROR, "Failed to alloc cap\n");
-		ast_free(l);
+		rpt_free_link_helper(l);
 		return -1;
 	}
 
@@ -783,7 +773,7 @@ int connect_link(struct rpt *myrpt, char *node, int mode, int perma)
 		if (myrpt->p.archivedir) {
 			donodelog_fmt(myrpt, "LINKFAIL,%s/%s", deststr, tele);
 		}
-		ast_free(l);
+		rpt_free_link_helper(l);
 		ao2_ref(cap, -1);
 		return -1;
 	}
@@ -793,7 +783,7 @@ int connect_link(struct rpt *myrpt, char *node, int mode, int perma)
 	if (__rpt_request_pseudo(l, cap, RPT_PCHAN, RPT_LINK_CHAN)) {
 		ao2_ref(cap, -1);
 		ast_hangup(l->chan);
-		ast_free(l);
+		rpt_free_link_helper(l);
 		return -1;
 	}
 
@@ -803,7 +793,7 @@ int connect_link(struct rpt *myrpt, char *node, int mode, int perma)
 	if (rpt_conf_add_speaker(l->pchan, myrpt)) {
 		ast_hangup(l->chan);
 		ast_hangup(l->pchan);
-		ast_free(l);
+		rpt_free_link_helper(l);
 		return -1;
 	}
 	rpt_mutex_lock(&myrpt->lock);

--- a/apps/app_rpt/rpt_link.h
+++ b/apps/app_rpt/rpt_link.h
@@ -58,11 +58,17 @@ void rpt_link_add(struct rpt *myrpt, struct rpt_link *l);
  */
 void rpt_link_remove(struct rpt *myrpt, struct rpt_link *l);
 
-/*! \brief must be called locked */
-int __mklinklist(struct rpt *myrpt, struct rpt_link *mylink, char *buf, size_t bufsize, int flag);
+/*!
+ * \brief Create a list of links for this node.
+ * Must be called locked.
+ * \param myrpt		Pointer to rpt structure.
+ * \param mylink	Pointer to rpt_link structure.
+ * \param buf		Pointer to ast_str buffer - link string is generated in this buffer.
+ * \param alink_format	Flag to indicate if RPT_ALINK format is returned. If not, RPT_LINK
+ * format is returned. \retval		link count.
+ */
 
-/*! \brief must be called locked */
-int __get_nodelist_size (struct rpt *myrpt);
+int __mklinklist(struct rpt *myrpt, struct rpt_link *mylink, struct ast_str **buf, int alink_format);
 
 /*! \brief must be called locked */
 void __kickshort(struct rpt *myrpt);
@@ -79,3 +85,8 @@ void rpt_update_links(struct rpt *myrpt);
  * \retval 2 Already connected to this node
  */
 int connect_link(struct rpt *myrpt, char *node, int mode, int perma);
+
+/*! \brief Free link and associated internal memory.
+ * \param link Link structure to free
+ */
+void rpt_free_link_helper(struct rpt_link *link);

--- a/apps/app_rpt/rpt_link.h
+++ b/apps/app_rpt/rpt_link.h
@@ -89,4 +89,4 @@ int connect_link(struct rpt *myrpt, char *node, int mode, int perma);
 /*! \brief Free link and associated internal memory.
  * \param link Link structure to free
  */
-void rpt_free_link_helper(struct rpt_link *link);
+void rpt_link_free(struct rpt_link *link);

--- a/apps/app_rpt/rpt_manager.c
+++ b/apps/app_rpt/rpt_manager.c
@@ -118,7 +118,7 @@ static int rpt_manager_do_xstat(struct mansession *ses, const struct message *m,
 {
 	int i, j;
 	unsigned int ns;
-	char lbuf[MAXLINKLIST], *strs[MAXLINKLIST];
+	char *strs[MAXNODES];
 	struct rpt *myrpt;
 	struct ast_var_t *newvariable;
 	char *connstate;
@@ -127,10 +127,13 @@ static int rpt_manager_do_xstat(struct mansession *ses, const struct message *m,
 	struct rpt_lstat s_head;
 	const char *node = astman_get_header(m, "Node");
 	int nrpts = rpt_num_rpts();
+	struct ast_str *lbuf = ast_str_create(RPT_AST_STR_INIT_SIZE);
 
 	char *parrot_ena, *sys_ena, *tot_ena, *link_ena, *patch_ena, *patch_state;
 	char *sch_ena, *user_funs, *tail_type, *iconns, *tot_state, *ider_state, *tel_mode;
-
+	if (!lbuf) {
+		return -1;
+	}
 	s = NULL;
 	s_head.next = &s_head;
 	s_head.prev = &s_head;
@@ -206,9 +209,9 @@ static int rpt_manager_do_xstat(struct mansession *ses, const struct message *m,
 
 			/* Get connected node info */
 			/* Traverse the list of connected nodes */
-
-			__mklinklist(myrpt, NULL, lbuf, sizeof(lbuf), 0);
-
+			ast_mutex_lock(&myrpt->lock);
+			__mklinklist(myrpt, NULL, &lbuf, 0);
+			ast_mutex_unlock(&myrpt->lock);
 			j = 0;
 			l = myrpt->links.next;
 			while (l && (l != &myrpt->links)) {
@@ -218,6 +221,7 @@ static int rpt_manager_do_xstat(struct mansession *ses, const struct message *m,
 				}
 				if (!(s = ast_malloc(sizeof(struct rpt_lstat)))) {
 					rpt_mutex_unlock(&myrpt->lock);
+					ast_free(lbuf);
 					return -1;
 				}
 				memset(s, 0, sizeof(struct rpt_lstat));
@@ -270,7 +274,7 @@ static int rpt_manager_do_xstat(struct mansession *ses, const struct message *m,
 			/* Get all linked nodes info */
 
 			/* parse em */
-			ns = finddelim(lbuf, strs, ARRAY_LEN(strs));
+			ns = finddelim(ast_str_buffer(lbuf), strs, ARRAY_LEN(strs));
 			/* sort em */
 			if (ns) {
 				qsort((void *) strs, ns, sizeof(char *), mycompar);
@@ -348,10 +352,12 @@ static int rpt_manager_do_xstat(struct mansession *ses, const struct message *m,
 			astman_append(ses, "tel_mode: %s\r\n", tel_mode);
 			astman_append(ses, "\r\n");
 
+			ast_free(lbuf);
 			return 0;
 		}
 	}
 	astman_send_error(ses, m, "RptStatus unknown or missing node");
+	ast_free(lbuf);
 	return 0;
 }
 

--- a/apps/app_rpt/rpt_utils.c
+++ b/apps/app_rpt/rpt_utils.c
@@ -30,6 +30,7 @@ int matchkeyword(char *string, char **param, char *keywords[])
 	return 0;
 }
 
+
 int explode_string(char *str, char *strp[], size_t limit, char delim, char quote)
 {
 	int i, inquo;
@@ -84,7 +85,14 @@ char *string_toupper(char *str)
 	}
 	return str;
 }
-
+/*!
+ * \brief Find the delimiter in a string and return a pointer array to the start of each token.
+ * Note: This modifies the string str, be sure to save an intact copy if you need it later.
+ * \param str The string to search
+ * \param strp An array of pointers to the start of each token
+ * \param limit The maximum number of tokens to find
+ * \return The number of tokens found
+ */
 int finddelim(char *str, char *strp[], size_t limit)
 {
 	return explode_string(str, strp, limit, DELIMCHR, QUOTECHR);

--- a/apps/app_rpt/rpt_utils.h
+++ b/apps/app_rpt/rpt_utils.h
@@ -9,20 +9,14 @@
 
 int matchkeyword(char *string, char **param, char *keywords[]);
 
-/*
-* Break up a delimited string into a table of substrings
-*
-* str - delimited string ( will be modified )
-* strp- list of pointers to substrings (this is built by this function), NULL will be placed at end of list
-* limit- maximum number of substrings to process
-* delim- user specified delimiter
-* quote- user specified quote for escaping a substring. Set to zero to escape nothing.
-*
-* Note: This modifies the string str, be suer to save an intact copy if you need it later.
-*
-* Returns number of substrings found.
-*/
-
+/*!
+ * \brief Explode a string into an array of pointers to the start of each token.
+ * \param str The string to explode (will be modified)
+ * \param strp An array of pointers to the start of each token
+ * \param delim The delimiter to use
+ * \param quote The quote character to use
+ * \return The number of substrings found.
+ */
 int explode_string(char *str, char *strp[], size_t limit, char delim, char quote);
 
 char *strupr(char *instr);


### PR DESCRIPTION
Refactor `l->linklist` to use `ast_str`.  This eliminates the limits on connected nodes related to the fixed size of `l->linklist`