### PR TITLE
chan_usbradio: fix numrxcodes != numtxcodes

### DIFF
--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -5026,6 +5026,7 @@ static struct chan_usbradio_pvt *store_config(const struct ast_config *cfg, cons
 
 	if (o->rxsdtype != SD_XPMR) {
 		o->rxctcssfreqs[0] = 0;
+		o->txctcssfreqs[0] = 0;
 	}
 
 	if ((o->txmixa == TX_OUT_COMPOSITE) && (o->txmixb == TX_OUT_VOICE)) {


### PR DESCRIPTION
With a USBRadio node configuration including `ctcssfrom = no` we are seeing log messages like:

```
[2025-05-21 13:47:52.754] ERROR[115298] ./xpmr/xpmr.c: numrxcodes != numtxcodes
```

This CTCSS RX/TX tone frequencies are not used unless `ctcssfrom = dsp` has been set so this error should never be reported.