### PR TITLE
Add Templating to iax.conf To Better Support Multiple Authenticated Clients

### DIFF
--- a/configs/rpt/an-clients.conf
+++ b/configs/rpt/an-clients.conf
@@ -1,0 +1,29 @@
+; We use a template so we don't have to repeat code blocks.
+; To add a new DVSwitch Mobile (or Zoiper) user, just repeat the lines below:
+; [<callsign>-an](iaxclient)
+; secret=<some password>
+; callerid="N0CALL-AN"
+;
+; They need to authenticate with username <callsign>-an (the context name),
+; and the password (the secret). This allows us to verify their connection/client.
+;
+; We will then override any callerid they send us, so we specify what
+; callerid ("N0CALL-AN") to use and display publicly in allmon.
+;
+; Don't forget to remind users to adjust their codec settings in their client to match 
+; your allowed codecs for the [iaxrpt] context in iax.conf, otherwise they will not 
+; be able to connect.
+;
+; The stock generic user, un-comment it and change the secret (the password) 
+; if you want to use the same account for all users
+; Be warned, whatever the user sets their CallerID Name to in their client will be 
+; passed and show up in the allmon dashboard (this could be undesired). You 
+; can force-override that by adding a callerid line as shown below.
+;[iaxclient](iaxclient)
+;secret = Your_Secret_Pasword_Here
+  
+; A custom user, un-comment and set the fields as necessary
+;[n0call-an](iaxclient)  ; pull in the config from the [iaxclient] context in
+;user=n0call             ; iax.conf and then add this user's specific information
+;secret=sm0keandmirr0rs  ; (user, secret, and callerid). n0call-an is the USERNAME in
+;callerid="N0CALL-AN"    ; their client account configuration.

--- a/configs/rpt/iax.conf
+++ b/configs/rpt/iax.conf
@@ -62,29 +62,42 @@ codecpriority = host
 context = radio-secure
 transfer = no
 
-[iaxrpt]                         ; Connect from iaxrpt Username field (PC AllStar Client)
+; The (!) for the [iaxrpt](!) context indicates this is a template. As such, we can store the 
+; actual users to authenticate in a separate file, to keep from cluttering up iax.conf.
+; The actual file used to store the users is included with the #tryinclude directive below.
+[iaxrpt](!)                      ; Connect from iaxrpt Username field (PC AllStar Client (iaxRpt))
 type = user                      ; Notice type is user here <---------------
 context = iaxrpt                 ; Context to jump to in extensions.conf
 auth = md5
-secret = Your_Secret_Pasword_Here
 host = dynamic
-disallow = all                    
+disallow = all
+;allow = slin16                   ; un-comment to allow high-fidelity codec (make sure to load module)
+;allow = slin                     ; un-comment to allow high-fidelity codec (make sure to load module)
 allow = ulaw
 allow = adpcm
 allow = gsm                       
 transfer = no
+requirecalltoken = no            ; Required for iaxRpt to connect, because it is SO old
+; Source the users to authenticate from here:
+#tryinclude pc-clients.conf      ; PC clients to authenticate
 
-[iaxclient]                      ; Connect from iax client (Zoiper...)
+; The (!) for the [iaxclient](!) context indicates this is a template. As such, we can store the 
+; actual users to authenticate in a separate file, to keep from cluttering up iax.conf.
+; The actual file used to store the users is included with the #tryinclude directive below.
+[iaxclient](!)                   ; Connect from iax client (Zoiper,DVSwitch Mobile, etc.)
 type = friend                    ; Notice type here is friend <--------------
 context = iax-client             ; Context to jump to in extensions.conf
 auth = md5
-secret = Your_Secret_Password_Here
 host = dynamic
 disallow = all
+;allow = slin16                   ; un-comment to allow high-fidelity codec (make sure to load module)
+;allow = slin                     ; un-comment to allow high-fidelity codec (make sure to load module)
 allow = ulaw
 allow = adpcm
 allow = gsm
 transfer = no
+; Source the users to authenticate from here:
+#tryinclude an-clients.conf      ; Android clients to authenticate
 
 [allstar-sys]
 type = user

--- a/configs/rpt/pc-clients.conf
+++ b/configs/rpt/pc-clients.conf
@@ -1,0 +1,34 @@
+; We use a template so we don't have to repeat code blocks.
+; To add a new PC Client user, just repeat the lines below:
+; [<callsign>-pc](iaxrpt)
+; secret=<some password>
+; callerid="N0CALL-I" <0>
+;
+; They need to authenticate with username <callsign>-pc,
+; and the secret (password). This allows us to verify their connection/client.
+; So, users need to set the Username in iaxRpt to match the context name here 
+; ie. n0call-pc and set the Password the same as the secret.
+;
+; We will then override any callerid they send us, so we specify what
+; callerid ("N0CALL-I") to use and display publicly in allmon.
+;
+; Note, the callerid number MUST be <0>. This replicates what the iaxRPT client
+; sends, and if it is non-0, weird things happen! Callerid name is limited to 8 char!
+;
+; Don't forget to remind users to adjust their codec settings in iaxRpt to match 
+; your allowed codecs for the [iaxrpt] context in iax.conf, otherwise they will not 
+; be able to connect.
+;
+; The stock generic user, un-comment it and change the secret (the password) 
+; if you want to use the same account for all users
+; Be warned, whatever the user sets their CallerID Name to in iaxRpt will be 
+; passed and show up in the allmon dashboard (this could be undesired). You 
+; can force-override that by adding a callerid line as shown below.
+;[iaxrpt](iaxrpt)
+;secret = Your_Secret_Pasword_Here
+  
+; A custom user, un-comment and set the fields as necessary
+;[n0call-pc](iaxrpt)     ; pull in the config from the [iaxrpt] context in
+;user=n0call             ; iax.conf and then add this user's specific information
+;secret=sm0keandmirr0rs  ; (user, secret, and callerid). n0call-pc is the USERNAME in
+;callerid="N0CALL-I" <0> ; the iaxRPT client account configuration.


### PR DESCRIPTION
This enhancement fixes the issue of iaxRpt clients not being able to connect by adding the `requirecalltoken = no` option to the `[iaxrpt]` context in `/etc/asterisk/iax.conf`.

This enhancements implements templating for additional users to be easily added, without cluttering up `iax.conf` by having to copy/paste the same code block each time you want to add a new individual user (such as net control operators, each with their own callerid and account credentials).

Users are stored in `/etc/asterisk/pc-clients.conf` (for iaxRpt clients), and `/etc/asterisk/an-clients.conf` for Android (ie DVSwitch Mobile or Zoiper) clients. They CAN be moved in to a folder such as `/etc/asterisk/custom/` by changing the include directive, such as `#tryinclude custom/pc-clients.conf`. Making sure, of course, that said folder has the proper ownership and permissions (asterisk:asterisk).

Adding new clients just requires duplicating the user authentication contexts, and adjusting account name (context), secret, and callerid, as required.