### PR TITLE
app_rpt: Don't crash without access to parallel port

### DIFF
--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -1683,12 +1683,14 @@ int function_cop(struct rpt *myrpt, char *param, char *digitbuf, int command_sou
 			}
 		/* go thru all the specs */
 		for (i = 1; i < argc; i++) {
-			if (sscanf(argv[i], "GPIO" N_FMT(d) "=" N_FMT(d), &j, &k) == 2 || sscanf(argv[i], "GPIO" N_FMT(d) ":" N_FMT(d), &j, &k) == 2) {
+			if (sscanf(argv[i], "%*[Gg]%*[Pp]%*[Ii]%*[oO]" N_FMT(d) "%*[=:]" N_FMT(d), &j, &k) == 2) {
 				sprintf(string, "GPIO %d %d", j, k);
 				ast_sendtext(myrpt->rxchannel, string);
-			} else if (sscanf(argv[i], "PP" N_FMT(d) "=" N_FMT(d), &j, &k) == 2) {
+			} else if (sscanf(argv[i], "%*2[pP]" N_FMT(d) "=" N_FMT(d), &j, &k) == 2) {
 				sprintf(string, "PP %d %d", j, k);
 				ast_sendtext(myrpt->rxchannel, string);
+			} else {
+				ast_log(LOG_WARNING, "Invalid command COP %s, %s", argv[0], argv[i]);
 			}
 		}
 		if (myatoi(argv[0]) == 61) {

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -678,9 +678,10 @@ int ast_radio_load_parallel_port(int *haspp, int *ppfd, int *pbase, const char *
 				if (ioperm(*pbase, 2, 1) == -1) {
 					ast_log(LOG_ERROR, "Can't get io permission on IO port %04x hex, disabling pp support\n", *pbase);
 					*haspp = 0;
+				} else {
+					*haspp = 2;
+					ast_verb(3, "Using direct IO port for pp support, since parport driver not available.\n");
 				}
-				*haspp = 2;
-				ast_verb(3, "Using direct IO port for pp support, since parport driver not available.\n");
 #else
 				ast_log(LOG_ERROR, "Parallel port I/O is not supported on this architecture\n");
 #endif


### PR DESCRIPTION
Don't crash without access to parallel port.
Allow PP= , pp= , pP=,  or Pp= for parallel port strings.
Allow all cases for GPIO= as well  
Fixes #653
Fixes #654 