### PR TITLE
Revert "app_rpt: Remove rpt_link->textq"

### DIFF
--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -445,6 +445,7 @@ struct rpt_link {
 	time_t	lastkeytime;
 	time_t	lastunkeytime;
 	AST_LIST_HEAD_NOLOCK(, ast_frame) rxq;
+	AST_LIST_HEAD_NOLOCK(, ast_frame) textq;
 };
 
 /*!

--- a/apps/app_rpt/rpt_channel.c
+++ b/apps/app_rpt/rpt_channel.c
@@ -436,7 +436,7 @@ int send_link_pl(struct rpt *myrpt, char *txt)
 	l = myrpt->links.next;
 	while (l && (l != &myrpt->links)) {
 		if ((l->chan) && l->name[0] && (l->name[0] != '0')) {
-			ast_write(l->chan, &wf);
+			rpt_qwrite(l, &wf);
 		}
 		l = l->next;
 	}

--- a/apps/app_rpt/rpt_link.h
+++ b/apps/app_rpt/rpt_link.h
@@ -26,6 +26,8 @@ void tele_link_remove(struct rpt *myrpt, struct rpt_tele *t);
 
 int altlink1(struct rpt *myrpt, struct rpt_link *mylink);
 
+void rpt_qwrite(struct rpt_link *l, struct ast_frame *f);
+
 int linkcount(struct rpt *myrpt);
 
 /*! \brief Considers repeater received RSSI and all voter link RSSI information and set values in myrpt structure. */

--- a/apps/app_rpt/rpt_mdc1200.c
+++ b/apps/app_rpt/rpt_mdc1200.c
@@ -133,7 +133,7 @@ void mdc1200_send(struct rpt *myrpt, char *data)
 			continue;
 		}
 		if (l->chan)
-			ast_write(l->chan, &wf);
+			rpt_qwrite(l, &wf);
 		l = l->next;
 	}
 }

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -406,7 +406,7 @@ static void send_tele_link(struct rpt *myrpt, char *cmd)
 	/* give it to everyone */
 	while (l != &myrpt->links) {
 		if (l->chan && (l->mode == 1))
-			ast_write(l->chan, &wf);
+			rpt_qwrite(l, &wf);
 		l = l->next;
 	}
 	rpt_telemetry(myrpt, VARCMD, cmd);


### PR DESCRIPTION
This reverts commit 96265a18bdd451b84b9c24bb4f6518f48948ea00. PR #582 
Turns out there are a few async calls to the channel, so we need the queue to only write to the channel while it's not locked.