### PR TITLE
rpt_install.sh: Clean up and simplify script and README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # app_rpt
-Refactoring and upgrade of AllStarLink's app_rpt, etc.
-
-ASL Grant Info: https://www.ampr.org/grants-old/grant-allstarlink-radio-over-ip-roip-app-enhancements-infrastructure-improvement-phase-1/
+**Refactoring and upgrade of AllStarLink's app_rpt, etc.**
 
 # Debugging and Submitting Bugs
 
@@ -18,10 +16,6 @@ Feel free to open an issue for *any* trouble you might be experiencing with thes
 Thank you!
 
 # Development
-
-## Helpful Resources
-
-AST_PBX_KEEPALIVE: https://github.com/asterisk/asterisk/commit/50a25ac8474d7900ba59a68ed4fd942074082435
 
 ## Prettifying
 
@@ -100,87 +94,3 @@ Add this near the bottom of `channels/Makefile`:
 This StackOverflow post contains the answer in an upvoted comment: https://unix.stackexchange.com/questions/103746/why-wont-linux-let-me-play-with-dev-dsp/103755#103755
 
 Run: `modprobe snd-pcm-oss` (as root/sudo)
-
-## Troubleshooting
-
-One-liner to kill Asterisk if it won't cleanly stop or restart:
-
-`kill -9 $(ps -aux | grep " asterisk" | grep -v "grep" | awk '{print $2}' )`
-
-Alternately you can simply run `phreaknet kill` or `phreaknet restart`
-
-# Files from AllStarLink Asterisk which are in scope
-
-```
-allstar/mdc_decode.c
-allstar/mdc_encode.c
-allstar/pocsag.c
-apps/app_gps.c
-apps/app_rpt.c
-channels/chan_tlb.c
-channels/chan_usbradio.c
-channels/chan_usrp.c
-channels/chan_usrp.h
-channels/chan_voter.c
-channels/chan_simpleusb.c
-channels/chan_echolink.c
-include/allstar/mdc_decode.h
-include/allstar/mdc_encode.h
-include/allstar/pocsag.h
-```
-
-# Files that may have changed over time
-
-```
-Files ./apps/app_rpt.c and ../ASL-Asterisk/asterisk/apps/app_rpt.c differ
-Files ./build_tools/make_version and ../ASL-Asterisk/asterisk/build_tools/make_version differ
-Files ./channels/chan_dahdi.c and ../ASL-Asterisk/asterisk/channels/chan_dahdi.c differ
-Files ./channels/chan_iax2.c and ../ASL-Asterisk/asterisk/channels/chan_iax2.c differ
-Files ./channels/iax2.h and ../ASL-Asterisk/asterisk/channels/iax2.h differ
-Files ./channels/iax2-parser.c and ../ASL-Asterisk/asterisk/channels/iax2-parser.c differ
-Files ./channels/iax2-parser.h and ../ASL-Asterisk/asterisk/channels/iax2-parser.h differ
-Files ./channels/iax2-provision.c and ../ASL-Asterisk/asterisk/channels/iax2-provision.c differ
-Files ./channels/Makefile and ../ASL-Asterisk/asterisk/channels/Makefile differ
-Files ./codecs/codec_adpcm.c and ../ASL-Asterisk/asterisk/codecs/codec_adpcm.c differ
-Files ./codecs/codec_ilbc.c and ../ASL-Asterisk/asterisk/codecs/codec_ilbc.c differ
-Files ./codecs/gsm/Makefile and ../ASL-Asterisk/asterisk/codecs/gsm/Makefile differ
-Files ./codecs/Makefile and ../ASL-Asterisk/asterisk/codecs/Makefile differ
-Files ./configs/dnsmgr.conf.sample and ../ASL-Asterisk/asterisk/configs/dnsmgr.conf.sample differ
-Files ./configs/extensions.conf.sample and ../ASL-Asterisk/asterisk/configs/extensions.conf.sample differ
-Files ./configs/iax.conf.sample and ../ASL-Asterisk/asterisk/configs/iax.conf.sample differ
-Files ./configs/indications.conf.sample and ../ASL-Asterisk/asterisk/configs/indications.conf.sample differ
-Files ./configs/manager.conf.sample and ../ASL-Asterisk/asterisk/configs/manager.conf.sample differ
-Files ./configs/modules.conf.sample and ../ASL-Asterisk/asterisk/configs/modules.conf.sample differ
-Files ./configs/rpt.conf.sample and ../ASL-Asterisk/asterisk/configs/rpt.conf.sample differ
-Files ./configs/sip.conf.sample and ../ASL-Asterisk/asterisk/configs/sip.conf.sample differ
-Files ./configure and ../ASL-Asterisk/asterisk/configure differ
-Files ./configure.ac and ../ASL-Asterisk/asterisk/configure.ac differ
-Files ./contrib/init.d/rc.debian.asterisk and ../ASL-Asterisk/asterisk/contrib/init.d/rc.debian.asterisk differ
-Files ./contrib/init.d/rc.gentoo.asterisk and ../ASL-Asterisk/asterisk/contrib/init.d/rc.gentoo.asterisk differ
-Files ./contrib/scripts/get_ilbc_source.sh and ../ASL-Asterisk/asterisk/contrib/scripts/get_ilbc_source.sh differ
-Files ./formats/format_ilbc.c and ../ASL-Asterisk/asterisk/formats/format_ilbc.c differ
-Files ./funcs/func_curl.c and ../ASL-Asterisk/asterisk/funcs/func_curl.c differ
-Files ./include/asterisk/astobj2.h and ../ASL-Asterisk/asterisk/include/asterisk/astobj2.h differ
-Files ./include/asterisk/frame.h and ../ASL-Asterisk/asterisk/include/asterisk/frame.h differ
-Files ./include/asterisk/inline_api.h and ../ASL-Asterisk/asterisk/include/asterisk/inline_api.h differ
-Files ./include/jitterbuf.h and ../ASL-Asterisk/asterisk/include/jitterbuf.h differ
-Files ./main/abstract_jb.c and ../ASL-Asterisk/asterisk/main/abstract_jb.c differ
-Files ./main/asterisk.c and ../ASL-Asterisk/asterisk/main/asterisk.c differ
-Files ./main/astobj2.c and ../ASL-Asterisk/asterisk/main/astobj2.c differ
-Files ./main/channel.c and ../ASL-Asterisk/asterisk/main/channel.c differ
-Files ./main/config.c and ../ASL-Asterisk/asterisk/main/config.c differ
-Files ./main/dnsmgr.c and ../ASL-Asterisk/asterisk/main/dnsmgr.c differ
-Files ./main/dsp.c and ../ASL-Asterisk/asterisk/main/dsp.c differ
-Files ./main/file.c and ../ASL-Asterisk/asterisk/main/file.c differ
-Files ./main/frame.c and ../ASL-Asterisk/asterisk/main/frame.c differ
-Files ./main/indications.c and ../ASL-Asterisk/asterisk/main/indications.c differ
-Files ./main/jitterbuf.c and ../ASL-Asterisk/asterisk/main/jitterbuf.c differ
-Files ./main/pbx.c and ../ASL-Asterisk/asterisk/main/pbx.c differ
-Files ./main/utils.c and ../ASL-Asterisk/asterisk/main/utils.c differ
-Files ./Makefile and ../ASL-Asterisk/asterisk/Makefile differ
-Files ./res/res_features.c and ../ASL-Asterisk/asterisk/res/res_features.c differ
-Files ./res/snmp/agent.c and ../ASL-Asterisk/asterisk/res/snmp/agent.c differ
-Files ./sounds/Makefile and ../ASL-Asterisk/asterisk/sounds/Makefile differ
-Files ./sounds/sounds.xml and ../ASL-Asterisk/asterisk/sounds/sounds.xml differ
-Files ./utils/Makefile and ../ASL-Asterisk/asterisk/utils/Makefile differ
-```

--- a/rpt_install.sh
+++ b/rpt_install.sh
@@ -29,7 +29,6 @@ if [ "$1" != "updated" ]; then
 fi
 
 printf "Script is now the latest version\n"
-sleep 1
 
 # cd into Asterisk source directory
 ls -d -v */ | grep "^asterisk" | tail -1
@@ -54,14 +53,6 @@ echoerr() {
 	printf "\e[31;1m%s\e[0m\n" "$*" >&2;
 }
 
-rpt_add() {
-	if [ ! -f ../$MYDIR/$1 ]; then
-		echoerr "WARNING: File $1 does not exist"
-	fi
-	printf "Adding module %s\n" "$1"
-	cp ../$MYDIR/$1 $1
-}
-
 if [ ! -d apps/app_rpt ]; then
 	mkdir apps/app_rpt
 fi
@@ -72,94 +63,17 @@ fi
 # Remove anything that may have been there before (mainly relevant for testing older HEADs)
 rm -f apps/app_rpt/*
 
-rpt_add "apps/app_rpt.c"
-rpt_add "apps/app_gps.c"
-rpt_add "apps/app_rpt/app_rpt.h"
-rpt_add "apps/app_rpt/mdc_encode.c"
-rpt_add "apps/app_rpt/mdc_encode.h"
-rpt_add "apps/app_rpt/mdc_decode.c"
-rpt_add "apps/app_rpt/mdc_decode.h"
-rpt_add "apps/app_rpt/rpt_mdc1200.c"
-rpt_add "apps/app_rpt/rpt_mdc1200.h"
-rpt_add "apps/app_rpt/pocsag.c"
-rpt_add "apps/app_rpt/pocsag.h"
-rpt_add "apps/app_rpt/rpt_cli.c"
-rpt_add "apps/app_rpt/rpt_cli.h"
-rpt_add "apps/app_rpt/rpt_daq.c"
-rpt_add "apps/app_rpt/rpt_daq.h"
-rpt_add "apps/app_rpt/rpt_lock.c"
-rpt_add "apps/app_rpt/rpt_lock.h"
-rpt_add "apps/app_rpt/rpt_utils.c"
-rpt_add "apps/app_rpt/rpt_utils.h"
-rpt_add "apps/app_rpt/rpt_call.c"
-rpt_add "apps/app_rpt/rpt_call.h"
-rpt_add "apps/app_rpt/rpt_serial.c"
-rpt_add "apps/app_rpt/rpt_serial.h"
-rpt_add "apps/app_rpt/rpt_xcat.c"
-rpt_add "apps/app_rpt/rpt_xcat.h"
-rpt_add "apps/app_rpt/rpt_capabilities.c"
-rpt_add "apps/app_rpt/rpt_capabilities.h"
-rpt_add "apps/app_rpt/rpt_vox.c"
-rpt_add "apps/app_rpt/rpt_vox.h"
-rpt_add "apps/app_rpt/rpt_uchameleon.c"
-rpt_add "apps/app_rpt/rpt_uchameleon.h"
-rpt_add "apps/app_rpt/rpt_bridging.c"
-rpt_add "apps/app_rpt/rpt_bridging.h"
-rpt_add "apps/app_rpt/rpt_radio.c"
-rpt_add "apps/app_rpt/rpt_radio.h"
-rpt_add "apps/app_rpt/rpt_channel.c"
-rpt_add "apps/app_rpt/rpt_channel.h"
-rpt_add "apps/app_rpt/rpt_config.c"
-rpt_add "apps/app_rpt/rpt_config.h"
-rpt_add "apps/app_rpt/rpt_link.c"
-rpt_add "apps/app_rpt/rpt_link.h"
-rpt_add "apps/app_rpt/rpt_functions.c"
-rpt_add "apps/app_rpt/rpt_functions.h"
-rpt_add "apps/app_rpt/rpt_telemetry.c"
-rpt_add "apps/app_rpt/rpt_telemetry.h"
-rpt_add "apps/app_rpt/rpt_manager.c"
-rpt_add "apps/app_rpt/rpt_manager.h"
-rpt_add "apps/app_rpt/rpt_translate.c"
-rpt_add "apps/app_rpt/rpt_translate.h"
-rpt_add "apps/app_rpt/rpt_rig.c"
-rpt_add "apps/app_rpt/rpt_rig.h"
-rpt_add "channels/chan_echolink.c"
-rpt_add "channels/chan_simpleusb.c"
-rpt_add "channels/chan_usbradio.c"
-rpt_add "channels/chan_tlb.c"
-rpt_add "channels/chan_voter.c"
-rpt_add "channels/chan_usrp.c"
-rpt_add "channels/xpmr/sinetabx.h"
-rpt_add "channels/xpmr/xpmr.c"
-rpt_add "channels/xpmr/xpmr.h"
-rpt_add "channels/xpmr/xpmr_coef.h"
-rpt_add "configs/samples/rpt_http_registrations.conf.sample"
-rpt_add "configs/samples/usbradio.conf.sample"
-rpt_add "configs/samples/simpleusb.conf.sample"
-rpt_add "include/asterisk/res_usbradio.h"
-rpt_add "res/res_rpt_http_registrations.c"
-rpt_add "res/res_usbradio.c"
-rpt_add "res/res_usbradio.exports.in"
+# Copy in the radio modules and files
+cp ../$MYDIR/apps/*.c apps
+cp ../$MYDIR/apps/app_rpt/* apps/app_rpt
+cp ../$MYDIR/channels/*.c channels
+cp ../$MYDIR/channels/xpmr/* channels/xpmr
+cp ../$MYDIR/configs/samples/*.conf.sample configs/samples
+cp ../$MYDIR/include/asterisk/*.h include/asterisk
+cp ../$MYDIR/res/* res
+cp ../$MYDIR/utils/*.c utils
 
-rpt_add "utils/radio-tune-menu.c"
-rpt_add "utils/simpleusb-tune-menu.c"
-
-make -j$(nproc) apps
-if [ $? -ne 0 ]; then
-	exit 1
-fi
-
-make -j$(nproc) channels
-if [ $? -ne 0 ]; then
-	exit 1
-fi
-
-make -j$(nproc) res
-if [ $? -ne 0 ]; then
-	exit 1
-fi
-
-make install
+make -j$(nproc) apps && make -j$(nproc) channels && make -j$(nproc) res && make install
 if [ $? -ne 0 ]; then
 	exit 1
 fi


### PR DESCRIPTION
* Use simpler cp commands rather than enumerating all the files we want to copy in the script.
* Remove outdated or old notes in the README that are no longer useful or needed, to make the README more useful to current audiences.