### PR TITLE
chan_usbradio: Add 1 null frame when USB buffer is emtpy.

### DIFF
--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -1522,6 +1522,7 @@ static int used_blocks(struct chan_usbradio_pvt *o)
 static int soundcard_writeframe(struct chan_usbradio_pvt *o, short *data)
 {
 	int res;
+	short outbuf[FRAME_SIZE * 2 * 2 * 6];
 
 	/* If the sound device is not open, setformat will open the device */
 	if (o->sounddev < 0) {
@@ -1552,7 +1553,11 @@ static int soundcard_writeframe(struct chan_usbradio_pvt *o, short *data)
 		}
 		return 0;
 	}
-
+	if (res == 0) { /* We are not keeping the buffer full, add 1 frame */
+		memset(outbuf, 0, sizeof(outbuf));
+		write(o->sounddev, ((void *) outbuf), FRAME_SIZE * 2 * 2 * 6);
+		ast_debug(7, "A null frame has been added");
+	}
 	res = write(o->sounddev, ((void *) data), FRAME_SIZE * 2 * 2 * 6);
 	if (res < 0) {
 		ast_log(LOG_ERROR, "Channel %s: Sound card write error %s\n", o->name, strerror(errno));

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -1522,7 +1522,7 @@ static int used_blocks(struct chan_usbradio_pvt *o)
 static int soundcard_writeframe(struct chan_usbradio_pvt *o, short *data)
 {
 	int res;
-	short outbuf[FRAME_SIZE * 2 * 2 * 6];
+	short outbuf[FRAME_SIZE * 2 * 6];
 
 	/* If the sound device is not open, setformat will open the device */
 	if (o->sounddev < 0) {
@@ -1555,7 +1555,7 @@ static int soundcard_writeframe(struct chan_usbradio_pvt *o, short *data)
 	}
 	if (res == 0) { /* We are not keeping the buffer full, add 1 frame */
 		memset(outbuf, 0, sizeof(outbuf));
-		write(o->sounddev, ((void *) outbuf), FRAME_SIZE * 2 * 2 * 6);
+		write(o->sounddev, ((void *) outbuf), sizeof(outbuf));
 		ast_debug(7, "A null frame has been added");
 	}
 	res = write(o->sounddev, ((void *) data), FRAME_SIZE * 2 * 2 * 6);


### PR DESCRIPTION
By adding 1 null frame (typically at the beginning of a transmission), chan_usbradio can then keep up with the usb device. Generally, the channel update is > 20ms (20.1ms -> 20.5ms) which allowed the usb buffer to empty.  This eliminates the need to set snd_usb_audio lowlatency=0