### PR TITLE
app_rpt: Add 1 to node count for explode string

### DIFF
--- a/apps/app_rpt/rpt_cli.c
+++ b/apps/app_rpt/rpt_cli.c
@@ -532,7 +532,7 @@ static int rpt_do_xnode(int fd, int argc, const char *const *argv)
 			 * Traverse the list of connected nodes
 			 */
 			rpt_mutex_lock(&myrpt->lock); /* LOCK */
-			n = __mklinklist(myrpt, NULL, &lbuf, 0);
+			n = __mklinklist(myrpt, NULL, &lbuf, 0) + 1;
 			rpt_mutex_unlock(&myrpt->lock); /* LOCK */
 
 			j = 0;
@@ -676,7 +676,7 @@ static int rpt_do_nodes(int fd, int argc, const char *const *argv)
 			/* Make a copy of all stat variables while locked */
 			myrpt = &rpt_vars[i];
 			rpt_mutex_lock(&myrpt->lock);	/* LOCK */
-			n = __mklinklist(myrpt, NULL, &lbuf, 0);
+			n = __mklinklist(myrpt, NULL, &lbuf, 0) + 1;
 			rpt_mutex_unlock(&myrpt->lock);	/* UNLOCK */
 			strs = ast_malloc(n * sizeof(char *));
 			if (!strs) {

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -687,7 +687,7 @@ int connect_link(struct rpt *myrpt, char *node, int mode, int perma)
 			rpt_mutex_unlock(&myrpt->lock);
 			return -1;
 		}
-		n = __mklinklist(myrpt, NULL, &lstr, 0);
+		n = __mklinklist(myrpt, NULL, &lstr, 0) + 1;
 		rpt_mutex_unlock(&myrpt->lock);
 		strs = ast_malloc(n * sizeof(char *));
 		if (!strs) {

--- a/apps/app_rpt/rpt_manager.c
+++ b/apps/app_rpt/rpt_manager.c
@@ -209,7 +209,7 @@ static int rpt_manager_do_xstat(struct mansession *ses, const struct message *m,
 			/* Get connected node info */
 			/* Traverse the list of connected nodes */
 			ast_mutex_lock(&myrpt->lock);
-			n = __mklinklist(myrpt, NULL, &lbuf, 0);
+			n = __mklinklist(myrpt, NULL, &lbuf, 0) + 1;
 			ast_mutex_unlock(&myrpt->lock);
 			j = 0;
 			l = myrpt->links.next;

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -1257,7 +1257,7 @@ treataslocal:
 		}
 		rpt_mutex_lock(&myrpt->lock);
 		/* get all the nodes */
-		n = __mklinklist(myrpt, NULL, &lbuf, 0);
+		n = __mklinklist(myrpt, NULL, &lbuf, 0) + 1;
 		rpt_mutex_unlock(&myrpt->lock);
 		strs = ast_malloc(n * sizeof(char *));
 		if (!strs) {
@@ -2153,7 +2153,7 @@ treataslocal:
 		}
 		rpt_mutex_lock(&myrpt->lock);
 		/* get all the nodes */
-		n = __mklinklist(myrpt, NULL, &lbuf, 0);
+		n = __mklinklist(myrpt, NULL, &lbuf, 0) + 1;
 		rpt_mutex_unlock(&myrpt->lock);
 		strs = ast_malloc(n * sizeof(char *));
 		if (!strs) {
@@ -2880,7 +2880,7 @@ void rpt_telemetry(struct rpt *myrpt, int mode, void *data)
 			rpt_mutex_lock(&myrpt->lock);
 			snprintf(mystr, sizeof(mystr), "STATUS,%s,%d", myrpt->name, myrpt->callmode);
 			/* get all the nodes */
-			n = __mklinklist(myrpt, NULL, &lbuf, 0);
+			n = __mklinklist(myrpt, NULL, &lbuf, 0) + 1;
 			rpt_mutex_unlock(&myrpt->lock);
 			strs = ast_malloc(n * sizeof(char *));
 			if (!strs) {

--- a/apps/app_rpt/rpt_utils.c
+++ b/apps/app_rpt/rpt_utils.c
@@ -89,8 +89,8 @@ char *string_toupper(char *str)
  * \brief Find the delimiter in a string and return a pointer array to the start of each token.
  * Note: This modifies the string str, be sure to save an intact copy if you need it later.
  * \param str The string to search
- * \param strp An array of pointers to the start of each token
- * \param limit The maximum number of tokens to find
+ * \param strp An array of pointers to the start of each token + 1 for a null end token
+ * \param limit The maximum number of tokens to find + 1 for the null end token
  * \return The number of tokens found
  */
 int finddelim(char *str, char *strp[], size_t limit)

--- a/apps/app_rpt/rpt_utils.h
+++ b/apps/app_rpt/rpt_utils.h
@@ -12,7 +12,8 @@ int matchkeyword(char *string, char **param, char *keywords[]);
 /*!
  * \brief Explode a string into an array of pointers to the start of each token.
  * \param str The string to explode (will be modified)
- * \param strp An array of pointers to the start of each token
+ * \param strp An array of pointers to the start of each token + 1 or more for a NULL end token
+ * \param limit The maximum number of tokens to find + 1 or more for the NULL end token
  * \param delim The delimiter to use
  * \param quote The quote character to use
  * \return The number of substrings found.

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -784,8 +784,8 @@ static int16_t deemp1(int16_t input, int32_t * restrict state0)
  * \brief Break up a delimited string into a table of substrings.
  * Uses defines for the delimiters: QUOTECHR and DELIMCHR.
  * \param str		Pointer to string to process (it will be modified).
- * \param strp		Pointer to a list of substrings created, NULL will be placed at the end of the list.
- * \param limit		Maximum number of substrings to process.
+ * \param strp		An array of pointers to the start of each token + 1 or more for a NULL end token
+ * \param limit		The maximum number of tokens to find + 1 or more for the NULL end token
  * \return			Count of strings.
  */
 static int finddelim(char *str, char *strp[], size_t limit)


### PR DESCRIPTION
Turns out `explodestring()` and `finddelmin()` need `strs` array to be 1 longer than the count due to a null terminated list requirement.   This is solved by adding 1 to the node count returned by `__mklinklist` and allocating the correct size. 