### PR TITLE
Revert "app_rpt: Update duplex mode 3 to pass audio to audioarchive."

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -1504,8 +1504,8 @@ void *rpt_call(void *this)
 	channel_revert(myrpt);
 	rpt_mutex_unlock(&myrpt->lock);
 
-	/* Put pchannel back on the conference in announce mode */
-	if (myrpt->p.duplex == 4 || myrpt->p.duplex == 3) {
+	/* first put the channel on the conference in announce mode */
+	if (myrpt->p.duplex == 2 || myrpt->p.duplex == 4) {
 		rpt_conf_add_announcer_monitor(myrpt->pchannel, myrpt);
 	}
 	ast_free(patch_thread_data);
@@ -2784,8 +2784,8 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 		return -1;
 	}
 
-	if (myrpt->p.duplex >= 2 && myrpt->p.duplex <= 4) {
-		res = rpt_conf_create(myrpt->pchannel, myrpt, RPT_CONF, RPT_CONF_CONFANNMON);
+	if (myrpt->p.duplex == 2 || myrpt->p.duplex == 4) {
+		res = rpt_conf_add_announcer_monitor(myrpt->pchannel, myrpt);
 	} else {
 		res = rpt_conf_create(myrpt->pchannel, myrpt, RPT_CONF, RPT_CONF_CONF | RPT_CONF_LISTENER | RPT_CONF_TALKER);
 	}
@@ -4114,9 +4114,6 @@ static inline int dahditxchannel_read(struct rpt *myrpt, char *restrict myfirst)
 		} else {
 			while ((f1 = AST_LIST_REMOVE_HEAD(&myrpt->txq, frame_list)))
 				ast_frfree(f1);
-		}
-		if (myrpt->p.duplex == 3 && myrpt->keyed) {
-			RPT_MUTE_FRAME(f);
 		}
 		ast_write(myrpt->txchannel, f);
 	}


### PR DESCRIPTION
This reverts commit 1dadccd83eb6b14b4c7dfa9d5c1cad371068e63b.
While "fixing" audio archive, we "broke" duplex mode 3 original "full duplex" behavior.
First step - back out PR#603, then explore other options to fix audio archive in mode 3.