### PR TITLE
apps, channels: Remove redundant code.

### DIFF
--- a/apps/app_rpt/mdc_decode.c
+++ b/apps/app_rpt/mdc_decode.c
@@ -42,9 +42,10 @@ mdc_decoder_t * mdc_decoder_new(int sampleRate)
 	mdc_decoder_t *decoder;
 	int i;
 
-	decoder = (mdc_decoder_t *) ast_malloc(sizeof(mdc_decoder_t));
-	if(!decoder)
+	decoder = ast_malloc(sizeof(mdc_decoder_t));
+	if (!decoder) {
 		return (mdc_decoder_t *) 0L;
+	}
 
 	decoder->hyst = 3;
 	decoder->incr = (1200.0 * TWOPI) / ((double)sampleRate);

--- a/apps/app_rpt/mdc_encode.c
+++ b/apps/app_rpt/mdc_encode.c
@@ -99,9 +99,10 @@ mdc_encoder_t * mdc_encoder_new(int sampleRate)
 {
 	mdc_encoder_t *encoder;
 
-	encoder = (mdc_encoder_t *) ast_malloc(sizeof(mdc_encoder_t));
-	if(!encoder)
+	encoder = ast_malloc(sizeof(mdc_encoder_t));
+	if (!encoder) {
 		return (mdc_encoder_t *) 0L;
+	}
 
 	encoder->incr = (1200.0 * TWOPI) / ((double)sampleRate);
 	encoder->loaded = 0;

--- a/apps/app_rpt/pocsag.c
+++ b/apps/app_rpt/pocsag.c
@@ -208,11 +208,9 @@ struct pocsag_batch *make_pocsag_batch(uint32_t ric,char *data,
 
 void free_batch(struct pocsag_batch *batch)
 {
-	if (batch != NULL)
-	{
+	if (batch != NULL) {
 		free_batch(batch->next);
 		ast_free(batch);
 	}
-	return;
 }
 

--- a/apps/app_rpt/rpt_call.c
+++ b/apps/app_rpt/rpt_call.c
@@ -142,5 +142,4 @@ void rpt_forward(struct ast_channel *chan, char *dialstr, char *nodefrom)
 
 	}
 	ast_hangup(dest);
-	return;
 }

--- a/apps/app_rpt/rpt_channel.c
+++ b/apps/app_rpt/rpt_channel.c
@@ -35,7 +35,6 @@ void rpt_safe_sleep(struct rpt *rpt, struct ast_channel *chan, int ms)
 		}
 		ast_frfree(f);
 	}
-	return;
 }
 
 int wait_interval(struct rpt *myrpt, int type, struct ast_channel *chan)
@@ -470,7 +469,6 @@ void send_newkey(struct ast_channel *chan)
 		ast_log(LOG_WARNING, "Failed to send text %s on %s\n", NEWKEY1STR, ast_channel_name(chan));
 	}
 	ast_channel_unlock(chan);
-	return;
 }
 
 void send_newkey_redundant(struct ast_channel *chan)
@@ -481,5 +479,4 @@ void send_newkey_redundant(struct ast_channel *chan)
 		ast_log(LOG_WARNING, "Failed to send text %s on %s\n", NEWKEYSTR, ast_channel_name(chan));
 	}
 	ast_channel_unlock(chan);
-	return;
 }

--- a/apps/app_rpt/rpt_cli.c
+++ b/apps/app_rpt/rpt_cli.c
@@ -347,8 +347,7 @@ static int rpt_do_lstats(int fd, int argc, const char *const *argv)
 					l = l->next;
 					continue;
 				}
-				if ((s = (struct rpt_lstat *) ast_malloc(sizeof(struct rpt_lstat))) == NULL) {
-					ast_log(LOG_ERROR, "Malloc failed in rpt_do_lstats\n");
+				if ((s = ast_malloc(sizeof(struct rpt_lstat))) == NULL) {
 					rpt_mutex_unlock(&myrpt->lock);	/* UNLOCK */
 					return RESULT_FAILURE;
 				}
@@ -539,8 +538,7 @@ static int rpt_do_xnode(int fd, int argc, const char *const *argv)
 					l = l->next;
 					continue;
 				}
-				if ((s = (struct rpt_lstat *) ast_malloc(sizeof(struct rpt_lstat))) == NULL) {
-					ast_log(LOG_ERROR, "Malloc failed in rpt_do_lstats\n");
+				if ((s = ast_malloc(sizeof(struct rpt_lstat))) == NULL) {
 					rpt_mutex_unlock(&myrpt->lock);	// UNLOCK 
 					return RESULT_FAILURE;
 				}

--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -279,7 +279,6 @@ void local_dtmfkey_helper(struct rpt *myrpt, char c)
 	ast_copy_string(myrpt->curdtmfuser, val, sizeof(myrpt->curdtmfuser));
 	myrpt->dtmfkeyed = 1;
 	myrpt->dtmfkeybuf[0] = 0;
-	return;
 }
 
 int elink_query_callsign(char *node, char *callsign, int callsignlen)

--- a/apps/app_rpt/rpt_daq.c
+++ b/apps/app_rpt/rpt_daq.c
@@ -33,12 +33,9 @@ struct daq_entry_tag *daq_open(int type, char *name, char *dev)
 	if (!name)
 		return NULL;
 
-	if ((t = ast_malloc(sizeof(struct daq_entry_tag))) == NULL) {
-		ast_log(LOG_WARNING, "daq_open out of memory\n");
+	if (!(t = ast_calloc(1, sizeof(struct daq_entry_tag)))) {
 		return NULL;
 	}
-
-	memset(t, 0, sizeof(struct daq_entry_tag));
 
 	/* Save the device path for open */
 	if (dev) {
@@ -224,7 +221,6 @@ int handle_userout_tele(struct rpt *myrpt, struct ast_channel *mychannel, char *
 	struct daq_entry_tag *t;
 
 	if (!(myargs = ast_strdup(args))) {	/* Make a local copy to slice and dice */
-		ast_log(LOG_WARNING, "Out of memory\n");
 		return -1;
 	}
 

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -1581,12 +1581,10 @@ int function_cop(struct rpt *myrpt, char *param, char *digitbuf, int command_sou
 				argv[i] = dtmf_tones[15];
 			j += strlen(argv[i]);
 		}
-		cp = ast_malloc(j + 100);
+		cp = ast_calloc(1, j + 100);
 		if (!cp) {
-			ast_log(LOG_WARNING, "cannot malloc");
 			return DC_ERROR;
 		}
-		memset(cp, 0, j + 100);
 		for (i = 1; i < argc; i++) {
 			if (i != 1)
 				strcat(cp, ",");
@@ -1675,9 +1673,9 @@ int function_cop(struct rpt *myrpt, char *param, char *digitbuf, int command_sou
 		if (argc < 3)
 			break;
 		mdcp = ast_calloc(1, sizeof(struct mdcparams));
-		if (!mdcp)
+		if (!mdcp) {
 			return DC_ERROR;
-		memset(mdcp, 0, sizeof(*mdcp));
+		}
 		if (*argv[1] == 'C') {
 			if (argc < 5)
 				return DC_ERROR;
@@ -1802,13 +1800,9 @@ int function_cmd(struct rpt *myrpt, char *param, char *digitbuf, int command_sou
 		if (*param == '#') {	/* to execute asterisk cli command */
 			ast_cli_command(rpt_nullfd(), param + 1);
 		} else {
-			cp = ast_malloc(strlen(param) + 10);
-			if (!cp) {
-				ast_log(LOG_WARNING, "Unable to malloc");
+			if (ast_asprintf(&cp, "%s &", param) < 0) {
 				return DC_ERROR;
 			}
-			memset(cp, 0, strlen(param) + 10);
-			sprintf(cp, "%s &", param);
 			ast_safe_system(cp);
 			ast_free(cp);
 		}

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -48,7 +48,6 @@ void init_linkmode(struct rpt *myrpt, struct rpt_link *mylink, int linktype)
 		mylink->linkmode = 1;
 		break;
 	}
-	return;
 }
 
 void set_linkmode(struct rpt_link *mylink, int linkmode)
@@ -70,7 +69,6 @@ void set_linkmode(struct rpt_link *mylink, int linkmode)
 		mylink->linkmode = 1;
 		break;
 	}
-	return;
 }
 
 int altlink(struct rpt *myrpt, struct rpt_link *mylink)
@@ -185,7 +183,6 @@ void rpt_qwrite(struct rpt_link *l, struct ast_frame *f)
 	f1 = ast_frdup(f);
 	memset(&f1->frame_list, 0, sizeof(f1->frame_list));
 	AST_LIST_INSERT_TAIL(&l->textq, f1, frame_list);
-	return;
 }
 
 int linkcount(struct rpt *myrpt)
@@ -290,7 +287,6 @@ void do_dtmf_phone(struct rpt *myrpt, struct rpt_link *mylink, char c)
 			ast_senddigit(l->chan, c, 0);
 		l = l->next;
 	}
-	return;
 }
 
 void rssi_send(struct rpt *myrpt)
@@ -360,7 +356,6 @@ void send_link_dtmf(struct rpt *myrpt, char c)
 			rpt_qwrite(l, &wf);
 		l = l->next;
 	}
-	return;
 }
 
 void send_link_keyquery(struct rpt *myrpt)
@@ -390,7 +385,6 @@ void send_link_keyquery(struct rpt *myrpt)
 			rpt_qwrite(l, &wf);
 		l = l->next;
 	}
-	return;
 }
 
 void send_tele_link(struct rpt *myrpt, char *cmd)
@@ -416,7 +410,6 @@ void send_tele_link(struct rpt *myrpt, char *cmd)
 		l = l->next;
 	}
 	rpt_telemetry(myrpt, VARCMD, cmd);
-	return;
 }
 
 static void check_link_list(struct rpt *myrpt)
@@ -568,7 +561,6 @@ void __kickshort(struct rpt *myrpt)
 	}
 	myrpt->linkposttimer = LINKPOSTSHORTTIME;
 	myrpt->lastgpstime = 0;
-	return;
 }
 
 void rpt_update_links(struct rpt *myrpt)
@@ -620,7 +612,6 @@ void rpt_update_links(struct rpt *myrpt)
 
 	ast_free(buf);
 	ast_free(obuf);
-	return;
 }
 
 int connect_link(struct rpt *myrpt, char *node, int mode, int perma)

--- a/apps/app_rpt/rpt_manager.c
+++ b/apps/app_rpt/rpt_manager.c
@@ -216,8 +216,7 @@ static int rpt_manager_do_xstat(struct mansession *ses, const struct message *m,
 					l = l->next;
 					continue;
 				}
-				if (!(s = (struct rpt_lstat *) ast_malloc(sizeof(struct rpt_lstat)))) {
-					ast_log(LOG_ERROR, "Malloc failed in rpt_do_lstats\r\n");
+				if (!(s = ast_malloc(sizeof(struct rpt_lstat)))) {
 					rpt_mutex_unlock(&myrpt->lock);
 					return -1;
 				}

--- a/apps/app_rpt/rpt_mdc1200.c
+++ b/apps/app_rpt/rpt_mdc1200.c
@@ -142,7 +142,6 @@ void mdc1200_send(struct rpt *myrpt, char *data)
 			rpt_qwrite(l, &wf);
 		l = l->next;
 	}
-	return;
 }
 
 static const char *my_variable_match(const struct ast_config *config, const char *category, const char *variable)
@@ -192,7 +191,6 @@ void mdc1200_cmd(struct rpt *myrpt, char *data)
 	}
 	if ((data[0] == 'I') && (!busy))
 		strcpy(myrpt->lastmdc, data);
-	return;
 }
 
 #ifdef	_MDC_ENCODE_H_
@@ -208,7 +206,6 @@ void mdc1200_ack_status(struct rpt *myrpt, short UnitID)
 	mdcp->type[0] = 'A';
 	mdcp->UnitID = UnitID;
 	rpt_telemetry(myrpt, MDC1200, (void *) mdcp);
-	return;
 }
 
 #endif
@@ -227,7 +224,6 @@ static void mdcgen_release(struct ast_channel *chan, void *params)
 	if (ps->mdc)
 		ast_free(ps->mdc);
 	ast_free(ps);
-	return;
 }
 
 static void *mdcgen_alloc(struct ast_channel *chan, void *params)
@@ -240,7 +236,6 @@ static void *mdcgen_alloc(struct ast_channel *chan, void *params)
 	ps->origwfmt = ast_channel_writeformat(chan);	/*! \todo does this need to be freed? */
 	ps->mdc = mdc_encoder_new(8000);
 	if (!ps->mdc) {
-		ast_log(LOG_ERROR, "Unable to make new MDC encoder!!\n");
 		ast_free(ps);
 		return NULL;
 	}

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -62,7 +62,6 @@ void rpt_telem_select(struct rpt *myrpt, int command_source, struct rpt_link *my
 		return;
 	}
 	myrpt->telemmode = TELEM_HANG_TIME;
-	return;
 }
 
 int handle_meter_tele(struct rpt *myrpt, struct ast_channel *mychannel, char *args)
@@ -89,7 +88,6 @@ int handle_meter_tele(struct rpt *myrpt, struct ast_channel *mychannel, char *ar
 	struct daq_entry_tag *entry;
 
 	if (!(myargs = ast_strdup(args))) {	/* Make a local copy to slice and dice */
-		ast_log(LOG_WARNING, "Out of memory\n");
 		return -1;
 	}
 
@@ -155,7 +153,6 @@ int handle_meter_tele(struct rpt *myrpt, struct ast_channel *mychannel, char *ar
 	}
 
 	if (!(meter_face = ast_strdup(p))) {
-		ast_log(LOG_WARNING, "Out of memory");
 		ast_free(myargs);
 		return -1;
 	}
@@ -941,7 +938,6 @@ void handle_varcmd_tele(struct rpt *myrpt, struct ast_channel *mychannel, char *
 		return;
 	}
 	ast_log(LOG_WARNING, "Got unknown link telemetry command: %s\n", strs[0]);
-	return;
 }
 
 /*! \brief Try to catch setting active_telem NULL when we weren't what it was set to

--- a/apps/app_rpt/rpt_uchameleon.c
+++ b/apps/app_rpt/rpt_uchameleon.c
@@ -486,12 +486,10 @@ int uchameleon_do_long(struct daq_entry_tag *t, int pin, int cmd, void (*exec)(s
 		if (cmd == DAQ_CMD_PINSET) {
 			if (arg1 && *arg1 && (*arg1 < 19)) {
 				/* New pin definition */
-				if (!(p = (struct daq_pin_entry_tag *) ast_malloc(sizeof(struct daq_pin_entry_tag)))) {
-					ast_log(LOG_ERROR, "Out of memory");
+				if (!(p = ast_calloc(1, sizeof(struct daq_pin_entry_tag)))) {
 					ast_mutex_unlock(&t->lock);
 					return -1;
 				}
-				memset(p, 0, sizeof(struct daq_pin_entry_tag));
 				p->pintype = *arg1;
 				p->command = DAQ_CMD_PINSET;
 				p->num = pin;
@@ -521,12 +519,9 @@ void uchameleon_queue_tx(struct daq_entry_tag *t, char *txbuff)
 	if (!t)
 		return;
 
-	if (!(q = (struct daq_tx_entry_tag *) ast_malloc(sizeof(struct daq_tx_entry_tag)))) {
-		ast_log(LOG_WARNING, "Out of memory\n");
+	if (!(q = ast_calloc(1, sizeof(struct daq_tx_entry_tag)))) {
 		return;
 	}
-
-	memset(q, 0, sizeof(struct daq_tx_entry_tag));
 
 	ast_copy_string(q->txbuff, txbuff, sizeof(q->txbuff));
 
@@ -534,9 +529,9 @@ void uchameleon_queue_tx(struct daq_entry_tag *t, char *txbuff)
 		t->txtail->next = q;
 		q->prev = t->txtail;
 		t->txtail = q;
-	} else
+	} else {
 		t->txhead = t->txtail = q;
-	return;
+	}
 }
 
 void *uchameleon_monitor_thread(void *this)

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -849,7 +849,7 @@ static struct eldb *el_db_put(const char *nodenum, const char *ipaddr, const cha
 {
 	struct eldb *node, *mynode;
 
-	node = (struct eldb *) ast_calloc(1, sizeof(struct eldb));
+	node = ast_calloc(1, sizeof(struct eldb));
 	if (!node) {
 		return NULL;
 	}
@@ -1207,7 +1207,6 @@ static void parse_sdes(unsigned char *packet, struct rtcp_sdes_request *r)
 		}
 		p += (ntohs(*((short *) (p + 2))) + 1) * 4;
 	}
-	return;
 }
 
 /*!
@@ -1224,7 +1223,6 @@ static void copy_sdes_item(const char *source, char *dest, int destlen)
 	}
 	memcpy(dest, source + 2, len);
 	dest[len] = 0;
-	return;
 }
 
 /*!
@@ -1941,7 +1939,6 @@ static void send_info(const void *nodep, const VISIT which, const int depth)
 		instp->tx_ctrl_packets++;
 		(*(struct el_node **) nodep)->tx_ctrl_packets++;
 	}
-	return;
 }
 
 /*!
@@ -2007,7 +2004,6 @@ static void send_text(const void *nodep, const VISIT which, const int depth)
 			node->tx_audio_packets++;
 		}
 	}
-	return;
 }
 
 /*!
@@ -2194,7 +2190,6 @@ static void process_cmd(char *buf, int buf_len, const char *fromip, struct el_in
 		return;
 	}
 	instp->rx_bad_packets++;
-	return;
 }
 
 /*!
@@ -3329,77 +3324,75 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 	char nodestr[30];
 	time_t now;
 
-	el_node_key = (struct el_node *) ast_calloc(1, sizeof(struct el_node));
-	if (el_node_key) {
-		ast_copy_string(el_node_key->call, call, EL_CALL_SIZE);
-		ast_copy_string(el_node_key->ip, instp->el_node_test.ip, EL_IP_SIZE);
-		ast_copy_string(el_node_key->name, name, EL_NAME_SIZE);
-
-		ast_mutex_lock(&el_db_lock);
-		mynode = el_db_find_ipaddr(el_node_key->ip);
-		if (!mynode) {
-			ast_log(LOG_ERROR, "Cannot find database entry for IP address %s, Callsign %s.\n", el_node_key->ip, call);
-			ast_free(el_node_key);
-			ast_mutex_unlock(&el_db_lock);
-			return 1;
-		}
-		ast_copy_string(nodestr, mynode->nodenum, sizeof(nodestr));
-		el_node_key->nodenum = atoi(nodestr);
-		el_node_key->countdown = instp->rtcptimeout;
-		el_node_key->seqnum = 1;
-		el_node_key->instp = instp;
-		if (tsearch(el_node_key, &el_node_list, compare_ip)) {
-			ast_debug(1, "New Call - Callsign %s, IP Address %s, Node %i, Name %s.\n", el_node_key->call, el_node_key->ip, el_node_key->nodenum, el_node_key->name);
-			if (pvt == NULL) {	/* if a new inbound call */
-				pvt = el_alloc(instp->name);
-				if (!pvt) {
-					ast_log(LOG_ERROR, "Cannot alloc el channel %s.\n", instp->name);
-					ast_free(el_node_key);
-					ast_mutex_unlock(&el_db_lock);
-					return -1;
-				}
-				el_node_key->pvt = pvt;
-				ast_copy_string(el_node_key->pvt->ip, instp->el_node_test.ip, EL_IP_SIZE);
-				el_node_key->chan = el_new(el_node_key->pvt, AST_STATE_RINGING, el_node_key->nodenum, NULL, NULL);
-				if (!el_node_key->chan) {
-					el_destroy(el_node_key->pvt);
-					ast_free(el_node_key);
-					ast_mutex_unlock(&el_db_lock);
-					return -1;
-				}
-				el_node_key->rx_ctrl_packets++;
-				ast_mutex_lock(&instp->lock);
-				time(&now);
-				if (instp->starttime < (now - EL_APRS_START_DELAY)) {
-					instp->aprstime = now;
-				}
-				ast_mutex_unlock(&instp->lock);
-			} else {
-				el_node_key->pvt = pvt;
-				ast_copy_string(el_node_key->pvt->ip, instp->el_node_test.ip, EL_IP_SIZE);
-				el_node_key->chan = pvt->owner;
-				el_node_key->outbound = 1;
-				el_node_key->rx_ctrl_packets++;
-				ast_mutex_lock(&instp->lock);
-				strcpy(instp->lastcall, mynode->callsign);
-				time(&now);
-				if (instp->starttime < (now - EL_APRS_START_DELAY)) {
-					instp->aprstime = now;
-				}
-				ast_mutex_unlock(&instp->lock);
-			}
-		} else {
-			ast_log(LOG_ERROR, "Failed to add new call, Callsign %s, IP Address %s, Name %s.\n",
-					el_node_key->call, el_node_key->ip, el_node_key->name);
-			ast_free(el_node_key);
-			ast_mutex_unlock(&el_db_lock);
-			return -1;
-		}
-		ast_mutex_unlock(&el_db_lock);
-	} else {
-		ast_log(LOG_ERROR, "calloc() failed for Callsign %s, IP Address %s.\n", call, instp->el_node_test.ip);
+	el_node_key = ast_calloc(1, sizeof(struct el_node));
+	if (!el_node_key) {
 		return -1;
 	}
+	ast_copy_string(el_node_key->call, call, EL_CALL_SIZE);
+	ast_copy_string(el_node_key->ip, instp->el_node_test.ip, EL_IP_SIZE);
+	ast_copy_string(el_node_key->name, name, EL_NAME_SIZE);
+
+	ast_mutex_lock(&el_db_lock);
+	mynode = el_db_find_ipaddr(el_node_key->ip);
+	if (!mynode) {
+		ast_log(LOG_ERROR, "Cannot find database entry for IP address %s, Callsign %s.\n", el_node_key->ip, call);
+		ast_free(el_node_key);
+		ast_mutex_unlock(&el_db_lock);
+		return 1;
+	}
+	ast_copy_string(nodestr, mynode->nodenum, sizeof(nodestr));
+	el_node_key->nodenum = atoi(nodestr);
+	el_node_key->countdown = instp->rtcptimeout;
+	el_node_key->seqnum = 1;
+	el_node_key->instp = instp;
+	if (tsearch(el_node_key, &el_node_list, compare_ip)) {
+		ast_debug(1, "New Call - Callsign %s, IP Address %s, Node %i, Name %s.\n", el_node_key->call, el_node_key->ip, el_node_key->nodenum, el_node_key->name);
+		if (pvt == NULL) {	/* if a new inbound call */
+			pvt = el_alloc(instp->name);
+			if (!pvt) {
+				ast_log(LOG_ERROR, "Cannot alloc el channel %s.\n", instp->name);
+				ast_free(el_node_key);
+				ast_mutex_unlock(&el_db_lock);
+				return -1;
+			}
+			el_node_key->pvt = pvt;
+			ast_copy_string(el_node_key->pvt->ip, instp->el_node_test.ip, EL_IP_SIZE);
+			el_node_key->chan = el_new(el_node_key->pvt, AST_STATE_RINGING, el_node_key->nodenum, NULL, NULL);
+			if (!el_node_key->chan) {
+				el_destroy(el_node_key->pvt);
+				ast_free(el_node_key);
+				ast_mutex_unlock(&el_db_lock);
+				return -1;
+			}
+			el_node_key->rx_ctrl_packets++;
+			ast_mutex_lock(&instp->lock);
+			time(&now);
+			if (instp->starttime < (now - EL_APRS_START_DELAY)) {
+				instp->aprstime = now;
+			}
+			ast_mutex_unlock(&instp->lock);
+		} else {
+			el_node_key->pvt = pvt;
+			ast_copy_string(el_node_key->pvt->ip, instp->el_node_test.ip, EL_IP_SIZE);
+			el_node_key->chan = pvt->owner;
+			el_node_key->outbound = 1;
+			el_node_key->rx_ctrl_packets++;
+			ast_mutex_lock(&instp->lock);
+			strcpy(instp->lastcall, mynode->callsign);
+			time(&now);
+			if (instp->starttime < (now - EL_APRS_START_DELAY)) {
+				instp->aprstime = now;
+			}
+			ast_mutex_unlock(&instp->lock);
+		}
+	} else {
+		ast_log(LOG_ERROR, "Failed to add new call, Callsign %s, IP Address %s, Name %s.\n",
+				el_node_key->call, el_node_key->ip, el_node_key->name);
+		ast_free(el_node_key);
+		ast_mutex_unlock(&el_db_lock);
+		return -1;
+	}
+	ast_mutex_unlock(&el_db_lock);
 	return 0;
 }
 

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -2352,7 +2352,7 @@ static struct ast_frame *simpleusb_read(struct ast_channel *c)
 			 u != (struct usbecho *) &o->echoq; u = (struct usbecho *) u->q_forw)
 			x++;
 		if (x < o->echomax) {
-			u = (struct usbecho *) ast_calloc(1, sizeof(struct usbecho));
+			u = ast_calloc(1, sizeof(struct usbecho));
 			if (u) {
 				memcpy(u->data, (o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET), FRAME_SIZE * 2);
 				insque((struct qelem *) u, o->echoq.q_back);
@@ -3093,7 +3093,6 @@ static void _menu_print(int fd, struct chan_simpleusb_pvt *o)
 	if (o->legacyaudioscaling) {
 		ast_cli(fd, "legacyaudioscaling is enabled\n");
 	}
-	return;
 }
 
 /*!
@@ -3121,7 +3120,6 @@ static void _menu_rx(int fd, struct chan_simpleusb_pvt *o, const char *str)
 	o->rxmixerset = i;
 	ast_cli(fd, "Channel %s: Changed setting on RX Channel to %d\n", o->name, o->rxmixerset);
 	mixer_write(o);
-	return;
 }
 
 /*!
@@ -3158,7 +3156,6 @@ static void _menu_txa(int fd, struct chan_simpleusb_pvt *o, const char *str)
 		}
 		_send_tx_test_tone(fd, o, 5000, 1);
 	}
-	return;
 }
 
 /*!
@@ -3195,7 +3192,6 @@ static void _menu_txb(int fd, struct chan_simpleusb_pvt *o, const char *str)
 		}
 		_send_tx_test_tone(fd, o, 5000, 1);
 	}
-	return;
 }
 
 /*!
@@ -3571,7 +3567,6 @@ static void tune_menusupport(int fd, struct chan_simpleusb_pvt *o, const char *c
 		break;
 	}
 	option_verbose = oldverbose;
-	return;
 }
 
 /*!

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -2342,7 +2342,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 			 u != (struct usbecho *) &o->echoq; u = (struct usbecho *) u->q_forw)
 			x++;
 		if (x < o->echomax) {
-			u = (struct usbecho *) ast_calloc(1, sizeof(struct usbecho));
+			u = ast_calloc(1, sizeof(struct usbecho));
 			if (u) {
 				memcpy(u->data, (o->usbradio_read_buf_8k + AST_FRIENDLY_OFFSET), FRAME_SIZE * 2);
 				insque((struct qelem *) u, o->echoq.q_back);
@@ -3649,7 +3649,6 @@ static void _menu_rxvoice(int fd, struct chan_usbradio_pvt *o, const char *str)
 	}
 	*(o->pmrChan->prxVoiceAdjust) = o->rxvoiceadj * M_Q8;
 	ast_cli(fd, "Changed rx voice setting to %d\n", i);
-	return;
 }
 
 /*!
@@ -3701,7 +3700,6 @@ static void _menu_print(int fd, struct chan_usbradio_pvt *o)
 	if (o->legacyaudioscaling) {
 		ast_cli(fd, "legacyaudioscaling is enabled\n");
 	}
-	return;
 }
 
 /*!
@@ -3740,7 +3738,6 @@ static void _menu_rxsquelch(int fd, struct chan_usbradio_pvt *o, const char *str
 			adjustment = 1000;
 	}
 	*(o->pmrChan->prxSquelchAdjust) = ((999 - i) * 32767) / adjustment;
-	return;
 }
 
 /*!
@@ -3819,7 +3816,6 @@ static void _menu_txvoice(int fd, struct chan_usbradio_pvt *o, const char *cstr)
 		o->pmrChan->b.txCtcssInhibit = 0;
 		ast_cli(fd, "DONE.\n");
 	}
-	return;
 }
 
 /*!
@@ -3862,7 +3858,6 @@ static void _menu_auxvoice(int fd, struct chan_usbradio_pvt *o, const char *str)
 	}
 	mixer_write(o);
 	mult_set(o);
-	return;
 }
 
 /*!
@@ -3906,7 +3901,6 @@ static void _menu_txtone(int fd, struct chan_usbradio_pvt *o, const char *cstr)
 		o->txtestkey = 0;
 		ast_cli(fd, "DONE.\n");
 	}
-	return;
 }
 
 /*!
@@ -4228,7 +4222,6 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 	}
 	o->pmrChan->b.tuning = 0;
 	option_verbose = oldverbose;
-	return;
 }
 
 /*!
@@ -4820,8 +4813,6 @@ static void pmrdump(struct chan_usbradio_pvt *o)
 	pd(p->b.radioactive);
 	pd(p->b.txboost);
 	pd(p->b.txCtcssOff);
-
-	return;
 }
 
 /*

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -1325,7 +1325,7 @@ static struct ast_frame *ast_frcat(const struct ast_frame * restrict f1, const s
 		ast_log(LOG_ERROR, "ast_frcat() called with non-matching frame types!!\n");
 		return NULL;
 	}
-	f = (struct ast_frame *) ast_calloc(1, sizeof(struct ast_frame));
+	f = ast_calloc(1, sizeof(struct ast_frame));
 	if (!f) {
 		return NULL;
 	}
@@ -3673,7 +3673,6 @@ static void voter_xmit_master(void)
 			memset(&client->sin, 0, sizeof(client->sin));
 		}
 	}
-	return;
 }
 
 /*!
@@ -5290,7 +5289,7 @@ static int reload(void)
 			newclient = 0;
 			/* if a new one, alloc its space */
 			if (!client) {
-				client = (struct voter_client *) ast_calloc(1, sizeof(struct voter_client));
+				client = ast_calloc(1, sizeof(struct voter_client));
 				if (!client) {
 					ast_free(cp);
 					close(udp_socket);
@@ -5350,9 +5349,8 @@ static int reload(void)
 				client->drainindex = 0;
 			}
 			if (client->audio && client->old_buflen && (client->buflen != client->old_buflen)) {
-				client->audio = (uint8_t *) ast_realloc(client->audio, client->buflen);
+				client->audio = ast_realloc(client->audio, client->buflen);
 				if (!client->audio) {
-					ast_log(LOG_ERROR, "Can't realloc()\n");
 					close(udp_socket);
 					ast_config_destroy(cfg);
 					ast_mutex_unlock(&voter_lock);
@@ -5360,7 +5358,7 @@ static int reload(void)
 				}
 				memset(client->audio, 0xff, client->buflen);
 			} else if (!client->audio) {
-				client->audio = (uint8_t *) ast_malloc(client->buflen);
+				client->audio = ast_malloc(client->buflen);
 				if (!client->audio) {
 					close(udp_socket);
 					ast_config_destroy(cfg);
@@ -5370,9 +5368,8 @@ static int reload(void)
 				memset(client->audio, 0xff, client->buflen);
 			}
 			if (client->rssi && client->old_buflen && (client->buflen != client->old_buflen)) {
-				client->rssi = (uint8_t *) ast_realloc(client->rssi, client->buflen);
+				client->rssi = ast_realloc(client->rssi, client->buflen);
 				if (!client->rssi) {
-					ast_log(LOG_ERROR, "Can't realloc()\n");
 					close(udp_socket);
 					ast_config_destroy(cfg);
 					ast_mutex_unlock(&voter_lock);
@@ -5380,7 +5377,7 @@ static int reload(void)
 				}
 				memset(client->rssi, 0, client->buflen);
 			} else if (!client->rssi) {
-				client->rssi = (uint8_t *) ast_calloc(1, client->buflen);
+				client->rssi = ast_calloc(1, client->buflen);
 				if (!client->rssi) {
 					close(udp_socket);
 					ast_config_destroy(cfg);


### PR DESCRIPTION
Many mostly minor stylistic changes to improve compliance with the Asterisk coding guidelines:

* Eliminate return statements at end of void functions.
* Eliminate redundant allocation failure warnings.
* Eliminate superfluous memset calls.
* Eliminate unneeded failure checks.
* Eliminate unnecessary casts from allocations.
* Eliminate some unneeded parentheses.
* Simplify some unnecessarily complicated allocations.