### PR TITLE
app_rpt: Update missed/default UDP port references 667 --> 1667

### DIFF
--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -155,9 +155,9 @@ isprimary = y
 
 The "secondary" server needs to have the following in all of its instances that require redundancy:
 
-primary = 12.34.56.78:667,mypswd
+primary = 12.34.56.78:1667,mypswd
 
-(where 12.34.56.78:667 is the IPADDDR:PORT of the "primary" server, and mypswd is the password of the
+(where 12.34.56.78:1667 is the IPADDDR:PORT of the "primary" server, and mypswd is the password of the
 "primary connectivity" client)
 
 Note: Master timing sources *MUST* be local to their associated server, and therefore, can not be operated
@@ -318,7 +318,7 @@ static int nullfd = -1;
 
 AST_MUTEX_DEFINE_STATIC(voter_lock);
 
-int16_t listen_port = 667;		/* port to listen to UDP packets on */
+int16_t listen_port = 1667; /* port to listen to UDP packets on */
 int udp_socket = -1;
 
 struct ast_timer *voter_thread_timer = NULL;

--- a/configs/rpt/voter.conf
+++ b/configs/rpt/voter.conf
@@ -48,7 +48,7 @@ thresholds = 255,110=5          ;
 ; streams = 67.215.233.178:1667 ; location to send voter data stream for this instance (used only with votemond Java program, which is deprecated)
 
 ; isprimary = y                 ; used in redundant server applications only. must be set on the primary server only
-; primary = 10.20.20.1:667,mypaswd  ; used in redundant server applications only. must be ONLY set on the secondary server to point to the primary
+; primary = 10.20.20.1:1667,mypaswd  ; used in redundant server applications only. must be ONLY set on the secondary server to point to the primary
 
 [1998]                          ; define another voting instance on this server (for another node). Three simulcast transmitters and four receivers.
                                 ; NOTE: there is NO "master" in this instance, since we already have a master timing source on this server defined above 


### PR DESCRIPTION
Outstanding references in voter.conf and chan_voter.c to the old port 667/UDP, which has now been changed to 1667/UDP by default.

Some are documentation changes, except for listen_port, which defines the default port if the port option isn't set in voter.conf.

UpgradeNote: ASL3 documentation specifies the change to port 1667/UDP, however, if users omitted the port=1667 option in voter.conf, chan_voter would have defaulted to the "old" port 667/UDP. This change will cause the default port to be the expected "new" port 1667/UDP.