### PR TITLE
Resolve parrot mode conflicts between app_rpt, rpt.conf

### DIFF
--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -492,6 +492,12 @@ enum link_mode {
 	MODE_LOCAL_MONITOR
 };
 
+enum rpt_parrot_mode {
+	PARROT_MODE_OFF = 0,
+	PARROT_MODE_ON_COMMAND,
+	PARROT_MODE_ON_ALWAYS
+};
+
 struct vox {
 	float	speech_energy;
 	float	noise_energy;
@@ -811,7 +817,7 @@ struct rpt {
 		int remotetimeoutwarningfreq;
 		int sysstate_cur;
 		struct sysstate s[MAX_SYSSTATES];
-		char parrotmode;
+		enum rpt_parrot_mode parrotmode;
 		int parrottime;
 		const char *rptnode;
 		char remote_mars;

--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -935,9 +935,9 @@ void load_rpt_vars(int n, int init)
 
 	val = ast_variable_retrieve(cfg, cat, "parrot");
 	if (val) {
-		rpt_vars[n].p.parrotmode = (ast_true(val)) ? 2 : 0;
+		rpt_vars[n].p.parrotmode = ast_true(val) ? PARROT_MODE_ON_ALWAYS : PARROT_MODE_OFF;
 	} else {
-		rpt_vars[n].p.parrotmode = 0;
+		rpt_vars[n].p.parrotmode = PARROT_MODE_OFF;
 	}
 
 	RPT_CONFIG_VAR_INT_DEFAULT(parrottime, "parrottime", PARROTTIME);

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -1311,20 +1311,20 @@ enum rpt_function_response function_cop(struct rpt *myrpt, char *param, char *di
 		rpt_telemetry(myrpt, ARB_ALPHA, (void *) "ATDIS");
 		return DC_COMPLETE;
 
-	case 21:					/* Parrot Mode Enable */
+	case 21: /* Parrot Mode Enable */
 		birdbath(myrpt);
-		if (myrpt->p.parrotmode < 2) {
+		if (myrpt->p.parrotmode != PARROT_MODE_ON_ALWAYS) {
 			myrpt->parrotonce = 0;
-			myrpt->p.parrotmode = 1;
+			myrpt->p.parrotmode = PARROT_MODE_ON_COMMAND;
 			rpt_telem_select(myrpt, command_source, mylink);
 			rpt_telemetry(myrpt, COMPLETE, NULL);
 			return DC_COMPLETE;
 		}
 		break;
-	case 22:					/* Parrot Mode Disable */
+	case 22: /* Parrot Mode Disable */
 		birdbath(myrpt);
-		if (myrpt->p.parrotmode < 2) {
-			myrpt->p.parrotmode = 0;
+		if (myrpt->p.parrotmode != PARROT_MODE_ON_ALWAYS) {
+			myrpt->p.parrotmode = PARROT_MODE_OFF;
 			rpt_telem_select(myrpt, command_source, mylink);
 			rpt_telemetry(myrpt, COMPLETE, NULL);
 			return DC_COMPLETE;

--- a/configs/rpt/rpt.conf
+++ b/configs/rpt/rpt.conf
@@ -174,10 +174,9 @@ telemdynamic = yes                  ; yes = disallow users to change the local t
 
 ;beaconing = 0                      ; Send ID regardless of repeater activity (Required in the UK, but probably illegal in the US)
 
-parrotmode = 0                      ; 0 = Parrot Off (default = 0)
-                                    ; 1 = Parrot On Command
-                                    ; 2 = Parrot Always
-                                    ; 3 = Parrot Once by Command
+parrot = 0                          ; Parrot mode will echo the audio you transmit back to the node
+                                    ; 0 = Parrot mode off or enabled with COP commands (default = 0)
+                                    ; 1 = Parrot mode always on
 
 parrottime = 1000                   ; Set the amount of time in milliseconds
                                     ; to wait before parroting what was received


### PR DESCRIPTION
The "rpt.conf" file had comments about the "parrotmode" variable when, in fact, we were using the "parrot" variable.  This change clears up the comments in the configuration file and its usage in the code.