### PR TITLE
app_rpt: Use previously added macro for sscanf format

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -6883,7 +6883,8 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 			int j, k;
 			char string[100];
 
-			if (sscanf(myrpt->p.lconn[i], "GPIO" N_FMT(d) "=" N_FMT(d), &j, &k) == 2 || sscanf(myrpt->p.lconn[i], "GPIO%d:%d", &j, &k) == 2) {
+			if (sscanf(myrpt->p.lconn[i], "GPIO" N_FMT(d) "=" N_FMT(d), &j, &k) == 2 ||
+				sscanf(myrpt->p.lconn[i], "GPIO" N_FMT(d) ":" N_FMT(d), &j, &k) == 2) {
 				snprintf(string, sizeof(string), "GPIO %d %d", j, k);
 				ast_sendtext(myrpt->rxchannel, string);
 			} else if (sscanf(myrpt->p.lconn[i], "PP" N_FMT(d) "=" N_FMT(d), &j, &k) == 2) {


### PR DESCRIPTION
app_rpt: Use previously added macro for sscanf format