### PR TITLE
simpleusb, usbradio: skip categories with no "devstr"

### DIFF
--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -3692,12 +3692,12 @@ static void mixer_write(struct chan_simpleusb_pvt *o)
 
 /*!
  * \brief Store configuration.
- *	Initializes chan_usbradio and loads it with the configuration data.
+ *	Initializes chan_simpleusb and loads it with the configuration data.
  * \param cfg			ast_config structure.
  * \param ctg			Category.
- * \return				chan_usbradio_pvt.
+ * \return				chan_simpleusb_pvt.
  */
-static struct chan_simpleusb_pvt *store_config(const struct ast_config *cfg, const char *ctg)
+static struct chan_simpleusb_pvt *store_config(struct ast_config *cfg, const char *ctg)
 {
 	const struct ast_variable *v;
 	struct chan_simpleusb_pvt *o;
@@ -3712,6 +3712,9 @@ static struct chan_simpleusb_pvt *store_config(const struct ast_config *cfg, con
 		if (strcmp(ctg, "general") == 0) {
 			o = &simpleusb_default;
 		} else {
+			if (!ast_variable_retrieve(cfg, ctg, "devstr")) {
+				return NULL;
+			}
 			if (!(o = ast_calloc(1, sizeof(*o)))) {
 				return NULL;
 			}

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -4879,7 +4879,7 @@ static int xpmr_config(struct chan_usbradio_pvt *o)
  * \param ctg			Category.
  * \return				chan_usbradio_pvt.
  */
-static struct chan_usbradio_pvt *store_config(const struct ast_config *cfg, const char *ctg)
+static struct chan_usbradio_pvt *store_config(struct ast_config *cfg, const char *ctg)
 {
 	const struct ast_variable *v;
 	struct chan_usbradio_pvt *o;
@@ -4894,6 +4894,9 @@ static struct chan_usbradio_pvt *store_config(const struct ast_config *cfg, cons
 		if (strcmp(ctg, "general") == 0) {
 			o = &usbradio_default;
 		} else {
+			if (!ast_variable_retrieve(cfg, ctg, "devstr")) {
+				return NULL;
+			}
 			if (!(o = ast_calloc(1, sizeof(*o)))) {
 				return NULL;
 			}


### PR DESCRIPTION
While testing some new menu / "customization" changes I found that the initial "active" device configuration was set to a category that did not have a "devstr" variable setting.  In this case, the category was intended to augment a templated configuration.  To ensure that these categories are not being considered we now look for the presence of a "devstr" variable.