### PR TITLE
chan_usbradio: Restore previous logging behavior broken in PR #244

### DIFF
--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -2315,8 +2315,10 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	/* Check conditions and set receiver active */
 	if (cd && sd) {
 		//if(!o->rxkeyed)o->pmrChan->dd.b.doitnow=1;
-		if (o->rxkeyed || ((o->txoffcnt >= o->txoffdelay) && (o->rxoncnt >= o->rxondelay))) {
+		if (!o->rxkeyed) {
 			ast_debug(3, "Channel %s: o->rxkeyed = 1.\n", o->name);
+		}
+		if (o->rxkeyed || ((o->txoffcnt >= o->txoffdelay) && (o->rxoncnt >= o->rxondelay))) {
 			o->rxkeyed = 1;
 		} else {
 			o->rxoncnt++;


### PR DESCRIPTION
Pre PR #244 , this message did not spam the log file, this restores the "one-shot" behavior on keyup