### PR TITLE
Update rpt.conf to Remove Uncommon Options

### DIFF
--- a/configs/rpt/rpt.conf
+++ b/configs/rpt/rpt.conf
@@ -152,11 +152,6 @@ linkunkeyct = ct8                   ; sent when a transmission received over the
 ;lnkactmacro = *52                  ; Function to execute when link activity timer expires.
 ;lnkacttimerwarn = 30seconds        ; Message to play when the link activity timer has 30 seconds left.
 
-;remote_inact_timeout =             ; Specifies the amount of time without keying from the link. Set to 0 to disable timeout. (15 * 60)
-;remote_timeout =                   ; Session time out for remote base. Set to 0 to disable. (60 * 60)
-;remote_timeout_warning_freq =      ; 30
-;remote_timeout_warning =           ; (3 * 60)
-
 ;nounkeyct = 0                      ; Set to a 1 to eliminate courtesy tones and associated delays.
 
 holdofftelem = 0                    ; Hold off all telemetry when signal is present on receiver or from connected nodes
@@ -181,10 +176,6 @@ parrotmode = 0                      ; 0 = Parrot Off (default = 0)
 
 parrottime = 1000                   ; Set the amount of time in milliseconds
                                     ; to wait before parroting what was received
-
-;rxnotch=1065,40                    ; (Optional) Notch a particular frequency for a specified
-                                    ; b/w. app_rpt must have been compiled with
-                                    ; the notch option
 
 ;startup_macro =                    ; Best use in your node stanza (below) when more than one node
 
@@ -416,50 +407,6 @@ parrottime = 1000                   ; Set the amount of time in milliseconds
 ; 964 = cop,64                      ; Send pre-configured APRStt notification, quietly (cop,64,CALL[,OVERLAYCHR])
 ; 965 = cop,65                      ; Send POCSAG page (equipped channel types only)
 
-; [functions-remote]
-;;;;; Functions for remote bases ;;;;;
-;
-; 0 = remote,1                      ; Retrieve Memory
-; 1 = remote,2                      ; Set freq.
-; 2 = remote,3                      ; Set TX PL tone
-; 3 = remote,4                      ; Set RX PL tone
-; 40 = remote,100                   ; RX PL off
-; 41 = remote,101                   ; RX PL on
-; 42 = remote,102                   ; TX PL off
-; 43 = remote,103                   ; TX PL on
-; 44 = remote,104                   ; Low Power
-; 45 = remote,105                   ; Medium Power
-; 46 = remote,106                   ; High Power
-; 711 = remote,107                  ; Bump -20
-; 714 = remote,108                  ; Bump -100
-; 717 = remote,109                  ; Bump -500
-; 713 = remote,110                  ; Bump +20
-; 716 = remote,111                  ; Bump +100
-; 719 = remote,112                  ; Bump +500
-; 721 = remote,113                  ; Scan - slow
-; 724 = remote,114                  ; Scan - quick
-; 727 = remote,115                  ; Scan - fast
-; 723 = remote,116                  ; Scan + slow
-; 726 = remote,117                  ; Scan + quick
-; 729 = remote,118                  ; Scan + fast
-; 79 = remote,119                   ; Tune
-; 51 = remote,5                     ; Long status query
-; 52 = remote,140                   ; Short status query
-; 67 = remote,210                   ; Send a *
-; 69 = remote,211                   ; Send a #
-; 91 = remote,99,CALLSIGN,LICENSETAG     ; Remote base login.
-                                    ; Define a different DTMF sequence for each user which is
-                                    ; authorized to use the remote base to control access to it.
-                                    ; For example 9139583=remote,99,WB6NIL,G would grant access to
-                                    ; the remote base and announce WB6NIL as being logged in.
-                                    ; Another entry, 9148351=remote,99,WA6ZFT,E would grant access to
-                                    ; the remote base and announce WA6ZFT as being logged in.
-                                    ; When the remote base is disconnected from the originating node, the
-                                    ; user will be logged out. The LICENSETAG argument is used to enforce
-                                    ; TX frequency limits. See [txlimits] below.
-; 85 = cop,6                        ; Remote base telephone key
-
-
 [telemetry]
 ;;;;; Telemetry ;;;;;
 ; Telemetry entries can be shared across all repeaters, or defined for each repeater.
@@ -545,93 +492,12 @@ idwait = 100                        ; Time to wait before starting ID
 unkeywait = 100                     ; Time to wait after unkey before sending CT's and link telemetry
 calltermwait = 2000                 ; Time to wait before announcing "call terminated"
 
-[memory]
-;;;;; Remote base memories ;;;;;
-; Memories for remote bases (not for repeaters or hotspots). Seldom used.
-;00 = 146.580,100.0,m
-;01 = 147.030,103.5,m+t
-;02 = 147.240,103.5,m+t
-;03 = 147.765,79.7,m-t
-;04 = 146.460,100.0,m
-;05 = 146.550,100.0,m
-
 [macro]
 ;;;;;  Macro commands ;;;;;
 ;1 = *812000
 ;2 = *822000
 ;3 = *832000
 ;4 = *31998*32000
-
-;[daq-list]
-;;;;; Data Acquisition configuration ;;;;;
-;Where: device_name1 and device_name2 are stanzas you define in this file
-;device = daq-cham-1
-;device = device_name1
-;device = device_name2
-
-;[daq-cham-1]                       ; Defined in [daq-list]
-; Device name
-;hwtype = uchameleon                ; DAQ hardware type
-;devnode = /dev/ttyUSB0             ; DAQ device node (if required)
-;1 = inadc                          ; Pin definition for an ADC channel
-;2 = inadc
-;3 = inadc
-;4 = inadc
-;5 = inadc
-;6 = inadc
-;7 = inadc
-;8 = inadc
-;9 = inp                            ; Pin definition for an input with a weak pullup resistor
-;10 = inp
-;11 = inp
-;12 = inp
-;13 = in                            ; Pin definition for an input without a weak pullup resistor
-;14 = out                           ; Pin definition for an output
-;15 = out
-;16 = out
-;17 = out
-;18 = out
-
-;[meter-faces]
-;
-;face = scale(scalepre,scalediv,scalepost),word/?,...
-;
-; scalepre = offset to add before dividing with scalediv
-; scalediv = full scale/number of whole units (e.g. 256/20 or 12.8 for 20 volts).
-; scalepost = offset to add after dividing with scalediv
-;
-;face = range(X-Y:word,X2-Y2:word,...),word/?,...
-;face = bit(low-word,high-word),word/?,...
-;
-; word/? is either a word in /usr/share/asterisk/sounds or one of its subdirectories,
-; or a question mark which is  a placeholder for the measured value.
-;
-;
-; Battery voltage 0-20 volts
-;batvolts = scale(0,12.8,0),rpt/thevoltageis,?,ha/volts
-; 4 quadrant wind direction
-;winddir = range(0-33:north,34-96:west,97-160:south,161-224:east,225-255:north),rpt/thewindis,?
-; LM34 temperature sensor with 130 deg. F full scale
-;lm34f = scale(0,1.969,0),rpt/thetemperatureis,?,degrees,fahrenheit
-; Status poll (non alarmed)
-;light = bit(ha/off,ha/on),ha/light,?
-
-;[alarms]
-;
-;tag = device,pin,node,ignorefirst,func-low,func-hi
-;
-;tag = a unique name for the alarm
-;device = daq device to poll
-;pin = the device pin to be monitored
-;ignorefirstalarm = set to 1 to throwaway first alarm event, or 0 to report it
-;node = the node number to execute the function on
-;func-low = the DTMF function to execute on a high to low transition
-;func-high = the DTMF function to execute on a low to high transition
-;
-; a  '-' as a function name is shorthand for no-operation
-;
-;door = daq-cham-1,9,1,2017,*7,-
-;pwrfail = daq-cham-1,10,0,2017,*911111,-
 
 [events]
 ;;;;; Events Management ;;;;;


### PR DESCRIPTION
Remove remote base and DAQ config options that are rarely used (remote base) or currently unsupported (DAQ), and are just adding clutter and confusion to rpt.conf.

ASL manual will document all the available config options and their usage, should users want/need to enable those options.

This cleans up the default template for new users.