### PR TITLE
rpt_channel.c: Fix uninitialized memory usage.

### DIFF
--- a/apps/app_rpt/rpt_channel.c
+++ b/apps/app_rpt/rpt_channel.c
@@ -128,7 +128,7 @@ int saynum(struct ast_channel *mychannel, int num)
 
 int saynode(struct rpt *myrpt, struct ast_channel *mychannel, char *name)
 {
-	int res = 0, tgn;
+	int res = 0, tgn = 0;
 	char *val, fname[300], str[100];
 
 	if (strlen(name) < 1)


### PR DESCRIPTION
tgn was undefined if the TLB branch was not taken.

Resolves: #550