### PR TITLE
app_rpt: add "archivedatefmt" variable for archive date string

### DIFF
--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -662,6 +662,7 @@ struct rpt {
 		struct rpt_xlat inxlat;
 		struct rpt_xlat outxlat;
 		const char *archivedir;
+		const char *archivedatefmt;
 		const char *archiveformat;
 		int authlevel;
 		const char *csstanzaname;

--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -928,6 +928,7 @@ void load_rpt_vars(int n, int init)
 
 	RPT_CONFIG_VAR(patchconnect, "patchconnect");
 	RPT_CONFIG_VAR(archivedir, "archivedir");
+	RPT_CONFIG_VAR(archivedatefmt, "archivedatefmt");
 	RPT_CONFIG_VAR(archiveformat, "archiveformat");
 	RPT_CONFIG_VAR_INT(authlevel, "authlevel");
 

--- a/configs/rpt/rpt.conf
+++ b/configs/rpt/rpt.conf
@@ -215,14 +215,23 @@ parrottime = 1000                   ; Set the amount of time in milliseconds
 ; Other options you may consider include "wav" (SLIN in a .wav file) and
 ; "gsm" (GSM in straight gsm format).
 ;
-; The "archivedir" and "archiveformat" lines can be enabled here (affecting
-; all nodes) or in the per-node stanzas (for recording of individual nodes).
+; The "archivedatefmt" line can be used to specify the filename used for
+; the recordings.  By default, the files will use a "%Y%m%d%H%M%S" date
+; format that maps to YYYYMMDDHHMMSS.  If desired, you can specify any
+; date format supported by the C function strftime(3) API.  For more
+; precision, you can also include the '%[n]q' format to add fractions
+; of a second, with leading zeros.
+;
+; The "archivedir", "archiveformat", and "archivedatefmt" lines can be
+; enabled here (affecting all nodes) or in the per-node stanzas (for
+; recording of individual nodes).
 ;
 ; Note: enabling these recordings can adversely impact the CPU utilization
 ;       on the device and consume large amounts of the available storage.
 ;
 ;archivedir = /var/spool/asterisk/monitor ; top-level recording directory
 ;archiveformat = wav49                    ; audio format (default = wav49)
+;archivedatefmt = %Y%m%d%H%M%S%2q         ; date/time (time to 1/100th secs)
 
 ;;; End of node-main template
 


### PR DESCRIPTION
Setting the `archivedir` variable enables a simple log and audio recording functionality.  Our documentation claimed that the file names would reflect the date and time down to the 1/100 of a second.  In reality, the names were limited to 1 second.

This change adds a new `archivedatefmt` variable allowing one to specify the date/time formatting.  The default format string remains the same but one can now add additional sub-second digits.