### PR TITLE
app_rpt: report actual "connection time"

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2282,7 +2282,7 @@ static int attempt_reconnect(struct rpt *myrpt, struct rpt_link *l)
 	}
 	*tele++ = 0;
 	l->elaptime = 0;
-	l->connecttime = 0;
+	l->connecttime.tv_sec = 0; /* not connected */
 	l->thisconnected = 0;
 	l->link_newkey = RADIO_KEY_ALLOWED;
 
@@ -3184,8 +3184,10 @@ static inline void periodic_process_links(struct rpt *myrpt, const int elap)
 
 		update_timer(&l->retrytimer, elap, 0);
 
-		/* Tally connect time */
-		l->connecttime += elap;
+		/* start tracking connect time */
+		if (l->connecttime.tv_sec == 0) {
+			l->connecttime = ast_tvnow();
+		}
 
 		/* ignore non-timing channels */
 		if (l->elaptime < 0) {
@@ -4102,7 +4104,7 @@ static void remote_hangup_helper(struct rpt *myrpt, struct rpt_link *l)
 			l->hasconnected = 1; /*! \todo BUGBUG XXX l->hasconnected has to be true to get here, why set it again? Is this a typo? */
 			l->retrytimer = RETRY_TIMER_MS;
 			l->elaptime = 0;
-			l->connecttime = 0;
+			l->connecttime.tv_sec = 0; /* no longer connected */
 			l->thisconnected = 0;
 			rpt_mutex_unlock(&myrpt->lock);
 			return;

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -419,7 +419,7 @@ struct rpt_link {
 	int	retries;
 	int	max_retries;
 	int	reconnects;
-	long long connecttime;
+	struct timeval connecttime;
 	struct ast_channel *chan;	
 	struct ast_channel *pchan;
 	struct ast_str *linklist;
@@ -453,16 +453,16 @@ void rpt_links_init(struct rpt_link *l);
 
 /*! \brief Structure used to manage link status */
 struct rpt_lstat {
-	struct	rpt_lstat *next;
-	struct	rpt_lstat *prev;
-	char	peer[MAXPEERSTR];
-	char	name[MAXNODESTR];
-	char	mode;
-	char	outbound;
-	int	reconnects;
-	char	thisconnected;
-	long long	connecttime;
-	struct	rpt_chan_stat chan_stat[NRPTSTAT];
+	struct rpt_lstat *next;
+	struct rpt_lstat *prev;
+	char peer[MAXPEERSTR];
+	char name[MAXNODESTR];
+	char mode;
+	char outbound;
+	int reconnects;
+	char thisconnected;
+	struct timeval connecttime;
+	struct rpt_chan_stat chan_stat[NRPTSTAT];
 };
 
 struct rpt_tele {

--- a/apps/app_rpt/rpt_cli.c
+++ b/apps/app_rpt/rpt_cli.c
@@ -373,7 +373,7 @@ static int rpt_do_lstats(int fd, int argc, const char *const *argv)
 
 			for (s = s_head.next; s != &s_head; s = s->next) {
 				int hours, minutes, seconds;
-				long long connecttime = s->connecttime;
+				long long connecttime = ast_tvdiff_ms(ast_tvnow(), s->connecttime);
 				char conntime[21];
 				hours = connecttime / 3600000L;
 				connecttime %= 3600000L;
@@ -565,7 +565,7 @@ static int rpt_do_xnode(int fd, int argc, const char *const *argv)
 			rpt_mutex_unlock(&myrpt->lock);	// UNLOCK 
 			for (s = s_head.next; s != &s_head; s = s->next) {
 				int hours, minutes, seconds;
-				long long connecttime = s->connecttime;
+				long long connecttime = ast_tvdiff_ms(ast_tvnow(), s->connecttime);
 				char conntime[21];
 				hours = connecttime / 3600000L;
 				connecttime %= 3600000L;

--- a/apps/app_rpt/rpt_manager.c
+++ b/apps/app_rpt/rpt_manager.c
@@ -242,7 +242,7 @@ static int rpt_manager_do_xstat(struct mansession *ses, const struct message *m,
 			rpt_mutex_unlock(&myrpt->lock);
 			for (s = s_head.next; s != &s_head; s = s->next) {
 				int hours, minutes, seconds;
-				long long connecttime = s->connecttime;
+				long long connecttime = ast_tvdiff_ms(ast_tvnow(), s->connecttime);
 				char conntime[21];
 				hours = connecttime / 3600000L;
 				connecttime %= 3600000L;


### PR DESCRIPTION
The "connection time" available via AMI and displayed by web apps like Allmon3 has not been correct. This was due to accumulating the time using incremental updates. We now report the time since connection was initiated.