### PR TITLE
app_rpt: Address negative elap times.

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -3212,7 +3212,7 @@ static inline void periodic_process_links(struct rpt *myrpt, const int elap)
 
 		/* start tracking connect time */
 		if (l->connecttime.tv_sec == 0) {
-			l->connecttime = ast_tvnow();
+			l->connecttime = rpt_tvnow();
 		}
 
 		/* ignore non-timing channels */
@@ -3756,12 +3756,12 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 	} else if (f->frametype == AST_FRAME_DTMF_BEGIN) {
 		mute_frame_helper(myrpt);
 		dtmfed = 1;
-		myrpt->lastdtmftime = ast_tvnow();
+		myrpt->lastdtmftime = rpt_tvnow();
 	} else if (f->frametype == AST_FRAME_DTMF) {
 		int x;
 		char c = (char) f->subclass.integer;	/* get DTMF char */
 		ast_frfree(f);
-		x = ast_tvdiff_ms(ast_tvnow(), myrpt->lastdtmftime);
+		x = ast_tvdiff_ms(rpt_tvnow(), myrpt->lastdtmftime);
 		if ((myrpt->p.litzcmd) && (x >= myrpt->p.litztime) && strchr(myrpt->p.litzchar, c)) {
 			ast_debug(1, "Doing litz command %s on node %s\n", myrpt->p.litzcmd, myrpt->name);
 			macro_append(myrpt, myrpt->p.litzcmd);
@@ -4231,7 +4231,7 @@ static inline int process_link_channels(struct rpt *myrpt, struct ast_channel *w
 		}
 		rpt_mutex_unlock(&myrpt->lock);
 
-		now = ast_tvnow();
+		now = rpt_tvnow();
 		if ((who == l->chan) || (!l->lastlinktv.tv_sec) || (ast_tvdiff_ms(now, l->lastlinktv) >= 19)) {
 			char mycalltx;
 
@@ -4822,7 +4822,7 @@ static void *rpt(void *this)
 	rpt_update_boolean(myrpt, "RPT_LINKS", -1);
 	rpt_update_boolean(myrpt, "RPT_ALINKS", -1);
 	myrpt->ready = 1;
-	looptimestart = ast_tvnow();
+	looptimestart = rpt_tvnow();
 
 	while (ms >= 0) {
 		struct ast_channel *who;
@@ -5278,7 +5278,7 @@ static void *rpt(void *this)
 			ms = 0;
 		}
 		/* calculate loop time */
-		looptimenow = ast_tvnow();
+		looptimenow = rpt_tvnow();
 		elap = ast_tvdiff_ms(looptimenow, looptimestart);
 		if (elap < 0) { /* The system time has changed? */
 			elap = 0;
@@ -7051,7 +7051,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 	}
 
 	myfirst = 0;
-	looptimestart = ast_tvnow();
+	looptimestart = rpt_tvnow();
 	/* start un-locked */
 	for (;;) {
 		struct ast_channel *who;
@@ -7129,7 +7129,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 		ms = MSWAIT;
 		who = ast_waitfor_n(cs, n, &ms);
 		/* calculate loop time */
-		looptimenow = ast_tvnow();
+		looptimenow = rpt_tvnow();
 		elap = ast_tvdiff_ms(looptimenow, looptimestart);
 		if (elap < 0) { /* The system time has changed? */
 			elap = 0;

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -5280,15 +5280,13 @@ static void *rpt(void *this)
 		/* calculate loop time */
 		looptimenow = ast_tvnow();
 		elap = ast_tvdiff_ms(looptimenow, looptimestart);
-		if (elap < 0) {
-			elap = 0;
-		}
+
 		if (elap > 0) {
 			looptimenow.tv_usec -= (looptimenow.tv_usec - looptimestart.tv_usec) - elap * 1000; /* Put the residual time back on now,
 																								 * eliminating accumulated error
 																								 */
+			looptimestart = looptimenow;
 		}
-		looptimestart = looptimenow;
 
 		rpt_mutex_lock(&myrpt->lock);
 		periodic_process_links(myrpt, elap);
@@ -7132,15 +7130,12 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 		/* calculate loop time */
 		looptimenow = ast_tvnow();
 		elap = ast_tvdiff_ms(looptimenow, looptimestart);
-		if (elap < 0) {
-			elap = 0;
-		}
 		if (elap > 0) {
 			looptimenow.tv_usec -= (looptimenow.tv_usec - looptimestart.tv_usec) - elap * 1000; /* Put the residual time back on now,
 																								 * eliminating accumulated error
 																								 */
+			looptimestart = looptimenow;
 		}
-		looptimestart = looptimenow;
 
 		update_timer(&myrpt->macrotimer, elap, 0);
 		if (who == NULL) {

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -5280,10 +5280,6 @@ static void *rpt(void *this)
 		/* calculate loop time */
 		looptimenow = rpt_tvnow();
 		elap = ast_tvdiff_ms(looptimenow, looptimestart);
-		if (elap < 0) { /* The system time has changed? */
-			elap = 0;
-			looptimestart = looptimenow;
-		}
 		intermediatetime.tv_sec = 0;			/* with 20ms loops, we should never have a full second */
 		intermediatetime.tv_usec = elap * 1000; /* usec accounted for */
 		residualtime = ast_tvsub(ast_tvsub(looptimenow, looptimestart), intermediatetime);
@@ -7131,10 +7127,6 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 		/* calculate loop time */
 		looptimenow = rpt_tvnow();
 		elap = ast_tvdiff_ms(looptimenow, looptimestart);
-		if (elap < 0) { /* The system time has changed? */
-			elap = 0;
-			looptimestart = looptimenow;
-		}
 		intermediatetime.tv_sec = 0;			/* with 20ms loops, we should never have a full second */
 		intermediatetime.tv_usec = elap * 1000; /* usec accounted for */
 		residualtime = ast_tvsub(ast_tvsub(looptimenow, looptimestart), intermediatetime);

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -5282,9 +5282,6 @@ static void *rpt(void *this)
 		elap = ast_tvdiff_ms(looptimenow, looptimestart);
 
 		if (elap > 0) {
-			looptimenow.tv_usec -= (looptimenow.tv_usec - looptimestart.tv_usec) - elap * 1000; /* Put the residual time back on now,
-																								 * eliminating accumulated error
-																								 */
 			looptimestart = looptimenow;
 		}
 
@@ -7131,12 +7128,8 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 		looptimenow = ast_tvnow();
 		elap = ast_tvdiff_ms(looptimenow, looptimestart);
 		if (elap > 0) {
-			looptimenow.tv_usec -= (looptimenow.tv_usec - looptimestart.tv_usec) - elap * 1000; /* Put the residual time back on now,
-																								 * eliminating accumulated error
-																								 */
 			looptimestart = looptimenow;
 		}
-
 		update_timer(&myrpt->macrotimer, elap, 0);
 		if (who == NULL) {
 			/* No channels had activity. Loop again. */

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -5280,6 +5280,10 @@ static void *rpt(void *this)
 		/* calculate loop time */
 		looptimenow = ast_tvnow();
 		elap = ast_tvdiff_ms(looptimenow, looptimestart);
+		if (elap < 0) { /* The system time has changed? */
+			elap = 0;
+			looptimestart = looptimenow;
+		}
 		intermediatetime.tv_sec = 0;			/* with 20ms loops, we should never have a full second */
 		intermediatetime.tv_usec = elap * 1000; /* usec accounted for */
 		residualtime = ast_tvsub(ast_tvsub(looptimenow, looptimestart), intermediatetime);
@@ -7127,6 +7131,10 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 		/* calculate loop time */
 		looptimenow = ast_tvnow();
 		elap = ast_tvdiff_ms(looptimenow, looptimestart);
+		if (elap < 0) { /* The system time has changed? */
+			elap = 0;
+			looptimestart = looptimenow;
+		}
 		intermediatetime.tv_sec = 0;			/* with 20ms loops, we should never have a full second */
 		intermediatetime.tv_usec = elap * 1000; /* usec accounted for */
 		residualtime = ast_tvsub(ast_tvsub(looptimenow, looptimestart), intermediatetime);

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -5280,8 +5280,14 @@ static void *rpt(void *this)
 		/* calculate loop time */
 		looptimenow = ast_tvnow();
 		elap = ast_tvdiff_ms(looptimenow, looptimestart);
-		looptimenow.tv_usec -= (looptimenow.tv_usec - looptimestart.tv_usec) - elap * 1000; /* Put the residual time back on now,
-																							   eliminating accumulated error */
+		if (elap < 0) {
+			elap = 0;
+		}
+		if (elap > 0) {
+			looptimenow.tv_usec -= (looptimenow.tv_usec - looptimestart.tv_usec) - elap * 1000; /* Put the residual time back on now,
+																								 * eliminating accumulated error
+																								 */
+		}
 		looptimestart = looptimenow;
 
 		rpt_mutex_lock(&myrpt->lock);
@@ -7126,8 +7132,14 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 		/* calculate loop time */
 		looptimenow = ast_tvnow();
 		elap = ast_tvdiff_ms(looptimenow, looptimestart);
-		looptimenow.tv_usec -= (looptimenow.tv_usec - looptimestart.tv_usec) - elap * 1000; /* Put the residual time back on now,
-																							   eliminating accumulated error */
+		if (elap < 0) {
+			elap = 0;
+		}
+		if (elap > 0) {
+			looptimenow.tv_usec -= (looptimenow.tv_usec - looptimestart.tv_usec) - elap * 1000; /* Put the residual time back on now,
+																								 * eliminating accumulated error
+																								 */
+		}
 		looptimestart = looptimenow;
 
 		update_timer(&myrpt->macrotimer, elap, 0);

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -950,3 +950,15 @@ void *rpt_call(void *this);
 #define RPT_MUTE_FRAME(f) \
 	if (f) \
 	ast_frame_clear(f)
+
+/*!
+ * \brief Returns current timeval. Meant to replace calls to gettimeofday().
+ */
+AST_INLINE_API(struct timeval rpt_tvnow(void), {
+	struct timeval t;
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	t.tv_sec = ts.tv_sec;
+	t.tv_usec = ts.tv_nsec / 1000;
+	return t;
+})

--- a/apps/app_rpt/rpt_cli.c
+++ b/apps/app_rpt/rpt_cli.c
@@ -373,7 +373,7 @@ static int rpt_do_lstats(int fd, int argc, const char *const *argv)
 
 			for (s = s_head.next; s != &s_head; s = s->next) {
 				int hours, minutes, seconds;
-				long long connecttime = ast_tvdiff_ms(ast_tvnow(), s->connecttime);
+				long long connecttime = ast_tvdiff_ms(rpt_tvnow(), s->connecttime);
 				char conntime[21];
 				hours = connecttime / 3600000L;
 				connecttime %= 3600000L;
@@ -565,7 +565,7 @@ static int rpt_do_xnode(int fd, int argc, const char *const *argv)
 			rpt_mutex_unlock(&myrpt->lock);	// UNLOCK 
 			for (s = s_head.next; s != &s_head; s = s->next) {
 				int hours, minutes, seconds;
-				long long connecttime = ast_tvdiff_ms(ast_tvnow(), s->connecttime);
+				long long connecttime = ast_tvdiff_ms(rpt_tvnow(), s->connecttime);
 				char conntime[21];
 				hours = connecttime / 3600000L;
 				connecttime %= 3600000L;

--- a/apps/app_rpt/rpt_manager.c
+++ b/apps/app_rpt/rpt_manager.c
@@ -245,7 +245,7 @@ static int rpt_manager_do_xstat(struct mansession *ses, const struct message *m,
 			rpt_mutex_unlock(&myrpt->lock);
 			for (s = s_head.next; s != &s_head; s = s->next) {
 				int hours, minutes, seconds;
-				long long connecttime = ast_tvdiff_ms(ast_tvnow(), s->connecttime);
+				long long connecttime = ast_tvdiff_ms(rpt_tvnow(), s->connecttime);
 				char conntime[21];
 				hours = connecttime / 3600000L;
 				connecttime %= 3600000L;


### PR DESCRIPTION
It's possible to have 0 ms values, so we should not update the start time unless we actually have 1ms or more. 
Once we have 1ms, we need to keep the residual usec in the count using `ast_tvsub()` rather than "normal" math.
Use of `ast_tvnow()` can result in negative time measurement with system time changes,  `rpt_tvnow()` uses monotonic time to eliminate negative measurements.  