### PR TITLE
Update Wiki URLs to ASL3 manual, fix sound file locations for ASL3.

### DIFF
--- a/configs/rpt/rpt.conf
+++ b/configs/rpt/rpt.conf
@@ -193,7 +193,7 @@ parrottime = 1000                   ; Set the amount of time in milliseconds
 
 ;startup_macro =                    ; Best use in your node stanza (below) when more than one node
 
-;nodenames = /var/lib/asterisk/sounds/custom/nodenames ; Point to alternate nodenames sound directory
+;nodenames = /usr/share/asterisk/sounds/custom/nodenames ; Point to alternate nodenames sound directory
 
 ;aprstt = general                   ; To enable APRStt, set this value to the stanza to use in gps.conf
                                     ; module app_gps.so will need to be enabled

--- a/configs/rpt/rpt.conf
+++ b/configs/rpt/rpt.conf
@@ -119,7 +119,7 @@ telemetry = telemetry               ; Telemetry stanza
 wait_times = wait-times             ; Wait times stanza
 
 ;inxlat = *,#,0123456789ABCD,Y      ; The Y is for dialtone on function, a la CACTUS
-                                    ; https://wiki.allstarlink.org/wiki/Rpt.conf#inxlat.3D
+                                    ; https://allstarlink.github.io/config/rpt_conf/#inxlat
 
 context = radio                     ; dialing context for phone
 callerid = "Repeater" <0000000000>  ; callerid for phone calls
@@ -134,7 +134,7 @@ idrecording = |iNOTSET              ; id recording or morse string
 idtime = 540000                     ; id interval time (in ms) (optional) Default 5 minutes (300000 ms)
 politeid = 30000                    ; time in milliseconds before ID timer expires to try and ID in the tail. (optional, default 30000)
 
-;tailmessagelist=/etc/asterisk/sounds/yourtailmessage
+;tailmessagelist=/usr/share/asterisk/sounds/custom/yourtailmessage
 ;tailsquashedtime=900000            ; 15 minutes
 ;tailmessagetime=21600000           ; 6 hours (200000000 ms, 55.5555 hours is the max value possible)
 
@@ -156,7 +156,7 @@ linkunkeyct = ct8                   ; sent when a transmission received over the
 
 ;lnkacttime = 1800                  ; Link activity timer time in seconds.
 ;lnkactmacro = *52                  ; Function to execute when link activity timer expires.
-;lnkacttimerwarn = 30seconds        ; Message to play when the link activity timer has 30 seconds left.
+;lnkacttimerwarn = rpt/timeout-warning ; Message to play when the link activity timer has 30 seconds left.
 
 ;remote_inact_timeout =             ; Specifies the amount of time without keying from the link. Set to 0 to disable timeout. (15 * 60)
 ;remote_timeout =                   ; Session time out for remote base. Set to 0 to disable. (60 * 60)
@@ -193,7 +193,7 @@ parrottime = 1000                   ; Set the amount of time in milliseconds
 
 ;startup_macro =                    ; Best use in your node stanza (below) when more than one node
 
-;nodenames = /var/lib/asterisk/sounds/rpt/nodenames.callsign  ; Point to alternate nodename sound directory
+;nodenames = /var/lib/asterisk/sounds/custom/nodenames ; Point to alternate nodenames sound directory
 
 ;aprstt = general                   ; To enable APRStt, set this value to the stanza to use in gps.conf
                                     ; module app_gps.so will need to be enabled
@@ -664,7 +664,7 @@ calltermwait = 2000                 ; Time to wait before announcing "call termi
 [controlstates]
 ;;;;; Control states ;;;;;
 ; Allow several control operator functions to be changed at once using one command (good for scheduling)
-;statenum = copcmd,[copcmd]... https://wiki.allstarlink.org/wiki/Rpt.conf#Control_States_Stanza
+;statenum = copcmd,[copcmd]... https://allstarlink.github.io/config/rpt_conf/#control-states-stanza
 0 = rptena,lnkena,apena,totena,ufena,noicd  ; Normal operation
 1 = rptena,lnkena,apdis,totdis,ufena,noice  ; Net and news operation
 2 = rptena,lnkdis,apdis,totena,ufdis,noice  ; Repeater only operation


### PR DESCRIPTION
Update Wiki URLs to Github.io ASL3 Manual URLs.

Update references to old sound file locations to be consistent with current ASL3 paths.

Change `lnkacttimerwarn` to a file that actually exists on the ASL3 system.