### PR TITLE
app_rpt: fix [echolink] choppy audio

### DIFF
--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -526,6 +526,10 @@ struct rpt_xlat {
 	time_t	lastone;
 };
 
+struct rpt_frame_queue {
+	struct ast_frame *lastf1, *lastf2;
+};
+
 /*! \brief Structure that holds information regarding app_rpt operation */
 struct rpt;
 
@@ -573,8 +577,8 @@ struct rpt_link {
 	int linklisttimer;
 	int linkunkeytocttimer;
 	struct timeval lastlinktv;
-	struct	ast_frame *lastf1,*lastf2;
-	struct	rpt_chan_stat chan_stat[NRPTSTAT];
+	struct rpt_frame_queue frame_queue;
+	struct rpt_chan_stat chan_stat[NRPTSTAT];
 	struct vox vox;
 	char wasvox;
 	int voxtotimer;
@@ -924,7 +928,7 @@ struct rpt {
 	struct ast_channel *telechannel;  	/*!< \brief pseudo channel between telemetry conference and txconf */
 	struct ast_channel *btelechannel;  	/*!< \brief pseudo channel buffer between telemetry conference and txconf */
 	struct ast_channel *voxchannel;
-	struct ast_frame *lastf1,*lastf2;
+	struct rpt_frame_queue frame_queue;
 	struct rpt_tele tele;
 	struct timeval lasttv,curtv;
 	pthread_t rpt_call_thread,rpt_thread;


### PR DESCRIPTION
First off, a HUGE thank you to Chuck/AI7SY for his help in identifying the PR that resulted in the choppy audio.

The changes that were made for [#538 ](https://github.com/AllStarLink/app_rpt/pull/538) had a few places where we updated the `struct rpt` frame queue (lastf1, lastf2) but should have updated the `struct rpt_link` frame queue.  This change restores the expected behavior.