### PR TITLE
app_rpt: If we are unkeyed, send an AST_FRAME_CNG.

### DIFF
--- a/.dev/.clang-format
+++ b/.dev/.clang-format
@@ -152,7 +152,7 @@ SpacesInLineCommentPrefix:
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 SpaceBeforeSquareBrackets: false
-BitFieldColonSpacing: Both
+BitFieldColonSpacing: None
 Standard:        Latest
 StatementAttributeLikeMacros:
   - Q_EMIT

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4215,22 +4215,18 @@ static inline int process_link_channels(struct rpt *myrpt, struct ast_channel *w
 						ast_indicate(l->chan, AST_CONTROL_RADIO_KEY);
 				} else {
 					ast_indicate(l->chan, AST_CONTROL_RADIO_UNKEY);
+					if (l->lastframe) {
+						memset(&wf, 0, sizeof(wf));
+						wf.frametype = AST_FRAME_CNG;
+						ast_write(l->chan, &wf);
+						l->lastframe = 0;
+					}
 				}
 				if (myrpt->p.archivedir) {
 					donodelog_fmt(myrpt, totx ? "TXKEY,%s" : "TXUNKEY,%s", l->name);
 				}
 			}
 			l->lasttx = *totx;
-
-			if (l->chan && l->lastframe && !l->lasttx) { /* Send a silence frame to clear jitter buffer */
-				ast_write(l->chan, &ast_null_frame);
-				wf.frametype = AST_FRAME_CNG;
-				wf.subclass.integer = 0;
-				wf.delivery.tv_sec = 0;
-				wf.delivery.tv_usec = 0;
-				ast_write(l->chan, &wf);
-				l->lastframe = 0;
-			}
 		}
 
 		rpt_mutex_lock(&myrpt->lock);

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2299,7 +2299,7 @@ static int attempt_reconnect(struct rpt *myrpt, struct rpt_link *l)
 	l->linkmode = 0;
 	l->lastrx1 = 0;
 	l->lastrealrx = 0;
-	l->lastframe = 0;
+	l->last_frame_sent = 0;
 	l->rxlingertimer = RX_LINGER_TIME;
 	l->newkeytimer = NEWKEYTIME;
 	l->link_newkey = RADIO_KEY_NOT_ALLOWED;
@@ -4215,9 +4215,9 @@ static inline int process_link_channels(struct rpt *myrpt, struct ast_channel *w
 						ast_indicate(l->chan, AST_CONTROL_RADIO_KEY);
 				} else {
 					ast_indicate(l->chan, AST_CONTROL_RADIO_UNKEY);
-					if (l->lastframe) {
+					if (l->last_frame_sent) {
 						ast_write(l->chan, &wf);
-						l->lastframe = 0;
+						l->last_frame_sent = 0;
 					}
 				}
 				if (myrpt->p.archivedir) {
@@ -4426,7 +4426,7 @@ static inline int process_link_channels(struct rpt *myrpt, struct ast_channel *w
 					 * 
 					 */
 					ast_write(l->chan, f);
-					l->lastframe = 1;
+					l->last_frame_sent = 1;
 				}
 			}
 			if (f->frametype == AST_FRAME_CONTROL && f->subclass.integer == AST_CONTROL_HANGUP) {
@@ -6560,7 +6560,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 		ast_copy_string(l->name, b1, MAXNODESTR);
 		l->isremote = 0;
 		l->chan = chan;
-		l->lastframe = 0;
+		l->last_frame_sent = 0;
 		l->connected = 1;
 		l->thisconnected = 1;
 		l->hasconnected = 1;

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4163,7 +4163,9 @@ static inline void rxkey_helper(struct rpt *myrpt, struct rpt_link *l)
 static inline int process_link_channels(struct rpt *myrpt, struct ast_channel *who, int *restrict totx, char *restrict myfirst)
 {
 	struct rpt_link *l, *m;
-	struct ast_frame wf = { .frametype = AST_FRAME_CNG };
+	struct ast_frame wf = {
+		.frametype = AST_FRAME_CNG
+	};
 
 	/* @@@@@ LOCK @@@@@ */
 	rpt_mutex_lock(&myrpt->lock);

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4163,7 +4163,7 @@ static inline void rxkey_helper(struct rpt *myrpt, struct rpt_link *l)
 static inline int process_link_channels(struct rpt *myrpt, struct ast_channel *who, int *restrict totx, char *restrict myfirst)
 {
 	struct rpt_link *l, *m;
-	struct ast_frame wf;
+	struct ast_frame wf = { .frametype = AST_FRAME_CNG };
 
 	/* @@@@@ LOCK @@@@@ */
 	rpt_mutex_lock(&myrpt->lock);
@@ -4216,8 +4216,6 @@ static inline int process_link_channels(struct rpt *myrpt, struct ast_channel *w
 				} else {
 					ast_indicate(l->chan, AST_CONTROL_RADIO_UNKEY);
 					if (l->lastframe) {
-						memset(&wf, 0, sizeof(wf));
-						wf.frametype = AST_FRAME_CNG;
 						ast_write(l->chan, &wf);
 						l->lastframe = 0;
 					}

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4163,10 +4163,11 @@ static inline void rxkey_helper(struct rpt *myrpt, struct rpt_link *l)
 static inline int process_link_channels(struct rpt *myrpt, struct ast_channel *who, int *restrict totx, char *restrict myfirst)
 {
 	struct rpt_link *l, *m;
+	// clang-format off
 	struct ast_frame wf = {
 		.frametype = AST_FRAME_CNG
 	};
-
+	// clang-format on
 	/* @@@@@ LOCK @@@@@ */
 	rpt_mutex_lock(&myrpt->lock);
 	l = myrpt->links.next;

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4163,11 +4163,9 @@ static inline void rxkey_helper(struct rpt *myrpt, struct rpt_link *l)
 static inline int process_link_channels(struct rpt *myrpt, struct ast_channel *who, int *restrict totx, char *restrict myfirst)
 {
 	struct rpt_link *l, *m;
-	// clang-format off
 	struct ast_frame wf = {
-		.frametype = AST_FRAME_CNG
+		.frametype = AST_FRAME_CNG,
 	};
-	// clang-format on
 	/* @@@@@ LOCK @@@@@ */
 	rpt_mutex_lock(&myrpt->lock);
 	l = myrpt->links.next;

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -400,7 +400,7 @@ struct rpt_link {
 	char lastrx;
 	char lastrealrx;
 	char lastrx1;
-	char last_frame_sent; /* We have written a single frame */
+	unsigned int last_frame_sent : 1; /* We have written a single frame */
 	char wouldtx;
 	char connected;
 	char hasconnected;

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -400,7 +400,7 @@ struct rpt_link {
 	char lastrx;
 	char lastrealrx;
 	char lastrx1;
-	unsigned int last_frame_sent : 1; /* We have written a single frame */
+	unsigned int last_frame_sent:1; /* We have written a single frame */
 	char wouldtx;
 	char connected;
 	char hasconnected;

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -400,7 +400,7 @@ struct rpt_link {
 	char lastrx;
 	char lastrealrx;
 	char lastrx1;
-	char lastframe; /* We have written a single frame */
+	char last_frame_sent; /* We have written a single frame */
 	char wouldtx;
 	char connected;
 	char hasconnected;

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -389,27 +389,28 @@ struct rpt;
 struct rpt_link {
 	struct rpt_link *next;
 	struct rpt_link *prev;
-	char	mode;			/* 1 if in tx mode */
-	char	isremote;
-	char	phonemode;
-	char	phonevox;		/* vox the phone */
-	char	phonemonitor;		/* no tx or funs for the phone */
-	char	name[MAXNODESTR];	/* identifier (routing) string */
-	char	lasttx;
-	char	lasttx1;
-	char	lastrx;
-	char	lastrealrx;
-	char	lastrx1;
-	char	wouldtx;
-	char	connected;
-	char	hasconnected;
-	char	perma;
-	char	thisconnected;
-	char	outbound;
-	char	disced;
-	char	killme;
-	long	elaptime;
-	int	disctime;
+	char mode; /* 1 if in tx mode */
+	char isremote;
+	char phonemode;
+	char phonevox;		   /* vox the phone */
+	char phonemonitor;	   /* no tx or funs for the phone */
+	char name[MAXNODESTR]; /* identifier (routing) string */
+	char lasttx;
+	char lasttx1;
+	char lastrx;
+	char lastrealrx;
+	char lastrx1;
+	char lastframe; /* We have written a single frame */
+	char wouldtx;
+	char connected;
+	char hasconnected;
+	char perma;
+	char thisconnected;
+	char outbound;
+	char disced;
+	char killme;
+	long elaptime;
+	int disctime;
 	int	retrytimer;
 	int	retxtimer;
 	int	rerxtimer;


### PR DESCRIPTION
AST_FRAME_CNG stops the jitter buffer and codec from interpolating missing frames.
app_rpt intentionally stops sending voice frames to indicate "unkey" to the receiving side.
Specifically when a loud noise (like a squelch burst) occurs in the last frame, the jitter buffer and the codec try to interpolate the missing frames for up to 10 frames.  Sending an AST_FRAME_CNG frame triggers the interpolater not interpolate