### PR TITLE
tests: Remove no longer needed logger.conf override.

### DIFF
--- a/tests/apps/rpt/fast_connect_disconnect/configs/ast1/logger.general.conf.inc
+++ b/tests/apps/rpt/fast_connect_disconnect/configs/ast1/logger.general.conf.inc
@@ -1,1 +1,0 @@
-dateformat=%F %T.%3q   ; with milliseconds


### PR DESCRIPTION
A logger.conf was initially included in the test to override the default settings, but these were merged in https://github.com/asterisk/testsuite/commit/7e804d5f7d96dfb78a3195cadec8eae41d020f09 As such, this override file is no longer needed.