### PR TITLE
chan_echolink: Echolink channel driver does not handle ast_channel_yank()

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -6676,7 +6676,6 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 		gettimeofday(&myrpt->lastlinktime, NULL);
 		rpt_mutex_unlock(&myrpt->lock);
 		rpt_update_links(myrpt);
-
 		return -1; /* We can now safely return -1 to the PBX, as the old channel pre-masquerade is what will get killed off */
 	}
 	/* well, then it is a remote */


### PR DESCRIPTION
`chan_echolink` was storing a channel pointer which it then attempted to use
after the `ast_channel_yank()`, causing a crash.  This stored pointer was
not necessary and has be refactored to remove it.

Fixes https://github.com/AllStarLink/app_rpt/issues/607