### PR TITLE
Revert "app_rpt: Update duplex mode 3 to pass audio to audioarchive (part 2)

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2785,7 +2785,7 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 	}
 
 	if (myrpt->p.duplex == 2 || myrpt->p.duplex == 4) {
-		res = rpt_conf_add_announcer_monitor(myrpt->pchannel, myrpt);
+		res = rpt_conf_create(myrpt->pchannel, myrpt, RPT_CONF, RPT_CONF_CONFANNMON);
 	} else {
 		res = rpt_conf_create(myrpt->pchannel, myrpt, RPT_CONF, RPT_CONF_CONF | RPT_CONF_LISTENER | RPT_CONF_TALKER);
 	}


### PR DESCRIPTION
While "fixing" audio archive, we "broke" duplex mode 3 original "full duplex" behavior.  The first step was to back out [PR #603](https://github.com/AllStarLink/app_rpt/pull/603).  That change was made with [PR #707](https://github.com/AllStarLink/app_rpt/pull/707) but the change was incomplete.  This change makes it right.