### PR TITLE
app_rpt: Remove textq

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -1619,7 +1619,7 @@ static int distribute_to_all_links(struct rpt *myrpt, struct rpt_link *mylink, c
 			/* send, but not to src */
 			if (strcmp(l->name, src)) {
 				if (l->chan) {
-					rpt_qwrite(l, wf);
+					ast_write(l->chan, wf);
 				}
 			}
 			if (dest) {
@@ -1846,7 +1846,7 @@ static void handle_link_data(struct rpt *myrpt, struct rpt_link *mylink, char *s
 			wf.data.ptr = tmp1;
 			wf.datalen = strlen(tmp1) + 1;
 			if (mylink->chan)
-				rpt_qwrite(mylink, &wf);
+				ast_write(mylink->chan, &wf);
 			return;
 		}
 		if (myrpt->topkeystate != 1)
@@ -2287,7 +2287,6 @@ static int attempt_reconnect(struct rpt *myrpt, struct rpt_link *l)
 	char *s1, *tele;
 	char tmp[300], deststr[325] = "";
 	char sx[320];
-	struct ast_frame *f1;
 	struct ast_format_cap *cap;
 
 	if (node_lookup(myrpt, l->name, tmp, sizeof(tmp) - 1, 1)) {
@@ -2331,8 +2330,6 @@ static int attempt_reconnect(struct rpt *myrpt, struct rpt_link *l)
 	l->rxlingertimer = RX_LINGER_TIME;
 	l->newkeytimer = NEWKEYTIME;
 	l->link_newkey = RADIO_KEY_NOT_ALLOWED;
-	while ((f1 = AST_LIST_REMOVE_HEAD(&l->textq, frame_list)))
-		ast_frfree(f1);
 	if (l->chan) {
 		rpt_make_call(l->chan, tele, 999, deststr, "(Remote Rx)", "attempt_reconnect", myrpt->name);
 	} else {
@@ -3043,17 +3040,11 @@ static inline void rxunkey_helper(struct rpt *myrpt, struct rpt_link *l)
 
 static inline void periodic_process_links(struct rpt *myrpt, const int elap)
 {
-	struct ast_frame *f;
 	int newkeytimer_last, max_retries;
 	struct rpt_link *l = myrpt->links.next;
 	while (l != &myrpt->links) {
 		int myrx, mymaxct;
 
-		if (l->chan && l->thisconnected && !AST_LIST_EMPTY(&l->textq)) {
-			f = AST_LIST_REMOVE_HEAD(&l->textq, frame_list);
-			ast_write(l->chan, f);
-			ast_frfree(f);
-		}
 		update_timer(&l->rxlingertimer, elap, 0);
 
 		/* Update the timer, checking if it expired just now. */
@@ -3176,7 +3167,7 @@ static inline void periodic_process_links(struct rpt *myrpt, const int elap)
 			if (l->chan) {
 				lf.datalen = ast_str_strlen(lstr) + 1;
 				lf.data.ptr = ast_str_buffer(lstr);
-				rpt_qwrite(l, &lf);
+				ast_write(l->chan, &lf);
 				ast_debug(7, "@@@@ node %s sent node string %s to node %s\n", myrpt->name, ast_str_buffer(lstr), l->name);
 			}
 			ast_free(lstr);
@@ -3954,7 +3945,7 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 						continue;
 					}
 					if (l->chan)
-						rpt_qwrite(l, &wf);
+						ast_write(l->chan, &wf);
 					l = l->next;
 				}
 			}

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -445,7 +445,6 @@ struct rpt_link {
 	time_t	lastkeytime;
 	time_t	lastunkeytime;
 	AST_LIST_HEAD_NOLOCK(, ast_frame) rxq;
-	AST_LIST_HEAD_NOLOCK(, ast_frame) textq;
 };
 
 /*!

--- a/apps/app_rpt/rpt_channel.c
+++ b/apps/app_rpt/rpt_channel.c
@@ -436,7 +436,7 @@ int send_link_pl(struct rpt *myrpt, char *txt)
 	l = myrpt->links.next;
 	while (l && (l != &myrpt->links)) {
 		if ((l->chan) && l->name[0] && (l->name[0] != '0')) {
-			rpt_qwrite(l, &wf);
+			ast_write(l->chan, &wf);
 		}
 		l = l->next;
 	}

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -186,20 +186,6 @@ int altlink1(struct rpt *myrpt, struct rpt_link *mylink)
 	return (0);
 }
 
-void rpt_qwrite(struct rpt_link *l, struct ast_frame *f)
-{
-	struct ast_frame *f1;
-
-	if (!l->chan)
-		return;
-	f1 = ast_frdup(f);
-	if (!f1) {
-		return;
-	}
-	memset(&f1->frame_list, 0, sizeof(f1->frame_list));
-	AST_LIST_INSERT_TAIL(&l->textq, f1, frame_list);
-}
-
 int linkcount(struct rpt *myrpt)
 {
 	struct rpt_link *l;
@@ -322,7 +308,7 @@ void rssi_send(struct rpt *myrpt)
 		}
 		ast_debug(6, "[%s] rssi=%i to %s\n", myrpt->name, myrpt->rxrssi, l->name);
 		if (l->chan)
-			rpt_qwrite(l, &wf);
+			ast_write(l->chan, &wf);
 		l = l->next;
 	}
 }
@@ -347,7 +333,7 @@ void send_link_dtmf(struct rpt *myrpt, char c)
 		/* if we found it, write it and were done */
 		if (!strcmp(l->name, myrpt->cmdnode)) {
 			if (l->chan)
-				rpt_qwrite(l, &wf);
+				ast_write(l->chan, &wf);
 			return;
 		}
 		l = l->next;
@@ -356,7 +342,7 @@ void send_link_dtmf(struct rpt *myrpt, char c)
 	/* if not, give it to everyone */
 	while (l != &myrpt->links) {
 		if (l->chan)
-			rpt_qwrite(l, &wf);
+			ast_write(l->chan, &wf);
 		l = l->next;
 	}
 }
@@ -380,7 +366,7 @@ void send_link_keyquery(struct rpt *myrpt)
 	/* give it to everyone */
 	while (l != &myrpt->links) {
 		if (l->chan)
-			rpt_qwrite(l, &wf);
+			ast_write(l->chan, &wf);
 		l = l->next;
 	}
 }

--- a/apps/app_rpt/rpt_link.h
+++ b/apps/app_rpt/rpt_link.h
@@ -26,8 +26,6 @@ void tele_link_remove(struct rpt *myrpt, struct rpt_tele *t);
 
 int altlink1(struct rpt *myrpt, struct rpt_link *mylink);
 
-void rpt_qwrite(struct rpt_link *l, struct ast_frame *f);
-
 int linkcount(struct rpt *myrpt);
 
 /*! \brief Considers repeater received RSSI and all voter link RSSI information and set values in myrpt structure. */

--- a/apps/app_rpt/rpt_mdc1200.c
+++ b/apps/app_rpt/rpt_mdc1200.c
@@ -133,7 +133,7 @@ void mdc1200_send(struct rpt *myrpt, char *data)
 			continue;
 		}
 		if (l->chan)
-			rpt_qwrite(l, &wf);
+			ast_write(l->chan, &wf);
 		l = l->next;
 	}
 }

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -406,7 +406,7 @@ static void send_tele_link(struct rpt *myrpt, char *cmd)
 	/* give it to everyone */
 	while (l != &myrpt->links) {
 		if (l->chan && (l->mode == 1))
-			rpt_qwrite(l, &wf);
+			ast_write(l->chan, &wf);
 		l = l->next;
 	}
 	rpt_telemetry(myrpt, VARCMD, cmd);


### PR DESCRIPTION
There is no need to queue text message frames on links.  Every "access" to the channel is located in a single thread (`rpt()`) such that simply writing to the channel is all the is needed.