### PR TITLE
app_rpt, chan: Fix #602, #658, and some cleanup

### DIFF
--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -54,7 +54,7 @@ static char remdtmfstr[] = "0123456789*#ABCD";
 int function_ilink(struct rpt *myrpt, char *param, char *digits, int command_source, struct rpt_link *mylink)
 {
 	char *s1, *s2, tmp[MAXNODESTR];
-	char digitbuf[MAXNODESTR], *strs[sizeof(myrpt->savednodes)];
+	char digitbuf[MAXNODESTR], *strs[ARRAY_LEN(myrpt->savednodes)];
 	char perma;
 	enum link_mode mode;
 	struct rpt_link *l;

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -514,12 +514,10 @@ void rpt_update_links(struct rpt *myrpt)
 
 	buf = ast_str_create(RPT_AST_STR_INIT_SIZE);
 	if (!buf) {
-		ast_mutex_unlock(&myrpt->lock);
 		return;
 	}
 	obuf = ast_str_create(RPT_AST_STR_INIT_SIZE);
 	if (!obuf) {
-		ast_mutex_unlock(&myrpt->lock);
 		ast_free(buf);
 		return;
 	}

--- a/apps/app_rpt/rpt_manager.c
+++ b/apps/app_rpt/rpt_manager.c
@@ -145,6 +145,7 @@ static int rpt_manager_do_xstat(struct mansession *ses, const struct message *m,
 			struct ast_channel *rxchan = NULL;
 			char rxchanname[256];
 			int pseudo = 0;
+
 			rpt_manager_success(ses, m);
 			astman_append(ses, "Node: %s\r\n", node);
 
@@ -222,7 +223,6 @@ static int rpt_manager_do_xstat(struct mansession *ses, const struct message *m,
 					continue;
 				}
 				if (!(s = ast_malloc(sizeof(struct rpt_lstat)))) {
-					rpt_mutex_unlock(&myrpt->lock);
 					ast_free(lbuf);
 					return -1;
 				}

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -1926,6 +1926,7 @@ treataslocal:
 		if (!strcmp(myrpt->remoterig, REMOTE_RIG_IC706)) {
 			set_mode_ic706(myrpt, REM_MODE_AM);
 			if (play_tone(mychannel, 800, 6000, 8192) == -1) {
+				ast_mutex_unlock(&myrpt->remlock);
 				break;
 			}
 			ast_safe_sleep(mychannel, 500);
@@ -1939,6 +1940,7 @@ treataslocal:
 			set_mode_ft100(myrpt, REM_MODE_AM);
 			simple_command_ft100(myrpt, 0x0f, 1);
 			if (play_tone(mychannel, 800, 6000, 8192) == -1) {
+				ast_mutex_unlock(&myrpt->remlock);
 				break;
 			}
 			simple_command_ft100(myrpt, 0x0f, 0);
@@ -1954,6 +1956,7 @@ treataslocal:
 		ast_safe_sleep(mychannel, 500);
 		myrpt->tunetx = 1;
 		if (play_tone(mychannel, 800, 6000, 8192) == -1) {
+			ast_mutex_unlock(&myrpt->remlock);
 			break;
 		}
 		myrpt->tunetx = 0;

--- a/apps/app_rpt/rpt_utils.h
+++ b/apps/app_rpt/rpt_utils.h
@@ -24,13 +24,13 @@ char *strupr(char *instr);
 
 char *string_toupper(char *str);
 
-/*
-* Break up a delimited string into a table of substrings
-*
-* str - delimited string ( will be modified )
-* strp- list of pointers to substrings (this is built by this function), NULL will be placed at end of list
-* limit- maximum number of substrings to process
-*/
+/*!
+ * \brief Break up a delimited string into a table of substrings
+ * \param str - delimited string (will be modified)
+ * \param strp- An array of pointers to the substrings (in the modified "str"), NULL will be placed at end of list
+ * \param limit- maximum number of substrings to process
+ * \return The number of substrings found
+ */
 int finddelim(char *str, char *strp[], size_t limit);
 
 /*


### PR DESCRIPTION
- Corrected issue with https://github.com/AllStarLink/app_rpt/pull/602 :
  - backed out the switch from ast_queue_frame() to ast_indicate()

- Corrected issue with https://github.com/AllStarLink/app_rpt/pull/658 :
  - don't return when holding lock

- Cleanup
  - add a "src" to many frames
  - when creating frames, use designated initializers
  - tweak elapsed time code for readability
  - corrected code that wasn't properly handling errors