### PR TITLE
app_rpt.c: Remove unnecessary duplicate send_newkey()

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -6695,10 +6695,6 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 					ast_free(l);
 					return -1;
 				}
-			} else {
-				if (!phone_mode) {
-					send_newkey(chan);
-				}
 			}
 		}
 


### PR DESCRIPTION
As suspected, the `send_newkey()` only needs to happen once per connection.
Testing confirmed.