### PR TITLE
Update/correct AMI "Response:" and "ActionID:" order

### DIFF
--- a/apps/app_rpt/rpt_manager.c
+++ b/apps/app_rpt/rpt_manager.c
@@ -73,9 +73,12 @@ static int manager_rpt_local_nodes(struct mansession *s, const struct message *m
 static void rpt_manager_success(struct mansession *s, const struct message *m)
 {
 	const char *id = astman_get_header(m, "ActionID");
-	if (!ast_strlen_zero(id))
-		astman_append(s, "ActionID: %s\r\n", id);
+
 	astman_append(s, "Response: Success\r\n");
+
+	if (!ast_strlen_zero(id)) {
+		astman_append(s, "ActionID: %s\r\n", id);
+	}
 }
 
 static int rpt_manager_do_sawstat(struct mansession *ses, const struct message *m, char *str)

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -3517,10 +3517,12 @@ static struct ast_cli_entry voter_cli[] = {
 static void rpt_manager_success(struct mansession *s, const struct message *m)
 {
 	const char *id = astman_get_header(m, "ActionID");
+
+	astman_append(s, "Response: Success\r\n");
+
 	if (!ast_strlen_zero(id)) {
 		astman_append(s, "ActionID: %s\r\n", id);
 	}
-	astman_append(s, "Response: Success\r\n");
 }
 
 /*!


### PR DESCRIPTION
The ordering of the AMI "Response:" and "ActionID:" lines in a reply to an AMI Action is important.  The "Response" needs to be first.