### PR TITLE
app_rpt.c: Remove blocklock

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -3533,9 +3533,7 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 	struct ast_frame *f, *f1;
 	int i, dtmfed = 0;
 
-	rpt_mutex_lock(&myrpt->blocklock);
 	f = ast_read(myrpt->rxchannel);
-	rpt_mutex_unlock(&myrpt->blocklock);
 	if (!f) {
 		ast_debug(1, "@@@@ rpt:Hung Up\n");
 		return -1;
@@ -4050,9 +4048,7 @@ static inline int dahditxchannel_read(struct rpt *myrpt, char *restrict myfirst)
 			while ((f1 = AST_LIST_REMOVE_HEAD(&myrpt->txq, frame_list)))
 				ast_frfree(f1);
 		}
-		rpt_mutex_lock(&myrpt->blocklock);
 		ast_write(myrpt->txchannel, f);
-		rpt_mutex_unlock(&myrpt->blocklock);
 	}
 	return hangup_frame_helper(myrpt->dahditxchannel, "dahditxchannel", f);
 }
@@ -4376,9 +4372,7 @@ static inline int process_link_channels(struct rpt *myrpt, struct ast_channel *w
 					l->thisconnected = 1;
 					l->elaptime = -1;
 					if (!l->phonemode) {
-						rpt_mutex_lock(&myrpt->blocklock);
 						send_newkey(l->chan);
-						rpt_mutex_unlock(&myrpt->blocklock);
 					}
 					if (!l->isremote)
 						l->retries = 0;
@@ -4781,11 +4775,9 @@ static void *rpt(void *this)
 		setrem(myrpt);
 	/* wait for telem to be done */
 	while ((ms >= 0) && (myrpt->tele.next != &myrpt->tele)) {
-		rpt_mutex_lock(&myrpt->blocklock);
 		if (ast_safe_sleep(myrpt->rxchannel, 50) == -1) {
 			ms = -1;
 		}
-		rpt_mutex_unlock(&myrpt->blocklock);
 	}
 	lastmyrx = 0;
 	myfirst = 0;
@@ -5248,9 +5240,7 @@ static void *rpt(void *this)
 			cs1[x] = cs[s];
 		}
 		myrpt->scram++;
-		rpt_mutex_lock(&myrpt->blocklock);
 		who = ast_waitfor_n(cs1, n, &ms);
-		rpt_mutex_unlock(&myrpt->blocklock);
 		if (who == NULL) {
 			ms = 0;
 		}
@@ -5537,7 +5527,6 @@ static int load_config(int reload)
 		ast_mutex_init(&rpt_vars[n].lock);
 		ast_mutex_init(&rpt_vars[n].remlock);
 		ast_mutex_init(&rpt_vars[n].statpost_lock);
-		ast_mutex_init(&rpt_vars[n].blocklock);
 		rpt_vars[n].tele.next = &rpt_vars[n].tele;
 		rpt_vars[n].tele.prev = &rpt_vars[n].tele;
 		rpt_vars[n].rpt_thread = AST_PTHREADT_NULL;
@@ -6062,14 +6051,12 @@ static inline int kenwood_uio_helper(struct rpt *myrpt)
 
 static void answer_newkey_helper(struct rpt *myrpt, struct ast_channel *chan, int phone_mode)
 {
-	rpt_mutex_lock(&myrpt->blocklock);
 	if (ast_channel_state(chan) != AST_STATE_UP) {
 		ast_answer(chan);
 		if (!phone_mode) {
 			send_newkey(chan);
 		}
 	}
-	rpt_mutex_unlock(&myrpt->blocklock);
 }
 
 static int rpt_exec(struct ast_channel *chan, const char *data)
@@ -6352,9 +6339,8 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 			if (ast_channel_state(chan) != AST_STATE_UP) {
 				ast_indicate(chan, AST_CONTROL_BUSY);
 			}
-			rpt_mutex_lock(&myrpt->blocklock);
-			while (ast_safe_sleep(chan, 10000) != -1);
-			rpt_mutex_unlock(&myrpt->blocklock);
+			while (ast_safe_sleep(chan, 10000) != -1) {
+			}
 			return -1;
 		}
 
@@ -6505,12 +6491,9 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 			if (ast_check_hangup(myrpt->rxchannel)) {
 				return -1;
 			}
-			rpt_mutex_lock(&myrpt->blocklock);
 			if (ast_safe_sleep(myrpt->rxchannel, 100) == -1) {
-				rpt_mutex_unlock(&myrpt->blocklock);
 				return -1;
 			}
-			rpt_mutex_unlock(&myrpt->blocklock);
 			rpt_mutex_lock(&myrpt->lock);
 			gettimeofday(&now, NULL);
 		}
@@ -6731,12 +6714,9 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 				ast_playtones_start(chan, 0, ts->data, 1);
 				i = 0;
 				while (ast_channel_generatordata(chan) && (i < 5000)) {
-					rpt_mutex_lock(&myrpt->blocklock);
 					if (ast_safe_sleep(chan, 20)) {
-						rpt_mutex_unlock(&myrpt->blocklock);
 						break;
 					}
-					rpt_mutex_unlock(&myrpt->blocklock);
 					i += 20;
 				}
 				ast_playtones_stop(chan);
@@ -6769,13 +6749,10 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 						killedit = 1;
 					}
 					rpt_mutex_unlock(&myrpt->lock);
-					rpt_mutex_lock(&myrpt->blocklock);
 					if (ast_safe_sleep(chan, 500) == -1) {
-						rpt_mutex_unlock(&myrpt->blocklock);
 						rpt_disable_cdr(chan);
 						return -1;
 					}
-					rpt_mutex_unlock(&myrpt->blocklock);
 					rpt_mutex_lock(&myrpt->lock);
 				}
 				break;
@@ -7035,11 +7012,9 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 	if (myrpt->rxchannel != myrpt->txchannel)
 		cs[n++] = myrpt->txchannel;
 
-	rpt_mutex_lock(&myrpt->blocklock);
 	if (!phone_mode) {
 		send_newkey(chan);
 	}
-	rpt_mutex_unlock(&myrpt->blocklock);
 
 	myfirst = 0;
 	looptimestart = ast_tvnow();
@@ -7117,9 +7092,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 			}
 		}
 		ms = MSWAIT;
-		rpt_mutex_lock(&myrpt->blocklock);
 		who = ast_waitfor_n(cs, n, &ms);
-		rpt_mutex_unlock(&myrpt->blocklock);
 		/* calculate loop time */
 		looptimenow = ast_tvnow();
 		elap = ast_tvdiff_ms(looptimenow, looptimestart);
@@ -7444,9 +7417,6 @@ static int unload_module(void)
 		ast_mutex_destroy(&rpt_vars[i].lock);
 		ast_mutex_destroy(&rpt_vars[i].remlock);
 		/* Lock and unlock in case somebody had the lock */
-		ast_mutex_lock(&rpt_vars[i].blocklock);
-		ast_mutex_unlock(&rpt_vars[i].blocklock);
-		ast_mutex_destroy(&rpt_vars[i].blocklock);
 	}
 
 	res = ast_unregister_application(app);

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -592,7 +592,6 @@ struct rpt {
 	ast_mutex_t lock;
 	ast_mutex_t remlock;
 	ast_mutex_t statpost_lock;
-	ast_mutex_t blocklock;	/*!< Lock added to prevent multiple threads from performing blocking operations simultaneously */
 	struct ast_config *cfg;
 	char reload;
 	char reload1;

--- a/apps/app_rpt/rpt_cli.c
+++ b/apps/app_rpt/rpt_cli.c
@@ -901,9 +901,7 @@ static int rpt_do_page(int fd, int argc, const char *const *argv)
 				telem = telem->next;
 			}
 			gettimeofday(&myrpt->paging, NULL);
-			rpt_mutex_lock(&myrpt->blocklock);
 			ast_sendtext(myrpt->rxchannel, str);
-			rpt_mutex_unlock(&myrpt->blocklock);
 			break;
 		}
 	}


### PR DESCRIPTION
In my quest to figure out what is causing the USB buffer under run, I noticed the commit message for adding the `blocklock` mentioned audio challenges.  I have been running a couple of nodes with the `blocklock` removed with no adverse effects.  On the positive side, it greatly reduced the audio artifacts (nearly none) when the USB is set up for low latency. 

I suspect there were other issues/bugs/mistakes that have now been addressed and we no longer need the `blocklock`.
I think we should test/verify this on a larger group of nodes.