### PR TITLE
Multiple: Eliminate MAXNODES and limits imposed by MAXNODES

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -3189,8 +3189,7 @@ static inline void periodic_process_links(struct rpt *myrpt, const int elap)
 				lf.datalen = ast_str_strlen(lstr) + 1;
 				lf.data.ptr = ast_str_buffer(lstr);
 				rpt_qwrite(l, &lf);
-				ast_debug(
-					7, "@@@@ node %s sent node string %s to node %s\n", myrpt->name, ast_str_buffer(lstr), l->name);
+				ast_debug(7, "@@@@ node %s sent node string %s to node %s\n", myrpt->name, ast_str_buffer(lstr), l->name);
 			}
 			ast_free(lstr);
 		}
@@ -6618,7 +6617,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 		l->linklist = ast_str_create(RPT_AST_STR_INIT_SIZE);
 		if (!l->linklist) {
 			ast_free(l);
-			pthread_exit(NULL);
+			return -1;
 		}
 		l->mode = 1;
 		ast_copy_string(l->name, b1, MAXNODESTR);

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -54,7 +54,7 @@ static char remdtmfstr[] = "0123456789*#ABCD";
 int function_ilink(struct rpt *myrpt, char *param, char *digits, int command_source, struct rpt_link *mylink)
 {
 	char *s1, *s2, tmp[MAXNODESTR];
-	char digitbuf[MAXNODESTR], *strs[MAXNODES];
+	char digitbuf[MAXNODESTR], *strs[sizeof(myrpt->savednodes)];
 	char mode, perma;
 	struct rpt_link *l;
 	int i, r;
@@ -363,7 +363,7 @@ int function_ilink(struct rpt *myrpt, char *param, char *digits, int command_sou
 	case 16:					/* Restore links disconnected with "disconnect all links" command */
 		strcpy(tmp, myrpt->savednodes);	/* Make a copy */
 		finddelim(tmp, strs, ARRAY_LEN(strs));	/* convert into substrings */
-		for (i = 0; tmp[0] && i < ARRAY_LEN(strs) && strs[i]; i++) {
+		for (i = 0; tmp[0] && strs[i] && i < ARRAY_LEN(strs); i++) {
 			s1 = strs[i];
 			if (s1[0] == 'X')
 				mode = 1;


### PR DESCRIPTION
Based on PR https://github.com/AllStarLink/app_rpt/pull/545
Use `ast_malloc()` rather than static sizes for `*strs[]`
Eliminate limits imposed by MAXNODES.
Remove MAXNODES define.
