### PR TITLE
app_rpt: add "archiveaudio" variable to control audio capture

### DIFF
--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -660,6 +660,7 @@ struct rpt {
 		int iospeed;
 		char funcchar;
 		char endchar;
+		unsigned int archiveaudio:1;
 		unsigned int nobusyout:1;
 		unsigned int notelemtx:1;
 		unsigned int propagate_dtmf:1;

--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -928,6 +928,7 @@ void load_rpt_vars(int n, int init)
 
 	RPT_CONFIG_VAR(patchconnect, "patchconnect");
 	RPT_CONFIG_VAR(archivedir, "archivedir");
+	RPT_CONFIG_VAR_BOOL_DEFAULT(archiveaudio, "archiveaudio", 1);
 	RPT_CONFIG_VAR(archivedatefmt, "archivedatefmt");
 	RPT_CONFIG_VAR(archiveformat, "archiveformat");
 	RPT_CONFIG_VAR_INT(authlevel, "authlevel");

--- a/configs/rpt/rpt.conf
+++ b/configs/rpt/rpt.conf
@@ -222,6 +222,11 @@ parrottime = 1000                   ; Set the amount of time in milliseconds
 ; precision, you can also include the '%[n]q' format to add fractions
 ; of a second, with leading zeros.
 ;
+; The "archiveaudio" line can be used to control whether the both the
+; simple activity log and audio recordings are included in the archive
+; directory.  If set to "no" then only the log will be created (the
+; audio recordings will not be saved).
+;
 ; The "archivedir", "archiveformat", and "archivedatefmt" lines can be
 ; enabled here (affecting all nodes) or in the per-node stanzas (for
 ; recording of individual nodes).
@@ -232,6 +237,7 @@ parrottime = 1000                   ; Set the amount of time in milliseconds
 ;archivedir = /var/spool/asterisk/monitor ; top-level recording directory
 ;archiveformat = wav49                    ; audio format (default = wav49)
 ;archivedatefmt = %Y%m%d%H%M%S%2q         ; date/time (time to 1/100th secs)
+;archiveaudio = yes                       ; enable/disable audio recordings
 
 ;;; End of node-main template
 


### PR DESCRIPTION
Adding a new (to ASL3) "archiveaudio" variable that can be used to control whether the both the simple activity log and audio recordings are included in the archive directory.  The variable defaults to "yes" (capture audio) but if set to "no" then only the log will be created (the audio recordings will not be saved).

This added functionality might be used by those who want to keep track of node activity without the added expense (and storage) associated with saving the audio content.