### PR TITLE
app_rpt: Use macros for repeater conference.

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2713,9 +2713,9 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 	}
 
 	if (myrpt->p.duplex == 2 || myrpt->p.duplex == 4) {
-		res = rpt_conf_create(myrpt->pchannel, myrpt, RPT_CONF, RPT_CONF_CONFANNMON);
+		res = rpt_conf_add_announcer_monitor(myrpt->pchannel, myrpt);
 	} else {
-		res = rpt_conf_create(myrpt->pchannel, myrpt, RPT_CONF, RPT_CONF_CONF | RPT_CONF_LISTENER | RPT_CONF_TALKER);
+		res = rpt_conf_add_speaker(myrpt->pchannel, myrpt);
 	}
 	if (res) {
 		rpt_hangup_rx_tx(myrpt);


### PR DESCRIPTION
Just a little "cleanup" on these conference setup calls.  The macros were defined awhile back, looks like these were missed.