### PR TITLE
app_rpt: Remove iaxkey and associated logic

### DIFF
--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -207,8 +207,7 @@ typedef struct {
 #define	SIMPLEX_PATCH_DELAY 25
 #define	SIMPLEX_PHONE_DELAY 25
 
-#define	RX_LINGER_TIME 50
-#define	RX_LINGER_TIME_IAXKEY 150
+#define RX_LINGER_TIME 50
 
 #define	STATPOST_PROGRAM "/usr/bin/wget,-q,--output-document=/dev/null,--no-check-certificate"
 
@@ -350,8 +349,6 @@ struct rpt_chan_stat {
 #define DISCSTR "!!DISCONNECT!!"
 #define NEWKEYSTR "!NEWKEY!"
 #define NEWKEY1STR "!NEWKEY1!"
-#define IAXKEYSTR "!IAXKEY!"
-
 
 /*! \brief Repeater link connection newkey handshake state */
 enum newkey { 
@@ -437,7 +434,6 @@ struct rpt_link {
 	int voxtotimer;
 	char voxtostate;
 	enum newkey link_newkey;
-	char iaxkey;
 	int linkmode;
 	int newkeytimer;
 	char gott;
@@ -858,9 +854,8 @@ struct rpt {
 	char voxtostate;
 	int linkposttimer;			
 	int keyposttimer;			
-	int lastkeytimer;			
+	int lastkeytimer;
 	enum newkey rpt_newkey;
-	char iaxkey;
 	char inpadtest;
 	int rxlingertimer;
 	char localoverride;

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -709,7 +709,6 @@ int connect_link(struct rpt *myrpt, char *node, int mode, int perma)
 		l->connected = 1;
 	l->hasconnected = l->perma = perma;
 	l->newkeytimer = NEWKEYTIME;
-	l->iaxkey = 0;
 	l->link_newkey = RADIO_KEY_NOT_ALLOWED;
 	l->voterlink = voterlink;
 	if (strncasecmp(s1, "echolink/", 9) == 0) {
@@ -798,7 +797,7 @@ int connect_link(struct rpt *myrpt, char *node, int mode, int perma)
 		l->max_retries = MAX_RETRIES_PERM;
 	if (l->isremote)
 		l->retries = l->max_retries + 1;
-	l->rxlingertimer = ((l->iaxkey) ? RX_LINGER_TIME_IAXKEY : RX_LINGER_TIME);
+	l->rxlingertimer = RX_LINGER_TIME;
 	rpt_link_add(myrpt, l);
 	__kickshort(myrpt);
 	rpt_mutex_unlock(&myrpt->lock);


### PR DESCRIPTION
Turns out there is no code to send the message !IAXKEY, so there is no reason to look for said key to arrive.