### PR TITLE
app_rpt: Add rxmutetimer delay to mode 3 addressing feedback introduced by PR#603

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4115,6 +4115,9 @@ static inline int dahditxchannel_read(struct rpt *myrpt, char *restrict myfirst)
 				ast_frfree(f1);
 		}
 		if (myrpt->p.duplex == 3 && myrpt->keyed) {
+			myrpt->rxmutetimer = RX_MUTE_TIMER;
+		}
+		if (myrpt->rxmutetimer) {
 			RPT_MUTE_FRAME(f);
 		}
 		ast_write(myrpt->txchannel, f);
@@ -7226,6 +7229,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 				myrx = myrx || myrpt->wasvox;
 		}
 		keyed = myrx;
+		update_timer(&myrpt->rxmutetimer, elap, 0);
 		update_timer(&myrpt->rxlingertimer, elap, 0);
 		if ((myrpt->rpt_newkey == RADIO_KEY_NOT_ALLOWED) && keyed && (!myrpt->rxlingertimer)) {
 			myrpt->rerxtimer = 0;

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -204,6 +204,7 @@ typedef struct {
 #define	SIMPLEX_PHONE_DELAY 25
 
 #define RX_LINGER_TIME 50
+#define RX_MUTE_TIMER 60
 
 #define	STATPOST_PROGRAM "/usr/bin/wget,-q,--output-document=/dev/null,--no-check-certificate"
 
@@ -996,6 +997,7 @@ struct rpt {
 	enum newkey rpt_newkey;
 	char inpadtest;
 	int rxlingertimer;
+	int rxmutetimer;
 	char localoverride;
 	char ready;
 	char lastrxburst;


### PR DESCRIPTION
Piping audio via the transmit conference and muting the frames while TX allows a small pipline of audio to leak into the TX audio.  Continuing to mute a few frames after the transmit output is "released" clears up the "leak"

Addresses issue #703 