### PR TITLE
app_rpt: Use "," in place of "|".

### DIFF
--- a/configs/rpt/extensions.conf
+++ b/configs/rpt/extensions.conf
@@ -42,7 +42,7 @@ exten => _XXXX!,1,NoOp(Connect from node: ${CALLERID(num)})
 ; Because incoming connections are validated in iax.conf,
 ; and we don't know where the user will be coming from in advance,
 ; the X option is required.
-exten => ${NODE},1,rpt(${EXTEN}|X)       ; NODE is the Name field in iaxrpt
+exten => ${NODE},1,rpt(${EXTEN},X)       ; NODE is the Name field in iaxrpt
 
 [iax-client]                            ; for IAX VoIP clients.
 exten => ${NODE},1,Ringing()
@@ -54,7 +54,7 @@ exten => ${NODE},1,Ringing()
 	same => n,GotoIf(${ISNULL(${CALLSIGN})}?hangit)
 	same => n,Playback(rpt/connected-to&rpt/node)
 	same => n,SayDigits(${NODE})
-	same => n,rpt(${NODE}|P|${CALLSIGN}-P)
+	same => n,rpt(${NODE},P,${CALLSIGN}-P)
 	same => n(hangit),NoOp(No Caller ID Name)
 	same => n,Playback(connection-failed)
 	same => n,Wait(1)
@@ -116,7 +116,7 @@ exten => s,1,Wait(1)
 	same => n,Hangup
 
 [allstar-sys]
-exten => _1.,1,Rpt(${EXTEN:1}|Rrpt/node:NODE:rpt/in-call:digits/0:PARKED|120)
+exten => _1.,1,Rpt(${EXTEN:1},Rrpt/node:NODE:rpt/in-call:digits/0:PARKED,120)
 exten => _1.,n,Hangup
 
 exten => _2.,1,Ringing
@@ -124,7 +124,7 @@ exten => _2.,n,Wait(3)
 exten => _2.,n,Answer
 exten => _2.,n,Playback(rpt/node)
 exten => _2.,n,Saydigits(${EXTEN:1})
-exten => _2.,n,Rpt(${EXTEN:1}|P|${CALLERID(name)}-P)
+exten => _2.,n,Rpt(${EXTEN:1},P,${CALLERID(name)}-P)
 exten => _2.,n,Hangup
 
 exten => _3.,1,Ringing
@@ -132,7 +132,7 @@ exten => _3.,n,Wait(3)
 exten => _3.,n,Answer
 exten => _3.,n,Playback(rpt/node)
 exten => _3.,n,Saydigits(${EXTEN:1})
-exten => _3.,n,Rpt(${EXTEN:1}|Pv|${CALLERID(name)}-P)
+exten => _3.,n,Rpt(${EXTEN:1},Pv,${CALLERID(name)}-P)
 exten => _3.,n,Hangup
 
 exten => _4.,1,Ringing
@@ -140,7 +140,7 @@ exten => _4.,n,Wait(3)
 exten => _4.,n,Answer
 exten => _4.,n,Playback(rpt/node)
 exten => _4.,n,Saydigits(${EXTEN:1})
-exten => _4.,n,Rpt(${EXTEN:1}|D|${CALLERID(name)}-P)
+exten => _4.,n,Rpt(${EXTEN:1},D,${CALLERID(name)}-P)
 exten => _4.,n,Hangup
 
 exten => _5.,1,Ringing
@@ -148,7 +148,7 @@ exten => _5.,n,Wait(3)
 exten => _5.,n,Answer
 exten => _5.,n,Playback(rpt/node)
 exten => _5.,n,Saydigits(${EXTEN:1})
-exten => _5.,n,Rpt(${EXTEN:1}|Dv|${CALLERID(name)}-P)
+exten => _5.,n,Rpt(${EXTEN:1},Dv,${CALLERID(name)}-P)
 exten => _5.,n,Hangup
 
 [allstar-public]
@@ -166,7 +166,7 @@ exten => s,1,Ringing
 	same => n,Saydigits(${NODENUM})
 	same => n,Set(CALLERID(name)=${CALLSIGN})
 	same => n,Set(CALLERID(num)=0)
-	same => n,Rpt(${NODENUM}|X)
+	same => n,Rpt(${NODENUM},X)
 	same => n,Hangup
 	same => n(hangit),Answer
 	same => n,Wait(1)


### PR DESCRIPTION
First step - allow either "," or "|" but not a mix. Once users have updated we can remove the "|" option
Resolves #133