### PR TITLE
app_rpt: rpt_play_tone incorrectly handling rpt_stop_tone.

### DIFF
--- a/apps/app_rpt/rpt_bridging.c
+++ b/apps/app_rpt/rpt_bridging.c
@@ -559,11 +559,11 @@ int rpt_conf_get_muted(struct ast_channel *chan, struct rpt *myrpt)
 
 /*!
  * \param chan
- * \param tone 0 = congestion, 1 = dialtone
+ * \param tone DAHDI_TONE_DIALTONE, DAHDI_TONE_CONGESTION, or -1 to stop tone
+ * \retval 0 on success, -1 on failure
  */
 static int rpt_play_tone(struct ast_channel *chan, int tone)
 {
-	tone = tone ? DAHDI_TONE_DIALTONE : DAHDI_TONE_CONGESTION;
 	if (tone_zone_play_tone(ast_channel_fd(chan, 0), tone)) {
 		ast_log(LOG_WARNING, "Cannot start tone on %s\n", ast_channel_name(chan));
 		return -1;
@@ -573,12 +573,12 @@ static int rpt_play_tone(struct ast_channel *chan, int tone)
 
 int rpt_play_dialtone(struct ast_channel *chan)
 {
-	return rpt_play_tone(chan, 1);
+	return rpt_play_tone(chan, DAHDI_TONE_DIALTONE);
 }
 
 int rpt_play_congestion(struct ast_channel *chan)
 {
-	return rpt_play_tone(chan, 0);
+	return rpt_play_tone(chan, DAHDI_TONE_CONGESTION);
 }
 
 int rpt_stop_tone(struct ast_channel *chan)


### PR DESCRIPTION
`rpt_stop_tone` calls `rpt_play_tone` with `-1`.  Reviewing the original code, this should send a `-1` to `tone_zone_play_tone()`. 
-1 was not possible.
