### PR TITLE
app_rpt: Update duplex mode 3 to pass audio to audioarchive.

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -1439,7 +1439,7 @@ void *rpt_call(void *this)
 	rpt_mutex_unlock(&myrpt->lock);
 
 	/* first put the channel on the conference in announce mode */
-	if (myrpt->p.duplex == 2 || myrpt->p.duplex == 4) {
+	if (myrpt->p.duplex >= 2 && myrpt->p.duplex <= 4) {
 		rpt_conf_add_announcer_monitor(myrpt->pchannel, myrpt);
 	} else {
 		rpt_conf_add_speaker(myrpt->pchannel, myrpt);
@@ -2725,7 +2725,7 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 		return -1;
 	}
 
-	if (myrpt->p.duplex == 2 || myrpt->p.duplex == 4) {
+	if (myrpt->p.duplex >= 2 && myrpt->p.duplex <= 4) {
 		res = rpt_conf_add_announcer_monitor(myrpt->pchannel, myrpt);
 	} else {
 		res = rpt_conf_add_speaker(myrpt->pchannel, myrpt);
@@ -4047,6 +4047,9 @@ static inline int dahditxchannel_read(struct rpt *myrpt, char *restrict myfirst)
 		} else {
 			while ((f1 = AST_LIST_REMOVE_HEAD(&myrpt->txq, frame_list)))
 				ast_frfree(f1);
+		}
+		if (myrpt->p.duplex == 3 && myrpt->keyed) {
+			RPT_MUTE_FRAME(f);
 		}
 		ast_write(myrpt->txchannel, f);
 	}


### PR DESCRIPTION
Mode 3 is intended to be a full duplex with local audio muted.  This WAS accomplished via conference settings but that prevented the local audio from reaching the monstream channel. Converting the conference settings to match modes 2 and 4 (full duplex) and simply muting the frames headed to the txchannel allows for monstream to catch the audio and prevent the audio from feeding back on the local speaker. Resolves issue archivedir recording (mostly) silence to WAV file when duplex=3 

Resolves #600