### PR TITLE
pre-commit.yml: update lint check

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -29,7 +29,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           version: '14'
-          lines-changed-only: diff
+          lines-changed-only: true
           style: 'file:.dev/.clang-format'  # Use .clang-format config file
           tidy-checks: '-*' # Use .clang-tidy config file
           # only 'update' a single comment in a pull request thread.


### PR DESCRIPTION
Turns out we need to check ONLY the changed lines.  Diff is causing the entire diff to be checked which causes "growth" in the update.