### PR TITLE
app_rpt: static for functions only called in telemetry

### DIFF
--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -385,26 +385,6 @@ void send_link_keyquery(struct rpt *myrpt)
 	}
 }
 
-void send_tele_link(struct rpt *myrpt, char *cmd)
-{
-	char str[400];
-	struct ast_frame wf;
-	struct rpt_link *l;
-
-	snprintf(str, sizeof(str) - 1, "T %s %s", myrpt->name, cmd);
-	init_text_frame(&wf, "send_tele_link");
-	wf.datalen = strlen(str) + 1;
-	wf.data.ptr = str;
-	l = myrpt->links.next;
-	/* give it to everyone */
-	while (l != &myrpt->links) {
-		if (l->chan && (l->mode == 1))
-			rpt_qwrite(l, &wf);
-		l = l->next;
-	}
-	rpt_telemetry(myrpt, VARCMD, cmd);
-}
-
 static void check_link_list(struct rpt *myrpt)
 {
 	struct rpt_link *l;

--- a/apps/app_rpt/rpt_link.h
+++ b/apps/app_rpt/rpt_link.h
@@ -42,8 +42,6 @@ void send_link_dtmf(struct rpt *myrpt, char c);
 
 void send_link_keyquery(struct rpt *myrpt);
 
-void send_tele_link(struct rpt *myrpt, char *cmd);
-
 /*!
  * \brief Add an rpt_link to a rpt
  * \param myrpt

--- a/apps/app_rpt/rpt_telemetry.h
+++ b/apps/app_rpt/rpt_telemetry.h
@@ -1,14 +1,6 @@
 
 void rpt_telem_select(struct rpt *myrpt, int command_source, struct rpt_link *mylink);
 
-/*
- * Parse a request METER request for telemetry thread
- * This is passed in a comma separated list of items from the function table entry
- * There should be 3 or 4 fields in the function table entry: device, channel, meter face, and  optionally: filter
- */
-
-int handle_meter_tele(struct rpt *myrpt, struct ast_channel *mychannel, char *args);
-
 void flush_telem(struct rpt *myrpt);
 
 /*! \brief Routine that hangs up all links and frees all threads related to them hence taking a "bird bath".  Makes a lot of noise/cleans up the mess */
@@ -16,19 +8,6 @@ void birdbath(struct rpt *myrpt);
 
 /*! \note must be called locked */
 void cancel_pfxtone(struct rpt *myrpt);
-
-/*! Send telemetry tones */
-int send_tone_telemetry(struct ast_channel *chan, char *tonestring);
-
-int telem_any(struct rpt *myrpt, struct ast_channel *chan, char *entry);
-
-/*! \brief This function looks up a telemetry name in the config file, and does a telemetry response as configured.
- * 4 types of telemetry are handled: Morse ID, Morse Message, Tone Sequence, and a File containing a recording. */
-int telem_lookup(struct rpt *myrpt, struct ast_channel *chan, char *node, char *name);
-
-/*! \brief Routine to process various telemetry commands that are in the myrpt structure
- * Used extensively when links and built/torn down and other events are processed by the rpt_master threads. */
-void handle_varcmd_tele(struct rpt *myrpt, struct ast_channel *mychannel, char *varcmd);
 
 void *rpt_tele_thread(void *this);
 


### PR DESCRIPTION
Bit of housekeeping.
static for functions only called in `rpt_telemetry.c`
move `send_tele_link()` to `rpt_telemetry.c` as it's only used in `rpt_telemetry.c`.