### PR TITLE
app_rpt: Use `rpt_pbx_run` in place of `ast_pbx_start`

### DIFF
--- a/apps/app_rpt/rpt_bridging.h
+++ b/apps/app_rpt/rpt_bridging.h
@@ -96,7 +96,7 @@ int rpt_equate_tx_conf(struct rpt *myrpt);
 #define rpt_tx_conf_add_announcer(chan, myrpt) rpt_conf_add(chan, myrpt, RPT_TXCONF, RPT_CONF_CONFANN)
 
 /*! \note Used in app_rpt.c */
-int rpt_call_bridge_setup(struct rpt *myrpt, struct ast_channel *mychannel, struct ast_channel *genchannel);
+int rpt_call_bridge_setup(struct rpt *myrpt, struct ast_channel *mychannel);
 
 /*! \note Used in app_rpt.c */
 int rpt_mon_setup(struct rpt *myrpt);


### PR DESCRIPTION
app_rpt: Create `rpt_pbx_run()` to eliminate race conditions between local and remote hangups
where the pbx could/would hangup the channel before `rpt_call()` could finish.
Use `ast_pbx_run_args()` with `no_hangup_chan=1` leaving full control of the channel to `rpt_call()`.
This addresses crashes related to short/invalid dialplans.