### PR TITLE
app_rpt.c: Check frame before adjusting audio

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4336,7 +4336,18 @@ static inline int process_link_channels(struct rpt *myrpt, struct ast_channel *w
 				if ((myrpt->p.linkmongain != 1.0) && (l->mode != 1) && (l->wouldtx))
 					fac *= myrpt->p.linkmongain;
 				if (fac != 1.0) {
-					ast_frame_adjust_volume_float(f, fac);
+					if (f->data.ptr && (f->samples == f->datalen / 2)) {
+						ast_frame_adjust_volume_float(f, fac);
+					} else {
+						ast_debug(3,
+							"Skip volume adjust on %s, fac = %f, data = %p, datalen = %d, samples = %d, src = %s\n",
+							ast_channel_name(l->chan),
+							fac,
+							f->data.ptr,
+							f->datalen,
+							f->samples,
+							f->src ? f->src : "(nil)");
+					}
 				}
 
 				l->rxlingertimer = RX_LINGER_TIME;
@@ -4497,7 +4508,18 @@ static inline int process_link_channels(struct rpt *myrpt, struct ast_channel *w
 					fac = myrpt->p.ttxgain;
 
 				if (fac != 1.0) {
-					ast_frame_adjust_volume_float(f, fac);
+					if (f->data.ptr && (f->samples == f->datalen / 2)) {
+						ast_frame_adjust_volume_float(f, fac);
+					} else {
+						ast_debug(3,
+							"Skip volume adjust on %s, fac = %f, data = %p, datalen = %d, samples = %d, src = %s\n",
+							ast_channel_name(l->chan),
+							fac,
+							f->data.ptr,
+							f->datalen,
+							f->samples,
+							f->src ? f->src : "(nil)");
+					}
 				}
 				/* foop */
 				if (l->chan && (l->lastrx || (!altlink(myrpt, l))) && ((l->link_newkey != RADIO_KEY_NOT_ALLOWED) || l->lasttx || strcasecmp(ast_channel_tech(l->chan)->type, "IAX2"))) {


### PR DESCRIPTION
When monitoring multiple nodes our call to ast_frame_adjust_volume_float() was crashing due to a frame with unexpected data.  Specifically:

```
$xx = { frametype = AST_FRAME_VOICE,
        subclass = {integer = 0, {format = 0x5556853f28, topology = 0x5556853f28}, frame_ending = 0},
        datalen = 0,
        samples = 160,
        mallocd = 1,
        mallocd_hdr_len = 222,
        offset = 64,
        src = 0x0,
        data = {ptr = 0x0, uint32 = 0, pad = "\000\000\000\000\000\000\000"},
        delivery = {tv_sec = 1745930822, tv_usec = 19338},
        frame_list = {next = 0x0},
        flags = 0,
        ts = 0,
        len = 0,
        seqno = 0,
        stream_num = 0
      }
```

For now, we're going to skip the audio adjustment for these frames.