### PR TITLE
configs: update config files for clarity and improved customization

### DIFF
--- a/configs/rpt/echolink.conf
+++ b/configs/rpt/echolink.conf
@@ -53,4 +53,4 @@ server4 = backup.echolink.org
 ; ipaddr
 ; port
 
-#tryinclude custom/echolink.conf
+#tryinclude "custom/echolink.conf"

--- a/configs/rpt/extensions.conf
+++ b/configs/rpt/extensions.conf
@@ -172,4 +172,4 @@ exten => s,1,Ringing
 	same => n,Wait(1)
 	same => n,Hangup
 
-#tryinclude custom/extensions.conf
+#tryinclude "custom/extensions.conf"

--- a/configs/rpt/gps.conf
+++ b/configs/rpt/gps.conf
@@ -107,5 +107,5 @@ elev = 123.4                ; Elevation of Antenna in Meters (*NOT* HAAT)
 ;comment = AllStar Node 1999 ; per-node setting
 ;freq = 432.100              ; per-node-setting
 
-#tryinclude custom/gps.conf
+#tryinclude "custom/gps.conf"
 

--- a/configs/rpt/iax.conf
+++ b/configs/rpt/iax.conf
@@ -119,4 +119,4 @@ allow = gsm
 ; allow = ulaw
 ; transfer = no
 
-#tryinclude custom/iax.conf
+#tryinclude "custom/iax.conf"

--- a/configs/rpt/rpt.conf
+++ b/configs/rpt/rpt.conf
@@ -14,9 +14,9 @@ node_lookup_method = both           ;method used to lookup nodes
                                     ;file = external file lookup only
 
 [nodes]
-; If you are using automatic update for allstar link nodes, and you probably are,
-; no allstar remote nodes should be defined here. Only place a definition
-; for your local nodes, and private (not on allstar directory) nodes here.
+; If you are using automatic update for AllStarLink nodes, and you probably are,
+; no AllStarLink remote nodes should be defined here. Only place a definition
+; for your local nodes, and private (not on AllStarLink directory) nodes here.
 
 ; Sample nodes on this server. These are required. Use IP 127.0.0.1
 ; IAX port number if not the default 4569.
@@ -30,25 +30,39 @@ node_lookup_method = both           ;method used to lookup nodes
 
 1999 = radio@127.0.0.1/1999,NONE
 
+;
+; Your nodes are configured in two places.  Below, you will find
+; a section that starts with :
+;
+;   [node-main](!)
+;
+; This is where you configure the defaults for your all your  node.
+;
+
+;
+; You should configure each of your individual nodes at the end of
+; the file with sections that would look like :
+;
+;   [1999](node-main)
+;   rxchannel = SimpleUSB/1999
+;
+; This is where you specify any per-node settings that differ from
+; the default values.
+;
+
 [node-main](!)
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;; Template for all your nodes ;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; Set the defaults for your node(s) here.
-; Add your nodes below the line that says
-; Add you nodes below.
 
 ;;; rxchannel ;;;
 ; Must also be enabled in modules.conf
 ; Enable the selected channel driver in modules.conf !!!
-; Rx/Tx audio/signalling channel. Choose ONLY 1 per node stanza.
+; Rx/Tx audio/signaling channel. Choose ONLY 1 per node stanza.
 ; rxchannel = dahdi/pseudo          ; No radio (hub)
 ; rxchannel = SimpleUSB/1999        ; SimpleUSB
 ; rxchannel = Radio/1999            ; USBRadio (DSP)
 ; rxchannel = Voter/1999            ; RTCM device
-; rxchannel = Pi/1                  ; Raspberry Pi PiTA
-; rxchannel = Dahdi/1               ; PCI Quad card
-; rxchannel = Beagle/1              ; BeagleBoard
 ; rxchannel = USRP/127.0.0.1:34001:32001    ;GNU Radio interface USRP
 
 rxchannel = dahdi/pseudo            ; No radio (hub)
@@ -57,7 +71,7 @@ duplex = 2                          ; 0 = Half duplex with no telemetry tones or
                                     ;     Special Case: Full duplex if linktolink is set to yes.
                                     ;     This mode is preferred when interfacing with an external multiport repeater controller.
                                     ;     Comment out idrecording and idtalkover to suppress IDs also
-                                    ; 1 = Half duplex with telemetry tones and hang time. Does not repeat audio.
+                                    ; 1 = Half duplex with telemetry tones and hang time. Do not repeat audio.
                                     ;     This mode is preferred when interfacing a simplex node.
                                     ; 2 = Full Duplex with telemetry tones and hang time.
                                     ;     This mode is preferred when interfacing a repeater.
@@ -72,32 +86,30 @@ linkmongain = -22                   ; Link Monitor Gain adjusts the audio level 
                                     ; If linkmongain set to a positive number monitored audio will increase by the set amount in db.
                                     ; The value of linkmongain is in db. The default value is 0 db.
 
-erxgain = -3                        ; Echolink receive gain adjustment
+erxgain = -3                        ; EchoLink receive gain adjustment
                                     ; Note: Gain is in db-volts (20logVI/VO)
-etxgain = 3                         ; Echolink transmit gain adjustment
+etxgain = 3                         ; EchoLink transmit gain adjustment
                                     ; Note: Gain is in db-volts (20logVI/VO)
-;eannmode = 1                       ; 1 = Say only node number on echolink connects (default = 1)
-                                    ; 2 = say phonetic call sign only on echolink connects
-                                    ; 3 = say phonetic call sign and node number on echolink connects
+;eannmode = 1                       ; 1 = Say only node number on EchoLink connects (default = 1)
+                                    ; 2 = say phonetic call sign only on EchoLink connects
+                                    ; 3 = say phonetic call sign and node number on EchoLink connects
 
-;echolinkdefault = 2				; 0 = Telemetry output off
-									; 1 = Telemetry output on
-									; 2 = Timed telemetry output on command execution and for a short time thereafter
-									; 3 = Follow local telemetry mode
+;echolinkdefault = 2                ; 0 = Telemetry output off
+                                    ; 1 = Telemetry output on
+                                    ; 2 = Timed telemetry output on command execution and for a short time thereafter
+                                    ; 3 = Follow local telemetry mode
 
-;echolinkdynamic = 1				; 0 = Disallow users to change current echolink telemetry setting with a COP command
-									; 1 = Allow users to change the setting with a COP command
+;echolinkdynamic = 1                ; 0 = Disallow users to change current EchoLink telemetry setting with a COP command
+                                    ; 1 = Allow users to change the setting with a COP command
 
-
-controlstates = controlstates       ; system control state stanza
-
-scheduler = schedule                ; scheduler stanza
+controlstates = controlstates       ; System control state stanza
+events = events                     ; Events Management
 functions = functions               ; Repeater Function stanza
-phone_functions = functions         ; Phone Function stanza
 link_functions = functions          ; Link Function stanza
-
-telemetry = telemetry               ; Telemetry stanza
 morse = morse                       ; Morse stanza
+phone_functions = functions         ; Phone Function stanza
+scheduler = schedule                ; Scheduler stanza
+telemetry = telemetry               ; Telemetry stanza
 wait_times = wait-times             ; Wait times stanza
 
 ;inxlat = *,#,0123456789ABCD,Y      ; The Y is for dialtone on function, a la CACTUS
@@ -134,8 +146,6 @@ linkunkeyct = ct8                   ; sent when a transmission received over the
                                     ; 1. node number in this stanza (us)
                                     ; 2. node number being disconnected from us (them)
 
-;events=events                      ; Events Management https://wiki.allstarlink.org/wiki/Event_Management
-
 ;lnkactenable = 0                   ; Set to 1 to enable the link activity timer. Applicable to standard nodes only.
 
 ;lnkacttime = 1800                  ; Link activity timer time in seconds.
@@ -153,7 +163,7 @@ holdofftelem = 0                    ; Hold off all telemetry when signal is pres
                                     ; except when an ID needs to be done and there is a signal coming from a connected node.
 
 telemnomdb = -3                     ; Telemetry Nominal Amplitude reference in dB
-telemduckdb = -15                   ; Telemetry Ducking in dB when local or link voice tx in progress
+telemduckdb = -15                   ; Telemetry Ducking in dB when local or link voice TX in progress
 
 telemdefault = 2                    ; 0 = telemetry output off
                                     ; 1 = telemetry output on (default = 1)
@@ -180,8 +190,8 @@ parrottime = 1000                   ; Set the amount of time in milliseconds
 
 ;nodenames = /var/lib/asterisk/sounds/rpt/nodenames.callsign  ; Point to alternate nodename sound directory
 
-;aprstt = general					; To enable APRStt, set this value to the stanza to use in gps.conf
-									; module app_gps.so will need to be enabled
+;aprstt = general                   ; To enable APRStt, set this value to the stanza to use in gps.conf
+                                    ; module app_gps.so will need to be enabled
 
 ; *** Status Reporting ***
 ;
@@ -208,31 +218,13 @@ parrottime = 1000                   ; Set the amount of time in milliseconds
 ; The "archivedir" and "archiveformat" lines can be enabled here (affecting
 ; all nodes) or in the per-node stanzas (for recording of individual nodes).
 ;
-; Note: enabling these recordings can adversly impact the CPU utilization
+; Note: enabling these recordings can adversely impact the CPU utilization
 ;       on the device and consume large amounts of the available storage.
 ;
 ;archivedir = /var/spool/asterisk/monitor ; top-level recording directory
 ;archiveformat = wav49                    ; audio format (default = wav49)
 
 ;;; End of node-main template
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;;;;;;;;;;;;;; Configure your nodes here ;;;;;;;;;;;;;;;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;
-; Note: there is no need to duplicate entire settings. Only
-;       place settings that are different than the template.
-;
-
-[1999](node-main)
-;;;;;;;;;;;;;;;;;;; Your node settings here ;;;;;;;;;;;;;;;;;;;
-rxchannel = SimpleUSB/1999      ; SimpleUSB
-;startup_macro = *8132000
-
-;[1998](node-main)
-;;;;;;;;;;;;;;;;;;; Another node settings here ;;;;;;;;;;;;;;;;;;;
-;startup_macro = *8132000
-;morse = morse_1998                 ; Sample morse stanza for node 1998
 
 [functions]
 ;;;;;;;;;;;;;;;;;;; functions stanza ;;;;;;;;;;;;;;;;;;;
@@ -247,7 +239,6 @@ rxchannel = SimpleUSB/1999      ; SimpleUSB
 ; *8        User Functions
 ; *9        User Functions
 ; *0        User Functions
-
 ; *A        User Functions
 ; *B        User Functions
 ; *C        User Functions
@@ -256,7 +247,7 @@ rxchannel = SimpleUSB/1999      ; SimpleUSB
 ;;;;;; Mandatory Command Codes ;;;;;
 1 = ilink,1                         ; Disconnect specified link
 2 = ilink,2                         ; Connect specified link -- monitor only
-3 = ilink,3                         ; Connect specified link -- tranceive
+3 = ilink,3                         ; Connect specified link -- transceive
 4 = ilink,4                         ; Enter command mode on specified link
 70 = ilink,5                        ; System status
 99 = cop,6                          ; PTT (phone mode only)
@@ -282,7 +273,7 @@ rxchannel = SimpleUSB/1999      ; SimpleUSB
 ; 2 - Give Time of Day (global)
 ; 3 - Give software Version (global)
 ; 4 - Give GPS location info
-; 5 - Last (dtmf) user
+; 5 - Last (DTMF) user
 ; 11 - Force ID (local only)
 ; 12 - Give Time of Day (local only)
 
@@ -290,14 +281,14 @@ rxchannel = SimpleUSB/1999      ; SimpleUSB
 722 = status,2                      ; Give Time of Day (global)
 723 = status,3                      ; Give software Version (global)
 724 = status,4                      ; Give GPS location info
-725 = status,5                      ; Last (dtmf) user
+725 = status,5                      ; Last (DTMF) user
 711 = status,11                     ; Force ID (local only)
 712 = status,12                     ; Give Time of Day (local only)
 
 ;;;;; Link Commands ;;;;;
 ; 1 - Disconnect specified link
 ; 2 - Connect specified link -- monitor only
-; 3 - Connect specified link -- tranceive
+; 3 - Connect specified link -- transceive
 ; 4 - Enter command mode on specified link
 ; 5 - System status
 ; 6 - Disconnect all links
@@ -307,11 +298,11 @@ rxchannel = SimpleUSB/1999      ; SimpleUSB
 ; 10 - Disconnect all RANGER links (except permalinks)
 ; 11 - Disconnect a previously permanently connected link
 ; 12 - Permanently connect specified link -- monitor only
-; 13 - Permanently connect specified link -- tranceive
+; 13 - Permanently connect specified link -- transceive
 ; 15 - Full system status (all nodes)
 ; 16 - Reconnect links disconnected with "disconnect all links"
 ; 17 - MDC test (for diag purposes)
-; 18 - Permanently Connect specified link -- local monitor only
+; 18 - Permanently connect specified link -- local monitor only
 
 ;;;;; ilink commands ;;;;;
 ; commands 1 through 5 are defined in the Mandatory Command section
@@ -323,11 +314,11 @@ rxchannel = SimpleUSB/1999      ; SimpleUSB
 ; 810 = ilink,10                    ; Disconnect all RANGER links (except permalinks)
 ; 811 = ilink,11                    ; Disconnect a previously permanently connected link
 ; 812 = ilink,12                    ; Permanently connect specified link -- monitor only
-; 813 = ilink,13                    ; Permanently connect specified link -- tranceive
+; 813 = ilink,13                    ; Permanently connect specified link -- transceive
 ; 815 = ilink,15                    ; Full system status (all nodes)
 ; 816 = ilink,16                    ; Reconnect links disconnected with "disconnect all links"
 ; 817 = ilink,17                    ; MDC test (for diag purposes)
-; 818 = ilink,18                    ; Permanently Connect specified link -- local monitor only
+; 818 = ilink,18                    ; Permanently connect specified link -- local monitor only
 
 ;;;;; Control operator (cop) functions. ;;;;;
 ;Change these to something other than these codes listed below!
@@ -367,9 +358,9 @@ rxchannel = SimpleUSB/1999      ; SimpleUSB
 ;924 = cop,24                       ; Flush all telemetry
 ;925 = cop,25                       ; Query last node un-keyed
 ;926 = cop,26                       ; Query all nodes keyed/unkeyed
-;930 = cop,30                       ; Recall Memory Setting in Attached Xcvr
+;930 = cop,30                       ; Recall Memory Setting in attached transceiver
 
-;931 = cop,31                       ; Channel Selector for Parallel Programmed Xcvr
+;931 = cop,31                       ; Channel Selector for parallel programmed transceiver
 
 ;932 = cop,32                       ; Touchtone pad test: command + Digit string + # to playback all digits pressed
 
@@ -382,9 +373,9 @@ rxchannel = SimpleUSB/1999      ; SimpleUSB
 ;938 = cop,38                       ; Foreign Link Local Output Path Follows Local Telemetry
 ;939 = cop,39                       ; Foreign Link Local Output Path on Demand
 
-;942 = cop,42                       ; Echolink announce node # only
-;943 = cop,43                       ; Echolink announce node Callsign only
-;944 = cop,44                       ; Echolink announce node # & Callsign
+;942 = cop,42                       ; EchoLink announce node # only
+;943 = cop,43                       ; EchoLink announce node Callsign only
+;944 = cop,44                       ; EchoLink announce node # & Callsign
 
 ;945 = cop,45                       ; Link Activity timer enable
 ;945 = cop,46                       ; Link Activity timer disable
@@ -401,11 +392,11 @@ rxchannel = SimpleUSB/1999      ; SimpleUSB
 ; 954 = cop,54                      ; Go to sleep
 ; 955 = cop,55                      ; Parrot Once if parrot mode is disabled
 
-; 956 = cop,56                      ; Rx CTCSS Enable
-; 957 = cop,57                      ; Rx CTCSS Disable
+; 956 = cop,56                      ; RX CTCSS Enable
+; 957 = cop,57                      ; RX CTCSS Disable
 
-; 958 = cop.58                      ; Tx CTCSS On Input only Enable
-; 959 = cop,59                      ; Tx CTCSS On Input only Disable
+; 958 = cop,58                      ; TX CTCSS On Input only Enable
+; 959 = cop,59                      ; TX CTCSS On Input only Disable
 
 ; 960 = cop,60                      ; Send MDC-1200 Burst (cop,60,type,UnitID[,DestID,SubCode])
                                     ; Type is 'I' for PttID, 'E' for Emergency, and 'C' for Call
@@ -421,8 +412,8 @@ rxchannel = SimpleUSB/1999      ; SimpleUSB
 ; 961 = cop,61                      ; Send Message to USB to control GPIO pins (cop,61,GPIO1=0[,GPIO4=1].....)
 ; 962 = cop,62                      ; Send Message to USB to control GPIO pins, quietly (cop,62,GPIO1=0[,GPIO4=1].....)
 
-; 963 = cop,63                      ; Send pre-configred APRStt notification (cop,63,CALL[,OVERLAYCHR])
-; 964 = cop,64                      ; Send pre-configred APRStt notification, quietly (cop,64,CALL[,OVERLAYCHR])
+; 963 = cop,63                      ; Send pre-configured APRStt notification (cop,63,CALL[,OVERLAYCHR])
+; 964 = cop,64                      ; Send pre-configured APRStt notification, quietly (cop,64,CALL[,OVERLAYCHR])
 ; 965 = cop,65                      ; Send POCSAG page (equipped channel types only)
 
 ; [functions-remote]
@@ -430,12 +421,12 @@ rxchannel = SimpleUSB/1999      ; SimpleUSB
 ;
 ; 0 = remote,1                      ; Retrieve Memory
 ; 1 = remote,2                      ; Set freq.
-; 2 = remote,3                      ; Set tx PL tone
-; 3 = remote,4                      ; Set rx PL tone
-; 40 = remote,100                   ; Rx PL off
-; 41 = remote,101                   ; Rx PL on
-; 42 = remote,102                   ; Tx PL off
-; 43 = remote,103                   ; Tx PL on
+; 2 = remote,3                      ; Set TX PL tone
+; 3 = remote,4                      ; Set RX PL tone
+; 40 = remote,100                   ; RX PL off
+; 41 = remote,101                   ; RX PL on
+; 42 = remote,102                   ; TX PL off
+; 43 = remote,103                   ; TX PL on
 ; 44 = remote,104                   ; Low Power
 ; 45 = remote,105                   ; Medium Power
 ; 46 = remote,106                   ; High Power
@@ -457,15 +448,15 @@ rxchannel = SimpleUSB/1999      ; SimpleUSB
 ; 67 = remote,210                   ; Send a *
 ; 69 = remote,211                   ; Send a #
 ; 91 = remote,99,CALLSIGN,LICENSETAG     ; Remote base login.
-                                    ; Define a different dtmf sequence for each user which is
+                                    ; Define a different DTMF sequence for each user which is
                                     ; authorized to use the remote base to control access to it.
-                                    ; For examble 9139583=remote,99,WB6NIL,G would grant access to
+                                    ; For example 9139583=remote,99,WB6NIL,G would grant access to
                                     ; the remote base and announce WB6NIL as being logged in.
                                     ; Another entry, 9148351=remote,99,WA6ZFT,E would grant access to
                                     ; the remote base and announce WA6ZFT as being logged in.
                                     ; When the remote base is disconnected from the originating node, the
                                     ; user will be logged out. The LICENSETAG argument is used to enforce
-                                    ; tx frequency limits. See [txlimits] below.
+                                    ; TX frequency limits. See [txlimits] below.
 ; 85 = cop,6                        ; Remote base telephone key
 
 
@@ -500,7 +491,7 @@ ct5 = |t(660,0,150,2048)
 ct6 = |t(880,0,150,2048)
 ct7 = |t(660,440,150,2048)
 ct8 = |t(700,1100,150,2048)
-ct9 = |t(1633,0,50,1000)(0,0,30,0)(1209,0,50,1000);
+ct9 = |t(1633,0,50,1000)(0,0,30,0)(1209,0,50,1000)
 ranger = |t(1800,0,60,3072)(0,0,50,0)(1800,0,60,3072)(0,0,50,0)(1800,0,60,3072)(0,0,50,0)(1800,0,60,3072)(0,0,50,0)(1800,0,60,3072)(0,0,50,0)(1800,0,60,3072)(0,0,150,0)
 remotemon = |t(1209,0,50,2048)                            ; local courtesy tone when receive only
 remotetx = |t(1633,0,50,3000)(0,0,80,0)(1209,0,50,3000)   ; local courtesy tone when linked Trancieve mode
@@ -523,7 +514,7 @@ patchdown = rpt/callterminated
 ; The numbers, like 350,440,10,2048 are 350Hz, 440Hz, 10ms delay, amplitude of 2048.
 
 [morse]
-;;;;; Mores code ;;;;;
+;;;;; Morse code ;;;;;
 ; Morse code parameters, these are common to all repeaters.
 speed = 20                          ; Approximate speed in WPM
 frequency = 800                     ; Morse Telemetry Frequency
@@ -532,8 +523,8 @@ idfrequency = 1065                  ; Morse ID Frequency
 idamplitude = 1024                  ; Morse ID Amplitude
 
 ;[morse]
-;speed = 35                         ; Not leagle in the USA
-;frequency = 800                    ; Morse Telemetry Frequency *Changed
+;speed = 35                         ; Not legal in the USA
+;frequency = 800                    ; Morse Telemetry Frequency
 ;amplitude = 4096                   ; Morse Telemetry Amplitude
 ;idfrequency = 750                  ; Morse ID Frequency        *Changed
 ;idamplitude = 512                  ; Morse ID Amplitude        *Changed
@@ -612,7 +603,7 @@ calltermwait = 2000                 ; Time to wait before announcing "call termi
 ;face = range(X-Y:word,X2-Y2:word,...),word/?,...
 ;face = bit(low-word,high-word),word/?,...
 ;
-; word/? is either a word in /var/lib/asterisk/sounds or one of its subdirectories,
+; word/? is either a word in /usr/share/asterisk/sounds or one of its subdirectories,
 ; or a question mark which is  a placeholder for the measured value.
 ;
 ;
@@ -642,7 +633,7 @@ calltermwait = 2000                 ; Time to wait before announcing "call termi
 ;door = daq-cham-1,9,1,2017,*7,-
 ;pwrfail = daq-cham-1,10,0,2017,*911111,-
 
-;[events]
+[events]
 ;;;;; Events Management ;;;;;
 ;status,2 = c|f|RPT_NUMLINKS               ; Say time of day when all links disconnect.
 
@@ -658,3 +649,25 @@ calltermwait = 2000                 ; Time to wait before announcing "call termi
 ;;;;; Scheduler - execute a macro at a given time ;;;;;
 ;dtmf_function =  m h dom mon dow   ; ala cron, star is implied
 ;2 = 00 00 * * *                    ; at midnight, execute macro 2.
+
+#tryinclude "custom/rpt.conf"
+#tryinclude "custom/rpt/*.conf"
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;; Configure your nodes here ;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; Note: there is no need to duplicate entire settings. Only
+;       place settings that are different than the template.
+;
+
+;;;;;;;;;;;;;;;;;;; Your node settings here ;;;;;;;;;;;;;;;;;;;
+[1999](node-main)
+rxchannel = SimpleUSB/1999      ; SimpleUSB
+;startup_macro = *8132000
+
+;;;;;;;;;;;;;;;;;;; Another node settings here ;;;;;;;;;;;;;;;;;;;
+;[1998](node-main)
+;startup_macro = *8132000
+;morse = morse_1998                 ; Sample morse stanza for node 1998
+

--- a/configs/rpt/simpleusb.conf
+++ b/configs/rpt/simpleusb.conf
@@ -123,6 +123,9 @@ legacyaudioscaling = no             ; If yes, continue to do raw audio sample sc
 
 ;;; End of node-main template
 
+#tryinclude "custom/simpleusb.conf"
+#tryinclude "custom/simpleusb/*.conf"
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;; Configure your nodes here ;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/configs/rpt/usbradio.conf
+++ b/configs/rpt/usbradio.conf
@@ -130,10 +130,8 @@ txlimonly = yes             ; Audio limiting with no pre-emphasis on output chan
 
 txtoctype = notone          ; Transmit tone control type: no,phase,notone
                             ; no - CTCSS tone encoding with no hang time
-                            ; phase - encode CTCSS and reverse phase
-                            ; AKA ("reverse burst") before unkeying TX
-                            ; notone - encode CTCSS and stop sending tone before unkeying TX
-                            ; AKA ("chicken burst")
+                            ; phase - encode CTCSS and reverse phase before unkeying TX (AKA "reverse burst")
+                            ; notone - encode CTCSS and stop sending tone before unkeying TX (AKA "chicken burst")
 
 txmixa = composite          ; Left channel output: no,voice,tone,composite,auxvoice
                             ; no - Do not output anything
@@ -186,6 +184,9 @@ legacyaudioscaling = no     ; If yes, continue to do raw audio sample scaling an
                             ; scaling/clipping code will be deleted once existing installs have been able to verify their audio levels
 
 ;;; End of node-main template
+
+#tryinclude "custom/usbradio.conf"
+#tryinclude "custom/usbradio/*.conf"
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;; Configure your nodes here ;;;;;;;;;;;;;;;;


### PR DESCRIPTION
The configuration files for all ASL nodes require some customization.  Some of the needed changes are for basic settings (e.g. node #, callsign, type of channel driver).  Other changes are to enable various features (e.g. enabling DTMF commands, GPIO usage).  These latter changes tend to require more detailed editing of the configuration files.

This change updates the default configuration files to allow for easier customization.  This is achieved, primarily, by the addition of #tryinclude statements that allow for additional configuration content to be added in separate files.

This change also cleans up some formatting, corrects some spelling errors, updates some abbreviations, etc.