### PR TITLE
chan_echolink: Not unkeying -> use ast_control_radio_unkey for unkey message

### DIFF
--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -2355,7 +2355,7 @@ static int el_xwrite(struct ast_channel *ast, struct ast_frame *frame)
 	if (p->rxkey == 1) {
 		struct ast_frame wf = {
 			.frametype = AST_FRAME_CONTROL,
-			.subclass.integer = AST_CONTROL_RADIO_KEY,
+			.subclass.integer = AST_CONTROL_RADIO_UNKEY,
 			.src = __PRETTY_FUNCTION__,
 		};
 


### PR DESCRIPTION
Address typo in PR #673 - used `AST_CONTROL_RADIO_KEY` where it was `AST_CONTROL_RADIO_UNKEY`
