### PR TITLE
app_rpt: add telemetry information to archive logs

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -732,6 +732,10 @@ void __attribute__ ((format (gnu_printf, 5, 6))) __donodelog_fmt(struct rpt *myr
 	char *buf;
 	int len;
 
+	if (!myrpt->p.archivedir) {
+		return;
+	}
+
 	va_start(ap, fmt);
 	len = ast_vasprintf(&buf, fmt, ap);
 	va_end(ap);
@@ -1937,9 +1941,7 @@ static void handle_link_data(struct rpt *myrpt, struct rpt_link *mylink, char *s
 		distribute_to_all_links(myrpt, mylink, src, NULL, &wf);
 		return;
 	}
-	if (myrpt->p.archivedir) {
-		donodelog_fmt(myrpt, "DTMF,%s,%c", mylink->name, c);
-	}
+	donodelog_fmt(myrpt, "DTMF,%s,%c", mylink->name, c);
 	c = func_xlat(myrpt, c, &myrpt->p.outxlat);
 	if (!c) {
 		return;
@@ -2009,9 +2011,7 @@ static void handle_link_phone_dtmf(struct rpt *myrpt, struct rpt_link *mylink, c
 	char cmd[300];
 	int res;
 
-	if (myrpt->p.archivedir) {
-		donodelog_fmt(myrpt, "DTMF(P),%s,%c", mylink->name, c);
-	}
+	donodelog_fmt(myrpt, "DTMF(P),%s,%c", mylink->name, c);
 	if (mylink->phonemonitor)
 		return;
 
@@ -2241,9 +2241,7 @@ static int handle_remote_data(struct rpt *myrpt, const char *str)
 	/* if not for me, ignore */
 	if (strcmp(dest, myrpt->name))
 		return 0;
-	if (myrpt->p.archivedir) {
-		donodelog_fmt(myrpt, "DTMF,%c", c);
-	}
+	donodelog_fmt(myrpt, "DTMF,%c", c);
 	c = func_xlat(myrpt, c, &myrpt->p.outxlat);
 	if (!c)
 		return 0;
@@ -2275,9 +2273,7 @@ static int handle_remote_phone_dtmf(struct rpt *myrpt, char c, char *restrict ke
 			return DC_INDETERMINATE;
 		}
 	}
-	if (myrpt->p.archivedir) {
-		donodelog_fmt(myrpt, "DTMF(P),%c", c);
-	}
+	donodelog_fmt(myrpt, "DTMF(P),%c", c);
 	res = handle_remote_dtmf_digit(myrpt, c, keyed, phonemode);
 	if (res != 1)
 		return res;
@@ -2390,9 +2386,7 @@ static void local_dtmf_helper(struct rpt *myrpt, char c_in)
 	snprintf(tone, sizeof(tone), "%c", c);
 	rpt_manager_trigger(myrpt, "DTMF", tone);
 
-	if (myrpt->p.archivedir) {
-		donodelog_fmt(myrpt, "DTMF,MAIN,%c", c);
-	}
+	donodelog_fmt(myrpt, "DTMF,MAIN,%c", c);
 	if (c == myrpt->p.endchar) {
 		/* if in simple mode, kill autopatch */
 		if (myrpt->p.simple && (myrpt->callmode != CALLMODE_DOWN)) {
@@ -3067,9 +3061,7 @@ static inline void rxunkey_helper(struct rpt *myrpt, struct rpt_link *l)
 	l->lastrealrx = 0;
 	l->rerxtimer = 0;
 	if (l->lastrx1) {
-		if (myrpt->p.archivedir) {
-			donodelog_fmt(myrpt, "RXUNKEY,%s", l->name);
-		}
+		donodelog_fmt(myrpt, "RXUNKEY,%s", l->name);
 		l->lastrx1 = 0;
 		/* XXX Note in first usage, rpt_update_links is first,
 		 * but in second, time was first. Don't think it matters though. */
@@ -3235,9 +3227,7 @@ static inline void periodic_process_links(struct rpt *myrpt, const int elap)
 				l->lastrealrx = 0;
 				l->rerxtimer = 0;
 				if (l->lastrx1) {
-					if (myrpt->p.archivedir) {
-						donodelog_fmt(myrpt, "RXUNKEY(T),%s", l->name);
-					}
+					donodelog_fmt(myrpt, "RXUNKEY(T),%s", l->name);
 					if (myrpt->p.duplex)
 						rpt_telemetry(myrpt, LINKUNKEY, l);
 					l->lastrx1 = 0;
@@ -3299,9 +3289,7 @@ static inline void periodic_process_links(struct rpt *myrpt, const int elap)
 			}
 			if (l->hasconnected)
 				rpt_update_links(myrpt);
-			if (myrpt->p.archivedir) {
-				donodelog_fmt(myrpt, l->hasconnected ? "LINKDISC,%s" : "LINKFAIL,%s", l->name);
-			}
+			donodelog_fmt(myrpt, l->hasconnected ? "LINKDISC,%s" : "LINKFAIL,%s", l->name);
 			/* hang-up on call to device */
 			ast_hangup(l->pchan);
 			rpt_link_free(l);
@@ -3321,9 +3309,7 @@ static inline void periodic_process_links(struct rpt *myrpt, const int elap)
 				rpt_telemetry(myrpt, REMDISC, l);
 			}
 			rpt_update_links(myrpt);
-			if (myrpt->p.archivedir) {
-				donodelog_fmt(myrpt, "LINKDISC,%s", l->name);
-			}
+			donodelog_fmt(myrpt, "LINKDISC,%s", l->name);
 			dodispgm(myrpt, l->name);
 			/* hang-up on call to device */
 			ast_hangup(l->pchan);
@@ -3940,9 +3926,7 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 				ast_closestream(myrpt->monstream);
 				myrpt->monstream = NULL;
 			}
-			if (myrpt->p.archivedir) {
-				donodelog(myrpt, "RXUNKEY,MAIN");
-			}
+			donodelog(myrpt, "RXUNKEY,MAIN");
 			rpt_update_boolean(myrpt, "RPT_RXKEYED", 0);
 		}
 	} else if (f->frametype == AST_FRAME_TEXT) {	/* if a message from a USB device */
@@ -4218,9 +4202,7 @@ static void remote_hangup_helper(struct rpt *myrpt, struct rpt_link *l)
 	if (l->hasconnected) {
 		rpt_update_links(myrpt);
 	}
-	if (myrpt->p.archivedir) {
-		donodelog_fmt(myrpt, l->hasconnected ? "LINKDISC,%s" : "LINKFAIL,%s", l->name);
-	}
+	donodelog_fmt(myrpt, l->hasconnected ? "LINKDISC,%s" : "LINKFAIL,%s", l->name);
 	if (l->hasconnected) {
 		dodispgm(myrpt, l->name);
 	}
@@ -4242,9 +4224,7 @@ static inline void rxkey_helper(struct rpt *myrpt, struct rpt_link *l)
 	l->lastrealrx = 1;
 	l->rerxtimer = 0;
 	if (!l->lastrx1) {
-		if (myrpt->p.archivedir) {
-			donodelog_fmt(myrpt, "RXKEY,%s", l->name);
-		}
+		donodelog_fmt(myrpt, "RXKEY,%s", l->name);
 		l->lastrx1 = 1;
 		rpt_update_links(myrpt);
 		time(&l->lastkeytime);
@@ -4314,9 +4294,7 @@ static inline int process_link_channels(struct rpt *myrpt, struct ast_channel *w
 						l->last_frame_sent = 0;
 					}
 				}
-				if (myrpt->p.archivedir) {
-					donodelog_fmt(myrpt, *totx_p ? "TXKEY,%s" : "TXUNKEY,%s", l->name);
-				}
+				donodelog_fmt(myrpt, *totx_p ? "TXKEY,%s" : "TXUNKEY,%s", l->name);
 			}
 			l->lasttx = *totx_p;
 		}
@@ -4470,14 +4448,12 @@ static inline int process_link_channels(struct rpt *myrpt, struct ast_channel *w
 						l->retries = 0;
 					if (!lconnected) {
 						rpt_telemetry(myrpt, CONNECTED, l);
-						if (myrpt->p.archivedir) {
-							if (l->mode == MODE_TRANSCEIVE) {
-								donodelog_fmt(myrpt, "LINKTRX,%s", l->name);
-							} else if (l->mode == MODE_LOCAL_MONITOR) {
-								donodelog_fmt(myrpt, "LINKLOCALMONITOR,%s", l->name);
-							} else {
-								donodelog_fmt(myrpt, "LINKMONITOR,%s", l->name);
-							}
+						if (l->mode == MODE_TRANSCEIVE) {
+							donodelog_fmt(myrpt, "LINKTRX,%s", l->name);
+						} else if (l->mode == MODE_LOCAL_MONITOR) {
+							donodelog_fmt(myrpt, "LINKLOCALMONITOR,%s", l->name);
+						} else {
+							donodelog_fmt(myrpt, "LINKMONITOR,%s", l->name);
 						}
 						rpt_update_links(myrpt);
 						doconpgm(myrpt, l->name);
@@ -4874,8 +4850,7 @@ static void *rpt(void *this)
 	ast_channel_setoption(myrpt->rxchannel, AST_OPTION_RELAXDTMF, &val, sizeof(char), 0);
 	ast_channel_setoption(myrpt->rxchannel, AST_OPTION_TONE_VERIFY, &val, sizeof(char), 0);
 
-	if (myrpt->p.archivedir)
-		donodelog(myrpt, "STARTUP");
+	donodelog(myrpt, "STARTUP");
 	if (myrpt->remoterig && !ISRIG_RTX(myrpt->remoterig))
 		setrem(myrpt);
 	/* wait for telem to be done */
@@ -5393,9 +5368,7 @@ static void *rpt(void *this)
 			if ((cin == 'p') || (cin == 'P'))
 				myrpt->macrotimer = MACROPTIME;
 			rpt_mutex_unlock(&myrpt->lock);
-			if (myrpt->p.archivedir) {
-				donodelog_fmt(myrpt, "DTMF(M),MAIN,%c", cin);
-			}
+			donodelog_fmt(myrpt, "DTMF(M),MAIN,%c", cin);
 			local_dtmf_helper(myrpt, c);
 		} else {
 			rpt_mutex_unlock(&myrpt->lock);
@@ -6752,9 +6725,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 			}
 		}
 
-		if (myrpt->p.archivedir) {
-			donodelog_fmt(myrpt,"LINK%s,%s", l->phonemode ? "(P)" : "", l->name);
-		}
+		donodelog_fmt(myrpt, "LINK%s,%s", l->phonemode ? "(P)" : "", l->name);
 		doconpgm(myrpt, l->name);
 		if ((!phone_mode) && (l->name[0] <= '9')) {
 			send_newkey(chan);
@@ -7335,9 +7306,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 						ast_indicate(myrpt->txchannel, AST_CONTROL_RADIO_KEY);
 					}
 					rpt_update_boolean(myrpt, "RPT_TXKEYED", 1);
-					if (myrpt->p.archivedir) {
-						donodelog(myrpt, "TXKEY");
-					}
+					donodelog(myrpt, "TXKEY");
 				}
 			}
 		}
@@ -7354,8 +7323,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 			} else {
 				ast_indicate(myrpt->txchannel, AST_CONTROL_RADIO_UNKEY);
 			}
-			if (myrpt->p.archivedir)
-				donodelog(myrpt, "TXUNKEY");
+			donodelog(myrpt, "TXUNKEY");
 			rpt_update_boolean(myrpt, "RPT_TXKEYED", 0);
 		}
 		if (myrpt->hfscanmode) {
@@ -7379,9 +7347,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 			if ((c == 'p') || (c == 'P'))
 				myrpt->macrotimer = MACROPTIME;
 			rpt_mutex_unlock(&myrpt->lock);
-			if (myrpt->p.archivedir) {
-				donodelog_fmt(myrpt, "DTMF(M),%c", c);
-			}
+			donodelog_fmt(myrpt, "DTMF(M),%c", c);
 			if (handle_remote_dtmf_digit(myrpt, c, &keyed, 0) == -1)
 				break;
 			continue;
@@ -7424,9 +7390,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 			ast_shrink_phone_number(b1);
 		}
 		rpt_update_links(myrpt);
-		if (myrpt->p.archivedir) {
-			donodelog_fmt(myrpt, "DISCONNECT,%s", b1);
-		}
+		donodelog_fmt(myrpt, "DISCONNECT,%s", b1);
 		dodispgm(myrpt, b1);
 	}
 	myrpt->remote_webtransceiver = 0;

--- a/apps/app_rpt/rpt_channel.c
+++ b/apps/app_rpt/rpt_channel.c
@@ -76,12 +76,12 @@ int priority_jump(struct rpt *myrpt, struct ast_channel *chan)
 	return res;
 }
 
-int sayfile(struct ast_channel *mychannel, char *fname)
+int sayfile(struct ast_channel *mychannel, const char *fname)
 {
 	return ast_stream_and_wait(mychannel, fname, "");
 }
 
-int saycharstr(struct ast_channel *mychannel, char *str)
+int saycharstr(struct ast_channel *mychannel, const char *str)
 {
 	int res;
 
@@ -94,7 +94,7 @@ int saycharstr(struct ast_channel *mychannel, char *str)
 	return res;
 }
 
-int sayphoneticstr(struct ast_channel *mychannel, char *str)
+int sayphoneticstr(struct ast_channel *mychannel, const char *str)
 {
 	int res;
 
@@ -246,9 +246,8 @@ static int morse_cat(char *str, int freq, int duration)
 	return 0;
 }
 
-int send_morse(struct ast_channel *chan, char *string, int speed, int freq, int amplitude)
+int send_morse(struct ast_channel *chan, const char *string, int speed, int freq, int amplitude)
 {
-
 	static struct morse_bits mbits[] = {
 		{ 0, 0 },				/* SPACE */
 		{ 0, 0 },
@@ -420,7 +419,7 @@ int send_usb_txt(struct rpt *myrpt, char *txt)
 	return 0;
 }
 
-int send_link_pl(struct rpt *myrpt, char *txt)
+int send_link_pl(struct rpt *myrpt, const char *txt)
 {
 	struct ast_frame wf;
 	struct rpt_link *l;

--- a/apps/app_rpt/rpt_channel.h
+++ b/apps/app_rpt/rpt_channel.h
@@ -9,12 +9,12 @@ int wait_interval(struct rpt *myrpt, enum rpt_delay type, struct ast_channel *ch
 int priority_jump(struct rpt *myrpt, struct ast_channel *chan);
 
 /*! \brief Say a file - streams file to output channel */
-int sayfile(struct ast_channel *mychannel, char *fname);
+int sayfile(struct ast_channel *mychannel, const char *fname);
 
-int saycharstr(struct ast_channel *mychannel, char *str);
+int saycharstr(struct ast_channel *mychannel, const char *str);
 
 /*! \brief Say a phonetic words -- streams corresponding sound file */
-int sayphoneticstr(struct ast_channel *mychannel, char *str);
+int sayphoneticstr(struct ast_channel *mychannel, const char *str);
 
 /*! \brief Say a number -- streams corresponding sound file */
 int saynum(struct ast_channel *mychannel, int num);
@@ -31,13 +31,13 @@ int play_tone_pair(struct ast_channel *chan, int f1, int f2, int duration, int a
 int play_tone(struct ast_channel *chan, int freq, int duration, int amplitude);
 
 /*! \brief Convert string into morse code */
-int send_morse(struct ast_channel *chan, char *string, int speed, int freq, int amplitude);
+int send_morse(struct ast_channel *chan, const char *string, int speed, int freq, int amplitude);
 
 /*! \brief send asterisk frame text message on the current tx channel */
 int send_usb_txt(struct rpt *myrpt, char *txt);
 
 /*! \brief send asterisk frame text message on the current tx channel */
-int send_link_pl(struct rpt *myrpt, char *txt);
+int send_link_pl(struct rpt *myrpt, const char *txt);
 
 /*! \brief send newkey request NEWKEY1STR to caller.  When a call is initiated
  * l->link_newkey is set to RADIO_KEY_NOT_ALLOWED, and l->newkeytimer is activate.

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -733,9 +733,7 @@ enum rpt_function_response function_remote(struct rpt *myrpt, char *param, char 
 			}
 			ast_copy_string(myrpt->loginuser, cp1 + 1, sizeof(myrpt->loginuser) - 1);
 			ast_mutex_unlock(&myrpt->lock);
-			if (myrpt->p.archivedir) {
-				donodelog_fmt(myrpt, "LOGIN,%s,%s", myrpt->loginuser, myrpt->loginlevel);
-			}
+			donodelog_fmt(myrpt, "LOGIN,%s,%s", myrpt->loginuser, myrpt->loginlevel);
 			ast_debug(1, "loginuser %s level %s\n", myrpt->loginuser, myrpt->loginlevel);
 			rpt_telemetry(myrpt, REMLOGIN, NULL);
 		}

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -740,9 +740,7 @@ int connect_link(struct rpt *myrpt, char *node, enum link_mode mode, int perma)
 	}
 	if (!l->chan) {
 		ast_log(LOG_WARNING, "Unable to place call to %s/%s\n", deststr, tele);
-		if (myrpt->p.archivedir) {
-			donodelog_fmt(myrpt, "LINKFAIL,%s/%s", deststr, tele);
-		}
+		donodelog_fmt(myrpt, "LINKFAIL,%s/%s", deststr, tele);
 		rpt_link_free(l);
 		ao2_ref(cap, -1);
 		return -1;

--- a/apps/app_rpt/rpt_rig.c
+++ b/apps/app_rpt/rpt_rig.c
@@ -2275,12 +2275,8 @@ int setrem(struct rpt *myrpt)
 		   myrpt->txpl, myrpt->rxpl, offsets[(int) myrpt->offset], powerlevels[(int) myrpt->powerlevel], myrpt->txplon,
 		   myrpt->rxplon);
 #endif
-	if (myrpt->p.archivedir) {
-		donodelog_fmt(myrpt, "FREQ,%s,%s,%s,%s,%s,%s,%d,%d", myrpt->freq,
-				modes[(int) myrpt->remmode],
-				myrpt->txpl, myrpt->rxpl, offsets[(int) myrpt->offset], powerlevels[(int) myrpt->powerlevel],
-				myrpt->txplon, myrpt->rxplon);
-	}
+	donodelog_fmt(myrpt, "FREQ,%s,%s,%s,%s,%s,%s,%d,%d", myrpt->freq, modes[(int) myrpt->remmode], myrpt->txpl, myrpt->rxpl,
+		offsets[(int) myrpt->offset], powerlevels[(int) myrpt->powerlevel], myrpt->txplon, myrpt->rxplon);
 	if (myrpt->remote && myrpt->remote_webtransceiver) {
 		if (myrpt->remmode == REM_MODE_FM) {
 			char myfreq[MAXREMSTR], *cp;


### PR DESCRIPTION
The "archivedir" variable is used to enable the simple node activity log (key, unkey, link changes) and, optionally, audio recordings.  Here, we are extending the log content to include telemetry information.