### PR TITLE
Add TX soft limiter adjustment to chan_usbradio.c, xpmr.c, and xpmr.h.

### DIFF
--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -62,34 +62,34 @@
 #endif
 
 #ifdef RADIO_XPMRX
-#define HAVE_XPMRX				1
+#define HAVE_XPMRX 1
 #endif
 
-#define CHAN_USBRADIO           1	/* Used in xpmr.h to configure that module */
-#define DEBUG_USBRADIO          0
-#define DEBUG_CAPTURES	 		1
-#define DEBUG_CAP_RX_OUT		0
-#define DEBUG_CAP_TX_OUT	    0
-#define DEBUG_FILETEST			0
-#define RX_CAP_RAW_FILE			"/tmp/rx_cap_in.pcm"
-#define RX_CAP_TRACE_FILE		"/tmp/rx_trace.pcm"
-#define RX_CAP_OUT_FILE			"/tmp/rx_cap_out.pcm"
-#define TX_CAP_RAW_FILE			"/tmp/tx_cap_in.pcm"
-#define TX_CAP_TRACE_FILE		"/tmp/tx_trace.pcm"
-#define TX_CAP_OUT_FILE			"/tmp/tx_cap_out.pcm"
+#define CHAN_USBRADIO 1 /* Used in xpmr.h to configure that module */
+#define DEBUG_USBRADIO 0
+#define DEBUG_CAPTURES 1
+#define DEBUG_CAP_RX_OUT 0
+#define DEBUG_CAP_TX_OUT 0
+#define DEBUG_FILETEST 0
+#define RX_CAP_RAW_FILE "/tmp/rx_cap_in.pcm"
+#define RX_CAP_TRACE_FILE "/tmp/rx_trace.pcm"
+#define RX_CAP_OUT_FILE "/tmp/rx_cap_out.pcm"
+#define TX_CAP_RAW_FILE "/tmp/tx_cap_in.pcm"
+#define TX_CAP_TRACE_FILE "/tmp/tx_trace.pcm"
+#define TX_CAP_OUT_FILE "/tmp/tx_cap_out.pcm"
 
 #define DELIMCHR ','
 #define QUOTECHR 34
 
 #define READERR_THRESHOLD 50
-#define DEFAULT_ECHO_MAX 1000	/* 20 secs of echo buffer, max */
+#define DEFAULT_ECHO_MAX 1000 /* 20 secs of echo buffer, max */
 #define DEFAULT_TX_SOFT_LIMITER_SETPOINT 12000
 #define PP_MASK 0xbffc
 #define PP_PORT "/dev/parport0"
 #define PP_IOPORT 0x378
 #define RPT_TO_STRING(x) #x
 #define S_FMT(x) "%" RPT_TO_STRING(x) "s "
-#define N_FMT(duf) "%30" #duf	/* Maximum sscanf conversion to numeric strings */
+#define N_FMT(duf) "%30" #duf /* Maximum sscanf conversion to numeric strings */
 
 #include "./xpmr/xpmr.h"
 #ifdef HAVE_XPMRX
@@ -133,9 +133,9 @@ static struct ast_jb_conf default_jbconf = {
 
 static struct ast_jb_conf global_jbconf;
 
-#define	QUEUE_SIZE	20			/* 400 milliseconds of sound card output buffer */
+#define QUEUE_SIZE 20 /* 400 milliseconds of sound card output buffer */
 
-#define CONFIG	"usbradio.conf"	/* default config file */
+#define CONFIG "usbradio.conf" /* default config file */
 
 /* file handles for writing debug audio packets */
 static FILE *frxcapraw = NULL, *frxcaptrace = NULL, *frxoutraw = NULL;
@@ -177,20 +177,25 @@ static const char *const mixer_type[] = { "no", "voice", "tone", "composite", "a
 struct chan_usbradio_pvt {
 	struct chan_usbradio_pvt *next;
 
-	char *name;					/* the internal name of our channel */
-	int devtype;				/* actual type of device */
-	int pttkick[2];				/* ptt kick pipe */
-	int total_blocks;			/* total blocks in the output device */
+	char *name;		  /* the internal name of our channel */
+	int devtype;	  /* actual type of device */
+	int pttkick[2];	  /* ptt kick pipe */
+	int total_blocks; /* total blocks in the output device */
 	int sounddev;
-	enum { M_UNSET, M_FULL, M_READ, M_WRITE } duplex;
+	enum {
+		M_UNSET,
+		M_FULL,
+		M_READ,
+		M_WRITE
+	} duplex;
 	int hookstate;
-	unsigned int queuesize;		/* max fragments in queue */
-	unsigned int frags;			/* parameter for SETFRAGMENT */
+	unsigned int queuesize; /* max fragments in queue */
+	unsigned int frags;		/* parameter for SETFRAGMENT */
 
-	int warned;					/* various flags used for warnings */
-#define WARN_used_blocks	1
-#define WARN_speed			2
-#define WARN_frag			4
+	int warned; /* various flags used for warnings */
+#define WARN_used_blocks 1
+#define WARN_speed 2
+#define WARN_frag 4
 
 	char devicenum;
 	char devstr[128];
@@ -209,29 +214,29 @@ struct chan_usbradio_pvt {
 	/* buffers used in usbradio_read - AST_FRIENDLY_OFFSET space for headers
 	 * plus enough room for a full frame
 	 */
-	char usbradio_read_buf[FRAME_SIZE * (2 * 12) + AST_FRIENDLY_OFFSET];	/* 2 bytes * 2 channels * 6 for 48K */
+	char usbradio_read_buf[FRAME_SIZE * (2 * 12) + AST_FRIENDLY_OFFSET]; /* 2 bytes * 2 channels * 6 for 48K */
 	char usbradio_read_buf_8k[FRAME_SIZE * 2 + AST_FRIENDLY_OFFSET];
-	int readpos;				/* read position above */
-	struct ast_frame read_f;	/* returned by usbradio_read */
+	int readpos;			 /* read position above */
+	struct ast_frame read_f; /* returned by usbradio_read */
 
 	char lastrx;
 	char rxhidsq;
 	char rxhidctcss;
-	char rxcarrierdetect;		// status from pmr channel
-	char rxctcssdecode;			// status from pmr channel
+	char rxcarrierdetect; // status from pmr channel
+	char rxctcssdecode;	  // status from pmr channel
 	char rxppsq;
 	char rxppctcss;
 
-	char rxkeyed;				/* Indicates rx signal is present */
+	char rxkeyed; /* Indicates rx signal is present */
 
 	char lasttx;
-	char txkeyed;				/* tx key request from upper layers */
+	char txkeyed; /* tx key request from upper layers */
 	char txtestkey;
 
 	time_t lasthidtime;
 	struct ast_dsp *dsp;
 
-	char radioduplex;			/* parameter for radio duplex setting */
+	char radioduplex; /* parameter for radio duplex setting */
 
 	char didpmrtx;
 	int notxcnt;
@@ -249,19 +254,19 @@ struct chan_usbradio_pvt {
 	int rxdcsdecode;
 	int rxlsddecode;
 
-	int rxoncnt;				/* Counts the number of 20 ms intervals after RX activity */
-	int txoffcnt;				/* Counts the number of 20 ms intervals after TX unkey */
-	int rxondelay;				/* This is the value which RX is ignored after RX activity */
-	int txoffdelay;				/* This is the value which RX is ignored after TX unkey */
+	int rxoncnt;	/* Counts the number of 20 ms intervals after RX activity */
+	int txoffcnt;	/* Counts the number of 20 ms intervals after TX unkey */
+	int rxondelay;	/* This is the value which RX is ignored after RX activity */
+	int txoffdelay; /* This is the value which RX is ignored after TX unkey */
 
 	t_pmr_chan *pmrChan;
 
 	enum radio_rx_audio rxdemod;
 	float rxgain;
 	enum radio_carrier_detect rxcdtype;
-	int voxhangtime;			/* if rxcdtype=vox, ms to wait detecting RX audio before setting CD=0 */
+	int voxhangtime; /* if rxcdtype=vox, ms to wait detecting RX audio before setting CD=0 */
 	enum radio_squelch_detect rxsdtype;
-	int rxsquelchadj;			/* this copy needs to be here for initialization */
+	int rxsquelchadj; /* this copy needs to be here for initialization */
 	int rxsqhyst;
 	int rxsqvoxadj;
 	int rxnoisefiltype;
@@ -280,37 +285,37 @@ struct chan_usbradio_pvt {
 	char rxctcssrelax;
 	float rxctcssgain;
 
-	char txctcssdefault[16];	// for repeater operation
-	char rxctcssfreqs[512];		// a string
+	char txctcssdefault[16]; // for repeater operation
+	char rxctcssfreqs[512];	 // a string
 	char txctcssfreqs[512];
 
-	char txctcssfreq[32];		// encode now
-	char rxctcssfreq[32];		// decode now
+	char txctcssfreq[32]; // encode now
+	char rxctcssfreq[32]; // decode now
 
-	char numrxctcssfreqs;		// how many
+	char numrxctcssfreqs; // how many
 	char numtxctcssfreqs;
 
-	char *rxctcss[CTCSS_NUM_CODES];	// pointers to strings
+	char *rxctcss[CTCSS_NUM_CODES]; // pointers to strings
 	char *txctcss[CTCSS_NUM_CODES];
 
-	int txfreq;					// in Hz
+	int txfreq; // in Hz
 	int rxfreq;
 
 	//      start remote operation info
-	char set_txctcssdefault[16];	// for remote operation
-	char set_txctcssfreq[16];	// encode now
-	char set_rxctcssfreq[16];	// decode now
+	char set_txctcssdefault[16]; // for remote operation
+	char set_txctcssfreq[16];	 // encode now
+	char set_rxctcssfreq[16];	 // decode now
 
-	char set_numrxctcssfreqs;	// how many
+	char set_numrxctcssfreqs; // how many
 	char set_numtxctcssfreqs;
 
-	char set_rxctcssfreqs[16];	// a string
+	char set_rxctcssfreqs[16]; // a string
 	char set_txctcssfreqs[16];
 
-	char *set_rxctcss;			// pointers to strings
+	char *set_rxctcss; // pointers to strings
 	char *set_txctcss;
 
-	int set_txfreq;				// in Hz
+	int set_txfreq; // in Hz
 	int set_rxfreq;
 
 	//      end remote operation info
@@ -354,34 +359,34 @@ struct chan_usbradio_pvt {
 	char had_pp_in;
 
 	/* bit fields */
-	unsigned int rxcapraw:1;	/* indicator if receive capture is enabled */
-	unsigned int txcapraw:1;	/* indicator if transmit capture is enabled */
-	unsigned int rxcap2:1;		/* indicator if receive capture 2 is enabled */
-	unsigned int txcap2:1;		/* indicator if transmit capture 2 is enabled */
-	unsigned int remoted:1;		/* indicator if rx/tx frequency adjusted */
-	unsigned int forcetxcode:1;	/* indicator to force use of first ctcss code */
-	unsigned int rxpolarity:1;	/* indicator for receive polarity */
-	unsigned int txpolarity:1;	/* indicator for transmit polarity */
+	unsigned int rxcapraw:1;		/* indicator if receive capture is enabled */
+	unsigned int txcapraw:1;		/* indicator if transmit capture is enabled */
+	unsigned int rxcap2:1;			/* indicator if receive capture 2 is enabled */
+	unsigned int txcap2:1;			/* indicator if transmit capture 2 is enabled */
+	unsigned int remoted:1;			/* indicator if rx/tx frequency adjusted */
+	unsigned int forcetxcode:1;		/* indicator to force use of first ctcss code */
+	unsigned int rxpolarity:1;		/* indicator for receive polarity */
+	unsigned int txpolarity:1;		/* indicator for transmit polarity */
 	unsigned int dcsrxpolarity:1;	/* indicator for dcs receive polarity */
 	unsigned int dcstxpolarity:1;	/* indicator for dcs transmit polarity */
 	unsigned int lsdrxpolarity:1;	/* indicator for lsd receive polarity */
 	unsigned int lsdtxpolarity:1;	/* indicator for lsd transmit polarity */
-	unsigned int radioactive:1;	/* indicator for active radio channel */
+	unsigned int radioactive:1;		/* indicator for active radio channel */
 	unsigned int device_error:1;	/* indicator set when we cannot find the USB device */
-	unsigned int newname:1;		/* indicator that we should use MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW */
-	unsigned int hasusb:1;		/* indicator for has a USB device */
-	unsigned int usbass:1;		/* indicator for USB device assigned */
-	unsigned int wanteeprom:1;	/* indicator if we should use EEPROM */
-	unsigned int usedtmf:1;		/* indicator is we should decode DTMF */
-	unsigned int invertptt:1;	/* indicator if we need to invert ptt */
-	unsigned int rxboost:1;		/* indicator if receive boost is needed */
-	unsigned int rxcpusaver:1;	/* indicator if receive cpu save is enabled */
-	unsigned int txcpusaver:1;	/* indicator if transmit cpu save is enabled */
-	unsigned int txprelim:1;	/* indicator if tx pre lim is enabled */
-	unsigned int txlimonly:1;	/* indicator if tx lim only is enabled */
-	unsigned int rxctcssoverride:1;	/* indicator if receive ctcss override is enabled */
+	unsigned int newname:1;			/* indicator that we should use MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW */
+	unsigned int hasusb:1;			/* indicator for has a USB device */
+	unsigned int usbass:1;			/* indicator for USB device assigned */
+	unsigned int wanteeprom:1;		/* indicator if we should use EEPROM */
+	unsigned int usedtmf:1;			/* indicator is we should decode DTMF */
+	unsigned int invertptt:1;		/* indicator if we need to invert ptt */
+	unsigned int rxboost:1;			/* indicator if receive boost is needed */
+	unsigned int rxcpusaver:1;		/* indicator if receive cpu save is enabled */
+	unsigned int txcpusaver:1;		/* indicator if transmit cpu save is enabled */
+	unsigned int txprelim:1;		/* indicator if tx pre lim is enabled */
+	unsigned int txlimonly:1;		/* indicator if tx lim only is enabled */
+	unsigned int rxctcssoverride:1; /* indicator if receive ctcss override is enabled */
 	unsigned int rx_cos_active:1;	/* indicator if cos is active - active state after processing */
-	unsigned int rx_ctcss_active:1;	/* indicator if ctcss is active - active state after processing */
+	unsigned int rx_ctcss_active:1; /* indicator if ctcss is active - active state after processing */
 
 	/* EEPROM access variables */
 	unsigned short eeprom[EEPROM_USER_LEN];
@@ -393,7 +398,7 @@ struct chan_usbradio_pvt {
 	struct timeval tonetime;
 	int toneflag;
 	int duplex3;
-	int clipledgpio;			/* enables ADC Clip Detect feature to output on a specified GPIO# */
+	int clipledgpio; /* enables ADC Clip Detect feature to output on a specified GPIO# */
 
 	int fever;
 	int count_rssi_update;
@@ -418,7 +423,7 @@ static struct chan_usbradio_pvt usbradio_default = {
 	.duplex = M_UNSET,
 	.queuesize = QUEUE_SIZE,
 	.frags = FRAGS,
-	.readpos = AST_FRIENDLY_OFFSET,	/* start here on reads */
+	.readpos = AST_FRIENDLY_OFFSET, /* start here on reads */
 	.wanteeprom = 1,
 	.usedtmf = 1,
 	.rxondelay = 0,
@@ -440,8 +445,7 @@ static int hidhdwconfig(struct chan_usbradio_pvt *o);
 static void mixer_write(struct chan_usbradio_pvt *o);
 static int setformat(struct chan_usbradio_pvt *o, int mode);
 static struct ast_channel *usbradio_request(const char *type, struct ast_format_cap *cap,
-											const struct ast_assigned_ids *assignedids,
-											const struct ast_channel *requestor, const char *data, int *cause);
+	const struct ast_assigned_ids *assignedids, const struct ast_channel *requestor, const char *data, int *cause);
 static int usbradio_digit_begin(struct ast_channel *c, char digit);
 static int usbradio_digit_end(struct ast_channel *c, char digit, unsigned int duration);
 static int usbradio_text(struct ast_channel *c, const char *text);
@@ -467,11 +471,11 @@ static void tune_txoutput(struct chan_usbradio_pvt *o, int value, int fd, int fl
 static void tune_write(struct chan_usbradio_pvt *o);
 static int xpmr_config(struct chan_usbradio_pvt *o);
 static int xpmr_set_tx_soft_limiter(struct chan_usbradio_pvt *o, int setpoint);
-#if	DEBUG_FILETEST == 1
+#if DEBUG_FILETEST == 1
 static int RxTestIt(struct chan_usbradio_pvt *o);
 #endif
 
-static char *usbradio_active;	/* the active device */
+static char *usbradio_active; /* the active device */
 
 static const int ppinshift[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 7, 5, 4, 0, 3 };
 
@@ -499,7 +503,6 @@ static struct ast_channel_tech usbradio_tech = {
 	.setoption = usbradio_setoption,
 };
 
-
 /*!
  * \brief Configure our private structure based on the
  * found hardware type.
@@ -510,51 +513,51 @@ static int hidhdwconfig(struct chan_usbradio_pvt *o)
 {
 	int i;
 
-/* NOTE: on the CM-108AH, GPIO2 is *not* a REAL GPIO.. it was re-purposed
- *  as a signal called "HOOK" which can only be read from the HID.
- *  Apparently, in a REAL CM-108, GPIO really works as a GPIO
- */
+	/* NOTE: on the CM-108AH, GPIO2 is *not* a REAL GPIO.. it was re-purposed
+	 *  as a signal called "HOOK" which can only be read from the HID.
+	 *  Apparently, in a REAL CM-108, GPIO really works as a GPIO
+	 */
 
-	if (o->hdwtype == 1) {		//sphusb
-		o->hid_gpio_ctl = 0x08;	/* set GPIO4 to output mode */
-		o->hid_gpio_ctl_loc = 2;	/* For CTL of GPIO */
-		o->hid_io_cor = 4;		/* GPIO3 is COR */
-		o->hid_io_cor_loc = 1;	/* GPIO3 is COR */
-		o->hid_io_ctcss = 2;	/* GPIO 2 is External CTCSS */
-		o->hid_io_ctcss_loc = 1;	/* is GPIO 2 */
-		o->hid_io_ptt = 8;		/* GPIO 4 is PTT */
-		o->hid_gpio_loc = 1;	/* For ALL GPIO */
-		o->valid_gpios = 1;		/* for GPIO 1 */
-	} else if (o->hdwtype == 0) {	//dudeusb
-		o->hid_gpio_ctl = 4;	/* set GPIO 3 to output mode */
-		o->hid_gpio_ctl_loc = 2;	/* For CTL of GPIO */
-		o->hid_io_cor = 2;		/* VOLD DN is COR */
-		o->hid_io_cor_loc = 0;	/* VOL DN COR */
-		o->hid_io_ctcss = 1;	/* VOL UP External CTCSS */
-		o->hid_io_ctcss_loc = 0;	/* VOL UP External CTCSS */
-		o->hid_io_ptt = 4;		/* GPIO 3 is PTT */
-		o->hid_gpio_loc = 1;	/* For ALL GPIO */
-		o->valid_gpios = 0xfb;	/* for GPIO 1,2,4,5,6,7,8 (5,6,7,8 for CM-119 only) */
-	} else if (o->hdwtype == 2) {	//NHRC (N1KDO) (dudeusb w/o user GPIO)
-		o->hid_gpio_ctl = 4;	/* set GPIO 3 to output mode */
-		o->hid_gpio_ctl_loc = 2;	/* For CTL of GPIO */
-		o->hid_io_cor = 2;		/* VOLD DN is COR */
-		o->hid_io_cor_loc = 0;	/* VOL DN COR */
-		o->hid_io_ctcss = 1;	/* VOL UP is External CTCSS */
-		o->hid_io_ctcss_loc = 0;	/* VOL UP CTCSS */
-		o->hid_io_ptt = 4;		/* GPIO 3 is PTT */
-		o->hid_gpio_loc = 1;	/* For ALL GPIO */
-		o->valid_gpios = 0;		/* for GPIO 1,2,4 */
-	} else if (o->hdwtype == 3) {	// custom version
-		o->hid_gpio_ctl = 0x0c;	/* set GPIO 3 & 4 to output mode */
-		o->hid_gpio_ctl_loc = 2;	/* For CTL of GPIO */
-		o->hid_io_cor = 2;		/* VOLD DN is COR */
-		o->hid_io_cor_loc = 0;	/* VOL DN COR */
-		o->hid_io_ctcss = 2;	/* GPIO 2 is External CTCSS */
-		o->hid_io_ctcss_loc = 1;	/* is GPIO 2 */
-		o->hid_io_ptt = 4;		/* GPIO 3 is PTT */
-		o->hid_gpio_loc = 1;	/* For ALL GPIO */
-		o->valid_gpios = 1;		/* for GPIO 1 */
+	if (o->hdwtype == 1) {		  // sphusb
+		o->hid_gpio_ctl = 0x08;	  /* set GPIO4 to output mode */
+		o->hid_gpio_ctl_loc = 2;  /* For CTL of GPIO */
+		o->hid_io_cor = 4;		  /* GPIO3 is COR */
+		o->hid_io_cor_loc = 1;	  /* GPIO3 is COR */
+		o->hid_io_ctcss = 2;	  /* GPIO 2 is External CTCSS */
+		o->hid_io_ctcss_loc = 1;  /* is GPIO 2 */
+		o->hid_io_ptt = 8;		  /* GPIO 4 is PTT */
+		o->hid_gpio_loc = 1;	  /* For ALL GPIO */
+		o->valid_gpios = 1;		  /* for GPIO 1 */
+	} else if (o->hdwtype == 0) { // dudeusb
+		o->hid_gpio_ctl = 4;	  /* set GPIO 3 to output mode */
+		o->hid_gpio_ctl_loc = 2;  /* For CTL of GPIO */
+		o->hid_io_cor = 2;		  /* VOLD DN is COR */
+		o->hid_io_cor_loc = 0;	  /* VOL DN COR */
+		o->hid_io_ctcss = 1;	  /* VOL UP External CTCSS */
+		o->hid_io_ctcss_loc = 0;  /* VOL UP External CTCSS */
+		o->hid_io_ptt = 4;		  /* GPIO 3 is PTT */
+		o->hid_gpio_loc = 1;	  /* For ALL GPIO */
+		o->valid_gpios = 0xfb;	  /* for GPIO 1,2,4,5,6,7,8 (5,6,7,8 for CM-119 only) */
+	} else if (o->hdwtype == 2) { // NHRC (N1KDO) (dudeusb w/o user GPIO)
+		o->hid_gpio_ctl = 4;	  /* set GPIO 3 to output mode */
+		o->hid_gpio_ctl_loc = 2;  /* For CTL of GPIO */
+		o->hid_io_cor = 2;		  /* VOLD DN is COR */
+		o->hid_io_cor_loc = 0;	  /* VOL DN COR */
+		o->hid_io_ctcss = 1;	  /* VOL UP is External CTCSS */
+		o->hid_io_ctcss_loc = 0;  /* VOL UP CTCSS */
+		o->hid_io_ptt = 4;		  /* GPIO 3 is PTT */
+		o->hid_gpio_loc = 1;	  /* For ALL GPIO */
+		o->valid_gpios = 0;		  /* for GPIO 1,2,4 */
+	} else if (o->hdwtype == 3) { // custom version
+		o->hid_gpio_ctl = 0x0c;	  /* set GPIO 3 & 4 to output mode */
+		o->hid_gpio_ctl_loc = 2;  /* For CTL of GPIO */
+		o->hid_io_cor = 2;		  /* VOLD DN is COR */
+		o->hid_io_cor_loc = 0;	  /* VOL DN COR */
+		o->hid_io_ctcss = 2;	  /* GPIO 2 is External CTCSS */
+		o->hid_io_ctcss_loc = 1;  /* is GPIO 2 */
+		o->hid_io_ptt = 4;		  /* GPIO 3 is PTT */
+		o->hid_gpio_loc = 1;	  /* For ALL GPIO */
+		o->valid_gpios = 1;		  /* for GPIO 1 */
 	}
 	/* validate clipledgpio setting (Clip LED GPIO#) */
 	if (o->clipledgpio) {
@@ -562,7 +565,7 @@ static int hidhdwconfig(struct chan_usbradio_pvt *o)
 			ast_log(LOG_ERROR, "Channel %s: clipledgpio = GPIO%d not supported\n", o->name, o->clipledgpio);
 			o->clipledgpio = 0;
 		} else {
-			o->hid_gpio_ctl |= 1 << (o->clipledgpio - 1);	/* confirm Clip LED GPIO set to output mode */
+			o->hid_gpio_ctl |= 1 << (o->clipledgpio - 1); /* confirm Clip LED GPIO set to output mode */
 		}
 	}
 	o->hid_gpio_val = 0;
@@ -582,11 +585,10 @@ static int hidhdwconfig(struct chan_usbradio_pvt *o)
 		}
 		/* skip if not a valid GPIO */
 		if (!(o->valid_gpios & (1 << i))) {
-			ast_log(LOG_ERROR, "Channel %s: You can't specify gpio%d, it is not valid in this configuration.\n",
-					o->name, i + 1);
+			ast_log(LOG_ERROR, "Channel %s: You can't specify gpio%d, it is not valid in this configuration.\n", o->name, i + 1);
 			continue;
 		}
-		o->hid_gpio_ctl |= (1 << i);	/* set this one to output, also */
+		o->hid_gpio_ctl |= (1 << i); /* set this one to output, also */
 		/* if default value is 1, set it */
 		if (!strcasecmp(o->gpios[i], "out1")) {
 			o->hid_gpio_val |= (1 << i);
@@ -632,7 +634,8 @@ static struct chan_usbradio_pvt *find_desc(const char *dev)
 {
 	struct chan_usbradio_pvt *o = NULL;
 
-	for (o = usbradio_default.next; o && o->name && dev && strcmp(o->name, dev) != 0; o = o->next);
+	for (o = usbradio_default.next; o && o->name && dev && strcmp(o->name, dev) != 0; o = o->next)
+		;
 	if (!o) {
 		ast_log(LOG_WARNING, "Cannot find USB descriptor <%s>.\n", dev ? dev : "-- Null Descriptor --");
 		return NULL;
@@ -654,7 +657,8 @@ static struct chan_usbradio_pvt *find_desc_usb(const char *devstr)
 		ast_log(LOG_WARNING, "USB Descriptor is null.\n");
 	}
 
-	for (o = usbradio_default.next; o && devstr && strcmp(o->devstr, devstr) != 0; o = o->next);
+	for (o = usbradio_default.next; o && devstr && strcmp(o->devstr, devstr) != 0; o = o->next)
+		;
 
 	return o;
 }
@@ -724,7 +728,7 @@ static void *pulserthread(void *arg)
 				pp_pulsemask |= 1 << (i - 2);
 			}
 		}
-		if (pp_pulsemask != pp_lastmask) {	/* if anything inverted (temporarily) */
+		if (pp_pulsemask != pp_lastmask) { /* if anything inverted (temporarily) */
 			pp_val ^= pp_lastmask ^ pp_pulsemask;
 			ast_radio_ppwrite(haspp, ppfd, pbase, pport, pp_val);
 		}
@@ -766,8 +770,7 @@ static int load_tune_config(struct chan_usbradio_pvt *o, const struct ast_config
 		struct ast_flags zeroflag = { 0 };
 		cfg2 = ast_config_load(CONFIG, zeroflag);
 		if (!cfg2) {
-			ast_log(LOG_WARNING, "Can't %sload settings for %s, using default parameters\n", reload ? "re" : "",
-					o->name);
+			ast_log(LOG_WARNING, "Can't %sload settings for %s, using default parameters\n", reload ? "re" : "", o->name);
 			return -1;
 		}
 		opened = 1;
@@ -791,14 +794,13 @@ static int load_tune_config(struct chan_usbradio_pvt *o, const struct ast_config
 	}
 	if (!reload) {
 		/* Using the ternary operator in CV_STR won't work, due to butchering the sizeof, so copy after if needed */
-		strcpy(o->devstr, devstr);	/* Safe */
+		strcpy(o->devstr, devstr); /* Safe */
 	}
 	if (opened) {
 		ast_config_destroy(cfg2);
 	}
 	if (!configured) {
-		ast_log(LOG_WARNING, "Can't %sload settings for %s (no section available), using default parameters\n",
-				reload ? "re" : "", o->name);
+		ast_log(LOG_WARNING, "Can't %sload settings for %s (no section available), using default parameters\n", reload ? "re" : "", o->name);
 		return -1;
 	}
 	return 0;
@@ -911,8 +913,7 @@ static void *hidthread(void *arg)
 				}
 				/* We found an unused device assign it to our node */
 				ast_copy_string(o->devstr, index_devstr, sizeof(o->devstr));
-				ast_log(LOG_NOTICE, "Channel %s: Automatically assigned USB device %s to USBRadio channel\n", o->name,
-						o->devstr);
+				ast_log(LOG_NOTICE, "Channel %s: Automatically assigned USB device %s to USBRadio channel\n", o->name, o->devstr);
 				break;
 			}
 			if (ast_strlen_zero(o->devstr)) {
@@ -949,8 +950,7 @@ static void *hidthread(void *arg)
 				}
 			}
 			if (ao) {
-				ast_log(LOG_ERROR, "Channel %s: Device string %s is already assigned to channel %s", o->name, s,
-						ao->name);
+				ast_log(LOG_ERROR, "Channel %s: Device string %s is already assigned to channel %s", o->name, s, ao->name);
 				ast_mutex_unlock(&usb_dev_lock);
 				usleep(500000);
 				continue;
@@ -964,8 +964,7 @@ static void *hidthread(void *arg)
 				break;
 		}
 		if (ao) {
-			ast_log(LOG_ERROR, "Channel %s: Device string %s is already assigned to channel %s", o->name, o->devstr,
-					ao->name);
+			ast_log(LOG_ERROR, "Channel %s: Device string %s is already assigned to channel %s", o->name, o->devstr, ao->name);
 			ast_mutex_unlock(&usb_dev_lock);
 			usleep(500000);
 			continue;
@@ -1130,20 +1129,16 @@ static void *hidthread(void *arg)
 			o->pmrChan->rxCtcss->relax = o->rxctcssrelax;
 			o->pmrChan->txTocType = o->txtoctype;
 
-			if ((o->txmixa == TX_OUT_LSD) ||
-				(o->txmixa == TX_OUT_COMPOSITE) || (o->txmixb == TX_OUT_LSD) || (o->txmixb == TX_OUT_COMPOSITE)) {
+			if ((o->txmixa == TX_OUT_LSD) || (o->txmixa == TX_OUT_COMPOSITE) || (o->txmixb == TX_OUT_LSD) || (o->txmixb == TX_OUT_COMPOSITE)) {
 				set_txctcss_level(o);
 			}
 
-			if ((o->txmixa != TX_OUT_VOICE) && (o->txmixb != TX_OUT_VOICE) &&
-				(o->txmixa != TX_OUT_COMPOSITE) && (o->txmixb != TX_OUT_COMPOSITE)
-				) {
+			if ((o->txmixa != TX_OUT_VOICE) && (o->txmixb != TX_OUT_VOICE) && (o->txmixa != TX_OUT_COMPOSITE) && (o->txmixb != TX_OUT_COMPOSITE)) {
 				ast_log(LOG_ERROR, "Channel %s: No txvoice output configured.\n", o->name);
 			}
 
-			if (o->txctcssfreq[0] &&
-				o->txmixa != TX_OUT_LSD && o->txmixa != TX_OUT_COMPOSITE &&
-				o->txmixb != TX_OUT_LSD && o->txmixb != TX_OUT_COMPOSITE) {
+			if (o->txctcssfreq[0] && o->txmixa != TX_OUT_LSD && o->txmixa != TX_OUT_COMPOSITE && o->txmixb != TX_OUT_LSD &&
+				o->txmixb != TX_OUT_COMPOSITE) {
 				ast_log(LOG_ERROR, "No txtone output configured.\n");
 			}
 
@@ -1162,7 +1157,6 @@ static void *hidthread(void *arg)
 
 		/* reload the settings from the tune file */
 		load_tune_config(o, NULL, 1);
-		
 
 		mixer_write(o);
 		mult_set(o);
@@ -1196,7 +1190,6 @@ static void *hidthread(void *arg)
 		 * the pttkick pipe.
 		 */
 		while ((!o->stophid) && o->hasusb) {
-
 			then = ast_radio_tvnow();
 			/* poll the pttkick pipe - timeout after 50 milliseconds */
 			res = ast_poll(rfds, 1, 50);
@@ -1216,7 +1209,7 @@ static void *hidthread(void *arg)
 			/* see if we need to process an eeprom read or write */
 			if (o->wanteeprom) {
 				ast_mutex_lock(&o->eepromlock);
-				if (o->eepromctl == 1) {	/* to read */
+				if (o->eepromctl == 1) { /* to read */
 					/* if CS okay */
 					if (!ast_radio_get_eeprom(usb_handle, o->eeprom)) {
 						if (o->eeprom[EEPROM_USER_MAGIC_ADDR] != EEPROM_MAGIC) {
@@ -1235,12 +1228,11 @@ static void *hidthread(void *arg)
 							set_txctcss_level(o);
 						}
 					} else {
-						ast_log(LOG_ERROR, "Channel %s: USB adapter has no EEPROM installed or Checksum is bad\n",
-								o->name);
+						ast_log(LOG_ERROR, "Channel %s: USB adapter has no EEPROM installed or Checksum is bad\n", o->name);
 					}
 					ast_radio_hid_set_outputs(usb_handle, bufsave);
 				}
-				if (o->eepromctl == 2) {	/* to write */
+				if (o->eepromctl == 2) { /* to write */
 					ast_radio_put_eeprom(usb_handle, o->eeprom);
 					ast_radio_hid_set_outputs(usb_handle, bufsave);
 					ast_log(LOG_NOTICE, "Channel %s: USB parameters written to EEPROM\n", o->name);
@@ -1268,7 +1260,7 @@ static void *hidthread(void *arg)
 			/* If this device is a CM108AH, map the "HOOK" bit (which used to
 			   be GPIO2 in the CM108 into the GPIO position */
 			if (o->devtype == C108AH_PRODUCT_ID) {
-				j |= 2;			/* set GPIO2 bit */
+				j |= 2; /* set GPIO2 bit */
 				/* if HOOK is asserted, clear GPIO bit */
 				if (buf[o->hid_io_cor_loc] & 0x10) {
 					j &= ~2;
@@ -1279,7 +1271,7 @@ static void *hidthread(void *arg)
 				if ((o->gpios[i]) && (!strcasecmp(o->gpios[i], "in")) && (o->valid_gpios & (1 << i))) {
 					continue;
 				}
-				j &= ~(1 << i);	/* clear the bit, since its not an input */
+				j &= ~(1 << i); /* clear the bit, since its not an input */
 			}
 			if ((!o->had_gpios_in) || (o->last_gpios_in != j)) {
 				char buf1[100];
@@ -1316,14 +1308,14 @@ static void *hidthread(void *arg)
 			/* process the parallel port GPIO */
 			if (haspp) {
 				ast_mutex_lock(&pp_lock);
-				j = k = ast_radio_ppread(haspp, ppfd, pbase, pport) ^ 0x80;	/* get PP input */
+				j = k = ast_radio_ppread(haspp, ppfd, pbase, pport) ^ 0x80; /* get PP input */
 				ast_mutex_unlock(&pp_lock);
 				for (i = 10; i <= 15; i++) {
 					/* if a valid input bit, dont clear it */
 					if ((o->pps[i]) && (!strcasecmp(o->pps[i], "in")) && (PP_MASK & (1 << i))) {
 						continue;
 					}
-					j &= ~(1 << ppinshift[i]);	/* clear the bit, since its not an input */
+					j &= ~(1 << ppinshift[i]); /* clear the bit, since its not an input */
 				}
 				if ((!o->had_pp_in) || (o->last_pp_in != j)) {
 					char buf1[100];
@@ -1360,13 +1352,13 @@ static void *hidthread(void *arg)
 				o->rxppsq = o->rxppctcss = 0;
 				for (i = 10; i <= 15; i++) {
 					if ((o->pps[i]) && (!strcasecmp(o->pps[i], "cor")) && (PP_MASK & (1 << i))) {
-						j = k & (1 << ppinshift[i]);	/* set the bit accordingly */
+						j = k & (1 << ppinshift[i]); /* set the bit accordingly */
 						if (j != o->rxppsq) {
 							ast_debug(2, "Channel %s: update rxppsq = %d\n", o->name, j);
 							o->rxppsq = j;
 						}
 					} else if ((o->pps[i]) && (!strcasecmp(o->pps[i], "ctcss")) && (PP_MASK & (1 << i))) {
-						o->rxppctcss = k & (1 << ppinshift[i]);	/* set the bit accordingly */
+						o->rxppctcss = k & (1 << ppinshift[i]); /* set the bit accordingly */
 					}
 				}
 			}
@@ -1387,7 +1379,7 @@ static void *hidthread(void *arg)
 					o->hid_gpio_pulsemask |= 1 << i;
 				}
 			}
-			if (o->hid_gpio_pulsemask || o->hid_gpio_lastmask) {	/* if anything inverted (temporarily) */
+			if (o->hid_gpio_pulsemask || o->hid_gpio_lastmask) { /* if anything inverted (temporarily) */
 				buf[o->hid_gpio_loc] = o->hid_gpio_val ^ o->hid_gpio_pulsemask;
 				buf[o->hid_gpio_ctl_loc] = o->hid_gpio_ctl;
 				ast_radio_hid_set_outputs(usb_handle, buf);
@@ -1412,7 +1404,7 @@ static void *hidthread(void *arg)
 					if (strncasecmp(o->pps[i], "ptt", 3)) {
 						continue;
 					}
-					k |= (1 << (i - 2));	/* make mask */
+					k |= (1 << (i - 2)); /* make mask */
 				}
 			}
 			if (o->lasttx != lasttxtmp) {
@@ -1498,8 +1490,8 @@ static int used_blocks(struct chan_usbradio_pvt *o)
 
 	/* Set the total blocks */
 	if (o->total_blocks == 0) {
-		ast_debug(1, "Channel %s: fragment total %d, size %d, available %d, bytes %d\n",
-				  o->name, info.fragstotal, info.fragsize, info.fragments, info.bytes);
+		ast_debug(1, "Channel %s: fragment total %d, size %d, available %d, bytes %d\n", o->name, info.fragstotal, info.fragsize,
+			info.fragments, info.bytes);
 		o->total_blocks = info.fragments;
 		/* Check the queue size, it cannot exceed the total fragments */
 		if (o->queuesize >= info.fragstotal) {
@@ -1532,7 +1524,7 @@ static int soundcard_writeframe(struct chan_usbradio_pvt *o, short *data)
 		setformat(o, O_RDWR);
 	}
 	if (o->sounddev < 0) {
-		return 0;				/* not fatal */
+		return 0; /* not fatal */
 	}
 	/*  This may or may not be a good thing
 	 *  drop the frame if not transmitting, this keeps from gradually
@@ -1548,14 +1540,14 @@ static int soundcard_writeframe(struct chan_usbradio_pvt *o, short *data)
 	 * a number of failures, to restart the output chain.
 	 */
 	res = used_blocks(o);
-	if (res > o->queuesize) {	/* no room to write a block */
+	if (res > o->queuesize) { /* no room to write a block */
 		/* Only report a buffer overflow when we are transmitting */
 		if (o->pmrChan->txPttIn || o->pmrChan->txPttOut) {
 			ast_log(LOG_WARNING, "Channel %s: Sound device write buffer overflow - used %d blocks\n", o->name, res);
 		}
 		return 0;
 	}
-	if (res == 0) {				/* We are not keeping the buffer full, add 1 frame */
+	if (res == 0) { /* We are not keeping the buffer full, add 1 frame */
 		memset(outbuf, 0, sizeof(outbuf));
 		res = write(o->sounddev, ((void *) outbuf), sizeof(outbuf));
 		if (res < 0) {
@@ -1596,7 +1588,7 @@ static int setformat(struct chan_usbradio_pvt *o, int mode)
 		o->duplex = M_UNSET;
 		o->sounddev = -1;
 	}
-	if (mode == O_CLOSE)		/* we are done */
+	if (mode == O_CLOSE) /* we are done */
 		return 0;
 
 	strcpy(device, "/dev/dsp");
@@ -1647,7 +1639,7 @@ static int setformat(struct chan_usbradio_pvt *o, int mode)
 		ast_log(LOG_WARNING, "Channel %s: Failed to set audio device to stereo\n", o->name);
 		return -1;
 	}
-	fmt = desired = 48000;		/* 48000 Hz desired */
+	fmt = desired = 48000; /* 48000 Hz desired */
 	res = ioctl(fd, SNDCTL_DSP_SPEED, &fmt);
 	if (res < 0) {
 		ast_log(LOG_WARNING, "Channel %s: Failed to set audio device sample rate.\n", o->name);
@@ -1655,8 +1647,7 @@ static int setformat(struct chan_usbradio_pvt *o, int mode)
 	}
 	if (fmt != desired) {
 		if (!(o->warned & WARN_speed)) {
-			ast_log(LOG_WARNING, "Channel %s: Requested %d Hz, got %d Hz -- sound may be choppy.\n", o->name, desired,
-					fmt);
+			ast_log(LOG_WARNING, "Channel %s: Requested %d Hz, got %d Hz -- sound may be choppy.\n", o->name, desired, fmt);
 			o->warned |= WARN_speed;
 		}
 	}
@@ -1721,7 +1712,7 @@ static int usbradio_text(struct ast_channel *c, const char *text)
 	char *cmd, pwr;
 	int cnt, i, j;
 	double tx, rx;
-#define STR_SZ 15				/* Size of text strings */
+#define STR_SZ 15 /* Size of text strings */
 	char rxs[STR_SZ + 1], txs[STR_SZ + 1], txpl[STR_SZ + 1], rxpl[STR_SZ + 1];
 
 #ifdef HAVE_SYS_IO
@@ -1735,9 +1726,7 @@ static int usbradio_text(struct ast_channel *c, const char *text)
 	/* print received messages */
 	ast_debug(3, "Channel %s: Console Received usbradio text %s >>\n", o->name, text);
 
-	cnt =
-		sscanf(text, "%s " S_FMT(STR_SZ) S_FMT(STR_SZ) S_FMT(STR_SZ) S_FMT(STR_SZ) "%c", cmd, rxs, txs, rxpl, txpl,
-			   &pwr);
+	cnt = sscanf(text, "%s " S_FMT(STR_SZ) S_FMT(STR_SZ) S_FMT(STR_SZ) S_FMT(STR_SZ) "%c", cmd, rxs, txs, rxpl, txpl, &pwr);
 
 	/* set channel on parallel port */
 	if (strcmp(cmd, "SETCHAN") == 0) {
@@ -1783,7 +1772,7 @@ static int usbradio_text(struct ast_channel *c, const char *text)
 			return 0;
 		}
 		ast_mutex_lock(&o->usblock);
-		if (j > 1) {			/* if to request pulse-age */
+		if (j > 1) { /* if to request pulse-age */
 			o->hid_gpio_pulsetimer[i] = j - 1;
 		} else {
 			/* clear pulsetimer, if in the middle of running */
@@ -1813,7 +1802,7 @@ static int usbradio_text(struct ast_channel *c, const char *text)
 			return 0;
 		}
 		ast_mutex_lock(&pp_lock);
-		if (j > 1) {			/* if to request pulse-age */
+		if (j > 1) { /* if to request pulse-age */
 			pp_pulsetimer[i] = j - 1;
 		} else {
 			/* clear pulsetimer, if in the middle of running */
@@ -1843,8 +1832,8 @@ static int usbradio_text(struct ast_channel *c, const char *text)
 		o->set_txfreq = round(tx * (double) 1000000);
 		o->set_rxfreq = round(rx * (double) 1000000);
 		o->pmrChan->txpower = (pwr == 'H');
-		strcpy(o->set_rxctcssfreqs, rxpl);	/* Safe */
-		strcpy(o->set_txctcssfreqs, txpl);	/* Safe */
+		strcpy(o->set_rxctcssfreqs, rxpl); /* Safe */
+		strcpy(o->set_txctcssfreqs, txpl); /* Safe */
 
 		o->remoted = 1;
 		xpmr_config(o);
@@ -1923,7 +1912,7 @@ static int usbradio_write(struct ast_channel *c, struct ast_frame *f)
 		setformat(o, O_RDWR);
 	}
 	if (o->sounddev < 0) {
-		return 0;				/* not fatal */
+		return 0; /* not fatal */
 	}
 	/*
 	 * we could receive a block which is not a multiple of our
@@ -2041,7 +2030,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	 * in stereo format.
 	 */
 	res = read(o->sounddev, o->usbradio_read_buf + o->readpos, sizeof(o->usbradio_read_buf) - o->readpos);
-	if (res < 0) {				/* Audio data not ready, return a NULL frame */
+	if (res < 0) { /* Audio data not ready, return a NULL frame */
 		if (errno != EAGAIN) {
 			o->readerrs = 0;
 			o->hasusb = 0;
@@ -2070,7 +2059,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 
 	o->readerrs = 0;
 	o->readpos += res;
-	if (o->readpos < sizeof(o->usbradio_read_buf)) {	/* not enough samples */
+	if (o->readpos < sizeof(o->usbradio_read_buf)) { /* not enough samples */
 		return &ast_null_frame;
 	}
 
@@ -2136,16 +2125,15 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	}
 	o->didpmrtx = 0;
 
-	PmrRx(o->pmrChan,
-		  (i16 *) (o->usbradio_read_buf + AST_FRIENDLY_OFFSET),
-		  (i16 *) (o->usbradio_read_buf_8k + AST_FRIENDLY_OFFSET), (i16 *) (o->usbradio_write_buf));
+	PmrRx(o->pmrChan, (i16 *) (o->usbradio_read_buf + AST_FRIENDLY_OFFSET),
+		(i16 *) (o->usbradio_read_buf_8k + AST_FRIENDLY_OFFSET), (i16 *) (o->usbradio_write_buf));
 
 	if (oldpttout != o->pmrChan->txPttOut) {
 		ast_debug(3, "Channel %s: txPttOut = %i.\n", o->name, o->pmrChan->txPttOut);
 		kickptt(o);
 	}
 
-#if 0							// to write 48KS/s stereo tx data to a file
+#if 0 // to write 48KS/s stereo tx data to a file
 	if (!ftxoutraw) {
 		ftxoutraw = fopen(TX_CAP_OUT_FILE, "w");
 	}
@@ -2154,7 +2142,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	}
 #endif
 
-#if DEBUG_CAPTURES == 1	&& XPMR_DEBUG0 == 1
+#if DEBUG_CAPTURES == 1 && XPMR_DEBUG0 == 1
 	if (o->txcap2 && ftxcaptrace) {
 		fwrite((o->pmrChan->ptxDebug), 1, FRAME_SIZE * 2 * 16, ftxcaptrace);
 	}
@@ -2232,10 +2220,8 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 		o->pmrChan->rxExtCarrierDetect = !o->rxhidsq;
 	}
 
-	if ((o->rxcdtype == CD_HID && o->rxhidsq) ||
-		(o->rxcdtype == CD_HID_INVERT && !o->rxhidsq) ||
-		(o->rxcdtype == CD_XPMR_NOISE && o->pmrChan->rxCarrierDetect) ||
-		(o->rxcdtype == CD_PP && o->rxppsq) ||
+	if ((o->rxcdtype == CD_HID && o->rxhidsq) || (o->rxcdtype == CD_HID_INVERT && !o->rxhidsq) ||
+		(o->rxcdtype == CD_XPMR_NOISE && o->pmrChan->rxCarrierDetect) || (o->rxcdtype == CD_PP && o->rxppsq) ||
 		(o->rxcdtype == CD_PP_INVERT && !o->rxppsq) || (o->rxcdtype == CD_XPMR_VOX && o->pmrChan->rxCarrierDetect)) {
 		if (!o->pmrChan->txPttOut || o->radioduplex) {
 			cd = 1;
@@ -2259,17 +2245,14 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	/* Check for SD - CTCSS active */
 #ifndef HAVE_XPMRX
 	if (!o->pmrChan->b.ctcssRxEnable ||
-		(o->pmrChan->b.ctcssRxEnable && o->pmrChan->rxCtcss->decode > CTCSS_NULL && o->pmrChan->smode == SMODE_CTCSS)
-		) {
+		(o->pmrChan->b.ctcssRxEnable && o->pmrChan->rxCtcss->decode > CTCSS_NULL && o->pmrChan->smode == SMODE_CTCSS)) {
 		sd = 1;
 	} else {
 		sd = 0;
 	}
 #else
 	if ((!o->pmrChan->b.ctcssRxEnable && !o->pmrChan->b.dcsRxEnable && !o->pmrChan->b.lmrRxEnable) ||
-		(o->pmrChan->b.ctcssRxEnable &&
-		 o->pmrChan->rxCtcss->decode > CTCSS_NULL &&
-		 o->pmrChan->smode == SMODE_CTCSS) ||
+		(o->pmrChan->b.ctcssRxEnable && o->pmrChan->rxCtcss->decode > CTCSS_NULL && o->pmrChan->smode == SMODE_CTCSS) ||
 		(o->pmrChan->b.dcsRxEnable && o->pmrChan->decDcs->decode > 0 && o->pmrChan->smode == SMODE_DCS)) {
 		sd = 1;
 	} else {
@@ -2288,9 +2271,8 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 		strcpy(o->rxctcssfreq, o->pmrChan->rxctcssfreq);
 	}
 
-	if ((o->pmrChan->rptnum > 0 && o->pmrChan->smode == SMODE_LSD
-		 && o->pmrChan->pLsdCtl->cs[o->pmrChan->rptnum].b.rxkeyed) || (o->pmrChan->smode == SMODE_DCS
-																	   && o->pmrChan->decDcs->decode > 0)) {
+	if ((o->pmrChan->rptnum > 0 && o->pmrChan->smode == SMODE_LSD && o->pmrChan->pLsdCtl->cs[o->pmrChan->rptnum].b.rxkeyed) ||
+		(o->pmrChan->smode == SMODE_DCS && o->pmrChan->decDcs->decode > 0)) {
 		sd = 1;
 	}
 #endif
@@ -2318,18 +2300,18 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	/* Timer for how long TX has been unkeyed - used with txoffdelay */
 	if (o->txoffdelay) {
 		if (o->txkeyed == 1) {
-			o->txoffcnt = 0;	/* If keyed, set this to zero. */
+			o->txoffcnt = 0; /* If keyed, set this to zero. */
 		} else {
 			o->txoffcnt++;
 			if (o->txoffcnt > 50000) {
-				o->txoffcnt = 20000;	/* Cap this timer at 20000 - 400 seconds */
+				o->txoffcnt = 20000; /* Cap this timer at 20000 - 400 seconds */
 			}
 		}
 	}
 
 	/* Check conditions and set receiver active */
 	if (cd && sd) {
-		//if(!o->rxkeyed)o->pmrChan->dd.b.doitnow=1;
+		// if(!o->rxkeyed)o->pmrChan->dd.b.doitnow=1;
 		if (!o->rxkeyed) {
 			ast_debug(3, "Channel %s: o->rxkeyed = 1.\n", o->name);
 		}
@@ -2339,7 +2321,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 			o->rxoncnt++;
 		}
 	} else {
-		//if(o->rxkeyed)o->pmrChan->dd.b.doitnow=1;
+		// if(o->rxkeyed)o->pmrChan->dd.b.doitnow=1;
 		if (o->rxkeyed) {
 			ast_debug(3, "Channel %s: o->rxkeyed = 0.\n", o->name);
 		}
@@ -2357,8 +2339,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 		ast_mutex_lock(&o->echolock);
 		x = 0;
 		/* get count of frames */
-		for (u = (struct usbecho *) o->echoq.q_forw;
-			 u != (struct usbecho *) &o->echoq; u = (struct usbecho *) u->q_forw)
+		for (u = (struct usbecho *) o->echoq.q_forw; u != (struct usbecho *) &o->echoq; u = (struct usbecho *) u->q_forw)
 			x++;
 		if (x < o->echomax) {
 			u = ast_calloc(1, sizeof(struct usbecho));
@@ -2432,8 +2413,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 			if (f1->frametype == AST_FRAME_DTMF_END) {
 				f1->len = ast_tvdiff_ms(ast_radio_tvnow(), o->tonetime);
 				if (option_verbose) {
-					ast_log(LOG_NOTICE, "Channel %s: Got DTMF char %c duration %ld ms\n", o->name, f1->subclass.integer,
-							f1->len);
+					ast_log(LOG_NOTICE, "Channel %s: Got DTMF char %c duration %ld ms\n", o->name, f1->subclass.integer, f1->len);
 				}
 				o->toneflag = 0;
 			} else {
@@ -2546,7 +2526,7 @@ static int usbradio_indicate(struct ast_channel *c, int cond_in, const void *dat
 		ast_debug(1, "Channel %s: ACRK code=%s TX ON.\n", o->name, (char *) data);
 		if (datalen && ((char *) (data))[0] != '0') {
 			o->forcetxcode = 1;
-			memset(o->set_txctcssfreq, 0, sizeof(o->set_txctcssfreq));	/* Possibly unnecessary, if this is used as a string? */
+			memset(o->set_txctcssfreq, 0, sizeof(o->set_txctcssfreq)); /* Possibly unnecessary, if this is used as a string? */
 			ast_copy_string(o->set_txctcssfreq, data, sizeof(o->set_txctcssfreq));
 			xpmr_config(o);
 		}
@@ -2627,7 +2607,7 @@ static int usbradio_setoption(struct ast_channel *chan, int option, void *data, 
  * \return 				Asterisk channel.
  */
 static struct ast_channel *usbradio_new(struct chan_usbradio_pvt *o, char *ext, char *ctx, int state,
-										const struct ast_assigned_ids *assignedids, const struct ast_channel *requestor)
+	const struct ast_assigned_ids *assignedids, const struct ast_channel *requestor)
 {
 	struct ast_channel *c;
 
@@ -2639,7 +2619,7 @@ static struct ast_channel *usbradio_new(struct chan_usbradio_pvt *o, char *ext, 
 	if ((o->sounddev < 0) && o->hasusb) {
 		setformat(o, O_RDWR);
 	}
-	ast_channel_internal_fd_set(c, 0, o->sounddev);	/* -1 if device closed, override later */
+	ast_channel_internal_fd_set(c, 0, o->sounddev); /* -1 if device closed, override later */
 	ast_channel_nativeformats_set(c, usbradio_tech.capabilities);
 	ast_channel_set_readformat(c, ast_format_slin);
 	ast_channel_set_writeformat(c, ast_format_slin);
@@ -2675,8 +2655,7 @@ static struct ast_channel *usbradio_new(struct chan_usbradio_pvt *o, char *ext, 
  * \return				ast_channel if successful
  */
 static struct ast_channel *usbradio_request(const char *type, struct ast_format_cap *cap,
-											const struct ast_assigned_ids *assignedids,
-											const struct ast_channel *requestor, const char *data, int *cause)
+	const struct ast_assigned_ids *assignedids, const struct ast_channel *requestor, const char *data, int *cause)
 {
 	struct ast_channel *c;
 	struct chan_usbradio_pvt *o = find_desc(data);
@@ -2688,8 +2667,8 @@ static struct ast_channel *usbradio_request(const char *type, struct ast_format_
 
 	if (!(ast_format_cap_iscompatible(cap, usbradio_tech.capabilities))) {
 		struct ast_str *cap_buf = ast_str_alloca(AST_FORMAT_CAP_NAMES_LEN);
-		ast_log(LOG_NOTICE, "Channel %s: Channel requested with unsupported format(s): '%s'\n",
-				o->name, ast_format_cap_get_names(cap, &cap_buf));
+		ast_log(LOG_NOTICE, "Channel %s: Channel requested with unsupported format(s): '%s'\n", o->name,
+			ast_format_cap_get_names(cap, &cap_buf));
 		return NULL;
 	}
 
@@ -2766,8 +2745,7 @@ static int radio_active(int fd, int argc, const char *const *argv)
 		if (!strcmp(argv[2], "show")) {
 			ast_mutex_lock(&usb_dev_lock);
 			for (o = usbradio_default.next; o; o = o->next) {
-				ast_cli(fd, "Device [%s] exists as device=%s card=%d\n", o->name, o->devstr,
-						ast_radio_usb_get_usbdev(o->devstr));
+				ast_cli(fd, "Device [%s] exists as device=%s card=%d\n", o->name, o->devstr, ast_radio_usb_get_usbdev(o->devstr));
 			}
 			ast_mutex_unlock(&usb_dev_lock);
 			return RESULT_SUCCESS;
@@ -2839,7 +2817,7 @@ static int usb_device_swap(int fd, const char *other)
  */
 static void tune_flash(int fd, struct chan_usbradio_pvt *o, int intflag)
 {
-#define	NFLASH 3
+#define NFLASH 3
 
 	int i;
 
@@ -2849,7 +2827,7 @@ static void tune_flash(int fd, struct chan_usbradio_pvt *o, int intflag)
 	for (i = 0; i < NFLASH; i++) {
 		o->txtestkey = 1;
 		o->pmrChan->txPttIn = 1;
-		TxTestTone(o->pmrChan, 1);	// generate 1KHz tone at 7200 peak
+		TxTestTone(o->pmrChan, 1); // generate 1KHz tone at 7200 peak
 		if ((fd > 0) && intflag) {
 			if (ast_radio_wait_or_poll(fd, 1000, intflag)) {
 				o->pmrChan->txPttIn = 0;
@@ -2933,8 +2911,8 @@ static int radio_tune(int fd, int argc, const char *const *argv)
 		if (argc == 3) {
 			ast_cli(fd, "Current Signal Strength is %d\n", ((32767 - o->pmrChan->rxRssi) * 1000 / 32767));
 			ast_cli(fd, "Current Squelch setting is %d\n", o->rxsquelchadj);
-			//ast_cli(fd,"Current Raw RSSI        is %d\n",o->pmrChan->rxRssi);
-			//ast_cli(fd,"Current (real) Squelch setting is %d\n",*(o->pmrChan->prxSquelchAdjust));
+			// ast_cli(fd,"Current Raw RSSI        is %d\n",o->pmrChan->rxRssi);
+			// ast_cli(fd,"Current (real) Squelch setting is %d\n",*(o->pmrChan->prxSquelchAdjust));
 		} else {
 			i = atoi(argv[3]);
 			if ((i < 0) || (i > 999)) {
@@ -2955,9 +2933,7 @@ static int radio_tune(int fd, int argc, const char *const *argv)
 	} else if (!strcasecmp(argv[2], "txvoice")) {
 		i = 0;
 
-		if ((o->txmixa != TX_OUT_VOICE) && (o->txmixb != TX_OUT_VOICE) &&
-			(o->txmixa != TX_OUT_COMPOSITE) && (o->txmixb != TX_OUT_COMPOSITE)
-			) {
+		if ((o->txmixa != TX_OUT_VOICE) && (o->txmixb != TX_OUT_VOICE) && (o->txmixa != TX_OUT_COMPOSITE) && (o->txmixb != TX_OUT_COMPOSITE)) {
 			ast_log(LOG_ERROR, "No txvoice output configured.\n");
 		} else if (argc == 3) {
 			if ((o->txmixa == TX_OUT_VOICE) || (o->txmixa == TX_OUT_COMPOSITE))
@@ -2987,8 +2963,7 @@ static int radio_tune(int fd, int argc, const char *const *argv)
 	} else if (!strcasecmp(argv[2], "txall")) {
 		i = 0;
 
-		if ((o->txmixa != TX_OUT_VOICE) && (o->txmixb != TX_OUT_VOICE) &&
-			(o->txmixa != TX_OUT_COMPOSITE) && (o->txmixb != TX_OUT_COMPOSITE)) {
+		if ((o->txmixa != TX_OUT_VOICE) && (o->txmixb != TX_OUT_VOICE) && (o->txmixa != TX_OUT_COMPOSITE) && (o->txmixb != TX_OUT_COMPOSITE)) {
 			ast_log(LOG_ERROR, "No txvoice output configured.\n");
 		} else if (argc == 3) {
 			if ((o->txmixa == TX_OUT_VOICE) || (o->txmixa == TX_OUT_COMPOSITE)) {
@@ -3039,7 +3014,7 @@ static int radio_tune(int fd, int argc, const char *const *argv)
 			mixer_write(o);
 			mult_set(o);
 		}
-		//tune_auxoutput(o,i);
+		// tune_auxoutput(o,i);
 	} else if (!strcasecmp(argv[2], "txtone")) {
 		if (argc == 3) {
 			ast_cli(fd, "Current Tx CTCSS modulation setting = %d\n", o->txctcssadj);
@@ -3117,7 +3092,7 @@ static int radio_tune(int fd, int argc, const char *const *argv)
 			usleep(10000);
 			ast_mutex_lock(&o->eepromlock);
 		}
-		o->eepromctl = 1;		/* request a load */
+		o->eepromctl = 1; /* request a load */
 		ast_mutex_unlock(&o->eepromlock);
 
 		ast_cli(fd, "Requesting loading of tuning settings from EEPROM for channel %s\n", o->name);
@@ -3154,17 +3129,17 @@ static int set_txctcss_level(struct chan_usbradio_pvt *o)
 	int adjustment;
 
 	if (o->txmixa == TX_OUT_LSD) {
-//      o->txmixaset=(151*o->txctcssadj) / 1000;
+		//      o->txmixaset=(151*o->txctcssadj) / 1000;
 		o->txmixaset = o->txctcssadj;
 		mixer_write(o);
 		mult_set(o);
 	} else if (o->txmixb == TX_OUT_LSD) {
-//      o->txmixbset=(151*o->txctcssadj) / 1000;
+		//      o->txmixbset=(151*o->txctcssadj) / 1000;
 		o->txmixbset = o->txctcssadj;
 		mixer_write(o);
 		mult_set(o);
 	} else {
-		if (o->pmrChan->ptxCtcssAdjust) {	/* Ignore if ptr not defined */
+		if (o->pmrChan->ptxCtcssAdjust) { /* Ignore if ptr not defined */
 			/* adjust settings based on the device */
 			switch (o->devtype) {
 			case C119B_PRODUCT_ID:
@@ -3182,8 +3157,8 @@ static int set_txctcss_level(struct chan_usbradio_pvt *o)
 /*!
  * \brief Set transmit soft limiting threshold.
  * Modifies the set point in xpmr where soft limiting starts to take place.
- * 
- * 
+ *
+ *
  * \param o				chan_usbradio structure.
  * \param setpoint      A value which indicates the onset of soft limiting.
  * \return			    zero if successful, -1 if otherwise
@@ -3191,14 +3166,11 @@ static int set_txctcss_level(struct chan_usbradio_pvt *o)
 
 static int xpmr_set_tx_soft_limiter(struct chan_usbradio_pvt *o, int setpoint)
 {
-
-	
 	/* Check for a valid pmrChan has to be done here. Data structures in xpmr are all dynamic. */
-	
+
 	if (o->pmrChan) {
 		return SetTxSoftLimiterSetpoint(o->pmrChan, setpoint);
-	}
-	else {
+	} else {
 		/* Not initialized yet */
 		ast_debug(3, "Attempt to set soft limiter value before xpmr is initialized, request ignored\n");
 		return -1;
@@ -3400,7 +3372,7 @@ static void tune_txoutput(struct chan_usbradio_pvt *o, int value, int fd, int in
 {
 	o->txtestkey = 1;
 	o->pmrChan->txPttIn = 1;
-	TxTestTone(o->pmrChan, 1);	// generate 1KHz tone at 7200 peak
+	TxTestTone(o->pmrChan, 1); // generate 1KHz tone at 7200 peak
 	if (fd > 0) {
 		ast_cli(fd, "Tone output starting on channel %s...\n", o->name);
 		if (ast_radio_wait_or_poll(fd, 5000, intflag)) {
@@ -3521,8 +3493,7 @@ static void tune_rxinput(int fd, struct chan_usbradio_pvt *o, int setsql, int in
 		return;
 	}
 
-	ast_cli(fd, "DONE tries=%i, setting=%i, meas=%i, sqnoise=%i\n", tries,
-			((setting * 1000) + (o->micmax / 2)) / o->micmax, meas, measnoise);
+	ast_cli(fd, "DONE tries=%i, setting=%i, meas=%i, sqnoise=%i\n", tries, ((setting * 1000) + (o->micmax / 2)) / o->micmax, meas, measnoise);
 
 	if (meas < (target - tolerance) || meas > (target + tolerance)) {
 		ast_cli(fd, "ERROR: RX INPUT ADJUST FAILED.\n");
@@ -3653,15 +3624,13 @@ static void tune_rxtx_status(int fd, struct chan_usbradio_pvt *o)
 		if (ast_radio_poll_input(fd, 200)) {
 			break;
 		}
-		ast_cli(fd, " %s  | %s  | %s | %s\r",
-				o->rxcdtype ? (o->rx_cos_active ? "Keyed" : "Clear") : "Off  ",
-				o->rxsdtype ? (o->rx_ctcss_active ? "Keyed" : "Clear") : "Off  ",
-				o->rxkeyed ? "Keyed" : "Clear", (o->txkeyed || o->txtestkey) ? "Keyed" : "Clear");
+		ast_cli(fd, " %s  | %s  | %s | %s\r", o->rxcdtype ? (o->rx_cos_active ? "Keyed" : "Clear") : "Off  ",
+			o->rxsdtype ? (o->rx_ctcss_active ? "Keyed" : "Clear") : "Off  ", o->rxkeyed ? "Keyed" : "Clear",
+			(o->txkeyed || o->txtestkey) ? "Keyed" : "Clear");
 	}
 
 	option_verbose = wasverbose;
 }
-
 
 /*!
  * \brief Set received voice level.
@@ -3702,7 +3671,7 @@ static void _menu_rxvoice(int fd, struct chan_usbradio_pvt *o, const char *str)
 			adjustment = o->rxmixerset * o->micmax / C119B_ADJUSTMENT;
 			/* get interval step size */
 			f = C119B_ADJUSTMENT / (float) o->micmax;
-			o->rxboost = 1;		/*rxboost is always set for this device */
+			o->rxboost = 1; /*rxboost is always set for this device */
 			break;
 		default:
 			adjustment = o->rxmixerset * o->micmax / 1000;
@@ -3816,8 +3785,7 @@ static void _menu_txvoice(int fd, struct chan_usbradio_pvt *o, const char *cstr)
 	const char *str = cstr;
 	int i, j, x, dokey, withctcss;
 
-	if ((o->txmixa != TX_OUT_VOICE) && (o->txmixb != TX_OUT_VOICE) &&
-		(o->txmixa != TX_OUT_COMPOSITE) && (o->txmixb != TX_OUT_COMPOSITE)) {
+	if ((o->txmixa != TX_OUT_VOICE) && (o->txmixb != TX_OUT_VOICE) && (o->txmixa != TX_OUT_COMPOSITE) && (o->txmixb != TX_OUT_COMPOSITE)) {
 		ast_cli(fd, "Error, No txvoice output configured.\n");
 		return;
 	}
@@ -4018,38 +3986,31 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 		flatrx = 1;
 	}
 	txhasctcss = 0;
-	if ((o->txmixa == TX_OUT_LSD) || (o->txmixa == TX_OUT_COMPOSITE) ||
-		(o->txmixb == TX_OUT_LSD) || (o->txmixb == TX_OUT_COMPOSITE)) {
+	if ((o->txmixa == TX_OUT_LSD) || (o->txmixa == TX_OUT_COMPOSITE) || (o->txmixb == TX_OUT_LSD) || (o->txmixb == TX_OUT_COMPOSITE)) {
 		txhasctcss = 1;
 	}
 	switch (cmd[0]) {
-	case '0':					/* return audio processing configuration */
+	case '0': /* return audio processing configuration */
 		/* note: to maintain backward compatibility for those expecting a specific # of
 		   values to be returned (and in a specific order).  So, we only add to the end
 		   of the returned list.  Also, once an update has been released we can't change
 		   the format/content of any previously returned string */
-		if (!strcmp(cmd, "0+10")) {	/* With o->txslimsp tx soft limiter set point */
-			ast_cli(fd, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%f,%d,%d,%d,%d,%d,%d,%d,%d\n",
-					flatrx, txhasctcss, o->echomode, o->rxboost, o->txboost,
-					o->rxcdtype, o->rxsdtype, o->rxondelay, o->txoffdelay,
-					o->txprelim, o->txlimonly, o->rxdemod, o->txmixa, o->txmixb,
-					o->rxmixerset, o->rxvoiceadj, o->rxsquelchadj, o->txmixaset,
-					o->txmixbset, o->txctcssadj, o->micplaymax, o->spkrmax, o->micmax, o->txslimsp);
+		if (!strcmp(cmd, "0+10")) { /* With o->txslimsp tx soft limiter set point */
+			ast_cli(fd, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%f,%d,%d,%d,%d,%d,%d,%d,%d\n", flatrx, txhasctcss,
+				o->echomode, o->rxboost, o->txboost, o->rxcdtype, o->rxsdtype, o->rxondelay, o->txoffdelay, o->txprelim,
+				o->txlimonly, o->rxdemod, o->txmixa, o->txmixb, o->rxmixerset, o->rxvoiceadj, o->rxsquelchadj, o->txmixaset,
+				o->txmixbset, o->txctcssadj, o->micplaymax, o->spkrmax, o->micmax, o->txslimsp);
 		} else if (!strcmp(cmd, "0+9")) {
-			ast_cli(fd, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%f,%d,%d,%d,%d,%d,%d,%d\n",
-					flatrx, txhasctcss, o->echomode, o->rxboost, o->txboost,
-					o->rxcdtype, o->rxsdtype, o->rxondelay, o->txoffdelay,
-					o->txprelim, o->txlimonly, o->rxdemod, o->txmixa, o->txmixb,
-					o->rxmixerset, o->rxvoiceadj, o->rxsquelchadj, o->txmixaset,
-					o->txmixbset, o->txctcssadj, o->micplaymax, o->spkrmax, o->micmax);
+			ast_cli(fd, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%f,%d,%d,%d,%d,%d,%d,%d\n", flatrx, txhasctcss, o->echomode,
+				o->rxboost, o->txboost, o->rxcdtype, o->rxsdtype, o->rxondelay, o->txoffdelay, o->txprelim, o->txlimonly,
+				o->rxdemod, o->txmixa, o->txmixb, o->rxmixerset, o->rxvoiceadj, o->rxsquelchadj, o->txmixaset, o->txmixbset,
+				o->txctcssadj, o->micplaymax, o->spkrmax, o->micmax);
 		} else {
-			ast_cli(fd, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
-					flatrx, txhasctcss, o->echomode, o->rxboost, o->txboost,
-					o->rxcdtype, o->rxsdtype, o->rxondelay, o->txoffdelay,
-					o->txprelim, o->txlimonly, o->rxdemod, o->txmixa, o->txmixb);
+			ast_cli(fd, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n", flatrx, txhasctcss, o->echomode, o->rxboost, o->txboost,
+				o->rxcdtype, o->rxsdtype, o->rxondelay, o->txoffdelay, o->txprelim, o->txlimonly, o->rxdemod, o->txmixa, o->txmixb);
 		}
 		break;
-	case '1':					/* return usb device name list */
+	case '1': /* return usb device name list */
 		for (x = 0, oy = usbradio_default.next; oy && oy->name; oy = oy->next, x++) {
 			if (x) {
 				ast_cli(fd, ",");
@@ -4058,10 +4019,10 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 		}
 		ast_cli(fd, "\n");
 		break;
-	case '2':					/* print parameters */
+	case '2': /* print parameters */
 		_menu_print(fd, o);
 		break;
-	case '3':					/* return usb device name list except current */
+	case '3': /* return usb device name list except current */
 		for (x = 0, oy = usbradio_default.next; oy && oy->name; oy = oy->next) {
 			if (!strcmp(oy->name, o->name)) {
 				continue;
@@ -4074,74 +4035,74 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 		}
 		ast_cli(fd, "\n");
 		break;
-	case 'a':					/* receive tune */
+	case 'a': /* receive tune */
 		if (!o->hasusb) {
 			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
 		}
 		tune_rxinput(fd, o, 1, 1);
 		break;
-	case 'b':					/* receive tune display */
+	case 'b': /* receive tune display */
 		if (!o->hasusb) {
 			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
 		}
 		tune_rxdisplay(fd, o);
 		break;
-	case 'c':					/* set receive voice level */
+	case 'c': /* set receive voice level */
 		if (!o->hasusb) {
 			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
 		}
 		_menu_rxvoice(fd, o, cmd + 1);
 		break;
-	case 'd':					/* set receive ctcss level */
+	case 'd': /* set receive ctcss level */
 		if (!o->hasusb) {
 			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
 		}
 		tune_rxctcss(fd, o, 1);
 		break;
-	case 'e':					/* set squelch level */
+	case 'e': /* set squelch level */
 		if (!o->hasusb) {
 			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
 		}
 		_menu_rxsquelch(fd, o, cmd + 1);
 		break;
-	case 'f':					/* set voice transmit level */
+	case 'f': /* set voice transmit level */
 		if (!o->hasusb) {
 			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
 		}
 		_menu_txvoice(fd, o, cmd + 1);
 		break;
-	case 'g':					/* set aux transmit level */
+	case 'g': /* set aux transmit level */
 		if (!o->hasusb) {
 			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
 		}
 		_menu_auxvoice(fd, o, cmd + 1);
 		break;
-	case 'h':					/* transmit a test tone */
+	case 'h': /* transmit a test tone */
 		if (!o->hasusb) {
 			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
 		}
 		_menu_txtone(fd, o, cmd + 1);
 		break;
-	case 'i':					/* tune receive level */
+	case 'i': /* tune receive level */
 		if (!o->hasusb) {
 			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
 		}
 		tune_rxvoice(fd, o, 1);
 		break;
-	case 'j':					/* save tune settings */
+	case 'j': /* save tune settings */
 		tune_write(o);
 		ast_cli(fd, "Saved radio tuning settings to usbradio.conf\n");
 		break;
-	case 'k':					/* change echo mode */
+	case 'k': /* change echo mode */
 		if (cmd[1]) {
 			if (cmd[1] > '0') {
 				o->echomode = 1;
@@ -4153,7 +4114,7 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 			ast_cli(fd, "Echo Mode is currently %s\n", (o->echomode) ? "Enabled" : "Disabled");
 		}
 		break;
-	case 'l':					/* transmit test tone */
+	case 'l': /* transmit test tone */
 		if (!o->hasusb) {
 			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
@@ -4161,7 +4122,7 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 		tune_flash(fd, o, 1);
 		break;
 
-	case 'L':					/* Set TX soft limiter when operating with preemphasized and limited tx audio */
+	case 'L': /* Set TX soft limiter when operating with preemphasized and limited tx audio */
 		if (cmd[1]) {
 			int setpoint = atoi(cmd + 1);
 			if (xpmr_set_tx_soft_limiter(o, setpoint)) {
@@ -4170,14 +4131,14 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 			} else {
 				o->txslimsp = setpoint;
 			}
-				
+
 			ast_cli(fd, "TX soft limiting setpoint changed to %i\n", setpoint);
 		} else {
 			ast_cli(fd, "TX soft limiting setpoint currently set to: %i\n", o->txslimsp);
 		}
 		break;
 
-	case 'm':					/* change rxboost */
+	case 'm': /* change rxboost */
 		if (cmd[1]) {
 			if (cmd[1] > '0') {
 				o->rxboost = 1;
@@ -4189,7 +4150,7 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 			ast_cli(fd, "RxBoost is currently %s\n", (o->rxboost) ? "Enabled" : "Disabled");
 		}
 		break;
-	case 'n':					/* change txboost */
+	case 'n': /* change txboost */
 		if (cmd[1]) {
 			if (cmd[1] > '0') {
 				o->txboost = 1;
@@ -4201,7 +4162,7 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 			ast_cli(fd, "TxBoost is currently %s\n", (o->txboost) ? "Enabled" : "Disabled");
 		}
 		break;
-	case 'o':					/* change carrier from */
+	case 'o': /* change carrier from */
 		if (cmd[1]) {
 			o->rxcdtype = atoi(&cmd[1]);
 			ast_cli(fd, "Carrier From changed to %s\n", cd_signal_type[o->rxcdtype]);
@@ -4209,7 +4170,7 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 			ast_cli(fd, "Carrier From is currently %s\n", cd_signal_type[o->rxcdtype]);
 		}
 		break;
-	case 'p':					/* change ctcss from */
+	case 'p': /* change ctcss from */
 		if (cmd[1]) {
 			o->rxsdtype = atoi(&cmd[1]);
 			ast_cli(fd, "CTCSS From changed to %s\n", sd_signal_type[o->rxsdtype]);
@@ -4217,7 +4178,7 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 			ast_cli(fd, "CTCSS From is currently %s\n", sd_signal_type[o->rxsdtype]);
 		}
 		break;
-	case 'q':					/* change rx on delay */
+	case 'q': /* change rx on delay */
 		if (cmd[1]) {
 			o->rxondelay = atoi(&cmd[1]);
 			ast_cli(fd, "RX On Delay From changed to %d\n", o->rxondelay);
@@ -4225,7 +4186,7 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 			ast_cli(fd, "RX On Delay is currently %d\n", o->rxondelay);
 		}
 		break;
-	case 'r':					/* change tx off delay */
+	case 'r': /* change tx off delay */
 		if (cmd[1]) {
 			o->txoffdelay = atoi(&cmd[1]);
 			ast_cli(fd, "TX Off Delay From changed to %d\n", o->txoffdelay);
@@ -4233,7 +4194,7 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 			ast_cli(fd, "TX Off Delay is currently %d\n", o->txoffdelay);
 		}
 		break;
-	case 's':					/* change txprelim */
+	case 's': /* change txprelim */
 		if (cmd[1]) {
 			if (cmd[1] > '0') {
 				o->txprelim = 1;
@@ -4245,7 +4206,7 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 			ast_cli(fd, "TxPrelim is currently %s\n", (o->txprelim) ? "Enabled" : "Disabled");
 		}
 		break;
-	case 't':					/* change txlimonly */
+	case 't': /* change txlimonly */
 		if (cmd[1]) {
 			if (cmd[1] > '0') {
 				o->txlimonly = 1;
@@ -4257,7 +4218,7 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 			ast_cli(fd, "TxLimonly is currently %s\n", (o->txlimonly) ? "Enabled" : "Disabled");
 		}
 		break;
-	case 'u':					/* change rxdemod */
+	case 'u': /* change rxdemod */
 		if (cmd[1]) {
 			o->rxdemod = atoi(&cmd[1]);
 			ast_cli(fd, "RX Demodulation changed to %d\n", o->rxdemod);
@@ -4265,14 +4226,14 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 			ast_cli(fd, "RX Demodulation is currently %d\n", o->rxdemod);
 		}
 		break;
-	case 'v':					/* receiver/transmitter status display */
+	case 'v': /* receiver/transmitter status display */
 		if (!o->hasusb) {
 			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
 		}
 		tune_rxtx_status(fd, o);
 		break;
-	case 'w':					/* change txmixa */
+	case 'w': /* change txmixa */
 		if (cmd[1]) {
 			o->txmixa = atoi(&cmd[1]);
 			ast_cli(fd, "TX Mixer A changed to %d\n", o->txmixa);
@@ -4280,7 +4241,7 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 			ast_cli(fd, "TX Mixer A is currently %d\n", o->txmixa);
 		}
 		break;
-	case 'x':					/* change txmixb */
+	case 'x': /* change txmixb */
 		if (cmd[1]) {
 			o->txmixb = atoi(&cmd[1]);
 			ast_cli(fd, "TX Mixer B changed to %d\n", o->txmixb);
@@ -4288,8 +4249,8 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 			ast_cli(fd, "TX Mixer B is currently %d\n", o->txmixb);
 		}
 		break;
-	case 'y':					/* display receive audio statistics (interactive) */
-	case 'Y':					/* display receive audio statistics (once only) */
+	case 'y': /* display receive audio statistics (interactive) */
+	case 'Y': /* display receive audio statistics (once only) */
 		if (!o->hasusb) {
 			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
@@ -4305,7 +4266,6 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 		}
 		break;
 
-			
 	default:
 		ast_cli(fd, "Invalid Command\n");
 		break;
@@ -4322,8 +4282,8 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
  */
 static void tune_rxvoice(int fd, struct chan_usbradio_pvt *o, int intflag)
 {
-	const int target = 7200;	// peak
-	const int tolerance = 360;	// peak to peak
+	const int target = 7200;   // peak
+	const int tolerance = 360; // peak to peak
 	const float settingmin = 0.1;
 	const float settingmax = 5;
 	const float settingstart = 1;
@@ -4401,7 +4361,7 @@ static void tune_rxvoice(int fd, struct chan_usbradio_pvt *o, int intflag)
  */
 static void tune_rxctcss(int fd, struct chan_usbradio_pvt *o, int intflag)
 {
-	const int target = 2400;	// was 4096 pre 20080205
+	const int target = 2400; // was 4096 pre 20080205
 	const int tolerance = 100;
 	const float settingmin = 0.1;
 	const float settingmax = 8;
@@ -4476,12 +4436,10 @@ static void tune_rxctcss(int fd, struct chan_usbradio_pvt *o, int intflag)
 		normRssi = ((32767 - o->pmrChan->rxRssi) * adjustment / 32767);
 
 		if (o->rxsquelchadj > normRssi) {
-			ast_cli(fd, "WARNING: RSSI=%i SQUELCH=%i and is too tight. Use 'radio tune rxsquelch'.\n", normRssi,
-					o->rxsquelchadj);
+			ast_cli(fd, "WARNING: RSSI=%i SQUELCH=%i and is too tight. Use 'radio tune rxsquelch'.\n", normRssi, o->rxsquelchadj);
 		} else {
 			ast_cli(fd, "INFO: RX RSSI=%i\n", normRssi);
 		}
-
 	}
 	o->pmrChan->b.tuning = 0;
 }
@@ -4495,8 +4453,7 @@ static void tune_rxctcss(int fd, struct chan_usbradio_pvt *o, int intflag)
  * \retval 0		If successful.
  * \retval -1		If unsuccessful.
  */
-static int tune_variable_update(const char *filename, struct ast_category *category,
-								const char *variable, const char *value)
+static int tune_variable_update(const char *filename, struct ast_category *category, const char *variable, const char *value)
 {
 	int res;
 	struct ast_variable *var;
@@ -4540,32 +4497,33 @@ static void tune_write(struct chan_usbradio_pvt *o)
 		ast_log(LOG_WARNING, "Failed to update %s\n", #field); \
 	}
 
-#define CONFIG_UPDATE_INT(field) { \
-	char _buf[15]; \
-	snprintf(_buf, sizeof(_buf), "%d", o->field); \
-	if (tune_variable_update(CONFIG, category, #field, _buf)) { \
-		ast_log(LOG_WARNING, "Failed to update %s\n", #field); \
-	} \
-}
+#define CONFIG_UPDATE_INT(field) \
+	{ \
+		char _buf[15]; \
+		snprintf(_buf, sizeof(_buf), "%d", o->field); \
+		if (tune_variable_update(CONFIG, category, #field, _buf)) { \
+			ast_log(LOG_WARNING, "Failed to update %s\n", #field); \
+		} \
+	}
 
 #define CONFIG_UPDATE_BOOL(field) \
 	if (tune_variable_update(CONFIG, category, #field, o->field ? "yes" : "no")) { \
 		ast_log(LOG_WARNING, "Failed to update %s\n", #field); \
 	}
 
-#define CONFIG_UPDATE_FLOAT(field) { \
-	char _buf[15]; \
-	snprintf(_buf, sizeof(_buf), "%f", o->field); \
-	if (tune_variable_update(CONFIG, category, #field, _buf)) { \
-		ast_log(LOG_WARNING, "Failed to update %s\n", #field); \
-	} \
-}
+#define CONFIG_UPDATE_FLOAT(field) \
+	{ \
+		char _buf[15]; \
+		snprintf(_buf, sizeof(_buf), "%f", o->field); \
+		if (tune_variable_update(CONFIG, category, #field, _buf)) { \
+			ast_log(LOG_WARNING, "Failed to update %s\n", #field); \
+		} \
+	}
 
 #define CONFIG_UPDATE_SIGNAL(key, field, signal_type) \
 	if (tune_variable_update(CONFIG, category, #key, signal_type[o->field])) { \
 		ast_log(LOG_WARNING, "Failed to update %s\n", #field); \
 	}
-
 
 	category = ast_category_get(cfg, o->name, NULL);
 	if (!category) {
@@ -4619,7 +4577,7 @@ static void tune_write(struct chan_usbradio_pvt *o)
 		memcpy(&o->eeprom[EEPROM_USER_RXCTCSSADJ], &o->rxctcssadj, sizeof(float));
 		o->eeprom[EEPROM_USER_TXCTCSSADJ] = o->txctcssadj;
 		o->eeprom[EEPROM_USER_RXSQUELCHADJ] = o->rxsquelchadj;
-		o->eepromctl = 2;		/* request a write */
+		o->eepromctl = 2; /* request a write */
 		ast_mutex_unlock(&o->eepromlock);
 	}
 }
@@ -4643,16 +4601,15 @@ static void mixer_write(struct chan_usbradio_pvt *o)
 		ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_VOL, 0, 0);
 	}
 	ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_SW, 0, 0);
-	ast_radio_setamixer(o->devicenum, (o->newname) ? MIXER_PARAM_SPKR_PLAYBACK_SW_NEW : MIXER_PARAM_SPKR_PLAYBACK_SW, 1,
-						0);
+	ast_radio_setamixer(o->devicenum, (o->newname) ? MIXER_PARAM_SPKR_PLAYBACK_SW_NEW : MIXER_PARAM_SPKR_PLAYBACK_SW, 1, 0);
 	ast_radio_setamixer(o->devicenum, (o->newname) ? MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW : MIXER_PARAM_SPKR_PLAYBACK_VOL,
-						ast_radio_make_spkr_playback_value(o->spkrmax, o->txmixaset, o->devtype),
-						ast_radio_make_spkr_playback_value(o->spkrmax, o->txmixbset, o->devtype));
+		ast_radio_make_spkr_playback_value(o->spkrmax, o->txmixaset, o->devtype),
+		ast_radio_make_spkr_playback_value(o->spkrmax, o->txmixbset, o->devtype));
 	/* adjust settings based on the device */
 	switch (o->devtype) {
 	case C119B_PRODUCT_ID:
 		mic_setting = o->rxmixerset * o->micmax / C119B_ADJUSTMENT;
-		o->rxboost = 1;			/*rxboost is always set for this device */
+		o->rxboost = 1; /*rxboost is always set for this device */
 		break;
 	default:
 		mic_setting = o->rxmixerset * o->micmax / 1000;
@@ -4930,7 +4887,6 @@ static void pmrdump(struct chan_usbradio_pvt *o, int fd)
 
 static int xpmr_config(struct chan_usbradio_pvt *o)
 {
-
 	if (o->pmrChan == NULL) {
 		ast_log(LOG_ERROR, "pmr channel structure NULL\n");
 		return 1;
@@ -4968,7 +4924,6 @@ static int xpmr_config(struct chan_usbradio_pvt *o)
 	if (o->pmrChan->rxfreq) {
 		o->pmrChan->b.reprog = 1;
 	}
-	
 
 	return 0;
 }
@@ -5110,7 +5065,7 @@ static struct chan_usbradio_pvt *store_config(const struct ast_config *cfg, cons
 		ast_log(LOG_ERROR, "Invalid Configuration: Can not have A channel be Voice with B channel being Composite!!\n");
 	}
 
-	if (o == &usbradio_default) {	/* we are done with the default */
+	if (o == &usbradio_default) { /* we are done with the default */
 		return NULL;
 	}
 
@@ -5140,7 +5095,7 @@ static struct chan_usbradio_pvt *store_config(const struct ast_config *cfg, cons
 			usleep(10000);
 			ast_mutex_lock(&o->eepromlock);
 		}
-		o->eepromctl = 1;		/* request a load */
+		o->eepromctl = 1; /* request a load */
 		ast_mutex_unlock(&o->eepromlock);
 	}
 	o->dsp = ast_dsp_new();
@@ -5152,8 +5107,7 @@ static struct chan_usbradio_pvt *store_config(const struct ast_config *cfg, cons
 		o->rxsqhyst = 3000;
 
 	if (o->rxsquelchdelay > RXSQDELAYBUFSIZE / 8 - 1) {
-		ast_log(LOG_WARNING, "rxsquelchdelay of %i is > maximum of %i. Set to maximum.\n",
-				o->rxsquelchdelay, RXSQDELAYBUFSIZE / 8 - 1);
+		ast_log(LOG_WARNING, "rxsquelchdelay of %i is > maximum of %i. Set to maximum.\n", o->rxsquelchdelay, RXSQDELAYBUFSIZE / 8 - 1);
 		o->rxsquelchdelay = RXSQDELAYBUFSIZE / 8 - 1;
 	}
 	if (o->pmrChan == NULL) {
@@ -5172,7 +5126,6 @@ static struct chan_usbradio_pvt *store_config(const struct ast_config *cfg, cons
 		tChan.rxCarrierHyst = o->rxsqhyst;
 		tChan.rxSqVoxAdj = o->rxsqvoxadj;
 		tChan.rxSquelchDelay = o->rxsquelchdelay;
-		
 
 		if (o->txlimonly) {
 			tChan.txMod = 1;
@@ -5243,14 +5196,12 @@ static struct chan_usbradio_pvt *store_config(const struct ast_config *cfg, cons
 			set_txctcss_level(o);
 		}
 #endif
-		if ((o->txmixa != TX_OUT_VOICE) && (o->txmixb != TX_OUT_VOICE) &&
-			(o->txmixa != TX_OUT_COMPOSITE) && (o->txmixb != TX_OUT_COMPOSITE)) {
+		if ((o->txmixa != TX_OUT_VOICE) && (o->txmixb != TX_OUT_VOICE) && (o->txmixa != TX_OUT_COMPOSITE) && (o->txmixb != TX_OUT_COMPOSITE)) {
 			ast_log(LOG_ERROR, "No txvoice output configured.\n");
 		}
 
-		if (o->txctcssfreq[0] &&
-			o->txmixa != TX_OUT_LSD && o->txmixa != TX_OUT_COMPOSITE &&
-			o->txmixb != TX_OUT_LSD && o->txmixb != TX_OUT_COMPOSITE) {
+		if (o->txctcssfreq[0] && o->txmixa != TX_OUT_LSD && o->txmixa != TX_OUT_COMPOSITE && o->txmixb != TX_OUT_LSD &&
+			o->txmixb != TX_OUT_COMPOSITE) {
 			ast_log(LOG_ERROR, "No txtone output configured.\n");
 		}
 
@@ -5284,7 +5235,7 @@ static struct chan_usbradio_pvt *store_config(const struct ast_config *cfg, cons
 	return o;
 }
 
-#if	DEBUG_FILETEST == 1
+#if DEBUG_FILETEST == 1
 /*
 	Test It on a File
 */
@@ -5336,7 +5287,7 @@ int RxTestIt(struct chan_usbradio_pvt *o)
 
 		if (pChan->rxCtcss->decode && !txEnable) {
 			txEnable = 1;
-			//pChan->inputBlanking=(8000/1000*200);
+			// pChan->inputBlanking=(8000/1000*200);
 		} else if (!pChan->rxCtcss->decode && txEnable) {
 			txEnable = 0;
 		}
@@ -5388,7 +5339,8 @@ static char *handle_console_key(struct ast_cli_entry *e, int cmd, struct ast_cli
 	switch (cmd) {
 	case CLI_INIT:
 		e->command = "radio key";
-		e->usage = "Usage: radio key\n" "       Simulates COR active.\n";
+		e->usage = "Usage: radio key\n"
+				   "       Simulates COR active.\n";
 		return NULL;
 	case CLI_GENERATE:
 		return NULL;
@@ -5408,7 +5360,8 @@ static char *handle_console_unkey(struct ast_cli_entry *e, int cmd, struct ast_c
 	switch (cmd) {
 	case CLI_INIT:
 		e->command = "radio unkey";
-		e->usage = "Usage: radio unkey\n" "       Simulates COR un-active.\n";
+		e->usage = "Usage: radio unkey\n"
+				   "       Simulates COR un-active.\n";
 		return NULL;
 	case CLI_GENERATE:
 		return NULL;
@@ -5427,14 +5380,22 @@ static char *handle_radio_tune(struct ast_cli_entry *e, int cmd, struct ast_cli_
 {
 	switch (cmd) {
 	case CLI_INIT:
-		e->command =
-			"radio tune {auxvoice|dump|swap|rxnoise|rxvoice|rxtone|txvoice|txtone|txall|flash|rxsquelch|nocap|rxtracecap|txtracecap|rxcap|txcap|save|load|menu-support|txslimsp}";
-		e->usage =
-			"Usage: radio tune <function>\n" "       rxnoise\n" "       rxvoice\n" "       rxtone\n"
-			"       rxsquelch [newsetting]\n" "       txvoice [newsetting]\n" "       txtone [newsetting]\n"
-			"       txslimsp [setpoint]\n" "       auxvoice [newsetting]\n" "       save (settings to tuning file)\n"
-			"       load (tuning settings from EEPROM)\n\n" "       All [newsetting]'s are values 0-999\n"
-			"       [setpoint] is 5000 to 13000\n\n";
+		e->command = "radio tune "
+					 "{auxvoice|dump|swap|rxnoise|rxvoice|rxtone|txvoice|txtone|txall|flash|rxsquelch|nocap|rxtracecap|"
+					 "txtracecap|rxcap|txcap|save|load|menu-support|txslimsp}";
+		e->usage = "Usage: radio tune <function>\n"
+				   "       rxnoise\n"
+				   "       rxvoice\n"
+				   "       rxtone\n"
+				   "       rxsquelch [newsetting]\n"
+				   "       txvoice [newsetting]\n"
+				   "       txtone [newsetting]\n"
+				   "       txslimsp [setpoint]\n"
+				   "       auxvoice [newsetting]\n"
+				   "       save (settings to tuning file)\n"
+				   "       load (tuning settings from EEPROM)\n\n"
+				   "       All [newsetting]'s are values 0-999\n"
+				   "       [setpoint] is 5000 to 13000\n\n";
 
 		return NULL;
 	case CLI_GENERATE:
@@ -5456,9 +5417,9 @@ static char *handle_radio_active(struct ast_cli_entry *e, int cmd, struct ast_cl
 	case CLI_INIT:
 		e->command = "radio active";
 		e->usage = "Usage: radio active [device-name]\n"
-			"       If used without a parameter, displays which device is the current\n"
-			"       one being commanded.  If a device is specified, the commanded radio device is changed\n"
-			"       to the device specified.\n";
+				   "       If used without a parameter, displays which device is the current\n"
+				   "       one being commanded.  If a device is specified, the commanded radio device is changed\n"
+				   "       to the device specified.\n";
 		return NULL;
 	case CLI_GENERATE:
 		return NULL;
@@ -5505,7 +5466,9 @@ static char *handle_set_xdebug(struct ast_cli_entry *e, int cmd, struct ast_cli_
 	switch (cmd) {
 	case CLI_INIT:
 		e->command = "radio set xdebug";
-		e->usage = "Usage: radio set xdebug [level]\n" "       Level 0 to 100.\n" "       Set xpmr debug level.\n";
+		e->usage = "Usage: radio set xdebug [level]\n"
+				   "       Level 0 to 100.\n"
+				   "       Set xpmr debug level.\n";
 		return NULL;
 	case CLI_GENERATE:
 		return NULL;
@@ -5513,14 +5476,10 @@ static char *handle_set_xdebug(struct ast_cli_entry *e, int cmd, struct ast_cli_
 	return res2cli(radio_set_xpmr_debug(a->fd, a->argc, a->argv));
 }
 
-static struct ast_cli_entry cli_usbradio[] = {
-	AST_CLI_DEFINE(handle_console_key, "Simulate Rx Signal Present"),
-	AST_CLI_DEFINE(handle_console_unkey, "Simulate Rx Signal Loss"),
-	AST_CLI_DEFINE(handle_radio_tune, "Change radio settings"),
+static struct ast_cli_entry cli_usbradio[] = { AST_CLI_DEFINE(handle_console_key, "Simulate Rx Signal Present"),
+	AST_CLI_DEFINE(handle_console_unkey, "Simulate Rx Signal Loss"), AST_CLI_DEFINE(handle_radio_tune, "Change radio settings"),
 	AST_CLI_DEFINE(handle_radio_active, "Change commanded device"),
-	AST_CLI_DEFINE(handle_set_xdebug, "Radio set xpmr debug level"),
-	AST_CLI_DEFINE(handle_show_settings, "Show device settings")
-};
+	AST_CLI_DEFINE(handle_set_xdebug, "Radio set xpmr debug level"), AST_CLI_DEFINE(handle_show_settings, "Show device settings") };
 
 #include "./xpmr/xpmr.c"
 #ifdef HAVE_XPMRX
@@ -5637,7 +5596,6 @@ static int unload_module(void)
 	ast_cli_unregister_multiple(cli_usbradio, sizeof(cli_usbradio) / sizeof(struct ast_cli_entry));
 
 	for (o = usbradio_default.next; o; o = o->next) {
-
 		if (o->pmrChan) {
 			destroyPmrChannel(o->pmrChan);
 		}
@@ -5679,7 +5637,7 @@ static int unload_module(void)
 		if (o->owner) {
 			ast_softhangup(o->owner, AST_SOFTHANGUP_APPUNLOAD);
 		}
-		if (o->owner) {			/* XXX how ??? */
+		if (o->owner) { /* XXX how ??? */
 			return -1;
 		}
 		/* XXX what about the thread ? */
@@ -5692,6 +5650,5 @@ static int unload_module(void)
 	return 0;
 }
 
-AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_DEFAULT, "USB Console Channel Driver",.support_level =
-				AST_MODULE_SUPPORT_EXTENDED,.load = load_module,.unload = unload_module,.reload =
-				reload_module,.requires = "res_usbradio",);
+AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_DEFAULT, "USB Console Channel Driver", .support_level = AST_MODULE_SUPPORT_EXTENDED,
+	.load = load_module, .unload = unload_module, .reload = reload_module, .requires = "res_usbradio", );

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -3195,7 +3195,7 @@ static int xpmr_set_tx_soft_limiter(struct chan_usbradio_pvt *o, int setpoint)
 	
 	/* Check for a valid pmrChan has to be done here. Data structures in xpmr are all dynamic. */
 	
-	if(o->pmrChan) {
+	if (o->pmrChan) {
 		return SetTxSoftLimiterSetpoint(o->pmrChan, setpoint);
 	}
 	else {
@@ -3531,13 +3531,12 @@ static void tune_rxinput(int fd, struct chan_usbradio_pvt *o, int setsql, int in
 		o->rxmixerset = ((setting * 1000) + (o->micmax / 2)) / o->micmax;
 
 		/* adjust settings based on the device */
-		switch (o->devtype)
-		{
-			case C119B_PRODUCT_ID:
-				adjustment = C119B_ADJUSTMENT;
-				break;
-			default:
-				adjustment = 1000;
+		switch (o->devtype) {
+		case C119B_PRODUCT_ID:
+			adjustment = C119B_ADJUSTMENT;
+			break;
+		default:
+			adjustment = 1000;
 		}
 
 		if (o->rxcdtype == CD_XPMR_NOISE) {
@@ -4035,7 +4034,7 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 					o->rxcdtype, o->rxsdtype, o->rxondelay, o->txoffdelay,
 					o->txprelim, o->txlimonly, o->rxdemod, o->txmixa, o->txmixb,
 					o->rxmixerset, o->rxvoiceadj, o->rxsquelchadj, o->txmixaset,
-					o->txmixbset, o->txctcssadj, o->micplaymax, o->spkrmax, o->micmax, o->txslimsp);		   
+					o->txmixbset, o->txctcssadj, o->micplaymax, o->spkrmax, o->micmax, o->txslimsp);
 		} else if (!strcmp(cmd, "0+9")) {
 			ast_cli(fd, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%f,%d,%d,%d,%d,%d,%d,%d\n",
 					flatrx, txhasctcss, o->echomode, o->rxboost, o->txboost,
@@ -4165,11 +4164,10 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 	case 'L':					/* Set TX soft limiter when operating with preemphasized and limited tx audio */
 		if (cmd[1]) {
 			int setpoint = atoi(cmd + 1);
-			if(xpmr_set_tx_soft_limiter(o, setpoint)) {
+			if (xpmr_set_tx_soft_limiter(o, setpoint)) {
 				ast_debug(3, "TX soft limiter set failed in tune menu-support\n");
 				break;
-			}
-			else {
+			} else {
 				o->txslimsp = setpoint;
 			}
 				

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -65,7 +65,7 @@
 #define HAVE_XPMRX				1
 #endif
 
-#define CHAN_USBRADIO           1			/* Used in xpmr.h to configure that module */
+#define CHAN_USBRADIO           1	/* Used in xpmr.h to configure that module */
 #define DEBUG_USBRADIO          0
 #define DEBUG_CAPTURES	 		1
 #define DEBUG_CAP_RX_OUT		0
@@ -82,14 +82,14 @@
 #define QUOTECHR 34
 
 #define READERR_THRESHOLD 50
-#define DEFAULT_ECHO_MAX 1000 /* 20 secs of echo buffer, max */
+#define DEFAULT_ECHO_MAX 1000	/* 20 secs of echo buffer, max */
 #define DEFAULT_TX_SOFT_LIMITER_SETPOINT 12000
 #define PP_MASK 0xbffc
 #define PP_PORT "/dev/parport0"
 #define PP_IOPORT 0x378
 #define RPT_TO_STRING(x) #x
 #define S_FMT(x) "%" RPT_TO_STRING(x) "s "
-#define N_FMT(duf) "%30" #duf /* Maximum sscanf conversion to numeric strings */
+#define N_FMT(duf) "%30" #duf	/* Maximum sscanf conversion to numeric strings */
 
 #include "./xpmr/xpmr.h"
 #ifdef HAVE_XPMRX
@@ -135,7 +135,7 @@ static struct ast_jb_conf global_jbconf;
 
 #define	QUEUE_SIZE	20			/* 400 milliseconds of sound card output buffer */
 
-#define CONFIG	"usbradio.conf"				/* default config file */
+#define CONFIG	"usbradio.conf"	/* default config file */
 
 /* file handles for writing debug audio packets */
 static FILE *frxcapraw = NULL, *frxcaptrace = NULL, *frxoutraw = NULL;
@@ -158,14 +158,14 @@ static char hasout;
 pthread_t pulserid;
 
 /*! \brief type of signal detection used for carrier (cd) or ctcss (sd) */
-static const char * const cd_signal_type[] = {"no", "dsp", "vox", "usb", "usbinvert", "pp", "ppinvert"};
-static const char * const sd_signal_type[] = {"no", "usb", "usbinvert", "dsp", "pp", "ppinvert"};
+static const char *const cd_signal_type[] = { "no", "dsp", "vox", "usb", "usbinvert", "pp", "ppinvert" };
+static const char *const sd_signal_type[] = { "no", "usb", "usbinvert", "dsp", "pp", "ppinvert" };
 
 /*! \brief demodulation type */
-static const char * const demodulation_type[] = {"no", "speaker", "flat"};
+static const char *const demodulation_type[] = { "no", "speaker", "flat" };
 
 /*! \brief mixer type */
-static const char * const mixer_type[] = {"no", "voice", "tone", "composite", "auxvoice"};
+static const char *const mixer_type[] = { "no", "voice", "tone", "composite", "auxvoice" };
 
 /*!
  * \brief Descriptor for one of our channels.
@@ -259,9 +259,9 @@ struct chan_usbradio_pvt {
 	enum radio_rx_audio rxdemod;
 	float rxgain;
 	enum radio_carrier_detect rxcdtype;
-	int voxhangtime; /* if rxcdtype=vox, ms to wait detecting RX audio before setting CD=0 */
+	int voxhangtime;			/* if rxcdtype=vox, ms to wait detecting RX audio before setting CD=0 */
 	enum radio_squelch_detect rxsdtype;
-	int rxsquelchadj; /* this copy needs to be here for initialization */
+	int rxsquelchadj;			/* this copy needs to be here for initialization */
 	int rxsqhyst;
 	int rxsqvoxadj;
 	int rxnoisefiltype;
@@ -354,31 +354,31 @@ struct chan_usbradio_pvt {
 	char had_pp_in;
 
 	/* bit fields */
-	unsigned int rxcapraw:1;		/* indicator if receive capture is enabled */
-	unsigned int txcapraw:1;		/* indicator if transmit capture is enabled */
-	unsigned int rxcap2:1;			/* indicator if receive capture 2 is enabled */
-	unsigned int txcap2:1;			/* indicator if transmit capture 2 is enabled */
-	unsigned int remoted:1;			/* indicator if rx/tx frequency adjusted */
-	unsigned int forcetxcode:1;		/* indicator to force use of first ctcss code */
-	unsigned int rxpolarity:1;		/* indicator for receive polarity */
-	unsigned int txpolarity:1;		/* indicator for transmit polarity */
+	unsigned int rxcapraw:1;	/* indicator if receive capture is enabled */
+	unsigned int txcapraw:1;	/* indicator if transmit capture is enabled */
+	unsigned int rxcap2:1;		/* indicator if receive capture 2 is enabled */
+	unsigned int txcap2:1;		/* indicator if transmit capture 2 is enabled */
+	unsigned int remoted:1;		/* indicator if rx/tx frequency adjusted */
+	unsigned int forcetxcode:1;	/* indicator to force use of first ctcss code */
+	unsigned int rxpolarity:1;	/* indicator for receive polarity */
+	unsigned int txpolarity:1;	/* indicator for transmit polarity */
 	unsigned int dcsrxpolarity:1;	/* indicator for dcs receive polarity */
 	unsigned int dcstxpolarity:1;	/* indicator for dcs transmit polarity */
 	unsigned int lsdrxpolarity:1;	/* indicator for lsd receive polarity */
 	unsigned int lsdtxpolarity:1;	/* indicator for lsd transmit polarity */
-	unsigned int radioactive:1;		/* indicator for active radio channel */
+	unsigned int radioactive:1;	/* indicator for active radio channel */
 	unsigned int device_error:1;	/* indicator set when we cannot find the USB device */
-	unsigned int newname:1;			/* indicator that we should use MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW */
-	unsigned int hasusb:1;			/* indicator for has a USB device */
-	unsigned int usbass:1;			/* indicator for USB device assigned */
-	unsigned int wanteeprom:1;		/* indicator if we should use EEPROM */
-	unsigned int usedtmf:1;			/* indicator is we should decode DTMF */
-	unsigned int invertptt:1;		/* indicator if we need to invert ptt */
-	unsigned int rxboost:1;			/* indicator if receive boost is needed */
-	unsigned int rxcpusaver:1;		/* indicator if receive cpu save is enabled */
-	unsigned int txcpusaver:1;		/* indicator if transmit cpu save is enabled */
-	unsigned int txprelim:1;		/* indicator if tx pre lim is enabled */
-	unsigned int txlimonly:1;		/* indicator if tx lim only is enabled */
+	unsigned int newname:1;		/* indicator that we should use MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW */
+	unsigned int hasusb:1;		/* indicator for has a USB device */
+	unsigned int usbass:1;		/* indicator for USB device assigned */
+	unsigned int wanteeprom:1;	/* indicator if we should use EEPROM */
+	unsigned int usedtmf:1;		/* indicator is we should decode DTMF */
+	unsigned int invertptt:1;	/* indicator if we need to invert ptt */
+	unsigned int rxboost:1;		/* indicator if receive boost is needed */
+	unsigned int rxcpusaver:1;	/* indicator if receive cpu save is enabled */
+	unsigned int txcpusaver:1;	/* indicator if transmit cpu save is enabled */
+	unsigned int txprelim:1;	/* indicator if tx pre lim is enabled */
+	unsigned int txlimonly:1;	/* indicator if tx lim only is enabled */
 	unsigned int rxctcssoverride:1;	/* indicator if receive ctcss override is enabled */
 	unsigned int rx_cos_active:1;	/* indicator if cos is active - active state after processing */
 	unsigned int rx_ctcss_active:1;	/* indicator if ctcss is active - active state after processing */
@@ -393,7 +393,7 @@ struct chan_usbradio_pvt {
 	struct timeval tonetime;
 	int toneflag;
 	int duplex3;
-	int clipledgpio;           /* enables ADC Clip Detect feature to output on a specified GPIO# */
+	int clipledgpio;			/* enables ADC Clip Detect feature to output on a specified GPIO# */
 
 	int fever;
 	int count_rssi_update;
@@ -440,7 +440,8 @@ static int hidhdwconfig(struct chan_usbradio_pvt *o);
 static void mixer_write(struct chan_usbradio_pvt *o);
 static int setformat(struct chan_usbradio_pvt *o, int mode);
 static struct ast_channel *usbradio_request(const char *type, struct ast_format_cap *cap,
-	const struct ast_assigned_ids *assignedids, const struct ast_channel *requestor, const char *data, int *cause);
+											const struct ast_assigned_ids *assignedids,
+											const struct ast_channel *requestor, const char *data, int *cause);
 static int usbradio_digit_begin(struct ast_channel *c, char digit);
 static int usbradio_digit_end(struct ast_channel *c, char digit, unsigned int duration);
 static int usbradio_text(struct ast_channel *c, const char *text);
@@ -498,7 +499,6 @@ static struct ast_channel_tech usbradio_tech = {
 	.setoption = usbradio_setoption,
 };
 
-
 /*!
  * \brief Configure our private structure based on the
  * found hardware type.
@@ -514,46 +514,46 @@ static int hidhdwconfig(struct chan_usbradio_pvt *o)
  *  Apparently, in a REAL CM-108, GPIO really works as a GPIO
  */
 
-	if (o->hdwtype == 1) {			//sphusb
-		o->hid_gpio_ctl = 0x08;		/* set GPIO4 to output mode */
+	if (o->hdwtype == 1) {		//sphusb
+		o->hid_gpio_ctl = 0x08;	/* set GPIO4 to output mode */
 		o->hid_gpio_ctl_loc = 2;	/* For CTL of GPIO */
-		o->hid_io_cor = 4;			/* GPIO3 is COR */
-		o->hid_io_cor_loc = 1;		/* GPIO3 is COR */
-		o->hid_io_ctcss = 2;		/* GPIO 2 is External CTCSS */
+		o->hid_io_cor = 4;		/* GPIO3 is COR */
+		o->hid_io_cor_loc = 1;	/* GPIO3 is COR */
+		o->hid_io_ctcss = 2;	/* GPIO 2 is External CTCSS */
 		o->hid_io_ctcss_loc = 1;	/* is GPIO 2 */
-		o->hid_io_ptt = 8;			/* GPIO 4 is PTT */
-		o->hid_gpio_loc = 1;		/* For ALL GPIO */
-		o->valid_gpios = 1;			/* for GPIO 1 */
-	} else if (o->hdwtype == 0) { 	//dudeusb
-		o->hid_gpio_ctl = 4;		/* set GPIO 3 to output mode */
+		o->hid_io_ptt = 8;		/* GPIO 4 is PTT */
+		o->hid_gpio_loc = 1;	/* For ALL GPIO */
+		o->valid_gpios = 1;		/* for GPIO 1 */
+	} else if (o->hdwtype == 0) {	//dudeusb
+		o->hid_gpio_ctl = 4;	/* set GPIO 3 to output mode */
 		o->hid_gpio_ctl_loc = 2;	/* For CTL of GPIO */
-		o->hid_io_cor = 2;			/* VOLD DN is COR */
-		o->hid_io_cor_loc = 0;		/* VOL DN COR */
-		o->hid_io_ctcss = 1;		/* VOL UP External CTCSS */
+		o->hid_io_cor = 2;		/* VOLD DN is COR */
+		o->hid_io_cor_loc = 0;	/* VOL DN COR */
+		o->hid_io_ctcss = 1;	/* VOL UP External CTCSS */
 		o->hid_io_ctcss_loc = 0;	/* VOL UP External CTCSS */
-		o->hid_io_ptt = 4;			/* GPIO 3 is PTT */
-		o->hid_gpio_loc = 1;		/* For ALL GPIO */
-		o->valid_gpios = 0xfb;		/* for GPIO 1,2,4,5,6,7,8 (5,6,7,8 for CM-119 only) */
+		o->hid_io_ptt = 4;		/* GPIO 3 is PTT */
+		o->hid_gpio_loc = 1;	/* For ALL GPIO */
+		o->valid_gpios = 0xfb;	/* for GPIO 1,2,4,5,6,7,8 (5,6,7,8 for CM-119 only) */
 	} else if (o->hdwtype == 2) {	//NHRC (N1KDO) (dudeusb w/o user GPIO)
-		o->hid_gpio_ctl = 4;		/* set GPIO 3 to output mode */
+		o->hid_gpio_ctl = 4;	/* set GPIO 3 to output mode */
 		o->hid_gpio_ctl_loc = 2;	/* For CTL of GPIO */
-		o->hid_io_cor = 2;			/* VOLD DN is COR */
-		o->hid_io_cor_loc = 0;		/* VOL DN COR */
-		o->hid_io_ctcss = 1;		/* VOL UP is External CTCSS */
+		o->hid_io_cor = 2;		/* VOLD DN is COR */
+		o->hid_io_cor_loc = 0;	/* VOL DN COR */
+		o->hid_io_ctcss = 1;	/* VOL UP is External CTCSS */
 		o->hid_io_ctcss_loc = 0;	/* VOL UP CTCSS */
-		o->hid_io_ptt = 4;			/* GPIO 3 is PTT */
-		o->hid_gpio_loc = 1;		/* For ALL GPIO */
-		o->valid_gpios = 0;			/* for GPIO 1,2,4 */
-	} else if (o->hdwtype == 3)	{	// custom version
-		o->hid_gpio_ctl = 0x0c;		/* set GPIO 3 & 4 to output mode */
+		o->hid_io_ptt = 4;		/* GPIO 3 is PTT */
+		o->hid_gpio_loc = 1;	/* For ALL GPIO */
+		o->valid_gpios = 0;		/* for GPIO 1,2,4 */
+	} else if (o->hdwtype == 3) {	// custom version
+		o->hid_gpio_ctl = 0x0c;	/* set GPIO 3 & 4 to output mode */
 		o->hid_gpio_ctl_loc = 2;	/* For CTL of GPIO */
-		o->hid_io_cor = 2;			/* VOLD DN is COR */
-		o->hid_io_cor_loc = 0;		/* VOL DN COR */
-		o->hid_io_ctcss = 2;		/* GPIO 2 is External CTCSS */
+		o->hid_io_cor = 2;		/* VOLD DN is COR */
+		o->hid_io_cor_loc = 0;	/* VOL DN COR */
+		o->hid_io_ctcss = 2;	/* GPIO 2 is External CTCSS */
 		o->hid_io_ctcss_loc = 1;	/* is GPIO 2 */
-		o->hid_io_ptt = 4;			/* GPIO 3 is PTT */
-		o->hid_gpio_loc = 1;		/* For ALL GPIO */
-		o->valid_gpios = 1;			/* for GPIO 1 */
+		o->hid_io_ptt = 4;		/* GPIO 3 is PTT */
+		o->hid_gpio_loc = 1;	/* For ALL GPIO */
+		o->valid_gpios = 1;		/* for GPIO 1 */
 	}
 	/* validate clipledgpio setting (Clip LED GPIO#) */
 	if (o->clipledgpio) {
@@ -561,7 +561,7 @@ static int hidhdwconfig(struct chan_usbradio_pvt *o)
 			ast_log(LOG_ERROR, "Channel %s: clipledgpio = GPIO%d not supported\n", o->name, o->clipledgpio);
 			o->clipledgpio = 0;
 		} else {
-			o->hid_gpio_ctl |= 1 << (o->clipledgpio - 1); /* confirm Clip LED GPIO set to output mode */
+			o->hid_gpio_ctl |= 1 << (o->clipledgpio - 1);	/* confirm Clip LED GPIO set to output mode */
 		}
 	}
 	o->hid_gpio_val = 0;
@@ -581,7 +581,8 @@ static int hidhdwconfig(struct chan_usbradio_pvt *o)
 		}
 		/* skip if not a valid GPIO */
 		if (!(o->valid_gpios & (1 << i))) {
-			ast_log(LOG_ERROR, "Channel %s: You can't specify gpio%d, it is not valid in this configuration.\n", o->name, i + 1);
+			ast_log(LOG_ERROR, "Channel %s: You can't specify gpio%d, it is not valid in this configuration.\n",
+					o->name, i + 1);
 			continue;
 		}
 		o->hid_gpio_ctl |= (1 << i);	/* set this one to output, also */
@@ -667,7 +668,7 @@ static char *find_installed_usb_match(void)
 	struct chan_usbradio_pvt *o = NULL;
 	char *match = NULL;
 
-	for (o = usbradio_default.next; o ; o = o->next) {
+	for (o = usbradio_default.next; o; o = o->next) {
 		if (ast_radio_usb_list_check(o->devstr)) {
 			match = o->devstr;
 			break;
@@ -764,7 +765,8 @@ static int load_tune_config(struct chan_usbradio_pvt *o, const struct ast_config
 		struct ast_flags zeroflag = { 0 };
 		cfg2 = ast_config_load(CONFIG, zeroflag);
 		if (!cfg2) {
-			ast_log(LOG_WARNING, "Can't %sload settings for %s, using default parameters\n", reload ? "re": "", o->name);
+			ast_log(LOG_WARNING, "Can't %sload settings for %s, using default parameters\n", reload ? "re" : "",
+					o->name);
 			return -1;
 		}
 		opened = 1;
@@ -788,13 +790,14 @@ static int load_tune_config(struct chan_usbradio_pvt *o, const struct ast_config
 	}
 	if (!reload) {
 		/* Using the ternary operator in CV_STR won't work, due to butchering the sizeof, so copy after if needed */
-		strcpy(o->devstr, devstr); /* Safe */
+		strcpy(o->devstr, devstr);	/* Safe */
 	}
 	if (opened) {
 		ast_config_destroy(cfg2);
 	}
 	if (!configured) {
-		ast_log(LOG_WARNING, "Can't %sload settings for %s (no section available), using default parameters\n", reload ? "re": "", o->name);
+		ast_log(LOG_WARNING, "Can't %sload settings for %s (no section available), using default parameters\n",
+				reload ? "re" : "", o->name);
 		return -1;
 	}
 	return 0;
@@ -888,7 +891,7 @@ static void *hidthread(void *arg)
 				index_devstr = ast_radio_usb_get_devstr(index);
 				if (ast_strlen_zero(index_devstr)) {
 					if (!o->device_error) {
-						ast_log(LOG_ERROR, "Channel %s: No USB devices are available for assignment.\n",  o->name);
+						ast_log(LOG_ERROR, "Channel %s: No USB devices are available for assignment.\n", o->name);
 						o->device_error = 1;
 					}
 					ast_mutex_unlock(&usb_dev_lock);
@@ -907,7 +910,8 @@ static void *hidthread(void *arg)
 				}
 				/* We found an unused device assign it to our node */
 				ast_copy_string(o->devstr, index_devstr, sizeof(o->devstr));
-				ast_log(LOG_NOTICE, "Channel %s: Automatically assigned USB device %s to USBRadio channel\n", o->name, o->devstr);
+				ast_log(LOG_NOTICE, "Channel %s: Automatically assigned USB device %s to USBRadio channel\n", o->name,
+						o->devstr);
 				break;
 			}
 			if (ast_strlen_zero(o->devstr)) {
@@ -924,7 +928,7 @@ static void *hidthread(void *arg)
 			s = find_installed_usb_match();
 			if (ast_strlen_zero(s)) {
 				if (!o->device_error) {
-					ast_log(LOG_ERROR, "Channel %s: Device string %s was not found.\n",  o->name, o->devstr);
+					ast_log(LOG_ERROR, "Channel %s: Device string %s was not found.\n", o->name, o->devstr);
 					o->device_error = 1;
 				}
 				ast_mutex_unlock(&usb_dev_lock);
@@ -944,7 +948,8 @@ static void *hidthread(void *arg)
 				}
 			}
 			if (ao) {
-				ast_log(LOG_ERROR, "Channel %s: Device string %s is already assigned to channel %s", o->name, s, ao->name);
+				ast_log(LOG_ERROR, "Channel %s: Device string %s is already assigned to channel %s", o->name, s,
+						ao->name);
 				ast_mutex_unlock(&usb_dev_lock);
 				usleep(500000);
 				continue;
@@ -958,7 +963,8 @@ static void *hidthread(void *arg)
 				break;
 		}
 		if (ao) {
-			ast_log(LOG_ERROR, "Channel %s: Device string %s is already assigned to channel %s", o->name, o->devstr, ao->name);
+			ast_log(LOG_ERROR, "Channel %s: Device string %s is already assigned to channel %s", o->name, o->devstr,
+					ao->name);
 			ast_mutex_unlock(&usb_dev_lock);
 			usleep(500000);
 			continue;
@@ -1110,15 +1116,12 @@ static void *hidthread(void *arg)
 			o->pmrChan->txCpuSaver = o->txcpusaver;
 
 			/* adjust settings based on the device */
-			switch (o->devtype)
-			{
-				case C119B_PRODUCT_ID:
-					*(o->pmrChan->prxSquelchAdjust) =
-						((999 - o->rxsquelchadj) * 32767) / C119B_ADJUSTMENT;
-					break;
-				default:
-					*(o->pmrChan->prxSquelchAdjust) =
-						((999 - o->rxsquelchadj) * 32767) / 1000;
+			switch (o->devtype) {
+			case C119B_PRODUCT_ID:
+				*(o->pmrChan->prxSquelchAdjust) = ((999 - o->rxsquelchadj) * 32767) / C119B_ADJUSTMENT;
+				break;
+			default:
+				*(o->pmrChan->prxSquelchAdjust) = ((999 - o->rxsquelchadj) * 32767) / 1000;
 			}
 
 			*(o->pmrChan->prxVoiceAdjust) = o->rxvoiceadj * M_Q8;
@@ -1158,16 +1161,15 @@ static void *hidthread(void *arg)
 
 		/* reload the settings from the tune file */
 		load_tune_config(o, NULL, 1);
-		
 
 		mixer_write(o);
 		mult_set(o);
 		set_txctcss_level(o);
 		/* Sync soft limiter level in xpmr with what we read from the tuning config. */
-		if(set_tx_soft_limiter_xpmr(o, o->txslimsp)) {
+		if (set_tx_soft_limiter_xpmr(o, o->txslimsp)) {
 			/* Invalid setting in config file. Set default */
 			o->txslimsp = DEFAULT_TX_SOFT_LIMITER_SETPOINT;
-			set_tx_soft_limiter_xpmr(o, o->txslimsp); 
+			set_tx_soft_limiter_xpmr(o, o->txslimsp);
 		}
 
 		ast_mutex_lock(&o->eepromlock);
@@ -1230,7 +1232,8 @@ static void *hidthread(void *arg)
 							set_txctcss_level(o);
 						}
 					} else {
-						ast_log(LOG_ERROR, "Channel %s: USB adapter has no EEPROM installed or Checksum is bad\n", o->name);
+						ast_log(LOG_ERROR, "Channel %s: USB adapter has no EEPROM installed or Checksum is bad\n",
+								o->name);
 					}
 					ast_radio_hid_set_outputs(usb_handle, bufsave);
 				}
@@ -1493,7 +1496,7 @@ static int used_blocks(struct chan_usbradio_pvt *o)
 	/* Set the total blocks */
 	if (o->total_blocks == 0) {
 		ast_debug(1, "Channel %s: fragment total %d, size %d, available %d, bytes %d\n",
-			o->name, info.fragstotal, info.fragsize, info.fragments, info.bytes);
+				  o->name, info.fragstotal, info.fragsize, info.fragments, info.bytes);
 		o->total_blocks = info.fragments;
 		/* Check the queue size, it cannot exceed the total fragments */
 		if (o->queuesize >= info.fragstotal) {
@@ -1545,12 +1548,11 @@ static int soundcard_writeframe(struct chan_usbradio_pvt *o, short *data)
 	if (res > o->queuesize) {	/* no room to write a block */
 		/* Only report a buffer overflow when we are transmitting */
 		if (o->pmrChan->txPttIn || o->pmrChan->txPttOut) {
-			ast_log(LOG_WARNING, "Channel %s: Sound device write buffer overflow - used %d blocks\n",
-				o->name, res);
+			ast_log(LOG_WARNING, "Channel %s: Sound device write buffer overflow - used %d blocks\n", o->name, res);
 		}
 		return 0;
 	}
-	if (res == 0) { /* We are not keeping the buffer full, add 1 frame */
+	if (res == 0) {				/* We are not keeping the buffer full, add 1 frame */
 		memset(outbuf, 0, sizeof(outbuf));
 		res = write(o->sounddev, ((void *) outbuf), sizeof(outbuf));
 		if (res < 0) {
@@ -1562,8 +1564,7 @@ static int soundcard_writeframe(struct chan_usbradio_pvt *o, short *data)
 	if (res < 0) {
 		ast_log(LOG_ERROR, "Channel %s: Sound card write error %s\n", o->name, strerror(errno));
 	} else if (res != FRAME_SIZE * 2 * 2 * 6) {
-		ast_log(LOG_ERROR, "Channel %s: Sound card wrote %d bytes of %d\n",
-			o->name, res, (FRAME_SIZE * 2 * 2 * 6));
+		ast_log(LOG_ERROR, "Channel %s: Sound card wrote %d bytes of %d\n", o->name, res, (FRAME_SIZE * 2 * 2 * 6));
 	}
 
 	return res;
@@ -1651,7 +1652,8 @@ static int setformat(struct chan_usbradio_pvt *o, int mode)
 	}
 	if (fmt != desired) {
 		if (!(o->warned & WARN_speed)) {
-			ast_log(LOG_WARNING, "Channel %s: Requested %d Hz, got %d Hz -- sound may be choppy.\n", o->name, desired, fmt);
+			ast_log(LOG_WARNING, "Channel %s: Requested %d Hz, got %d Hz -- sound may be choppy.\n", o->name, desired,
+					fmt);
 			o->warned |= WARN_speed;
 		}
 	}
@@ -1716,7 +1718,7 @@ static int usbradio_text(struct ast_channel *c, const char *text)
 	char *cmd, pwr;
 	int cnt, i, j;
 	double tx, rx;
-#define STR_SZ 15 /* Size of text strings */
+#define STR_SZ 15				/* Size of text strings */
 	char rxs[STR_SZ + 1], txs[STR_SZ + 1], txpl[STR_SZ + 1], rxpl[STR_SZ + 1];
 
 #ifdef HAVE_SYS_IO
@@ -1730,7 +1732,9 @@ static int usbradio_text(struct ast_channel *c, const char *text)
 	/* print received messages */
 	ast_debug(3, "Channel %s: Console Received usbradio text %s >>\n", o->name, text);
 
-	cnt = sscanf(text, "%s " S_FMT(STR_SZ) S_FMT(STR_SZ) S_FMT(STR_SZ) S_FMT(STR_SZ) "%c", cmd, rxs, txs, rxpl, txpl, &pwr);
+	cnt =
+		sscanf(text, "%s " S_FMT(STR_SZ) S_FMT(STR_SZ) S_FMT(STR_SZ) S_FMT(STR_SZ) "%c", cmd, rxs, txs, rxpl, txpl,
+			   &pwr);
 
 	/* set channel on parallel port */
 	if (strcmp(cmd, "SETCHAN") == 0) {
@@ -1836,8 +1840,8 @@ static int usbradio_text(struct ast_channel *c, const char *text)
 		o->set_txfreq = round(tx * (double) 1000000);
 		o->set_rxfreq = round(rx * (double) 1000000);
 		o->pmrChan->txpower = (pwr == 'H');
-		strcpy(o->set_rxctcssfreqs, rxpl); /* Safe */
-		strcpy(o->set_txctcssfreqs, txpl); /* Safe */
+		strcpy(o->set_rxctcssfreqs, rxpl);	/* Safe */
+		strcpy(o->set_txctcssfreqs, txpl);	/* Safe */
 
 		o->remoted = 1;
 		xpmr_config(o);
@@ -2138,7 +2142,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 		kickptt(o);
 	}
 
-#if 0	// to write 48KS/s stereo tx data to a file
+#if 0							// to write 48KS/s stereo tx data to a file
 	if (!ftxoutraw) {
 		ftxoutraw = fopen(TX_CAP_OUT_FILE, "w");
 	}
@@ -2283,7 +2287,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 
 	if ((o->pmrChan->rptnum > 0 && o->pmrChan->smode == SMODE_LSD
 		 && o->pmrChan->pLsdCtl->cs[o->pmrChan->rptnum].b.rxkeyed) || (o->pmrChan->smode == SMODE_DCS
-		 && o->pmrChan->decDcs->decode > 0)) {
+																	   && o->pmrChan->decDcs->decode > 0)) {
 		sd = 1;
 	}
 #endif
@@ -2311,7 +2315,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	/* Timer for how long TX has been unkeyed - used with txoffdelay */
 	if (o->txoffdelay) {
 		if (o->txkeyed == 1) {
-			o->txoffcnt = 0;		/* If keyed, set this to zero. */
+			o->txoffcnt = 0;	/* If keyed, set this to zero. */
 		} else {
 			o->txoffcnt++;
 			if (o->txoffcnt > 50000) {
@@ -2425,7 +2429,8 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 			if (f1->frametype == AST_FRAME_DTMF_END) {
 				f1->len = ast_tvdiff_ms(ast_radio_tvnow(), o->tonetime);
 				if (option_verbose) {
-					ast_log(LOG_NOTICE, "Channel %s: Got DTMF char %c duration %ld ms\n", o->name, f1->subclass.integer, f1->len);
+					ast_log(LOG_NOTICE, "Channel %s: Got DTMF char %c duration %ld ms\n", o->name, f1->subclass.integer,
+							f1->len);
 				}
 				o->toneflag = 0;
 			} else {
@@ -2473,8 +2478,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 			ast_queue_frame(o->owner, &wf);
 
 			o->count_rssi_update = 10;
-			ast_debug(4, "Channel %s: Count_rssi_update %i\n",
-						o->name, ((32767 - o->pmrChan->rxRssi) * 1000 / 32767));
+			ast_debug(4, "Channel %s: Count_rssi_update %i\n", o->name, ((32767 - o->pmrChan->rxRssi) * 1000 / 32767));
 		}
 	}
 
@@ -2539,7 +2543,7 @@ static int usbradio_indicate(struct ast_channel *c, int cond_in, const void *dat
 		ast_debug(1, "Channel %s: ACRK code=%s TX ON.\n", o->name, (char *) data);
 		if (datalen && ((char *) (data))[0] != '0') {
 			o->forcetxcode = 1;
-			memset(o->set_txctcssfreq, 0, sizeof(o->set_txctcssfreq)); /* Possibly unnecessary, if this is used as a string? */
+			memset(o->set_txctcssfreq, 0, sizeof(o->set_txctcssfreq));	/* Possibly unnecessary, if this is used as a string? */
 			ast_copy_string(o->set_txctcssfreq, data, sizeof(o->set_txctcssfreq));
 			xpmr_config(o);
 		}
@@ -2620,8 +2624,7 @@ static int usbradio_setoption(struct ast_channel *chan, int option, void *data, 
  * \return 				Asterisk channel.
  */
 static struct ast_channel *usbradio_new(struct chan_usbradio_pvt *o, char *ext, char *ctx, int state,
-										const struct ast_assigned_ids *assignedids,
-										const struct ast_channel *requestor)
+										const struct ast_assigned_ids *assignedids, const struct ast_channel *requestor)
 {
 	struct ast_channel *c;
 
@@ -2633,7 +2636,7 @@ static struct ast_channel *usbradio_new(struct chan_usbradio_pvt *o, char *ext, 
 	if ((o->sounddev < 0) && o->hasusb) {
 		setformat(o, O_RDWR);
 	}
-	ast_channel_internal_fd_set(c, 0, o->sounddev); /* -1 if device closed, override later */
+	ast_channel_internal_fd_set(c, 0, o->sounddev);	/* -1 if device closed, override later */
 	ast_channel_nativeformats_set(c, usbradio_tech.capabilities);
 	ast_channel_set_readformat(c, ast_format_slin);
 	ast_channel_set_writeformat(c, ast_format_slin);
@@ -2683,13 +2686,12 @@ static struct ast_channel *usbradio_request(const char *type, struct ast_format_
 	if (!(ast_format_cap_iscompatible(cap, usbradio_tech.capabilities))) {
 		struct ast_str *cap_buf = ast_str_alloca(AST_FORMAT_CAP_NAMES_LEN);
 		ast_log(LOG_NOTICE, "Channel %s: Channel requested with unsupported format(s): '%s'\n",
-			o->name, ast_format_cap_get_names(cap, &cap_buf));
+				o->name, ast_format_cap_get_names(cap, &cap_buf));
 		return NULL;
 	}
 
 	if (o->owner) {
-		ast_log(LOG_NOTICE, "Channel %s: Already have a call (chan %p) on the usb channel\n",
-			o->name, o->owner);
+		ast_log(LOG_NOTICE, "Channel %s: Already have a call (chan %p) on the usb channel\n", o->name, o->owner);
 		*cause = AST_CAUSE_BUSY;
 		return NULL;
 	}
@@ -2761,7 +2763,8 @@ static int radio_active(int fd, int argc, const char *const *argv)
 		if (!strcmp(argv[2], "show")) {
 			ast_mutex_lock(&usb_dev_lock);
 			for (o = usbradio_default.next; o; o = o->next) {
-				ast_cli(fd, "Device [%s] exists as device=%s card=%d\n", o->name, o->devstr, ast_radio_usb_get_usbdev(o->devstr));
+				ast_cli(fd, "Device [%s] exists as device=%s card=%d\n", o->name, o->devstr,
+						ast_radio_usb_get_usbdev(o->devstr));
 			}
 			ast_mutex_unlock(&usb_dev_lock);
 			return RESULT_SUCCESS;
@@ -2897,8 +2900,7 @@ static int radio_tune(int fd, int argc, const char *const *argv)
 
 	if (!strcasecmp(argv[2], "dump")) {
 		pmrdump(o, fd);
-	}
-	else if (!strcasecmp(argv[2], "swap")) {
+	} else if (!strcasecmp(argv[2], "swap")) {
 		if (argc > 3) {
 			usb_device_swap(fd, argv[3]);
 			return RESULT_SUCCESS;
@@ -2938,13 +2940,12 @@ static int radio_tune(int fd, int argc, const char *const *argv)
 			ast_cli(fd, "Changed Squelch setting to %d\n", i);
 			o->rxsquelchadj = i;
 			/* adjust settings based on the device */
-			switch (o->devtype)
-			{
-				case C119B_PRODUCT_ID:
-					adjustment = C119B_ADJUSTMENT;
-					break;
-				default:
-					adjustment = 1000;
+			switch (o->devtype) {
+			case C119B_PRODUCT_ID:
+				adjustment = C119B_ADJUSTMENT;
+				break;
+			default:
+				adjustment = 1000;
 			}
 			*(o->pmrChan->prxSquelchAdjust) = ((999 - i) * 32767) / adjustment;
 		}
@@ -3054,8 +3055,7 @@ static int radio_tune(int fd, int argc, const char *const *argv)
 	} else if (!strcasecmp(argv[2], "nocap")) {
 		ast_cli(fd, "File capture (trace) was rx=%d tx=%d and now off.\n", o->rxcap2, o->txcap2);
 		ast_cli(fd, "File capture (raw)   was rx=%d tx=%d and now off.\n", o->rxcapraw, o->txcapraw);
-		o->rxcapraw = o->txcapraw = o->rxcap2 = o->txcap2 = o->pmrChan->b.rxCapture = o->pmrChan->b.txCapture =
-			0;
+		o->rxcapraw = o->txcapraw = o->rxcap2 = o->txcap2 = o->pmrChan->b.rxCapture = o->pmrChan->b.txCapture = 0;
 		if (frxcapraw) {
 			fclose(frxcapraw);
 			frxcapraw = NULL;
@@ -3118,13 +3118,12 @@ static int radio_tune(int fd, int argc, const char *const *argv)
 		ast_mutex_unlock(&o->eepromlock);
 
 		ast_cli(fd, "Requesting loading of tuning settings from EEPROM for channel %s\n", o->name);
-	} else if (!strcasecmp(argv[2],"txslimsp")) {
-		if(argc == 3) {
+	} else if (!strcasecmp(argv[2], "txslimsp")) {
+		if (argc == 3) {
 			ast_cli(fd, "Current tx limiter setpoint: %i\n", (int) o->txslimsp);
-		}
-		else {
+		} else {
 			int new_slsetpoint = atoi(argv[3]);
-			if(set_tx_soft_limiter_xpmr(o, new_slsetpoint)) {
+			if (set_tx_soft_limiter_xpmr(o, new_slsetpoint)) {
 				ast_cli(fd, "Limiter set point out of range, needs to be between 5000 and 13000\n");
 				return RESULT_SHOWUSAGE;
 			}
@@ -3164,13 +3163,12 @@ static int set_txctcss_level(struct chan_usbradio_pvt *o)
 	} else {
 		if (o->pmrChan->ptxCtcssAdjust) {	/* Ignore if ptr not defined */
 			/* adjust settings based on the device */
-			switch (o->devtype)
-			{
-				case C119B_PRODUCT_ID:
-					adjustment = C119B_ADJUSTMENT;
-					break;
-				default:
-					adjustment = 1000;
+			switch (o->devtype) {
+			case C119B_PRODUCT_ID:
+				adjustment = C119B_ADJUSTMENT;
+				break;
+			default:
+				adjustment = 1000;
 			}
 			*o->pmrChan->ptxCtcssAdjust = (o->txctcssadj * M_Q8) / adjustment;
 		}
@@ -3188,16 +3186,15 @@ static int set_txctcss_level(struct chan_usbradio_pvt *o)
  * \return			    zero if successful, 1 if otherwise
  */
 
-static int set_tx_soft_limiter_xpmr(struct chan_usbradio_pvt *o, int setpoint) {
+static int set_tx_soft_limiter_xpmr(struct chan_usbradio_pvt *o, int setpoint)
+{
 	// Update xpmr with new value if it is within range
-	if((setpoint < 5000) || (setpoint > 13000)) {
+	if ((setpoint < 5000) || (setpoint > 13000)) {
 		return 1;
 	}
 	SetTxSoftLimiterSetpoint(o->pmrChan, setpoint);
 	return 0;
 }
-
-
 
 /*!
  * \brief Process Asterisk CLI request to set xpmr debug level.
@@ -3525,13 +3522,12 @@ static void tune_rxinput(int fd, struct chan_usbradio_pvt *o, int setsql, int in
 		o->rxmixerset = ((setting * 1000) + (o->micmax / 2)) / o->micmax;
 
 		/* adjust settings based on the device */
-		switch (o->devtype)
-		{
-			case C119B_PRODUCT_ID:
-				adjustment = C119B_ADJUSTMENT;
-				break;
-			default:
-				adjustment = 1000;
+		switch (o->devtype) {
+		case C119B_PRODUCT_ID:
+			adjustment = C119B_ADJUSTMENT;
+			break;
+		default:
+			adjustment = 1000;
 		}
 
 		if (o->rxcdtype == CD_XPMR_NOISE) {
@@ -3649,15 +3645,13 @@ static void tune_rxtx_status(int fd, struct chan_usbradio_pvt *o)
 			break;
 		}
 		ast_cli(fd, " %s  | %s  | %s | %s\r",
-			o->rxcdtype ? (o->rx_cos_active ? "Keyed" : "Clear") : "Off  ",
-			o->rxsdtype ? (o->rx_ctcss_active ? "Keyed" : "Clear") : "Off  ",
-			o->rxkeyed ? "Keyed" : "Clear",
-			(o->txkeyed || o->txtestkey) ? "Keyed" : "Clear");
+				o->rxcdtype ? (o->rx_cos_active ? "Keyed" : "Clear") : "Off  ",
+				o->rxsdtype ? (o->rx_ctcss_active ? "Keyed" : "Clear") : "Off  ",
+				o->rxkeyed ? "Keyed" : "Clear", (o->txkeyed || o->txtestkey) ? "Keyed" : "Clear");
 	}
 
 	option_verbose = wasverbose;
 }
-
 
 /*!
  * \brief Set received voice level.
@@ -3693,18 +3687,17 @@ static void _menu_rxvoice(int fd, struct chan_usbradio_pvt *o, const char *str)
 	} else {
 		o->rxmixerset = i;
 		/* adjust settings based on the device */
-		switch (o->devtype)
-		{
-			case C119B_PRODUCT_ID:
-				adjustment = o->rxmixerset * o->micmax / C119B_ADJUSTMENT;
-				/* get interval step size */
-	            f = C119B_ADJUSTMENT / (float) o->micmax;
-				o->rxboost = 1;		/*rxboost is always set for this device */
-				break;
-			default:
-				adjustment = o->rxmixerset * o->micmax / 1000;
-                /* get interval step size */
-                f = 1000.0 / (float) o->micmax;
+		switch (o->devtype) {
+		case C119B_PRODUCT_ID:
+			adjustment = o->rxmixerset * o->micmax / C119B_ADJUSTMENT;
+			/* get interval step size */
+			f = C119B_ADJUSTMENT / (float) o->micmax;
+			o->rxboost = 1;		/*rxboost is always set for this device */
+			break;
+		default:
+			adjustment = o->rxmixerset * o->micmax / 1000;
+			/* get interval step size */
+			f = 1000.0 / (float) o->micmax;
 		}
 		ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL, adjustment, 0);
 		ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_BOOST, o->rxboost, 0);
@@ -3792,13 +3785,12 @@ static void _menu_rxsquelch(int fd, struct chan_usbradio_pvt *o, const char *str
 	ast_cli(fd, "Changed Rx Squelch Level setting to %d\n", i);
 	o->rxsquelchadj = i;
 	/* adjust settings based on the device */
-	switch (o->devtype)
-	{
-		case C119B_PRODUCT_ID:
-			adjustment = C119B_ADJUSTMENT;
-			break;
-		default:
-			adjustment = 1000;
+	switch (o->devtype) {
+	case C119B_PRODUCT_ID:
+		adjustment = C119B_ADJUSTMENT;
+		break;
+	default:
+		adjustment = 1000;
 	}
 	*(o->pmrChan->prxSquelchAdjust) = ((999 - i) * 32767) / adjustment;
 }
@@ -4019,7 +4011,7 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 	if ((o->txmixa == TX_OUT_LSD) || (o->txmixa == TX_OUT_COMPOSITE) ||
 		(o->txmixb == TX_OUT_LSD) || (o->txmixb == TX_OUT_COMPOSITE)) {
 		txhasctcss = 1;
-		}
+	}
 	switch (cmd[0]) {
 	case '0':					/* return audio processing configuration */
 		/* note: to maintain backward compatibility for those expecting a specific # of
@@ -4028,25 +4020,23 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 		   the format/content of any previously returned string */
 		if (!strcmp(cmd, "0+9")) {
 			ast_cli(fd, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%f,%d,%d,%d,%d,%d,%d,%d\n",
-				flatrx, txhasctcss, o->echomode, o->rxboost, o->txboost,
-				o->rxcdtype, o->rxsdtype, o->rxondelay, o->txoffdelay,
-				o->txprelim, o->txlimonly, o->rxdemod, o->txmixa, o->txmixb,
-				o->rxmixerset, o->rxvoiceadj, o->rxsquelchadj, o->txmixaset,
-				o->txmixbset, o->txctcssadj, o->micplaymax, o->spkrmax,
-				o->micmax);
-		} else if (!strcmp(cmd, "0+10")) { /* With o->txslimsp tx soft limiter set point */
-			ast_cli(fd, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%f,%d,%d,%d,%d,%d,%d,%d,%d\n", 
-				flatrx, txhasctcss, o->echomode, o->rxboost, o->txboost,
-				o->rxcdtype, o->rxsdtype, o->rxondelay, o->txoffdelay,
-				o->txprelim, o->txlimonly, o->rxdemod, o->txmixa, o->txmixb,
-				o->rxmixerset, o->rxvoiceadj, o->rxsquelchadj, o->txmixaset,
-				o->txmixbset, o->txctcssadj, o->micplaymax, o->spkrmax,
-				o->micmax, o->txslimsp);
+					flatrx, txhasctcss, o->echomode, o->rxboost, o->txboost,
+					o->rxcdtype, o->rxsdtype, o->rxondelay, o->txoffdelay,
+					o->txprelim, o->txlimonly, o->rxdemod, o->txmixa, o->txmixb,
+					o->rxmixerset, o->rxvoiceadj, o->rxsquelchadj, o->txmixaset,
+					o->txmixbset, o->txctcssadj, o->micplaymax, o->spkrmax, o->micmax);
+		} else if (!strcmp(cmd, "0+10")) {	/* With o->txslimsp tx soft limiter set point */
+			ast_cli(fd, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%f,%d,%d,%d,%d,%d,%d,%d,%d\n",
+					flatrx, txhasctcss, o->echomode, o->rxboost, o->txboost,
+					o->rxcdtype, o->rxsdtype, o->rxondelay, o->txoffdelay,
+					o->txprelim, o->txlimonly, o->rxdemod, o->txmixa, o->txmixb,
+					o->rxmixerset, o->rxvoiceadj, o->rxsquelchadj, o->txmixaset,
+					o->txmixbset, o->txctcssadj, o->micplaymax, o->spkrmax, o->micmax, o->txslimsp);
 		} else {
 			ast_cli(fd, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
-				flatrx, txhasctcss, o->echomode, o->rxboost, o->txboost,
-				o->rxcdtype, o->rxsdtype, o->rxondelay, o->txoffdelay,
-				o->txprelim, o->txlimonly, o->rxdemod, o->txmixa, o->txmixb);
+					flatrx, txhasctcss, o->echomode, o->rxboost, o->txboost,
+					o->rxcdtype, o->rxsdtype, o->rxondelay, o->txoffdelay,
+					o->txprelim, o->txlimonly, o->rxdemod, o->txmixa, o->txmixb);
 		}
 		break;
 	case '1':					/* return usb device name list */
@@ -4160,18 +4150,17 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 		}
 		tune_flash(fd, o, 1);
 		break;
-		
-	case 'L':                  /* Set TX soft limiter when operating with preemphasized and limited tx audio */
+
+	case 'L':					/* Set TX soft limiter when operating with preemphasized and limited tx audio */
 		if (cmd[1]) {
-			int setpoint = atoi(cmd+1);
+			int setpoint = atoi(cmd + 1);
 			set_tx_soft_limiter_xpmr(o, setpoint);
 			ast_cli(fd, "TX soft limiting setpoint changed to %i\n", setpoint);
-		}
-		else {
-			ast_cli(fd, "TX soft limiting setpoint currently set to: %i\n", o->txslimsp);	
+		} else {
+			ast_cli(fd, "TX soft limiting setpoint currently set to: %i\n", o->txslimsp);
 		}
 		break;
-			
+
 	case 'm':					/* change rxboost */
 		if (cmd[1]) {
 			if (cmd[1] > '0') {
@@ -4300,7 +4289,6 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 		}
 		break;
 
-			
 	default:
 		ast_cli(fd, "Invalid Command\n");
 		break;
@@ -4461,13 +4449,12 @@ static void tune_rxctcss(int fd, struct chan_usbradio_pvt *o, int intflag)
 			return;
 		}
 		/* adjust settings based on the device */
-		switch (o->devtype)
-		{
-			case C119B_PRODUCT_ID:
-				adjustment = C119B_ADJUSTMENT;
-				break;
-			default:
-				adjustment = 1000;
+		switch (o->devtype) {
+		case C119B_PRODUCT_ID:
+			adjustment = C119B_ADJUSTMENT;
+			break;
+		default:
+			adjustment = 1000;
 		}
 		normRssi = ((32767 - o->pmrChan->rxRssi) * adjustment / 32767);
 
@@ -4562,7 +4549,6 @@ static void tune_write(struct chan_usbradio_pvt *o)
 		ast_log(LOG_WARNING, "Failed to update %s\n", #field); \
 	}
 
-
 	category = ast_category_get(cfg, o->name, NULL);
 	if (!category) {
 		ast_log(LOG_ERROR, "No category '%s' exists?\n", o->name);
@@ -4639,18 +4625,19 @@ static void mixer_write(struct chan_usbradio_pvt *o)
 		ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_VOL, 0, 0);
 	}
 	ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_SW, 0, 0);
-	ast_radio_setamixer(o->devicenum, (o->newname) ? MIXER_PARAM_SPKR_PLAYBACK_SW_NEW : MIXER_PARAM_SPKR_PLAYBACK_SW, 1, 0);
+	ast_radio_setamixer(o->devicenum, (o->newname) ? MIXER_PARAM_SPKR_PLAYBACK_SW_NEW : MIXER_PARAM_SPKR_PLAYBACK_SW, 1,
+						0);
 	ast_radio_setamixer(o->devicenum, (o->newname) ? MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW : MIXER_PARAM_SPKR_PLAYBACK_VOL,
-		ast_radio_make_spkr_playback_value(o->spkrmax, o->txmixaset, o->devtype),
-		ast_radio_make_spkr_playback_value(o->spkrmax, o->txmixbset, o->devtype));
+						ast_radio_make_spkr_playback_value(o->spkrmax, o->txmixaset, o->devtype),
+						ast_radio_make_spkr_playback_value(o->spkrmax, o->txmixbset, o->devtype));
 	/* adjust settings based on the device */
-	switch (o->devtype)	{
-		case C119B_PRODUCT_ID:
-			mic_setting = o->rxmixerset * o->micmax / C119B_ADJUSTMENT;
-			o->rxboost = 1;		/*rxboost is always set for this device */
-			break;
-		default:
-			mic_setting = o->rxmixerset * o-> micmax / 1000;
+	switch (o->devtype) {
+	case C119B_PRODUCT_ID:
+		mic_setting = o->rxmixerset * o->micmax / C119B_ADJUSTMENT;
+		o->rxboost = 1;			/*rxboost is always set for this device */
+		break;
+	default:
+		mic_setting = o->rxmixerset * o->micmax / 1000;
 	}
 	ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL, mic_setting, 0);
 	ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_BOOST, o->rxboost, 0);
@@ -4668,13 +4655,12 @@ static void mult_set(struct chan_usbradio_pvt *o)
 	int adjustment;
 
 	/* adjust settings based on the device */
-	switch (o->devtype)
-	{
-		case C119B_PRODUCT_ID:
-			adjustment = C119B_ADJUSTMENT;
-			break;
-		default:
-			adjustment = 1000;
+	switch (o->devtype) {
+	case C119B_PRODUCT_ID:
+		adjustment = C119B_ADJUSTMENT;
+		break;
+	default:
+		adjustment = 1000;
 	}
 	if (o->pmrChan->spsTxOutA) {
 		o->pmrChan->spsTxOutA->outputGain = mult_calc((o->txmixaset * 152) / adjustment);
@@ -4964,7 +4950,6 @@ static int xpmr_config(struct chan_usbradio_pvt *o)
 	if (o->pmrChan->rxfreq) {
 		o->pmrChan->b.reprog = 1;
 	}
-	
 
 	return 0;
 }
@@ -4980,7 +4965,7 @@ static struct chan_usbradio_pvt *store_config(const struct ast_config *cfg, cons
 {
 	const struct ast_variable *v;
 	struct chan_usbradio_pvt *o;
-	char  buf[100];
+	char buf[100];
 	int i;
 
 	if (ctg == NULL) {
@@ -5100,12 +5085,10 @@ static struct chan_usbradio_pvt *store_config(const struct ast_config *cfg, cons
 	}
 
 	if ((o->txmixa == TX_OUT_COMPOSITE) && (o->txmixb == TX_OUT_VOICE)) {
-		ast_log(LOG_ERROR,
-				"Invalid Configuration: Can not have B channel be Voice with A channel being Composite!!\n");
+		ast_log(LOG_ERROR, "Invalid Configuration: Can not have B channel be Voice with A channel being Composite!!\n");
 	}
 	if ((o->txmixb == TX_OUT_COMPOSITE) && (o->txmixa == TX_OUT_VOICE)) {
-		ast_log(LOG_ERROR,
-				"Invalid Configuration: Can not have A channel be Voice with B channel being Composite!!\n");
+		ast_log(LOG_ERROR, "Invalid Configuration: Can not have A channel be Voice with B channel being Composite!!\n");
 	}
 
 	if (o == &usbradio_default) {	/* we are done with the default */
@@ -5117,7 +5100,7 @@ static struct chan_usbradio_pvt *store_config(const struct ast_config *cfg, cons
 		if (!o->pps[i]) {
 			continue;
 		}
-		/* skip if not out or PTT*/
+		/* skip if not out or PTT */
 		if (strncasecmp(o->pps[i], "out", 3) && strcasecmp(o->pps[i], "ptt")) {
 			continue;
 		}
@@ -5170,7 +5153,6 @@ static struct chan_usbradio_pvt *store_config(const struct ast_config *cfg, cons
 		tChan.rxCarrierHyst = o->rxsqhyst;
 		tChan.rxSqVoxAdj = o->rxsqvoxadj;
 		tChan.rxSquelchDelay = o->rxsquelchdelay;
-		
 
 		if (o->txlimonly) {
 			tChan.txMod = 1;
@@ -5222,15 +5204,12 @@ static struct chan_usbradio_pvt *store_config(const struct ast_config *cfg, cons
 		o->pmrChan->txCpuSaver = o->txcpusaver;
 
 		/* adjust settings based on the device */
-		switch (o->devtype)
-		{
-			case C119B_PRODUCT_ID:
-	            *(o->pmrChan->prxSquelchAdjust) =
-					((999 - o->rxsquelchadj) * 32767) / C119B_ADJUSTMENT;
-				break;
-			default:
-				*(o->pmrChan->prxSquelchAdjust) =
-					((999 - o->rxsquelchadj) * 32767) / 1000;
+		switch (o->devtype) {
+		case C119B_PRODUCT_ID:
+			*(o->pmrChan->prxSquelchAdjust) = ((999 - o->rxsquelchadj) * 32767) / C119B_ADJUSTMENT;
+			break;
+		default:
+			*(o->pmrChan->prxSquelchAdjust) = ((999 - o->rxsquelchadj) * 32767) / 1000;
 		}
 
 		*(o->pmrChan->prxVoiceAdjust) = o->rxvoiceadj * M_Q8;
@@ -5389,8 +5368,7 @@ static char *handle_console_key(struct ast_cli_entry *e, int cmd, struct ast_cli
 	switch (cmd) {
 	case CLI_INIT:
 		e->command = "radio key";
-		e->usage = 	"Usage: radio key\n"
-					"       Simulates COR active.\n";
+		e->usage = "Usage: radio key\n" "       Simulates COR active.\n";
 		return NULL;
 	case CLI_GENERATE:
 		return NULL;
@@ -5410,8 +5388,7 @@ static char *handle_console_unkey(struct ast_cli_entry *e, int cmd, struct ast_c
 	switch (cmd) {
 	case CLI_INIT:
 		e->command = "radio unkey";
-		e->usage =	"Usage: radio unkey\n"
-					"       Simulates COR un-active.\n";
+		e->usage = "Usage: radio unkey\n" "       Simulates COR un-active.\n";
 		return NULL;
 	case CLI_GENERATE:
 		return NULL;
@@ -5430,20 +5407,14 @@ static char *handle_radio_tune(struct ast_cli_entry *e, int cmd, struct ast_cli_
 {
 	switch (cmd) {
 	case CLI_INIT:
-		e->command = "radio tune {auxvoice|dump|swap|rxnoise|rxvoice|rxtone|txvoice|txtone|txall|flash|rxsquelch|nocap|rxtracecap|txtracecap|rxcap|txcap|save|load|menu-support|txslimsp}";
-		e->usage =	"Usage: radio tune <function>\n"
-					"       rxnoise\n"
-					"       rxvoice\n"
-					"       rxtone\n"
-					"       rxsquelch [newsetting]\n"
-					"       txvoice [newsetting]\n"
-					"       txtone [newsetting]\n"
-                    "       txslimsp [setpoint]\n"
-					"       auxvoice [newsetting]\n"
-					"       save (settings to tuning file)\n"
-					"       load (tuning settings from EEPROM)\n\n"
-					"       All [newsetting]'s are values 0-999\n"
-					"       [setpoint] is 5000 to 13000\n\n";
+		e->command =
+			"radio tune {auxvoice|dump|swap|rxnoise|rxvoice|rxtone|txvoice|txtone|txall|flash|rxsquelch|nocap|rxtracecap|txtracecap|rxcap|txcap|save|load|menu-support|txslimsp}";
+		e->usage =
+			"Usage: radio tune <function>\n" "       rxnoise\n" "       rxvoice\n" "       rxtone\n"
+			"       rxsquelch [newsetting]\n" "       txvoice [newsetting]\n" "       txtone [newsetting]\n"
+			"       txslimsp [setpoint]\n" "       auxvoice [newsetting]\n" "       save (settings to tuning file)\n"
+			"       load (tuning settings from EEPROM)\n\n" "       All [newsetting]'s are values 0-999\n"
+			"       [setpoint] is 5000 to 13000\n\n";
 
 		return NULL;
 	case CLI_GENERATE:
@@ -5464,10 +5435,10 @@ static char *handle_radio_active(struct ast_cli_entry *e, int cmd, struct ast_cl
 	switch (cmd) {
 	case CLI_INIT:
 		e->command = "radio active";
-		e->usage =	"Usage: radio active [device-name]\n"
-					"       If used without a parameter, displays which device is the current\n"
-					"       one being commanded.  If a device is specified, the commanded radio device is changed\n"
-					"       to the device specified.\n";
+		e->usage = "Usage: radio active [device-name]\n"
+			"       If used without a parameter, displays which device is the current\n"
+			"       one being commanded.  If a device is specified, the commanded radio device is changed\n"
+			"       to the device specified.\n";
 		return NULL;
 	case CLI_GENERATE:
 		return NULL;
@@ -5489,7 +5460,7 @@ static char *handle_show_settings(struct ast_cli_entry *e, int cmd, struct ast_c
 	switch (cmd) {
 	case CLI_INIT:
 		e->command = "radio show settings";
-		e->usage = 	"Usage: radio show settings\n";
+		e->usage = "Usage: radio show settings\n";
 		return NULL;
 	case CLI_GENERATE:
 		return NULL;
@@ -5514,9 +5485,7 @@ static char *handle_set_xdebug(struct ast_cli_entry *e, int cmd, struct ast_cli_
 	switch (cmd) {
 	case CLI_INIT:
 		e->command = "radio set xdebug";
-		e->usage =	"Usage: radio set xdebug [level]\n"
-					"       Level 0 to 100.\n"
-					"       Set xpmr debug level.\n";
+		e->usage = "Usage: radio set xdebug [level]\n" "       Level 0 to 100.\n" "       Set xpmr debug level.\n";
 		return NULL;
 	case CLI_GENERATE:
 		return NULL;
@@ -5703,10 +5672,6 @@ static int unload_module(void)
 	return 0;
 }
 
-AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_DEFAULT, "USB Console Channel Driver",
-	.support_level = AST_MODULE_SUPPORT_EXTENDED,
-	.load = load_module,
-	.unload = unload_module,
-	.reload = reload_module,
-	.requires = "res_usbradio",
-);
+AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_DEFAULT, "USB Console Channel Driver",.support_level =
+				AST_MODULE_SUPPORT_EXTENDED,.load = load_module,.unload = unload_module,.reload =
+				reload_module,.requires = "res_usbradio",);

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -3186,7 +3186,7 @@ static int set_txctcss_level(struct chan_usbradio_pvt *o)
  * 
  * \param o				chan_usbradio structure.
  * \param setpoint      A value which indicates the onset of soft limiting.
- * \return			    zero if successful, 1 if otherwise
+ * \return			    zero if successful, -1 if otherwise
  */
 
 static int xpmr_set_tx_soft_limiter(struct chan_usbradio_pvt *o, int setpoint)

--- a/channels/xpmr/xpmr.c
+++ b/channels/xpmr/xpmr.c
@@ -2616,7 +2616,7 @@ Returns 0 if successful. -1 if the setpoint is out of bounds or the pChan isn't 
 
 i16 SetTxSoftLimiterSetpoint(t_pmr_chan *pChan, i16 setpoint)
 {
-	if((!pChan)) {
+	if(!pChan) {
 		return -1;
 	}
 

--- a/channels/xpmr/xpmr.c
+++ b/channels/xpmr/xpmr.c
@@ -2616,14 +2616,12 @@ Returns 0 if successful. -1 if the setpoint is out of bounds or the pChan isn't 
 
 i16 SetTxSoftLimiterSetpoint(t_pmr_chan *pChan, i16 setpoint)
 {
-	
-	if(!pChan) {
+	if((!pChan)) {
 		return -1;
 	}
 
-	/* Ignore if soft limiter setpoint adjust isn't enabled */
-	/* Limiter pSps won't be initialized in this case */
-	if(!pChan->txLimiterEnable) {
+	/* Ignore if soft limiter setpoint adjust isn't enabled or the pSps block pointer is NULL */
+	if((!pChan->spsLimiterTx) || (!pChan->txLimiterEnable)) {
 		TRACEF(1, "Request to set limiter setpoint ignored. Limiter not enabled\n");
 		return 0;
 	}

--- a/channels/xpmr/xpmr.c
+++ b/channels/xpmr/xpmr.c
@@ -2611,7 +2611,7 @@ i16 destroyPmrSps(t_pmr_sps *pSps)
 /*
 Set the tx soft limiter set point
 Takes the pmr channel and the new setpoint as arguments
-Returns 0 if successful. 1 if the setpoint is out of bounds or the pChan isn't properly initialized.
+Returns 0 if successful. -1 if the setpoint is out of bounds or the pChan isn't properly initialized.
 */
 
 i16 SetTxSoftLimiterSetpoint(t_pmr_chan *pChan, i16 setpoint)

--- a/channels/xpmr/xpmr.c
+++ b/channels/xpmr/xpmr.c
@@ -2621,12 +2621,12 @@ i16 SetTxSoftLimiterSetpoint(t_pmr_chan *pChan, i16 setpoint)
 	}
 
 	/* Ignore if soft limiter setpoint adjust isn't enabled or the pSps block pointer is NULL */
-	if((!pChan->spsLimiterTx) || (!pChan->txLimiterEnable)) {
+	if ((!pChan->spsLimiterTx) || (!pChan->txLimiterEnable)) {
 		TRACEF(1, "Request to set limiter setpoint ignored. Limiter not enabled\n");
 		return 0;
 	}
 	
-    /* Bounds check setpoint to ensure it is within range */
+	/* Bounds check setpoint to ensure it is within range */
 	if ((setpoint < 5000) || (setpoint > 13000)) {
 		return -1;
 	}

--- a/channels/xpmr/xpmr.c
+++ b/channels/xpmr/xpmr.c
@@ -64,7 +64,7 @@
 #pragma GCC diagnostic ignored "-Wsequence-point"
 #endif
 
-#define N_FMT(duf) "%30" #duf /* Maximum sscanf conversion to numeric strings */
+#define N_FMT(duf) "%30" #duf	/* Maximum sscanf conversion to numeric strings */
 #include "asterisk.h"
 
 #include <stdio.h>
@@ -77,16 +77,16 @@
 #include <sys/time.h>
 #include <stdlib.h>
 #include <errno.h>
-   
+
 #include "xpmr.h"
 #include "xpmr_coef.h"
 #include "sinetabx.h"
 
-static i16 pmrChanIndex=0;	 			// count of created pmr instances
+static i16 pmrChanIndex = 0;	// count of created pmr instances
 //static i16 pmrSpsIndex=0;
 
 #if (DTX_PROG == 1) || 	XPMR_PPTP == 1
-static int ppdrvdev=0;
+static int ppdrvdev = 0;
 #endif
 
 /*
@@ -95,30 +95,29 @@ static int ppdrvdev=0;
 void strace(i16 point, t_sdbg *sdbg, i16 index, i16 value)
 {
 	// make dbg_trace buffer in structure
-	if(!sdbg->mode || sdbg->point[point]<0){
+	if (!sdbg->mode || sdbg->point[point] < 0) {
 		return;
-    } else {
-		sdbg->buffer[(index*XPMR_DEBUG_CHANS) + sdbg->point[point]] = value;
+	} else {
+		sdbg->buffer[(index * XPMR_DEBUG_CHANS) + sdbg->point[point]] = value;
 	}
 }
+
 /*
 
 */
 void strace2(t_sdbg *sdbg)
 {
 	int i;
-	for(i=0;i<XPMR_DEBUG_CHANS;i++)
-	{
-		if(sdbg->source[i])
-		{
+	for (i = 0; i < XPMR_DEBUG_CHANS; i++) {
+		if (sdbg->source[i]) {
 			int ii;
-			for(ii=0;ii<SAMPLES_PER_BLOCK;ii++)
-			{
-				sdbg->buffer[ii*XPMR_DEBUG_CHANS + i] = sdbg->source[i][ii];
-		    }
+			for (ii = 0; ii < SAMPLES_PER_BLOCK; ii++) {
+				sdbg->buffer[ii * XPMR_DEBUG_CHANS + i] = sdbg->source[i][ii];
+			}
 		}
 	}
 }
+
 #if XPMR_PPTP == 1
 /*
 	Hardware Trace Signals via the PC Parallel Port
@@ -133,21 +132,23 @@ void pptp_init(void)
 		exit(0);
 	}
 	ioctl(ppdrvdev, PPDRV_IOC_PINMODE_OUT, DTX_CLK | DTX_DATA | DTX_ENABLE | DTX_TXPWR | DTX_TX | DTX_TP1 | DTX_TP2);
-	ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR,    DTX_CLK | DTX_DATA | DTX_ENABLE | DTX_TXPWR | DTX_TX | DTX_TP1 | DTX_TP2);
+	ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR, DTX_CLK | DTX_DATA | DTX_ENABLE | DTX_TXPWR | DTX_TX | DTX_TP1 | DTX_TP2);
 }
+
 /*
 */
-void	pptp_write(i16 bit, i16 state)
+void pptp_write(i16 bit, i16 state)
 {
-	if(bit==0)
-	{
-		if(state)ioctl(ppdrvdev,PPDRV_IOC_PINSET,DTX_TP1);
-		else ioctl(ppdrvdev,PPDRV_IOC_PINCLEAR,DTX_TP1);
-	}
-	else
-	{
-		if(state)ioctl(ppdrvdev,PPDRV_IOC_PINSET,DTX_TP2);
-		else ioctl(ppdrvdev,PPDRV_IOC_PINCLEAR,DTX_TP2);
+	if (bit == 0) {
+		if (state)
+			ioctl(ppdrvdev, PPDRV_IOC_PINSET, DTX_TP1);
+		else
+			ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR, DTX_TP1);
+	} else {
+		if (state)
+			ioctl(ppdrvdev, PPDRV_IOC_PINSET, DTX_TP2);
+		else
+			ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR, DTX_TP2);
 	}
 }
 #endif
@@ -160,56 +161,53 @@ void	pptp_write(i16 bit, i16 state)
 */
 i16 string_parse(char *src, char **dest, char ***ptrs)
 {
-	char *p,*pd;
+	char *p, *pd;
 	char *ptstr[1000];
 	i16 i, slen, numsub;
 
 	TRACEJ(2, "string_parse(%s)\n", src);
 
-	slen=strlen(src);
+	slen = strlen(src);
 	TRACEJ(2, " source len = %i\n", slen);
 
-	pd=*dest;
-	if(pd) ast_free(pd);
-    pd=ast_calloc(slen+1,1);
-	memcpy(pd,src,slen);
-	*dest=pd;
+	pd = *dest;
+	if (pd)
+		ast_free(pd);
+	pd = ast_calloc(slen + 1, 1);
+	memcpy(pd, src, slen);
+	*dest = pd;
 
-	p=0;
-	numsub=0;
-	for(i=0;i<slen+1;i++)
-	{
+	p = 0;
+	numsub = 0;
+	for (i = 0; i < slen + 1; i++) {
 		TRACEJ(5, " pd[%i] = %c\n", i, pd[i]);
 
-		if( p==0 && pd[i]!=',' && pd[i]!=' ' )
-		{
-			p=&(pd[i]);	
-		}
-		else if(pd[i]==',' || pd[i]==0 )
-		{
-			ptstr[numsub]=p;
-			pd[i]=0;
-			p=0;
+		if (p == 0 && pd[i] != ',' && pd[i] != ' ') {
+			p = &(pd[i]);
+		} else if (pd[i] == ',' || pd[i] == 0) {
+			ptstr[numsub] = p;
+			pd[i] = 0;
+			p = 0;
 			numsub++;
 		}
 	}
 
-	for(i=0;i<numsub;i++)
-	{
+	for (i = 0; i < numsub; i++) {
 		TRACEJ(5, " ptstr[%i] = %p %s\n", i, ptstr[i], ptstr[i]);
 	}
 
-	if(*ptrs)ast_free(*ptrs);
-	*ptrs=ast_calloc(numsub, sizeof(char*));
-	for(i=0;i<numsub;i++)
-	{
-		(*ptrs)[i]=ptstr[i];
+	if (*ptrs)
+		ast_free(*ptrs);
+	*ptrs = ast_calloc(numsub, sizeof(char *));
+	for (i = 0; i < numsub; i++) {
+		(*ptrs)[i] = ptstr[i];
 		TRACEJ(5, " %i = %s\n", i, (*ptrs)[i]);
 	}
 	TRACEJ(5, "string_parse()=%i\n\n", numsub);
 
 	return numsub;
 }
+
 /*
 	the parent program defines
 	pRxCodeSrc and pTxCodeSrc string pointers to the list of codes
@@ -222,8 +220,8 @@ i16 code_string_parse(t_pmr_chan *pChan)
 	char *p;
 	float f, maxctcsstxfreq;
 
-	t_pmr_sps  	*pSps;
-	i16	maxctcssindex;
+	t_pmr_sps *pSps;
+	i16 maxctcssindex;
 
 	TRACEF(1, "code_string_parse(%i)\n", 0);
 	TRACEF(1, "pChan->pRxCodeSrc %s \n", pChan->pRxCodeSrc);
@@ -232,59 +230,58 @@ i16 code_string_parse(t_pmr_chan *pChan)
 
 	//printf("code_string_parse() %s / %s / %s / %s \n",pChan->name, pChan->pTxCodeDefault,pChan->pTxCodeSrc,pChan->pRxCodeSrc);
 
- 	maxctcssindex=CTCSS_NULL;
-	maxctcsstxfreq=CTCSS_NULL;
-	pChan->txctcssdefault_index=CTCSS_NULL;
-	pChan->txctcssdefault_value=CTCSS_NULL;
+	maxctcssindex = CTCSS_NULL;
+	maxctcsstxfreq = CTCSS_NULL;
+	pChan->txctcssdefault_index = CTCSS_NULL;
+	pChan->txctcssdefault_value = CTCSS_NULL;
 
-	pChan->b.ctcssRxEnable=pChan->b.ctcssTxEnable=0;
-	pChan->b.dcsRxEnable=pChan->b.dcsTxEnable=0;
-	pChan->b.lmrRxEnable=pChan->b.lmrTxEnable=0;
-	pChan->b.mdcRxEnable=pChan->b.mdcTxEnable=0;
-	pChan->b.dstRxEnable=pChan->b.dstTxEnable=0;
-	pChan->b.p25RxEnable=pChan->b.p25TxEnable=0;
+	pChan->b.ctcssRxEnable = pChan->b.ctcssTxEnable = 0;
+	pChan->b.dcsRxEnable = pChan->b.dcsTxEnable = 0;
+	pChan->b.lmrRxEnable = pChan->b.lmrTxEnable = 0;
+	pChan->b.mdcRxEnable = pChan->b.mdcTxEnable = 0;
+	pChan->b.dstRxEnable = pChan->b.dstTxEnable = 0;
+	pChan->b.p25RxEnable = pChan->b.p25TxEnable = 0;
 
-	if(pChan->spsLsdGen){
-		pChan->spsLsdGen->enabled=0;
-		pChan->spsLsdGen->state=0;
+	if (pChan->spsLsdGen) {
+		pChan->spsLsdGen->enabled = 0;
+		pChan->spsLsdGen->state = 0;
 	}
 
 	TRACEF(1, "code_string_parse(%i) 05\n", 0);
 
-	pChan->numrxcodes = string_parse( pChan->pRxCodeSrc, &(pChan->pRxCodeStr), &(pChan->pRxCode));
-	pChan->numtxcodes = string_parse( pChan->pTxCodeSrc, &(pChan->pTxCodeStr), &(pChan->pTxCode));
+	pChan->numrxcodes = string_parse(pChan->pRxCodeSrc, &(pChan->pRxCodeStr), &(pChan->pRxCode));
+	pChan->numtxcodes = string_parse(pChan->pTxCodeSrc, &(pChan->pTxCodeStr), &(pChan->pTxCode));
 
 	if (pChan->numrxcodes != pChan->numtxcodes) {
 		ast_log(LOG_ERROR, "numrxcodes != numtxcodes \n");
 	}
-	pChan->rxCtcss->enabled=0;
-	pChan->rxCtcss->gain=1*M_Q8;
-	pChan->rxCtcss->limit=8192;
-	pChan->rxCtcss->input=pChan->pRxLsdLimit;
-	pChan->rxCtcss->decode=CTCSS_NULL;
+	pChan->rxCtcss->enabled = 0;
+	pChan->rxCtcss->gain = 1 * M_Q8;
+	pChan->rxCtcss->limit = 8192;
+	pChan->rxCtcss->input = pChan->pRxLsdLimit;
+	pChan->rxCtcss->decode = CTCSS_NULL;
 
-	pChan->rxCtcss->testIndex=0;
-	if(!pChan->rxCtcss->testIndex)pChan->rxCtcss->testIndex=3;
+	pChan->rxCtcss->testIndex = 0;
+	if (!pChan->rxCtcss->testIndex)
+		pChan->rxCtcss->testIndex = 3;
 
-	pChan->rxctcssfreq[0]=0;	// decode now	CTCSS_RXONLY
+	pChan->rxctcssfreq[0] = 0;	// decode now   CTCSS_RXONLY
 
-	for(i=0;i<CTCSS_NUM_CODES;i++)
-	{
-		pChan->rxctcss[i]=0;
-		pChan->txctcss[i]=0;
-		pChan->rxCtcssMap[i]=CTCSS_NULL;
+	for (i = 0; i < CTCSS_NUM_CODES; i++) {
+		pChan->rxctcss[i] = 0;
+		pChan->txctcss[i] = 0;
+		pChan->rxCtcssMap[i] = CTCSS_NULL;
 	}
 
 	TRACEF(1, "code_string_parse(%i) 10\n", 0);
 
 #ifdef XPMRX_H
-	xpmrx(pChan,XXO_LSDCODEPARSE);
-	#endif
+	xpmrx(pChan, XXO_LSDCODEPARSE);
+#endif
 
 	// Do Receive Codes String
-	for(i=0;i<pChan->numrxcodes;i++)
-	{
-		i16 ii,ri,ti;
+	for (i = 0; i < pChan->numrxcodes; i++) {
+		i16 ii, ri, ti;
 		float f;
 
 		p = pChan->pStr = pChan->pRxCode[i];
@@ -302,12 +299,12 @@ i16 code_string_parse(t_pmr_chan *pChan)
 				maxctcssindex = ri;
 			}
 
-			if (i < pChan->numtxcodes) { /* more rx codes than tx codes */
+			if (i < pChan->numtxcodes) {	/* more rx codes than tx codes */
 				sscanf(pChan->pTxCode[i], N_FMT(f), &f);
 				ti = CtcssFreqIndex(f);
 				if (ti == CTCSS_NULL) {
 					if (f != 0.0) {
-						f = -1.0; /* tone freq not valid */
+						f = -1.0;	/* tone freq not valid */
 						ast_log(LOG_ERROR, "Invalid TX CTCSS code detected and ignored. %i %s\n", i, pChan->pTxCode[i]);
 					}
 				} else if (f > maxctcsstxfreq) {
@@ -315,7 +312,7 @@ i16 code_string_parse(t_pmr_chan *pChan)
 				}
 			} else {
 				ti = CTCSS_NULL;
-				f = -1.0; /* tone freq not provided */
+				f = -1.0;		/* tone freq not provided */
 				ast_log(LOG_ERROR, "Invalid CTCSS configuration. Number of rx codes > number of tx codes\n");
 			}
 
@@ -326,7 +323,7 @@ i16 code_string_parse(t_pmr_chan *pChan)
 				pChan->numrxctcssfreqs++;
 				TRACEF(1, "pChan->rxctcss[%i]=%s  pChan->rxCtcssMap[%i]=%i\n", i, pChan->rxctcss[i], ri, ti);
 			} else if (ri > CTCSS_NULL && f == 0) {
-				pChan->b.ctcssRxEnable=1;
+				pChan->b.ctcssRxEnable = 1;
 				pChan->rxCtcssMap[ri] = CTCSS_RXONLY;
 				pChan->numrxctcssfreqs++;
 				TRACEF(1, "pChan->rxctcss[%i]=%s  pChan->rxCtcssMap[%i]=%i RXONLY\n", i, pChan->rxctcss[i], ri, ti);
@@ -341,32 +338,28 @@ i16 code_string_parse(t_pmr_chan *pChan)
 	}
 
 	TRACEF(1, "code_string_parse() CTCSS Init Struct  %i  %i\n", pChan->b.ctcssRxEnable, pChan->b.ctcssTxEnable);
-	if(pChan->b.ctcssRxEnable)
-	{
-		pChan->rxHpfEnable=1;
-		pChan->spsRxLsdNrz->enabled=pChan->rxCenterSlicerEnable=1;
-		pChan->rxCtcssDecodeEnable=1;
-		pChan->rxCtcss->enabled=1;
-	}
-	else
-	{
-		pChan->rxHpfEnable=1;
-		pChan->spsRxLsdNrz->enabled=pChan->rxCenterSlicerEnable=0;
-		pChan->rxCtcssDecodeEnable=0;
-		pChan->rxCtcss->enabled=0;
+	if (pChan->b.ctcssRxEnable) {
+		pChan->rxHpfEnable = 1;
+		pChan->spsRxLsdNrz->enabled = pChan->rxCenterSlicerEnable = 1;
+		pChan->rxCtcssDecodeEnable = 1;
+		pChan->rxCtcss->enabled = 1;
+	} else {
+		pChan->rxHpfEnable = 1;
+		pChan->spsRxLsdNrz->enabled = pChan->rxCenterSlicerEnable = 0;
+		pChan->rxCtcssDecodeEnable = 0;
+		pChan->rxCtcss->enabled = 0;
 	}
 
 	TRACEF(1, "code_string_parse() CTCSS Init Decoders \n");
-	for(i=0;i<CTCSS_NUM_CODES;i++)
-	{
+	for (i = 0; i < CTCSS_NUM_CODES; i++) {
 		t_tdet *ptdet;
-		ptdet=&(pChan->rxCtcss->tdet[i]);
-		ptdet->counterFactor=coef_ctcss_div[i];
-		ptdet->state=1;
-		ptdet->setpt=(M_Q15*0.041);		   			// 0.069
-		ptdet->hyst =(M_Q15*0.0130);
-		ptdet->binFactor=(M_Q15*0.135);			  	// was 0.140
-		ptdet->fudgeFactor=8;
+		ptdet = &(pChan->rxCtcss->tdet[i]);
+		ptdet->counterFactor = coef_ctcss_div[i];
+		ptdet->state = 1;
+		ptdet->setpt = (M_Q15 * 0.041);	// 0.069
+		ptdet->hyst = (M_Q15 * 0.0130);
+		ptdet->binFactor = (M_Q15 * 0.135);	// was 0.140
+		ptdet->fudgeFactor = 8;
 	}
 
 	// DEFAULT TX CODE
@@ -398,7 +391,7 @@ i16 code_string_parse(t_pmr_chan *pChan)
 
 	// set x for maximum length and just change pointers
 	TRACEF(1, "code_string_parse() Filter Config \n");
-	pSps=pChan->spsTxLsdLpf;
+	pSps = pChan->spsTxLsdLpf;
 	if (pSps->x) {
 		ast_free(pSps->x);
 	}
@@ -410,103 +403,99 @@ i16 code_string_parse(t_pmr_chan *pChan)
 		pSps->size_x = 2;
 		pSps->x = ast_calloc(pSps->nx, pSps->size_x);
 		if (pSps->x == NULL) {
-			; /* XXX do something here */
+			;					/* XXX do something here */
 		}
 		pSps->calcAdjust = gain_fir_lpf_250_9_66;
 		TRACEF(1, "code_string_parse() Tx Filter Freq High\n");
 	} else {
-		pSps->ncoef=taps_fir_lpf_215_9_88;
-		pSps->size_coef=2;
-		pSps->coef=(void*)coef_fir_lpf_215_9_88;
-		pSps->nx=taps_fir_lpf_215_9_88;
-		pSps->size_x=2;
+		pSps->ncoef = taps_fir_lpf_215_9_88;
+		pSps->size_coef = 2;
+		pSps->coef = (void *) coef_fir_lpf_215_9_88;
+		pSps->nx = taps_fir_lpf_215_9_88;
+		pSps->size_x = 2;
 		pSps->x = ast_calloc(pSps->nx, pSps->size_x);
 		if (pSps->x == NULL) {
-			; /* XXX do something here */
+			;					/* XXX do something here */
 		}
-		pSps->calcAdjust=gain_fir_lpf_215_9_88;
+		pSps->calcAdjust = gain_fir_lpf_215_9_88;
 		TRACEF(1, "code_string_parse() Tx Filter Freq Low\n");
 	}
 
 	// CTCSS Rx Decoder Low Pass Filter
-	hit=0;
-	ii=	CtcssFreqIndex(203.5);
-	for(i=ii;i<CTCSS_NUM_CODES;i++)
-	{
-		if(pChan->rxCtcssMap[i]>CTCSS_NULL)hit=1;
+	hit = 0;
+	ii = CtcssFreqIndex(203.5);
+	for (i = ii; i < CTCSS_NUM_CODES; i++) {
+		if (pChan->rxCtcssMap[i] > CTCSS_NULL)
+			hit = 1;
 	}
 
-	pSps=pChan->spsRxLsd;
-	if(pSps->x)ast_free(pSps->x);
-	if(hit)
-	{
-		pSps->ncoef=taps_fir_lpf_250_9_66;
-		pSps->size_coef=2;
-		pSps->coef=(void*)coef_fir_lpf_250_9_66;
-		pSps->nx=taps_fir_lpf_250_9_66;
-		pSps->size_x=2;
+	pSps = pChan->spsRxLsd;
+	if (pSps->x)
+		ast_free(pSps->x);
+	if (hit) {
+		pSps->ncoef = taps_fir_lpf_250_9_66;
+		pSps->size_coef = 2;
+		pSps->coef = (void *) coef_fir_lpf_250_9_66;
+		pSps->nx = taps_fir_lpf_250_9_66;
+		pSps->size_x = 2;
 		pSps->x = ast_calloc(pSps->nx, pSps->size_x);
 		if (pSps->x == NULL) {
-			; /* XXX do something here */
+			;					/* XXX do something here */
 		}
-		pSps->calcAdjust=gain_fir_lpf_250_9_66;
+		pSps->calcAdjust = gain_fir_lpf_250_9_66;
 		TRACEF(1, "code_string_parse() Rx Filter Freq High\n");
-	}
-	else
-	{
-		pSps->ncoef=taps_fir_lpf_215_9_88;
-		pSps->size_coef=2;
-		pSps->coef=(void*)coef_fir_lpf_215_9_88;
-		pSps->nx=taps_fir_lpf_215_9_88;
-		pSps->size_x=2;
+	} else {
+		pSps->ncoef = taps_fir_lpf_215_9_88;
+		pSps->size_coef = 2;
+		pSps->coef = (void *) coef_fir_lpf_215_9_88;
+		pSps->nx = taps_fir_lpf_215_9_88;
+		pSps->size_x = 2;
 		pSps->x = ast_calloc(pSps->nx, pSps->size_x);
 		if (pSps->x == NULL) {
-			; /* XXX do something here */
+			;					/* XXX do something here */
 		}
-		pSps->calcAdjust=gain_fir_lpf_215_9_88;
+		pSps->calcAdjust = gain_fir_lpf_215_9_88;
 		TRACEF(1, "code_string_parse() Rx Filter Freq Low\n");
 	}
 
-	if(pChan->b.ctcssRxEnable || pChan->b.dcsRxEnable || pChan->b.lmrRxEnable)
-	{
-		pChan->rxCenterSlicerEnable=1;
-		pSps->enabled=1;
-	}
-	else
-	{
-		pChan->rxCenterSlicerEnable=0;
-		pSps->enabled=0;
+	if (pChan->b.ctcssRxEnable || pChan->b.dcsRxEnable || pChan->b.lmrRxEnable) {
+		pChan->rxCenterSlicerEnable = 1;
+		pSps->enabled = 1;
+	} else {
+		pChan->rxCenterSlicerEnable = 0;
+		pSps->enabled = 0;
 	}
 
-	#if XPMR_DEBUG0 == 1
+#if XPMR_DEBUG0 == 1
 	TRACEF(2, "code_string_parse() ctcssRxEnable = %i \n", pChan->b.ctcssRxEnable);
 	TRACEF(2, "                    ctcssTxEnable = %i \n", pChan->b.ctcssTxEnable);
 	TRACEF(2, "                      dcsRxEnable = %i \n", pChan->b.dcsRxEnable);
 	TRACEF(2, "                      lmrRxEnable = %i \n", pChan->b.lmrRxEnable);
 	TRACEF(2, "               txcodedefaultsmode = %i \n", pChan->txcodedefaultsmode);
-	for(i=0;i<CTCSS_NUM_CODES;i++)
-	{
+	for (i = 0; i < CTCSS_NUM_CODES; i++) {
 		TRACEF(2, "rxCtcssMap[%i] = %i \n", i, pChan->rxCtcssMap[i]);
 	}
-    #endif
+#endif
 
-	#ifdef HAVE_XPMRX
-	lsd_code_parse(pChan,5);
-	#endif
+#ifdef HAVE_XPMRX
+	lsd_code_parse(pChan, 5);
+#endif
 
 	TRACEF(1, "code_string_parse(%i) end\n", 0);
 
 	return 0;
 }
+
 /*
 	Convert a Frequency in Hz to a zero based CTCSS Table index
 */
 i16 CtcssFreqIndex(float freq)
 {
-	i16 i,hit=CTCSS_NULL;
+	i16 i, hit = CTCSS_NULL;
 
-	for(i=0;i<CTCSS_NUM_CODES;i++){
-		if(freq==freq_ctcss[i])hit=i;
+	for (i = 0; i < CTCSS_NUM_CODES; i++) {
+		if (freq == freq_ctcss[i])
+			hit = i;
 	}
 	return hit;
 }
@@ -520,9 +509,9 @@ i16 CtcssFreqIndex(float freq)
 */
 i16 pmr_rx_frontend(t_pmr_sps *mySps)
 {
-	#define DCgainBpfNoise 	65536
+#define DCgainBpfNoise 	65536
 
-	i16 samples,nx,iOutput, *input, *output, *noutput;
+	i16 samples, nx, iOutput, *input, *output, *noutput;
 	i16 *x;
 	i16 decimator, decimate, doNoise, fever, fev1;
 	i32 i, naccum, outputGain, calcAdjust;
@@ -530,146 +519,134 @@ i16 pmr_rx_frontend(t_pmr_sps *mySps)
 
 	TRACEJ(5, "pmr_rx_frontend()\n");
 
-	if(!mySps->enabled)return(1);
+	if (!mySps->enabled)
+		return (1);
 
 	decimator = mySps->decimator;
 	decimate = mySps->decimate;
 
-	input     = mySps->source;
-	output    = mySps->sink;
-	noutput   = mySps->parentChan->pRxNoise;
-	fever   = mySps->parentChan->fever;
+	input = mySps->source;
+	output = mySps->sink;
+	noutput = mySps->parentChan->pRxNoise;
+	fever = mySps->parentChan->fever;
 
-	nx        = mySps->nx;
+	nx = mySps->nx;
 
 	calcAdjust = mySps->calcAdjust;
 	outputGain = mySps->outputGain;
 
-	samples=mySps->nSamples*decimate;
-	x=mySps->x;
-	iOutput=0;
-	npwr=0;
+	samples = mySps->nSamples * decimate;
+	x = mySps->x;
+	iOutput = 0;
+	npwr = 0;
 
-	if(mySps->parentChan->rxCdType!=CD_XPMR_VOX)doNoise=1;
-	else doNoise=0;
+	if (mySps->parentChan->rxCdType != CD_XPMR_VOX)
+		doNoise = 1;
+	else
+		doNoise = 0;
 
 	if (fever)
-	    fev1 = (nx - 1) * 2;
+		fev1 = (nx - 1) * 2;
 	else
-	    fev1 = nx - 1;
+		fev1 = nx - 1;
 
-	for(i=0;i<samples;i++)
-	{
+	for (i = 0; i < samples; i++) {
 		i16 n;
 
 		//shift the old samples
-        #if 0
-	    for(n=nx-1; n>0; n--)
-	       x[n] = x[n-1];
-        #else
-		memmove(x+1,x,fev1);
-        #endif
-	    x[0] = input[i*2];
+#if 0
+		for (n = nx - 1; n > 0; n--)
+			x[n] = x[n - 1];
+#else
+		memmove(x + 1, x, fev1);
+#endif
+		x[0] = input[i * 2];
 
 #if	XPMR_TRACE_FRONTEND == 1
-	    y=0;
-	    for(n=0; n<nx; n++)
-	        y +=  fir_rxlpf[mySps->parentChan->rxlpf].coefs[n] * x[n];
+		y = 0;
+		for (n = 0; n < nx; n++)
+			y += fir_rxlpf[mySps->parentChan->rxlpf].coefs[n] * x[n];
 
-	    y=((y/calcAdjust)*outputGain)/M_Q8;
-		input[i*2]=y;	 // debug output LowPass at 48KS/s
+		y = ((y / calcAdjust) * outputGain) / M_Q8;
+		input[i * 2] = y;		// debug output LowPass at 48KS/s
 #endif
 
-		if(doNoise)
-		{
+		if (doNoise) {
 			// calculate noise filter output
-			naccum=0;
-			if(mySps->parentChan->rxNoiseFilType==0)
-			{
-			    for(n=0; n<taps_fir_bpf_noise_1; n++)
-			        naccum += coef_fir_bpf_noise_1[n] * x[n];
-			    naccum /= DCgainBpfNoise;
-			}
-			else
-			{
-			    for(n=0; n<taps_fir_bpf_noise_2; n++)
-			        naccum += coef_fir_bpf_noise_2[n] * x[n];
-			    naccum /= gain_fir_bpf_noise_2;
+			naccum = 0;
+			if (mySps->parentChan->rxNoiseFilType == 0) {
+				for (n = 0; n < taps_fir_bpf_noise_1; n++)
+					naccum += coef_fir_bpf_noise_1[n] * x[n];
+				naccum /= DCgainBpfNoise;
+			} else {
+				for (n = 0; n < taps_fir_bpf_noise_2; n++)
+					naccum += coef_fir_bpf_noise_2[n] * x[n];
+				naccum /= gain_fir_bpf_noise_2;
 			}
 #if	XPMR_TRACE_FRONTEND == 1
-			input[i*2+1]=naccum;	 // output noise filter results
+			input[i * 2 + 1] = naccum;	// output noise filter results
 #endif
-		    npwr+=naccum*naccum;
+			npwr += naccum * naccum;
 		}
-
 
 		--decimator;
 
-		if(decimator<=0)
-		{
-			decimator=decimate;
+		if (decimator <= 0) {
+			decimator = decimate;
 
-		    y=0;
-		    for(n=0; n<nx; n++)
-		        y += fir_rxlpf[mySps->parentChan->rxlpf].coefs[n] * x[n];
+			y = 0;
+			for (n = 0; n < nx; n++)
+				y += fir_rxlpf[mySps->parentChan->rxlpf].coefs[n] * x[n];
 
-		    y=((y/calcAdjust)*outputGain)/M_Q8;
+			y = ((y / calcAdjust) * outputGain) / M_Q8;
 
 #if	XPMR_TRACE_OVFLW == 1
-			if(y>32767)
-			{
-				y=32767;
+			if (y > 32767) {
+				y = 32767;
 				ast_log(LOG_ERROR, "pmr_rx_frontend() OVRFLW \n");
-			}
-			else if(y<-32767)
-			{
-				y=-32767;
+			} else if (y < -32767) {
+				y = -32767;
 				ast_log(LOG_ERROR, "pmr_rx_frontend() UNDFLW \n");
 			}
 #else
-			if(y>32767)y=32767;
-			else if(y<-32767)y=-32767;
+			if (y > 32767)
+				y = 32767;
+			else if (y < -32767)
+				y = -32767;
 #endif
-		    output[iOutput++]=y;					// Rx Baseband decimated
+			output[iOutput++] = y;	// Rx Baseband decimated
 
-		}  // if decimator
+		}						// if decimator
 	}
 
-	if(doNoise)
-	{
-		npwr=sqrt(npwr)/16;
+	if (doNoise) {
+		npwr = sqrt(npwr) / 16;
 
 		// compOut=Squelched
-		if(mySps->blanking)mySps->blanking--;
-		mySps->blanking=0;
-		if( !mySps->compOut && 
-		    ( (npwr>(mySps->setpt+mySps->hyst)) || 
-		      ( (mySps->apeak<(mySps->setpt/4)) && (npwr>mySps->setpt) ) 
-		    )
-		   )
-		{
-			if(!mySps->compOut)
-			{
-				mySps->blanking=2;
-				mySps->compOut=1;
+		if (mySps->blanking)
+			mySps->blanking--;
+		mySps->blanking = 0;
+		if (!mySps->compOut &&
+			((npwr > (mySps->setpt + mySps->hyst)) || ((mySps->apeak < (mySps->setpt / 4)) && (npwr > mySps->setpt))
+			)
+			) {
+			if (!mySps->compOut) {
+				mySps->blanking = 2;
+				mySps->compOut = 1;
 			}
-		}
-        else if ((npwr<mySps->setpt)&&(!mySps->blanking))
-		{
-			mySps->compOut=0;
+		} else if ((npwr < mySps->setpt) && (!mySps->blanking)) {
+			mySps->compOut = 0;
 		}
 
-		#if	XPMR_DEBUG0 == 1
-		if(mySps->parentChan->tracetype)
-		{
-			for(i=0;i<mySps->nSamples;i++)
-			{
+#if	XPMR_DEBUG0 == 1
+		if (mySps->parentChan->tracetype) {
+			for (i = 0; i < mySps->nSamples; i++) {
 				noutput[i] = npwr;
 			}
 		}
-		#endif
+#endif
 
-		((t_pmr_chan *)(mySps->parentChan))->rxRssi=mySps->apeak=npwr; 
+		((t_pmr_chan *) (mySps->parentChan))->rxRssi = mySps->apeak = npwr;
 	}
 
 	return 0;
@@ -681,385 +658,383 @@ i16 pmr_rx_frontend(t_pmr_sps *mySps)
 */
 i16 pmr_gp_fir(t_pmr_sps *mySps)
 {
-	i32 nsamples,inputGain,outputGain,calcAdjust;
+	i32 nsamples, inputGain, outputGain, calcAdjust;
 	i16 *input, *output;
 	i16 *x, *coef;
-    i32 i, ii;
+	i32 i, ii;
 	i16 nx, hyst, setpt, compOut;
-	i16 amax, amin, apeak=0, discounteru=0, discounterl=0, discfactor;
+	i16 amax, amin, apeak = 0, discounteru = 0, discounterl = 0, discfactor;
 	i16 decimator, decimate, interpolate;
 	i16 numChanOut, selChanOut, mixOut, monoOut;
 
 	TRACEJ(5, "pmr_gp_fir() %i %i\n", mySps->index, mySps->enabled);
 
-	if(!mySps->enabled)return(1);
+	if (!mySps->enabled)
+		return (1);
 
-	inputGain  = mySps->inputGain;
+	inputGain = mySps->inputGain;
 	calcAdjust = mySps->calcAdjust;
 	outputGain = mySps->outputGain;
 
-	input      = mySps->source;
-	output     = mySps->sink;
-	x          = mySps->x;
-	nx         = mySps->nx;
-	coef       = mySps->coef;
+	input = mySps->source;
+	output = mySps->sink;
+	x = mySps->x;
+	nx = mySps->nx;
+	coef = mySps->coef;
 
-	decimator   = mySps->decimator;
-	decimate 	= mySps->decimate;
+	decimator = mySps->decimator;
+	decimate = mySps->decimate;
 	interpolate = mySps->interpolate;
 
-	setpt	   = mySps->setpt;
-	compOut    = mySps->compOut;
+	setpt = mySps->setpt;
+	compOut = mySps->compOut;
 
-	inputGain  = mySps->inputGain;
+	inputGain = mySps->inputGain;
 	outputGain = mySps->outputGain;
 	numChanOut = mySps->numChanOut;
 	selChanOut = mySps->selChanOut;
-	mixOut     = mySps->mixOut;
-	monoOut    = mySps->monoOut;
+	mixOut = mySps->mixOut;
+	monoOut = mySps->monoOut;
 
-	amax=mySps->amax;
-	amin=mySps->amin;
+	amax = mySps->amax;
+	amin = mySps->amin;
 
-	discfactor=mySps->discfactor;
-	hyst=mySps->hyst;
-	setpt=mySps->setpt;
-	nsamples=mySps->nSamples;
+	discfactor = mySps->discfactor;
+	hyst = mySps->hyst;
+	setpt = mySps->setpt;
+	nsamples = mySps->nSamples;
 
-	if(mySps->option==3)
-	{
-		mySps->option=0;
-		mySps->enabled=0;
-		for(i=0;i<nsamples;i++)
-		{
-			if(monoOut)
-				output[(i*2)]=output[(i*2)+1]=0;
+	if (mySps->option == 3) {
+		mySps->option = 0;
+		mySps->enabled = 0;
+		for (i = 0; i < nsamples; i++) {
+			if (monoOut)
+				output[(i * 2)] = output[(i * 2) + 1] = 0;
 			else
-				output[(i*numChanOut)+selChanOut]=0;
+				output[(i * numChanOut) + selChanOut] = 0;
 		}
 		return 0;
 	}
 
-	ii=0;
-	for(i=0;i<nsamples;i++)
-	{
+	ii = 0;
+	for (i = 0; i < nsamples; i++) {
 		int ix;
 
-		int64_t y=0;
+		int64_t y = 0;
 
-		if(decimate<0)
-		{
-			decimator=decimate;
+		if (decimate < 0) {
+			decimator = decimate;
 		}
 
-		for(ix=0;ix<interpolate;ix++)
-		{
+		for (ix = 0; ix < interpolate; ix++) {
 			i16 n;
-			y=0;
+			y = 0;
 
-			for(n=nx-1; n>0; n--)
-				x[n] = x[n-1];
-			x[0] = (input[i]*inputGain)/M_Q8;
+			for (n = nx - 1; n > 0; n--)
+				x[n] = x[n - 1];
+			x[0] = (input[i] * inputGain) / M_Q8;
 
-			#if 0
+#if 0
 			--decimator;
-			if(decimator<=0)
-			{
-				decimator=decimate;
-			    for(n=0; n<nx; n++)
-			        y += coef[n] * x[n];
-				y /= (outputGain*3);
-				output[ii++]=y;
+			if (decimator <= 0) {
+				decimator = decimate;
+				for (n = 0; n < nx; n++)
+					y += coef[n] * x[n];
+				y /= (outputGain * 3);
+				output[ii++] = y;
 			}
-		 	#else
-			for(n=0; n<nx; n++)
-		        	y += coef[n] * x[n];
+#else
+			for (n = 0; n < nx; n++)
+				y += coef[n] * x[n];
 
-		    	y=((y/calcAdjust)*outputGain)/M_Q8;
+			y = ((y / calcAdjust) * outputGain) / M_Q8;
 
-			if (y>32767)y=32767;		 			// overflow
-			else if(y<-32767)y=-32767;
+			if (y > 32767)
+				y = 32767;		// overflow
+			else if (y < -32767)
+				y = -32767;
 
-			if(mixOut){
-				if(monoOut){
-					output[(ii*2)]=output[(ii*2)+1]+=y;
+			if (mixOut) {
+				if (monoOut) {
+					output[(ii * 2)] = output[(ii * 2) + 1] += y;
+				} else {
+					output[(ii * numChanOut) + selChanOut] += y;
 				}
-				else{
-					output[(ii*numChanOut)+selChanOut]+=y;
-				}
-			}
-			else{
-				if(monoOut){
-					output[(ii*2)]=output[(ii*2)+1]=y;
-				}
-				else{
-					output[(ii*numChanOut)+selChanOut]=y;
+			} else {
+				if (monoOut) {
+					output[(ii * 2)] = output[(ii * 2) + 1] = y;
+				} else {
+					output[(ii * numChanOut) + selChanOut] = y;
 				}
 			}
 			ii++;
-		    #endif
+#endif
 		}
 
 		// amplitude detector
-		if(setpt)
-		{
-			i16 accum=y;
+		if (setpt) {
+			i16 accum = y;
 
-			if(accum>amax)
-			{
-				amax=accum;
-				discounteru=discfactor;
-			}
-			else if(--discounteru<=0)
-			{
-				discounteru=discfactor;
-				amax=(i32)((amax*32700)/32768);
+			if (accum > amax) {
+				amax = accum;
+				discounteru = discfactor;
+			} else if (--discounteru <= 0) {
+				discounteru = discfactor;
+				amax = (i32) ((amax * 32700) / 32768);
 			}
 
-			if(accum<amin)
-			{
-				amin=accum;
-				discounterl=discfactor;
-			}
-			else if(--discounterl<=0)
-			{
-				discounterl=discfactor;
-				amin=(i32)((amin*32700)/32768);
+			if (accum < amin) {
+				amin = accum;
+				discounterl = discfactor;
+			} else if (--discounterl <= 0) {
+				discounterl = discfactor;
+				amin = (i32) ((amin * 32700) / 32768);
 			}
 
-			apeak = (i32)(amax-amin)/2;
+			apeak = (i32) (amax - amin) / 2;
 
- 			if(apeak>setpt)compOut=1;
-			else if(compOut&&(apeak<(setpt-hyst)))compOut=0;
+			if (apeak > setpt)
+				compOut = 1;
+			else if (compOut && (apeak < (setpt - hyst)))
+				compOut = 0;
 		}
 	}
 
 	mySps->decimator = decimator;
 
-	mySps->amax=amax;
-	mySps->amin=amin;
-	mySps->apeak=apeak;
- 	mySps->discounteru=discounteru;
-	mySps->discounterl=discounterl;
+	mySps->amax = amax;
+	mySps->amin = amin;
+	mySps->apeak = apeak;
+	mySps->discounteru = discounteru;
+	mySps->discounterl = discounterl;
 
-	mySps->compOut=compOut;
+	mySps->compOut = compOut;
 
 	return 0;
 }
+
 /*
 	general purpose integrator lpf
 */
 i16 gp_inte_00(t_pmr_sps *mySps)
 {
 	i16 npoints;
- 	i16 *input, *output;
+	i16 *input, *output;
 
 	i32 outputGain;
-	i32	i;
+	i32 i;
 	i32 accum;
 
 	i32 state00;
- 	i16 coeff00, coeff01;
+	i16 coeff00, coeff01;
 
 	TRACEJ(5, "gp_inte_00() %i\n", mySps->enabled);
-	if(!mySps->enabled)return(1);
+	if (!mySps->enabled)
+		return (1);
 
-	input   = mySps->source;
-	output	= mySps->sink;
+	input = mySps->source;
+	output = mySps->sink;
 
-	npoints=mySps->nSamples;
+	npoints = mySps->nSamples;
 
-	outputGain=mySps->outputGain;
+	outputGain = mySps->outputGain;
 
-	coeff00=((i16*)mySps->coef)[0];
-	coeff01=((i16*)mySps->coef)[1];
-	state00=((i32*)mySps->x)[0];
+	coeff00 = ((i16 *) mySps->coef)[0];
+	coeff01 = ((i16 *) mySps->coef)[1];
+	state00 = ((i32 *) mySps->x)[0];
 
 	// note fixed gain of 2 to compensate for attenuation
 	// in passband
 
-	for(i=0;i<npoints;i++)
-	{
-		accum=input[i];
-		state00 = accum + (state00*coeff01)/M_Q15;
-		accum = (state00*coeff00)/(M_Q15/4);
-		output[i]=(accum*outputGain)/M_Q8;
+	for (i = 0; i < npoints; i++) {
+		accum = input[i];
+		state00 = accum + (state00 * coeff01) / M_Q15;
+		accum = (state00 * coeff00) / (M_Q15 / 4);
+		output[i] = (accum * outputGain) / M_Q8;
 	}
 
-	((i32*)(mySps->x))[0]=state00;
+	((i32 *) (mySps->x))[0] = state00;
 
 	return 0;
 }
+
 /*
 	general purpose differentiator hpf
 */
 i16 gp_diff(t_pmr_sps *mySps)
 {
- 	i16 *input, *output;
+	i16 *input, *output;
 	i16 npoints;
 	i32 outputGain, calcAdjust;
-	i32	i;
-	i32 temp0,temp1;
- 	i16 x0;
+	i32 i;
+	i32 temp0, temp1;
+	i16 x0;
 	i32 y0;
-	i16 a0,a1;
+	i16 a0, a1;
 	i16 *coef;
 	i16 *x;
 
-	input   = mySps->source;
-	output	= mySps->sink;
+	input = mySps->source;
+	output = mySps->sink;
 
-	npoints=mySps->nSamples;
+	npoints = mySps->nSamples;
 
-	outputGain=mySps->outputGain;
-	calcAdjust=mySps->calcAdjust;
+	outputGain = mySps->outputGain;
+	calcAdjust = mySps->calcAdjust;
 
-	coef=(i16*)(mySps->coef);
-	x=(i16*)(mySps->x);
-	a0=coef[0];
-	a1=coef[1];
+	coef = (i16 *) (mySps->coef);
+	x = (i16 *) (mySps->x);
+	a0 = coef[0];
+	a1 = coef[1];
 
-	x0=x[0];
+	x0 = x[0];
 
 	TRACEJ(5, "gp_diff()\n");
 
 	for (i = 0; i < npoints; i++) {
-		temp0 =	x0 * a1;
-		   x0 = input[i];
+		temp0 = x0 * a1;
+		x0 = input[i];
 		temp1 = input[i] * a0;
-		   y0 = (temp0 + temp1)/calcAdjust;
-		   y0 =(y0*outputGain)/M_Q8;
-		
-		if(y0>32767)y0=32767;
-		else if(y0<-32767)y0=-32767;
-        output[i]=y0;
+		y0 = (temp0 + temp1) / calcAdjust;
+		y0 = (y0 * outputGain) / M_Q8;
+
+		if (y0 > 32767)
+			y0 = 32767;
+		else if (y0 < -32767)
+			y0 = -32767;
+		output[i] = y0;
 	}
 
-	x[0]=x0;
+	x[0] = x0;
 
 	return 0;
 }
+
 /* 	----------------------------------------------------------------------
 	CenterSlicer
 */
 i16 CenterSlicer(t_pmr_sps *mySps)
 {
 	i16 npoints;
- 	i16 *input, *output, *buff;
+	i16 *input, *output, *buff;
 
 	i32 inputGainB;
-	i32	i;
+	i32 i;
 	i32 accum;
 
-	i32  amax;			// buffer amplitude maximum
-	i32  amin;			// buffer amplitude minimum
-	i32  apeak;			// buffer amplitude peak
-	i32  center;
-	i32  setpt;			// amplitude set point for peak tracking
+	i32 amax;					// buffer amplitude maximum
+	i32 amin;					// buffer amplitude minimum
+	i32 apeak;					// buffer amplitude peak
+	i32 center;
+	i32 setpt;					// amplitude set point for peak tracking
 
-	i32  discounteru;	// amplitude detector integrator discharge counter upper
-	i32  discounterl;	// amplitude detector integrator discharge counter lower
-	i32  discfactor;	// amplitude detector integrator discharge factor
+	i32 discounteru;			// amplitude detector integrator discharge counter upper
+	i32 discounterl;			// amplitude detector integrator discharge counter lower
+	i32 discfactor;				// amplitude detector integrator discharge factor
 
 	TRACEJ(5, "CenterSlicer() %i\n", mySps->enabled);
-	if(!mySps->enabled)return(1);
+	if (!mySps->enabled)
+		return (1);
 
-	input   = mySps->source;
-	output	= mySps->sink;	 			// limited output
-	buff    = mySps->buff;
+	input = mySps->source;
+	output = mySps->sink;		// limited output
+	buff = mySps->buff;
 
-	npoints=mySps->nSamples;
+	npoints = mySps->nSamples;
 
-	inputGainB=mySps->inputGainB;
+	inputGainB = mySps->inputGainB;
 
-	amax=mySps->amax;
-	amin=mySps->amin;
-	setpt=mySps->setpt;
-	apeak=mySps->apeak;
-	discounteru=mySps->discounteru;
-	discounterl=mySps->discounterl;
+	amax = mySps->amax;
+	amin = mySps->amin;
+	setpt = mySps->setpt;
+	apeak = mySps->apeak;
+	discounteru = mySps->discounteru;
+	discounterl = mySps->discounterl;
 
-	discfactor=mySps->discfactor;
-	npoints=mySps->nSamples;
+	discfactor = mySps->discfactor;
+	npoints = mySps->nSamples;
 
-	for(i=0;i<npoints;i++)
-	{
+	for (i = 0; i < npoints; i++) {
 		static i32 tfx;
-		accum=input[i];
+		accum = input[i];
 
-		if(accum>amax)
-		{
-			amax=accum;
-			if(amin<(amax-setpt))
-			{
-				amin=(amax-setpt);
+		if (accum > amax) {
+			amax = accum;
+			if (amin < (amax - setpt)) {
+				amin = (amax - setpt);
+			}
+		} else if (accum < amin) {
+			amin = accum;
+			if (amax > (amin + setpt)) {
+				amax = (amin + setpt);
 			}
 		}
-		else if(accum<amin)
-		{
-			amin=accum;
-			if(amax>(amin+setpt))
-			{
-				amax=(amin+setpt);
-			}
-		}
-		#if 0
-		if((discounteru-=1)<=0 && amax>amin)
-		{
-			if((amax-=10)<amin)amax=amin;
+#if 0
+		if ((discounteru -= 1) <= 0 && amax > amin) {
+			if ((amax -= 10) < amin)
+				amax = amin;
 		}
 
-		if((discounterl-=1)<=0 && amin<amax)
-		{
-			if((amin+=10)>amax)amin=amax;
-			lhit=1;
+		if ((discounterl -= 1) <= 0 && amin < amax) {
+			if ((amin += 10) > amax)
+				amin = amax;
+			lhit = 1;
 		}
-		if(uhit)discounteru=discfactor;
-		if(lhit)discounterl=discfactor;
+		if (uhit)
+			discounteru = discfactor;
+		if (lhit)
+			discounterl = discfactor;
 
-		#else
-		 
-		if((amax-=discfactor)<amin)amax=amin;
-		if((amin+=discfactor)>amax)amin=amax;
+#else
 
-		#endif
+		if ((amax -= discfactor) < amin)
+			amax = amin;
+		if ((amin += discfactor) > amax)
+			amin = amax;
 
-		apeak = (amax-amin)/2;
-		center = (amax+amin)/2;
+#endif
+
+		apeak = (amax - amin) / 2;
+		center = (amax + amin) / 2;
 		accum = accum - center;
 
-		output[i]=accum;  			// sink output unlimited/centered.
+		output[i] = accum;		// sink output unlimited/centered.
 
 		// do limiter function
-		if(accum>inputGainB)accum=inputGainB;
-		else if(accum<-inputGainB)accum=-inputGainB;
-		buff[i]=accum;
+		if (accum > inputGainB)
+			accum = inputGainB;
+		else if (accum < -inputGainB)
+			accum = -inputGainB;
+		buff[i] = accum;
 
-		#if XPMR_DEBUG0 == 1
-		#if 0
-		mySps->parentChan->pRxLsdCen[i]=center;	  	// trace center ref
-		#else
-		tfx=0;
-		if((tfx++/8)&1)				  				// trace min/max levels
-			mySps->parentChan->pRxLsdCen[i]=amax;
+#if XPMR_DEBUG0 == 1
+#if 0
+		mySps->parentChan->pRxLsdCen[i] = center;	// trace center ref
+#else
+		tfx = 0;
+		if ((tfx++ / 8) & 1)	// trace min/max levels
+			mySps->parentChan->pRxLsdCen[i] = amax;
 		else
-			mySps->parentChan->pRxLsdCen[i]=amin;
-		#endif
-	    #if 0
-		if(mySps->parentChan->frameCountRx&0x01) mySps->parentChan->prxDebug1[i]=amax;
-		else mySps->parentChan->prxDebug1[i]=amin;
-		#endif
-		#endif
+			mySps->parentChan->pRxLsdCen[i] = amin;
+#endif
+#if 0
+		if (mySps->parentChan->frameCountRx & 0x01)
+			mySps->parentChan->prxDebug1[i] = amax;
+		else
+			mySps->parentChan->prxDebug1[i] = amin;
+#endif
+#endif
 	}
 
-	mySps->amax=amax;
-	mySps->amin=amin;
-	mySps->apeak=apeak;
-	mySps->discounteru=discounteru;
-	mySps->discounterl=discounterl;
+	mySps->amax = amax;
+	mySps->amin = amin;
+	mySps->apeak = apeak;
+	mySps->discounteru = discounteru;
+	mySps->discounterl = discounterl;
 
 	return 0;
 }
+
 /* 	----------------------------------------------------------------------
 	MeasureBlock
 	determine peak amplitude
@@ -1067,87 +1042,82 @@ i16 CenterSlicer(t_pmr_sps *mySps)
 i16 MeasureBlock(t_pmr_sps *mySps)
 {
 	i16 npoints;
- 	i16 *input, *output;
+	i16 *input, *output;
 
-	i32	i;
+	i32 i;
 	i32 accum;
 
-	i16  amax;			// buffer amplitude maximum
-	i16  amin;			// buffer amplitude minimum
-	i16  apeak=0;			// buffer amplitude peak (peak to peak)/2
-	i16  setpt;			// amplitude set point for amplitude comparator
+	i16 amax;					// buffer amplitude maximum
+	i16 amin;					// buffer amplitude minimum
+	i16 apeak = 0;				// buffer amplitude peak (peak to peak)/2
+	i16 setpt;					// amplitude set point for amplitude comparator
 
-	i32  discounteru;	// amplitude detector integrator discharge counter upper
-	i32  discounterl;	// amplitude detector integrator discharge counter lower
-	i32  discfactor;	// amplitude detector integrator discharge factor
+	i32 discounteru;			// amplitude detector integrator discharge counter upper
+	i32 discounterl;			// amplitude detector integrator discharge counter lower
+	i32 discfactor;				// amplitude detector integrator discharge factor
 
 	TRACEJ(5, "MeasureBlock() %i\n", mySps->enabled);
 
-	if(!mySps->enabled)return 1;
+	if (!mySps->enabled)
+		return 1;
 
-	if(mySps->option==3)
-	{
-		mySps->amax = mySps->amin = mySps->apeak = \
-		mySps->discounteru = mySps->discounterl = \
-		mySps->enabled = 0;
+	if (mySps->option == 3) {
+		mySps->amax = mySps->amin = mySps->apeak = mySps->discounteru = mySps->discounterl = mySps->enabled = 0;
 		return 1;
 	}
 
-	input   = mySps->source;
-	output	= mySps->sink;
+	input = mySps->source;
+	output = mySps->sink;
 
-	npoints=mySps->nSamples;
+	npoints = mySps->nSamples;
 
-	amax=mySps->amax;
-	amin=mySps->amin;
-	setpt=mySps->setpt;
-	discounteru=mySps->discounteru;
-	discounterl=mySps->discounterl;
+	amax = mySps->amax;
+	amin = mySps->amin;
+	setpt = mySps->setpt;
+	discounteru = mySps->discounteru;
+	discounterl = mySps->discounterl;
 
-	discfactor=mySps->discfactor;
-	npoints=mySps->nSamples;
+	discfactor = mySps->discfactor;
+	npoints = mySps->nSamples;
 
-	for(i=0;i<npoints;i++)
-	{
-		accum=input[i];
+	for (i = 0; i < npoints; i++) {
+		accum = input[i];
 
-		if(accum>amax)
-		{
-			amax=accum;
-			discounteru=discfactor;
-		}
-		else if(--discounteru<=0)
-		{
-			discounteru=discfactor;
-			amax=(i32)((amax*32700)/32768);
+		if (accum > amax) {
+			amax = accum;
+			discounteru = discfactor;
+		} else if (--discounteru <= 0) {
+			discounteru = discfactor;
+			amax = (i32) ((amax * 32700) / 32768);
 		}
 
-		if(accum<amin)
-		{
-			amin=accum;
-			discounterl=discfactor;
-		}
-		else if(--discounterl<=0)
-		{
-			discounterl=discfactor;
-			amin=(i32)((amin*32700)/32768);
+		if (accum < amin) {
+			amin = accum;
+			discounterl = discfactor;
+		} else if (--discounterl <= 0) {
+			discounterl = discfactor;
+			amin = (i32) ((amin * 32700) / 32768);
 		}
 
-		apeak = (i32)(amax-amin)/2;
-		if(output)output[i]=apeak;
+		apeak = (i32) (amax - amin) / 2;
+		if (output)
+			output[i] = apeak;
 	}
 
-	mySps->amax=amax;
-	mySps->amin=amin;
-	mySps->apeak=apeak;
-	mySps->discounteru=discounteru;
-	mySps->discounterl=discounterl;
-	if(apeak>=setpt) mySps->compOut=1;
-	else mySps->compOut=0;
+	mySps->amax = amax;
+	mySps->amin = amin;
+	mySps->apeak = apeak;
+	mySps->discounteru = discounteru;
+	mySps->discounterl = discounterl;
+	if (apeak >= setpt)
+		mySps->compOut = 1;
+	else
+		mySps->compOut = 0;
 
 	// TRACEX((1, " -MeasureBlock()=%i\n",mySps->apeak));
 	return 0;
 }
+
 /*
 	SoftLimiter
 */
@@ -1155,56 +1125,55 @@ i16 SoftLimiter(t_pmr_sps *mySps)
 {
 	i16 npoints;
 	//i16 samples, lhit,uhit;
- 	i16 *input, *output;
+	i16 *input, *output;
 
 	i32 outputGain;
-	i32	i;
+	i32 i;
 	i32 accum;
-	i32  tmp;
+	i32 tmp;
 
-	i32  amax;			// buffer amplitude maximum
-	i32  amin;			// buffer amplitude minimum
-	//i32  apeak;		// buffer amplitude peak
-	i32  setpt;			// amplitude set point for amplitude comparator
+	i32 amax;					// buffer amplitude maximum
+	i32 amin;					// buffer amplitude minimum
+	//i32  apeak;       // buffer amplitude peak
+	i32 setpt;					// amplitude set point for amplitude comparator
 
-	input   = mySps->source;
-	output	= mySps->sink;
+	input = mySps->source;
+	output = mySps->sink;
 
-	outputGain=mySps->outputGain;
+	outputGain = mySps->outputGain;
 
-	npoints=mySps->nSamples;
+	npoints = mySps->nSamples;
 
-	setpt=mySps->setpt;
-	amax=(setpt*124)/128;
-	amin=-amax;
+	setpt = mySps->setpt;
+	amax = (setpt * 124) / 128;
+	amin = -amax;
 
 	TRACEJ(5, "SoftLimiter() %i %i %i) \n", amin, amax, setpt);
 
-	for(i=0;i<npoints;i++)
-	{
-		accum=input[i];
+	for (i = 0; i < npoints; i++) {
+		accum = input[i];
 		//accum=input[i]*mySps->inputGain/256;
 
-		if(accum>setpt)
-		{
-		    tmp=((accum-setpt)*4)/128;
-		    accum=setpt+tmp;
-			if(accum>amax)accum=amax;
-			accum=setpt;
-		}
-		else if(accum<-setpt)
-		{
-		    tmp=((accum+setpt)*4)/128;
-		    accum=(-setpt)-tmp;
-			if(accum<amin)accum=amin;
-			accum=-setpt;
+		if (accum > setpt) {
+			tmp = ((accum - setpt) * 4) / 128;
+			accum = setpt + tmp;
+			if (accum > amax)
+				accum = amax;
+			accum = setpt;
+		} else if (accum < -setpt) {
+			tmp = ((accum + setpt) * 4) / 128;
+			accum = (-setpt) - tmp;
+			if (accum < amin)
+				accum = amin;
+			accum = -setpt;
 		}
 
-		output[i]=(accum*outputGain)/M_Q8;
+		output[i] = (accum * outputGain) / M_Q8;
 	}
 
 	return 0;
 }
+
 /*
 	SigGen() - sine, square function generator
 	sps overloaded values
@@ -1214,107 +1183,98 @@ i16 SoftLimiter(t_pmr_sps *mySps)
 
 	sign table and output gain are in Q15 format (32767=.999)
 */
-i16	SigGen(t_pmr_sps *mySps)
+i16 SigGen(t_pmr_sps *mySps)
 {
-	#define PH_FRACT_FACT	128
+#define PH_FRACT_FACT	128
 
 	i32 ph;
-	i16 i,outputgain,waveform,numChanOut,selChanOut;
+	i16 i, outputgain, waveform, numChanOut, selChanOut;
 	i32 accum;
 
 	t_pmr_chan *pChan;
 	pChan = mySps->parentChan;
 	TRACEC(5, "SigGen(%i %i %i)\n", mySps->option, mySps->enabled, mySps->state);
 
-	if(!mySps->freq ||!mySps->enabled)return 0;
+	if (!mySps->freq || !mySps->enabled)
+		return 0;
 
-	outputgain=mySps->outputGain;
-	waveform=0;
-	numChanOut=mySps->numChanOut;
-	selChanOut=mySps->selChanOut;
+	outputgain = mySps->outputGain;
+	waveform = 0;
+	numChanOut = mySps->numChanOut;
+	selChanOut = mySps->selChanOut;
 
-    if(mySps->option==1)
-	{
-		mySps->option=0;
-		mySps->state=1;
-		mySps->discfactor=
-			(SAMPLES_PER_SINE*mySps->freq*PH_FRACT_FACT)/mySps->sampleRate/10;
+	if (mySps->option == 1) {
+		mySps->option = 0;
+		mySps->state = 1;
+		mySps->discfactor = (SAMPLES_PER_SINE * mySps->freq * PH_FRACT_FACT) / mySps->sampleRate / 10;
 
 		TRACEF(5, " SigGen() discfactor = %i\n", mySps->discfactor);
-		if(mySps->discounterl)mySps->state=2;
-	}
-	else if(mySps->option==2)
-	{
-		i16 shiftfactor=CTCSS_TURN_OFF_SHIFT;
+		if (mySps->discounterl)
+			mySps->state = 2;
+	} else if (mySps->option == 2) {
+		i16 shiftfactor = CTCSS_TURN_OFF_SHIFT;
 		// phase shift request
-		mySps->option=0;
-		mySps->state=2;
-		mySps->discounterl=CTCSS_TURN_OFF_TIME-(2*MS_PER_FRAME);   		//
+		mySps->option = 0;
+		mySps->state = 2;
+		mySps->discounterl = CTCSS_TURN_OFF_TIME - (2 * MS_PER_FRAME);	//
 
-		mySps->discounteru = \
-			(mySps->discounteru + (((SAMPLES_PER_SINE*shiftfactor)/360)*PH_FRACT_FACT)) % (SAMPLES_PER_SINE*PH_FRACT_FACT);
+		mySps->discounteru =
+			(mySps->discounteru +
+			 (((SAMPLES_PER_SINE * shiftfactor) / 360) * PH_FRACT_FACT)) % (SAMPLES_PER_SINE * PH_FRACT_FACT);
 		//printf("shiftfactor = %i\n",shiftfactor);
 		//shiftfactor+=10;
-	}
-	else if(mySps->option==3)
-	{
+	} else if (mySps->option == 3) {
 		// stop it and clear the output buffer
-		mySps->option=0;
-		mySps->state=0;
-		mySps->enabled=0;
-		mySps->b.mute=0;
-		for(i=0;i<mySps->nSamples;i++)
-			mySps->sink[(i*numChanOut)+selChanOut]=0;
-		return(0);
-	}
-	else if(mySps->state==2)
-	{
+		mySps->option = 0;
+		mySps->state = 0;
+		mySps->enabled = 0;
+		mySps->b.mute = 0;
+		for (i = 0; i < mySps->nSamples; i++)
+			mySps->sink[(i * numChanOut) + selChanOut] = 0;
+		return (0);
+	} else if (mySps->state == 2) {
 		// doing turn off
-		mySps->discounterl-=MS_PER_FRAME;
-		if(mySps->discounterl<=0)
-		{
-			mySps->option=3;
-			mySps->state=2;
+		mySps->discounterl -= MS_PER_FRAME;
+		if (mySps->discounterl <= 0) {
+			mySps->option = 3;
+			mySps->state = 2;
 		}
-	}
-	else if(mySps->state==0)
-	{
-		return(0);
+	} else if (mySps->state == 0) {
+		return (0);
 	}
 
-	ph=mySps->discounteru;
+	ph = mySps->discounteru;
 
-	for(i=0;i<mySps->nSamples;i++)
-	{
-		if(!waveform)
-		{
+	for (i = 0; i < mySps->nSamples; i++) {
+		if (!waveform) {
 			// sine
 			//tmp=(sinetablex[ph/PH_FRACT_FACT]*amplitude)/M_Q16;
-			accum=sinetablex[ph/PH_FRACT_FACT];
-			accum=(accum*outputgain)/M_Q8;
-	    }
-		else
-		{
+			accum = sinetablex[ph / PH_FRACT_FACT];
+			accum = (accum * outputgain) / M_Q8;
+		} else {
 			// square
-			if(ph>SAMPLES_PER_SINE/2)
-				accum=outputgain/M_Q8;
+			if (ph > SAMPLES_PER_SINE / 2)
+				accum = outputgain / M_Q8;
 			else
-				accum=-outputgain/M_Q8;
+				accum = -outputgain / M_Q8;
 		}
 
-		if(mySps->source)accum+=mySps->source[i];
+		if (mySps->source)
+			accum += mySps->source[i];
 
-		if(mySps->b.mute) accum = 0;
+		if (mySps->b.mute)
+			accum = 0;
 
-		mySps->sink[(i*numChanOut)+selChanOut]=accum;
+		mySps->sink[(i * numChanOut) + selChanOut] = accum;
 
-		ph=(ph+mySps->discfactor)%(SAMPLES_PER_SINE*PH_FRACT_FACT);
+		ph = (ph + mySps->discfactor) % (SAMPLES_PER_SINE * PH_FRACT_FACT);
 	}
 
-	mySps->discounteru=ph;
+	mySps->discounteru = ph;
 
 	return 0;
 }
+
 /*
 	adder/mixer
 	takes existing buffer and adds source buffer to destination buffer
@@ -1324,358 +1284,347 @@ i16 pmrMixer(t_pmr_sps *mySps)
 {
 	i32 accum;
 	i16 i, *input, *inputB, *output;
-	i16  inputGain, inputGainB;	  	// apply to input data	 in Q7.8 format
-	i16  outputGain;	// apply to output data  in Q7.8 format
-	i16	 discounteru,discounterl,amax,amin,setpt,discfactor;
-	i16	 npoints,uhit,lhit,apeak,measPeak;
+	i16 inputGain, inputGainB;	// apply to input data   in Q7.8 format
+	i16 outputGain;				// apply to output data  in Q7.8 format
+	i16 discounteru, discounterl, amax, amin, setpt, discfactor;
+	i16 npoints, uhit, lhit, apeak, measPeak;
 
 	t_pmr_chan *pChan;
 	pChan = mySps->parentChan;
 	TRACEF(5, "pmrMixer()\n");
 
-	input     = mySps->source;
-	inputB    = mySps->sourceB;
-	output    = mySps->sink;
+	input = mySps->source;
+	inputB = mySps->sourceB;
+	output = mySps->sink;
 
-	inputGain=mySps->inputGain;
-	inputGainB=mySps->inputGainB;
-	outputGain=mySps->outputGain;
+	inputGain = mySps->inputGain;
+	inputGainB = mySps->inputGainB;
+	outputGain = mySps->outputGain;
 
-	amax=mySps->amax;
-	amin=mySps->amin;
-	setpt=mySps->setpt;
-	discounteru=mySps->discounteru;
-	discounterl=mySps->discounteru;
+	amax = mySps->amax;
+	amin = mySps->amin;
+	setpt = mySps->setpt;
+	discounteru = mySps->discounteru;
+	discounterl = mySps->discounteru;
 
-	discfactor=mySps->discfactor;
-	npoints=mySps->nSamples;
-	measPeak=mySps->measPeak;
+	discfactor = mySps->discfactor;
+	npoints = mySps->nSamples;
+	measPeak = mySps->measPeak;
 
-	for(i=0;i<npoints;i++)
-	{
-		if (inputB)
-		{
-			accum = ((input[i]*inputGain)/M_Q8) +
-				((inputB[i]*inputGainB)/M_Q8);
+	for (i = 0; i < npoints; i++) {
+		if (inputB) {
+			accum = ((input[i] * inputGain) / M_Q8) + ((inputB[i] * inputGainB) / M_Q8);
+		} else {
+			accum = (input[i] * inputGain) / M_Q8;
 		}
-		else
-		{
-			accum = (input[i]*inputGain)/M_Q8;
-		}
-		accum=(accum*outputGain)/M_Q8;
-		output[i]=accum;
+		accum = (accum * outputGain) / M_Q8;
+		output[i] = accum;
 
-		if(measPeak){
-	  		lhit=uhit=0;
+		if (measPeak) {
+			lhit = uhit = 0;
 
-			if(accum>amax){
-				amax=accum;
-				uhit=1;
-				if(amin<(amax-setpt)){
-					amin=(amax-setpt);
-					lhit=1;
+			if (accum > amax) {
+				amax = accum;
+				uhit = 1;
+				if (amin < (amax - setpt)) {
+					amin = (amax - setpt);
+					lhit = 1;
 				}
-			}
-			else if(accum<amin){
-				amin=accum;
-				lhit=1;
-				if(amax>(amin+setpt)){
-					amax=(amin+setpt);
-					uhit=1;
+			} else if (accum < amin) {
+				amin = accum;
+				lhit = 1;
+				if (amax > (amin + setpt)) {
+					amax = (amin + setpt);
+					uhit = 1;
 				}
 			}
 
-			if(--discounteru<=0 && amax>0){
+			if (--discounteru <= 0 && amax > 0) {
 				amax--;
-				uhit=1;
+				uhit = 1;
 			}
 
-			if(--discounterl<=0 && amin<0){
+			if (--discounterl <= 0 && amin < 0) {
 				amin++;
-				lhit=1;
+				lhit = 1;
 			}
 
-			if(uhit)discounteru=discfactor;
-			if(lhit)discounterl=discfactor;
+			if (uhit)
+				discounteru = discfactor;
+			if (lhit)
+				discounterl = discfactor;
 		}
- 	}
+	}
 
-	if(measPeak){
-		apeak = (amax-amin)/2;
-		mySps->apeak=apeak;
-		mySps->amax=amax;
-		mySps->amin=amin;
-		mySps->discounteru=discounteru;
-		mySps->discounterl=discounterl;
+	if (measPeak) {
+		apeak = (amax - amin) / 2;
+		mySps->apeak = apeak;
+		mySps->amax = amax;
+		mySps->amin = amin;
+		mySps->discounteru = discounteru;
+		mySps->discounterl = discounterl;
 	}
 
 	return 0;
 }
+
 /*
 	DelayLine
 */
 i16 DelayLine(t_pmr_sps *mySps)
 {
 	i16 *input, *output, *buff;
-	i16	 i, npoints,buffsize,inindex,outindex;
+	i16 i, npoints, buffsize, inindex, outindex;
 
 	t_pmr_chan *pChan;
 	pChan = mySps->parentChan;
 	TRACEF(5, " DelayLine() %i\n", mySps->enabled);
 
-	if(!mySps->enabled || mySps->b.outzero)
-	{
-		if(mySps->b.dirty)
-		{
-			mySps->b.dirty=0; 
-			mySps->buffInIndex=0;
-			memset((void *)(mySps->buff),0,mySps->buffSize*2);
-			memset((void *)(mySps->sink),0,mySps->nSamples*2);
+	if (!mySps->enabled || mySps->b.outzero) {
+		if (mySps->b.dirty) {
+			mySps->b.dirty = 0;
+			mySps->buffInIndex = 0;
+			memset((void *) (mySps->buff), 0, mySps->buffSize * 2);
+			memset((void *) (mySps->sink), 0, mySps->nSamples * 2);
 		}
-		return(0);
+		return (0);
 	}
 
-	input    	= mySps->source;
-	output    	= mySps->sink;
-	buff     	= (i16*)(mySps->buff);
-	buffsize  	= mySps->buffSize;
-	npoints		= mySps->nSamples;
-	inindex		= mySps->buffInIndex;
-	outindex	= inindex-mySps->buffLead;
+	input = mySps->source;
+	output = mySps->sink;
+	buff = (i16 *) (mySps->buff);
+	buffsize = mySps->buffSize;
+	npoints = mySps->nSamples;
+	inindex = mySps->buffInIndex;
+	outindex = inindex - mySps->buffLead;
 
-	if(outindex<0)outindex+=buffsize;
-	
-	for(i=0;i<npoints;i++)
-	{
+	if (outindex < 0)
+		outindex += buffsize;
+
+	for (i = 0; i < npoints; i++) {
 		inindex %= buffsize;
 		outindex %= buffsize;
-		buff[inindex]=input[i];
-		output[i]=buff[outindex];
+		buff[inindex] = input[i];
+		output[i] = buff[outindex];
 		inindex++;
 		outindex++;
- 	}
-	mySps->buffInIndex=inindex;
-	mySps->b.dirty=1;
- 	return 0;
+	}
+	mySps->buffInIndex = inindex;
+	mySps->b.dirty = 1;
+	return 0;
 }
+
 /*
 	Continuous Tone Coded Squelch (CTCSS) Detector
 */
 i16 ctcss_detect(t_pmr_chan *pChan)
 {
-	i16 i,points2do,*pInput,hit,thit,relax;
-	i16 tnum, tmp,indexNow,diffpeak;
-	i16 tv0,tv1,tv2,tv3,indexDebug;
-	i16 points=0;
-	i16 indexWas=0;
+	i16 i, points2do, *pInput, hit, thit, relax;
+	i16 tnum, tmp, indexNow, diffpeak;
+	i16 tv0, tv1, tv2, tv3, indexDebug;
+	i16 points = 0;
+	i16 indexWas = 0;
 
-	TRACEF(5, "ctcss_detect(%p) %i %i %i %i\n", pChan, pChan->rxCtcss->enabled, 0, pChan->rxCtcss->testIndex, pChan->rxCtcss->decode);
+	TRACEF(5, "ctcss_detect(%p) %i %i %i %i\n", pChan, pChan->rxCtcss->enabled, 0, pChan->rxCtcss->testIndex,
+		   pChan->rxCtcss->decode);
 
-	if(!pChan->rxCtcss->enabled)return(1);
+	if (!pChan->rxCtcss->enabled)
+		return (1);
 
-	relax  = pChan->rxCtcss->relax;
+	relax = pChan->rxCtcss->relax;
 	pInput = pChan->rxCtcss->input;
 
-	thit=hit=-1;
+	thit = hit = -1;
 
 	// TRACEX((1, " ctcss_detect() %i  %i  %i  %i\n", CTCSS_NUM_CODES,0,0,0));
 
-	for(tnum=0;tnum<CTCSS_NUM_CODES;tnum++)
-	{
+	for (tnum = 0; tnum < CTCSS_NUM_CODES; tnum++) {
 		i32 accum, peak;
-		t_tdet	*ptdet;
+		t_tdet *ptdet;
 		i16 fudgeFactor;
 		i16 binFactor;
 
 		TRACEF(6, " ctcss_detect() tnum=%i %i\n", tnum, pChan->rxCtcssMap[tnum]);
 		//if(tnum==14)printf("ctcss_detect() %i %i %i\n",tnum,pChan->rxCtcssMap[tnum], pChan->rxCtcss->decode );
 
-		if( (pChan->rxCtcssMap[tnum]==CTCSS_NULL) ||
-		    (pChan->rxCtcss->decode>CTCSS_NULL && (tnum!= pChan->rxCtcss->decode))
-		  )
+		if ((pChan->rxCtcssMap[tnum] == CTCSS_NULL) ||
+			(pChan->rxCtcss->decode > CTCSS_NULL && (tnum != pChan->rxCtcss->decode))
+			)
 			continue;
 
 		TRACEF(6, " ctcss_detect() tnum=%i\n", tnum);
 
-		ptdet=&(pChan->rxCtcss->tdet[tnum]);
-		indexDebug=0;
-		points=points2do=pChan->nSamplesRx;
-		fudgeFactor=ptdet->fudgeFactor;
-		binFactor=ptdet->binFactor;
+		ptdet = &(pChan->rxCtcss->tdet[tnum]);
+		indexDebug = 0;
+		points = points2do = pChan->nSamplesRx;
+		fudgeFactor = ptdet->fudgeFactor;
+		binFactor = ptdet->binFactor;
 
-		while(ptdet->counter < (points2do*CTCSS_SCOUNT_MUL))
-		{
-			tmp=(ptdet->counter/CTCSS_SCOUNT_MUL)+1;
-		    ptdet->counter-=(tmp*CTCSS_SCOUNT_MUL);
-			points2do-=tmp;
-			indexNow=points-points2do;
+		while (ptdet->counter < (points2do * CTCSS_SCOUNT_MUL)) {
+			tmp = (ptdet->counter / CTCSS_SCOUNT_MUL) + 1;
+			ptdet->counter -= (tmp * CTCSS_SCOUNT_MUL);
+			points2do -= tmp;
+			indexNow = points - points2do;
 
 			ptdet->counter += ptdet->counterFactor;
 
-			accum = pInput[indexNow-1];	 	// duuuude's major bug fix!
+			accum = pInput[indexNow - 1];	// duuuude's major bug fix!
 
-			ptdet->z[ptdet->zIndex]+=
-				(((accum - ptdet->z[ptdet->zIndex])*binFactor)/M_Q15);
+			ptdet->z[ptdet->zIndex] += (((accum - ptdet->z[ptdet->zIndex]) * binFactor) / M_Q15);
 
-			peak = abs(ptdet->z[0]-ptdet->z[2]) + abs(ptdet->z[1]-ptdet->z[3]);
+			peak = abs(ptdet->z[0] - ptdet->z[2]) + abs(ptdet->z[1] - ptdet->z[3]);
 
 			if (ptdet->peak < peak)
-				ptdet->peak += ( ((peak-ptdet->peak)*binFactor)/M_Q15);
+				ptdet->peak += (((peak - ptdet->peak) * binFactor) / M_Q15);
 			else
-				ptdet->peak=peak;
+				ptdet->peak = peak;
 
 			{
-				static const i16 a0=13723;
-				static const i16 a1=-13723;
-				i32 temp0,temp1;
+				static const i16 a0 = 13723;
+				static const i16 a1 = -13723;
+				i32 temp0, temp1;
 				i16 x0;
 
 				//differentiate
-				x0=ptdet->zd;
-				temp0 =	x0 * a1;
+				x0 = ptdet->zd;
+				temp0 = x0 * a1;
 				ptdet->zd = ptdet->peak;
 				temp1 = ptdet->peak * a0;
-			    diffpeak = (temp0 + temp1)/1024;
+				diffpeak = (temp0 + temp1) / 1024;
 			}
 
-			if(diffpeak<(-0.03*M_Q15))ptdet->dvd-=4;
-			else if(ptdet->dvd<0)ptdet->dvd++;
+			if (diffpeak < (-0.03 * M_Q15))
+				ptdet->dvd -= 4;
+			else if (ptdet->dvd < 0)
+				ptdet->dvd++;
 
-			if((ptdet->dvd < -12) && diffpeak > (-0.02*M_Q15))ptdet->dvu+=2;
-			else if(ptdet->dvu)ptdet->dvu--;
+			if ((ptdet->dvd < -12) && diffpeak > (-0.02 * M_Q15))
+				ptdet->dvu += 2;
+			else if (ptdet->dvu)
+				ptdet->dvu--;
 
-			tmp=ptdet->setpt;
-			if(pChan->rxCtcss->decode==tnum)
-			{
-				if(relax)tmp=(tmp*55)/100;
-				else tmp=(tmp*80)/100;
+			tmp = ptdet->setpt;
+			if (pChan->rxCtcss->decode == tnum) {
+				if (relax)
+					tmp = (tmp * 55) / 100;
+				else
+					tmp = (tmp * 80) / 100;
 			}
 
-			if(ptdet->peak > tmp)
-			{
-			    if(ptdet->decode<(fudgeFactor*32))ptdet->decode++;
-			}
-			else if(pChan->rxCtcss->decode==tnum)
-			{
-				if(ptdet->peak > ptdet->hyst)ptdet->decode--;
-				else if(relax) ptdet->decode--;
-				else ptdet->decode-=4;
-			}
-			else
-			{
-				ptdet->decode=0;
+			if (ptdet->peak > tmp) {
+				if (ptdet->decode < (fudgeFactor * 32))
+					ptdet->decode++;
+			} else if (pChan->rxCtcss->decode == tnum) {
+				if (ptdet->peak > ptdet->hyst)
+					ptdet->decode--;
+				else if (relax)
+					ptdet->decode--;
+				else
+					ptdet->decode -= 4;
+			} else {
+				ptdet->decode = 0;
 			}
 
-			if((pChan->rxCtcss->decode==tnum) && !relax && (ptdet->dvu > (0.00075*M_Q15)))
-			{
-				ptdet->decode=0;
-				ptdet->z[0]=ptdet->z[1]=ptdet->z[2]=ptdet->z[3]=ptdet->dvu=0;
+			if ((pChan->rxCtcss->decode == tnum) && !relax && (ptdet->dvu > (0.00075 * M_Q15))) {
+				ptdet->decode = 0;
+				ptdet->z[0] = ptdet->z[1] = ptdet->z[2] = ptdet->z[3] = ptdet->dvu = 0;
 				TRACEF(4, "ctcss_detect() turnoff detected by dvdt for tnum = %i.\n", tnum);
 			}
 
-			if(ptdet->decode<0 || !pChan->rxCarrierDetect)ptdet->decode=0;
+			if (ptdet->decode < 0 || !pChan->rxCarrierDetect)
+				ptdet->decode = 0;
 
-			if(ptdet->decode>=fudgeFactor)
-			{
-				thit=tnum;
-				if(pChan->rxCtcss->decode!=tnum)
-				{
-					ptdet->zd=ptdet->dvu=ptdet->dvd=0;	
+			if (ptdet->decode >= fudgeFactor) {
+				thit = tnum;
+				if (pChan->rxCtcss->decode != tnum) {
+					ptdet->zd = ptdet->dvu = ptdet->dvd = 0;
 				}
 			}
 
-			#if XPMR_DEBUG0 == 1
-			if(thit>=0 && thit==tnum)
+#if XPMR_DEBUG0 == 1
+			if (thit >= 0 && thit == tnum)
 				TRACEF(6, " ctcss_detect() %i %i %i %i \n", tnum, ptdet->peak, ptdet->setpt, ptdet->hyst);
 
-			if(ptdet->pDebug0)
-			{
-				tv0=ptdet->peak;
-				tv1=ptdet->decode;
-				tv2=tmp;
-				tv3=ptdet->dvu*32;
+			if (ptdet->pDebug0) {
+				tv0 = ptdet->peak;
+				tv1 = ptdet->decode;
+				tv2 = tmp;
+				tv3 = ptdet->dvu * 32;
 
-				if(indexDebug==0)
-				{
-					ptdet->lasttv0=ptdet->pDebug0[points-1];
-					ptdet->lasttv1=ptdet->pDebug1[points-1];
-					ptdet->lasttv2=ptdet->pDebug2[points-1];
-					ptdet->lasttv3=ptdet->pDebug3[points-1];
+				if (indexDebug == 0) {
+					ptdet->lasttv0 = ptdet->pDebug0[points - 1];
+					ptdet->lasttv1 = ptdet->pDebug1[points - 1];
+					ptdet->lasttv2 = ptdet->pDebug2[points - 1];
+					ptdet->lasttv3 = ptdet->pDebug3[points - 1];
 				}
 
-				while(indexDebug<indexNow)
-				{
-					ptdet->pDebug0[indexDebug]=ptdet->lasttv0;
-					ptdet->pDebug1[indexDebug]=ptdet->lasttv1;
-					ptdet->pDebug2[indexDebug]=ptdet->lasttv2;
-					ptdet->pDebug3[indexDebug]=ptdet->lasttv3;
+				while (indexDebug < indexNow) {
+					ptdet->pDebug0[indexDebug] = ptdet->lasttv0;
+					ptdet->pDebug1[indexDebug] = ptdet->lasttv1;
+					ptdet->pDebug2[indexDebug] = ptdet->lasttv2;
+					ptdet->pDebug3[indexDebug] = ptdet->lasttv3;
 					indexDebug++;
 				}
-				ptdet->lasttv0=tv0;
-				ptdet->lasttv1=tv1;
-				ptdet->lasttv2=tv2;
-				ptdet->lasttv3=tv3;
+				ptdet->lasttv0 = tv0;
+				ptdet->lasttv1 = tv1;
+				ptdet->lasttv2 = tv2;
+				ptdet->lasttv3 = tv3;
 			}
-			#endif
-			indexWas=indexNow;
-			ptdet->zIndex=(++ptdet->zIndex)%4;
+#endif
+			indexWas = indexNow;
+			ptdet->zIndex = (++ptdet->zIndex) % 4;
 		}
-		ptdet->counter-=(points2do*CTCSS_SCOUNT_MUL);
+		ptdet->counter -= (points2do * CTCSS_SCOUNT_MUL);
 
-		#if XPMR_DEBUG0 == 1
-		for(i=indexWas;i<points;i++)
-		{
-			ptdet->pDebug0[i]=ptdet->lasttv0;
-			ptdet->pDebug1[i]=ptdet->lasttv1;
-			ptdet->pDebug2[i]=ptdet->lasttv2;
-			ptdet->pDebug3[i]=ptdet->lasttv3;
+#if XPMR_DEBUG0 == 1
+		for (i = indexWas; i < points; i++) {
+			ptdet->pDebug0[i] = ptdet->lasttv0;
+			ptdet->pDebug1[i] = ptdet->lasttv1;
+			ptdet->pDebug2[i] = ptdet->lasttv2;
+			ptdet->pDebug3[i] = ptdet->lasttv3;
 		}
-		#endif
+#endif
 	}
 
 	// TRACEX((1, " ctcss_detect() thit %i\n",thit));
 
-	if(pChan->rxCtcss->BlankingTimer>0)pChan->rxCtcss->BlankingTimer-=points;
-	if(pChan->rxCtcss->BlankingTimer<0)pChan->rxCtcss->BlankingTimer=0;
+	if (pChan->rxCtcss->BlankingTimer > 0)
+		pChan->rxCtcss->BlankingTimer -= points;
+	if (pChan->rxCtcss->BlankingTimer < 0)
+		pChan->rxCtcss->BlankingTimer = 0;
 
-    if(thit>CTCSS_NULL && pChan->rxCtcss->decode<=CTCSS_NULL && !pChan->rxCtcss->BlankingTimer)
-    {
-		pChan->rxCtcss->decode=thit;
-		sprintf(pChan->rxctcssfreq,"%.1f",freq_ctcss[thit]);
+	if (thit > CTCSS_NULL && pChan->rxCtcss->decode <= CTCSS_NULL && !pChan->rxCtcss->BlankingTimer) {
+		pChan->rxCtcss->decode = thit;
+		sprintf(pChan->rxctcssfreq, "%.1f", freq_ctcss[thit]);
 		TRACEC(1, "ctcss decode  %i  %.1f\n", thit, freq_ctcss[thit]);
-	}
-	else if(thit<=CTCSS_NULL && pChan->rxCtcss->decode>CTCSS_NULL)
-	{
-		pChan->rxCtcss->BlankingTimer=SAMPLE_RATE_NETWORK/5;
-		pChan->rxCtcss->decode=CTCSS_NULL;
-		strcpy(pChan->rxctcssfreq,"0");
+	} else if (thit <= CTCSS_NULL && pChan->rxCtcss->decode > CTCSS_NULL) {
+		pChan->rxCtcss->BlankingTimer = SAMPLE_RATE_NETWORK / 5;
+		pChan->rxCtcss->decode = CTCSS_NULL;
+		strcpy(pChan->rxctcssfreq, "0");
 		TRACEC(1, "ctcss decode  NULL\n");
-		for(tnum=0;tnum<CTCSS_NUM_CODES;tnum++)
-		{
-		    t_tdet	*ptdet=NULL;
-			ptdet=&(pChan->rxCtcss->tdet[tnum]);
-		    ptdet->decode=0;
-			ptdet->z[0]=ptdet->z[1]=ptdet->z[2]=ptdet->z[3]=0;
+		for (tnum = 0; tnum < CTCSS_NUM_CODES; tnum++) {
+			t_tdet *ptdet = NULL;
+			ptdet = &(pChan->rxCtcss->tdet[tnum]);
+			ptdet->decode = 0;
+			ptdet->z[0] = ptdet->z[1] = ptdet->z[2] = ptdet->z[3] = 0;
 		}
 	}
 	// TRACEX((1, " ctcss_detect() thit %i %i\n",thit,pChan->rxCtcss->decode));
-	return(0);
+	return (0);
 }
+
 /*
 	TxTestTone
 */
-i16	TxTestTone(t_pmr_chan *pChan, i16 function)
+i16 TxTestTone(t_pmr_chan *pChan, i16 function)
 {
-	if(function==1)
-	{
-		pChan->spsSigGen1->enabled=1;
-		pChan->spsSigGen1->option=1;
-		pChan->spsSigGen1->outputGain=(.23125*M_Q8);   // to match *99 level
-		pChan->spsTx->source=pChan->spsSigGen1->sink;
-	}
-	else
-	{
-		pChan->spsSigGen1->option=3;
+	if (function == 1) {
+		pChan->spsSigGen1->enabled = 1;
+		pChan->spsSigGen1->option = 1;
+		pChan->spsSigGen1->outputGain = (.23125 * M_Q8);	// to match *99 level
+		pChan->spsTx->source = pChan->spsSigGen1->sink;
+	} else {
+		pChan->spsSigGen1->option = 3;
 	}
 	return 0;
 }
@@ -1686,223 +1635,221 @@ i16	TxTestTone(t_pmr_chan *pChan, i16 function)
 	samples are all 16 bits
     samples are filtered and decimated by 1/6th
 */
-t_pmr_chan	*createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
+t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 {
 	i16 i, *inputTmp;
-	t_pmr_chan 	*pChan;
-	t_pmr_sps  	*pSps;
-	t_dec_ctcss	*pDecCtcss;
+	t_pmr_chan *pChan;
+	t_pmr_sps *pSps;
+	t_dec_ctcss *pDecCtcss;
 
 	TRACEJ(1, "createPmrChannel(%p,%i)\n", tChan, numSamples);
 
-	pChan = (t_pmr_chan *)ast_calloc(sizeof(t_pmr_chan),1);
-	if(pChan==NULL)
-	{
+	pChan = (t_pmr_chan *) ast_calloc(sizeof(t_pmr_chan), 1);
+	if (pChan == NULL) {
 		ast_log(LOG_ERROR, "createPmrChannel() failed\n");
-		return(NULL);
+		return (NULL);
 	}
 
-	#if XPMR_PPTP == 1
+#if XPMR_PPTP == 1
 	pptp_init();
-	#endif
+#endif
 
-	pChan->index=pmrChanIndex++;
-	pChan->nSamplesTx=pChan->nSamplesRx=numSamples;
+	pChan->index = pmrChanIndex++;
+	pChan->nSamplesTx = pChan->nSamplesRx = numSamples;
 
-	pDecCtcss = (t_dec_ctcss *)ast_calloc(sizeof(t_dec_ctcss),1);
-	pChan->rxCtcss=pDecCtcss;
-	pChan->rxctcssfreq[0]=0;
+	pDecCtcss = (t_dec_ctcss *) ast_calloc(sizeof(t_dec_ctcss), 1);
+	pChan->rxCtcss = pDecCtcss;
+	pChan->rxctcssfreq[0] = 0;
 
-	#ifdef HAVE_XPMRX
-	if(tChan->rptnum>=LSD_CHAN_MAX)tChan->rptnum=0;
-	#endif
+#ifdef HAVE_XPMRX
+	if (tChan->rptnum >= LSD_CHAN_MAX)
+		tChan->rptnum = 0;
+#endif
 
-	if(tChan==NULL)
-	{
+	if (tChan == NULL) {
 		ast_log(LOG_WARNING, "createPmrChannel() WARNING: NULL tChan!\n");
-		pChan->rxNoiseSquelchEnable=0;
-		pChan->rxHpfEnable=0;
-		pChan->rxDeEmpEnable=0;
-		pChan->rxCenterSlicerEnable=0;
-		pChan->rxCtcssDecodeEnable=0;
-		pChan->rxDcsDecodeEnable=0;
+		pChan->rxNoiseSquelchEnable = 0;
+		pChan->rxHpfEnable = 0;
+		pChan->rxDeEmpEnable = 0;
+		pChan->rxCenterSlicerEnable = 0;
+		pChan->rxCtcssDecodeEnable = 0;
+		pChan->rxDcsDecodeEnable = 0;
 
 		pChan->rxCarrierPoint = 17000;
 		pChan->rxCarrierHyst = 2500;
 
-		pChan->txHpfEnable=0;
-		pChan->txLimiterEnable=0;
-		pChan->txPreEmpEnable=0;
-		pChan->txLpfEnable=1;
-		pChan->txMixA=TX_OUT_VOICE;
-		pChan->txMixB=TX_OUT_LSD;
-	}
-	else
-	{
-		pChan->rxDemod=tChan->rxDemod;
-		pChan->rxCdType=tChan->rxCdType;
-		pChan->voxHangTime=tChan->voxHangTime;
+		pChan->txHpfEnable = 0;
+		pChan->txLimiterEnable = 0;
+		pChan->txPreEmpEnable = 0;
+		pChan->txLpfEnable = 1;
+		pChan->txMixA = TX_OUT_VOICE;
+		pChan->txMixB = TX_OUT_LSD;
+	} else {
+		pChan->rxDemod = tChan->rxDemod;
+		pChan->rxCdType = tChan->rxCdType;
+		pChan->voxHangTime = tChan->voxHangTime;
 		pChan->rxSquelchPoint = tChan->rxSquelchPoint;
 		pChan->rxCarrierHyst = tChan->rxCarrierHyst;
-		pChan->rxSqVoxAdj=tChan->rxSqVoxAdj;
-		pChan->rxSquelchDelay=tChan->rxSquelchDelay;
-		pChan->rxNoiseFilType=tChan->rxNoiseFilType;
+		pChan->rxSqVoxAdj = tChan->rxSqVoxAdj;
+		pChan->rxSquelchDelay = tChan->rxSquelchDelay;
+		pChan->rxNoiseFilType = tChan->rxNoiseFilType;
 
-		pChan->txMod=tChan->txMod;
-		pChan->txHpfEnable=1;
-		pChan->txLpfEnable=1;
+		pChan->txMod = tChan->txMod;
+		pChan->txHpfEnable = 1;
+		pChan->txLpfEnable = 1;
 
-		pChan->pTxCodeDefault=tChan->pTxCodeDefault;
-		pChan->pRxCodeSrc=tChan->pRxCodeSrc;
-		pChan->pTxCodeSrc=tChan->pTxCodeSrc;
+		pChan->pTxCodeDefault = tChan->pTxCodeDefault;
+		pChan->pRxCodeSrc = tChan->pRxCodeSrc;
+		pChan->pTxCodeSrc = tChan->pTxCodeSrc;
 
-		pChan->txMixA=tChan->txMixA;
-		pChan->txMixB=tChan->txMixB;
-		pChan->radioDuplex=tChan->radioDuplex;
-		pChan->area=tChan->area;
-		pChan->rptnum=tChan->rptnum;
-		pChan->idleinterval=tChan->idleinterval;
-		pChan->turnoffs=tChan->turnoffs;
-		pChan->b.rxpolarity=tChan->b.rxpolarity;
-		pChan->b.txpolarity=tChan->b.txpolarity;
-		pChan->b.dcsrxpolarity=tChan->b.dcsrxpolarity;
-		pChan->b.dcstxpolarity=tChan->b.dcstxpolarity;
-		pChan->b.lsdrxpolarity=tChan->b.lsdrxpolarity;
-		pChan->b.lsdtxpolarity=tChan->b.lsdtxpolarity;
-		pChan->b.txboost=tChan->b.txboost;
+		pChan->txMixA = tChan->txMixA;
+		pChan->txMixB = tChan->txMixB;
+		pChan->radioDuplex = tChan->radioDuplex;
+		pChan->area = tChan->area;
+		pChan->rptnum = tChan->rptnum;
+		pChan->idleinterval = tChan->idleinterval;
+		pChan->turnoffs = tChan->turnoffs;
+		pChan->b.rxpolarity = tChan->b.rxpolarity;
+		pChan->b.txpolarity = tChan->b.txpolarity;
+		pChan->b.dcsrxpolarity = tChan->b.dcsrxpolarity;
+		pChan->b.dcstxpolarity = tChan->b.dcstxpolarity;
+		pChan->b.lsdrxpolarity = tChan->b.lsdrxpolarity;
+		pChan->b.lsdtxpolarity = tChan->b.lsdtxpolarity;
+		pChan->b.txboost = tChan->b.txboost;
 
-		pChan->txsettletime=tChan->txsettletime;
-		pChan->tracelevel=tChan->tracelevel;
-		pChan->tracetype=tChan->tracetype;
-		pChan->ukey=tChan->ukey;
-		pChan->name=tChan->name;
+		pChan->txsettletime = tChan->txsettletime;
+		pChan->tracelevel = tChan->tracelevel;
+		pChan->tracetype = tChan->tracetype;
+		pChan->ukey = tChan->ukey;
+		pChan->name = tChan->name;
 		pChan->fever = tChan->fever;
 
-        if(tChan->rxlpf<MAX_RXLPF&&tChan->rxlpf>=0)
-            pChan->rxlpf=tChan->rxlpf;
-        else
-            pChan->rxlpf=0;
-        
-        if(tChan->rxhpf<MAX_RXHPF&&tChan->rxhpf>=0)
-            pChan->rxhpf=tChan->rxhpf;
-        else
-            pChan->rxhpf=0;
-        
-        if(tChan->txlpf<MAX_TXLPF&&tChan->txlpf>=0)
-            pChan->txlpf=tChan->txlpf;
-        else
-            pChan->txlpf=0;
-        
-        if(tChan->txhpf<MAX_TXHPF&&tChan->txhpf>=0)
-            pChan->txhpf=tChan->txhpf;
-        else
-            pChan->txhpf=0;
-        ast_log(LOG_NOTICE,"xpmr rxlpf: %d\n",pChan->rxlpf);
-        ast_log(LOG_NOTICE,"xpmr rxhpf: %d\n",pChan->rxhpf);
-        ast_log(LOG_NOTICE,"xpmr txlpf: %d\n",pChan->txlpf);
-        ast_log(LOG_NOTICE,"xpmr txhpf: %d\n",pChan->txhpf);
+		if (tChan->rxlpf < MAX_RXLPF && tChan->rxlpf >= 0)
+			pChan->rxlpf = tChan->rxlpf;
+		else
+			pChan->rxlpf = 0;
 
-    }
+		if (tChan->rxhpf < MAX_RXHPF && tChan->rxhpf >= 0)
+			pChan->rxhpf = tChan->rxhpf;
+		else
+			pChan->rxhpf = 0;
 
-	if(pChan->rxCarrierHyst==0)
-		pChan->rxCarrierHyst = 3000;
+		if (tChan->txlpf < MAX_TXLPF && tChan->txlpf >= 0)
+			pChan->txlpf = tChan->txlpf;
+		else
+			pChan->txlpf = 0;
 
-	pChan->txHpfEnable=1;
-	pChan->txLpfEnable=1;
+		if (tChan->txhpf < MAX_TXHPF && tChan->txhpf >= 0)
+			pChan->txhpf = tChan->txhpf;
+		else
+			pChan->txhpf = 0;
+		ast_log(LOG_NOTICE, "xpmr rxlpf: %d\n", pChan->rxlpf);
+		ast_log(LOG_NOTICE, "xpmr rxhpf: %d\n", pChan->rxhpf);
+		ast_log(LOG_NOTICE, "xpmr txlpf: %d\n", pChan->txlpf);
+		ast_log(LOG_NOTICE, "xpmr txhpf: %d\n", pChan->txhpf);
 
-	if(pChan->rxCdType==CD_XPMR_NOISE) pChan->rxNoiseSquelchEnable=1;
-
-	if(pChan->rxDemod==RX_AUDIO_FLAT) pChan->rxDeEmpEnable=1;
-
-	pChan->rxCarrierPoint=(pChan->rxSquelchPoint*32767)/100;
-	pChan->rxCarrierHyst = 3000; //pChan->rxCarrierPoint/15;
-
-	pChan->rxDcsDecodeEnable=0;
-
-	if(pChan->b.ctcssRxEnable || pChan->b.dcsRxEnable || pChan->b.lmrRxEnable)
-	{
-		pChan->rxHpfEnable=1;
-		pChan->rxCenterSlicerEnable=1;
-		pChan->rxCtcssDecodeEnable=1;
 	}
 
-	if(pChan->txMod)
-		pChan->txLimiterEnable=1;
-	if(pChan->txMod > 1)
-		pChan->txPreEmpEnable=1;
+	if (pChan->rxCarrierHyst == 0)
+		pChan->rxCarrierHyst = 3000;
 
-	pChan->dd.option=9;
+	pChan->txHpfEnable = 1;
+	pChan->txLpfEnable = 1;
+
+	if (pChan->rxCdType == CD_XPMR_NOISE)
+		pChan->rxNoiseSquelchEnable = 1;
+
+	if (pChan->rxDemod == RX_AUDIO_FLAT)
+		pChan->rxDeEmpEnable = 1;
+
+	pChan->rxCarrierPoint = (pChan->rxSquelchPoint * 32767) / 100;
+	pChan->rxCarrierHyst = 3000;	//pChan->rxCarrierPoint/15;
+
+	pChan->rxDcsDecodeEnable = 0;
+
+	if (pChan->b.ctcssRxEnable || pChan->b.dcsRxEnable || pChan->b.lmrRxEnable) {
+		pChan->rxHpfEnable = 1;
+		pChan->rxCenterSlicerEnable = 1;
+		pChan->rxCtcssDecodeEnable = 1;
+	}
+
+	if (pChan->txMod)
+		pChan->txLimiterEnable = 1;
+	if (pChan->txMod > 1)
+		pChan->txPreEmpEnable = 1;
+
+	pChan->dd.option = 9;
 	dedrift(pChan);
 
 	pChan->lastrxdecode = CTCSS_NULL;
 
 	TRACEF(1, "calloc buffers \n");
 
-	pChan->pRxDemod 	= ast_calloc(numSamples,2);
-	pChan->pRxNoise 	= ast_calloc(numSamples,2);
-	pChan->pRxBase 		= ast_calloc(numSamples,2);
-	pChan->pRxHpf 		= ast_calloc(numSamples,2);
-	pChan->pRxLsd 		= ast_calloc(numSamples,2);
-	pChan->pRxSpeaker 	= ast_calloc(numSamples,2);
-	pChan->pRxCtcss 	= ast_calloc(numSamples,2);
-	pChan->pRxDcTrack 	= ast_calloc(numSamples,2);
-	pChan->pRxLsdLimit 	= ast_calloc(numSamples,2);
+	pChan->pRxDemod = ast_calloc(numSamples, 2);
+	pChan->pRxNoise = ast_calloc(numSamples, 2);
+	pChan->pRxBase = ast_calloc(numSamples, 2);
+	pChan->pRxHpf = ast_calloc(numSamples, 2);
+	pChan->pRxLsd = ast_calloc(numSamples, 2);
+	pChan->pRxSpeaker = ast_calloc(numSamples, 2);
+	pChan->pRxCtcss = ast_calloc(numSamples, 2);
+	pChan->pRxDcTrack = ast_calloc(numSamples, 2);
+	pChan->pRxLsdLimit = ast_calloc(numSamples, 2);
 
-	pChan->pTxInput  	= ast_calloc(numSamples,2);
-	pChan->pTxBase  	= ast_calloc(numSamples,2);
-	pChan->pTxHpf	 	= ast_calloc(numSamples,2);
-	pChan->pTxPreEmp 	= ast_calloc(numSamples,2);
-	pChan->pTxLimiter 	= ast_calloc(numSamples,2);
-	pChan->pTxLsd	 	= ast_calloc(numSamples,2);
-	pChan->pTxLsdLpf    = ast_calloc(numSamples,2);
-	pChan->pTxComposite	= ast_calloc(numSamples,2);
-	pChan->pSigGen0		= ast_calloc(numSamples,2);
-    pChan->pSigGen1		= ast_calloc(numSamples,2);
-		
-	pChan->prxMeasure	= ast_calloc(numSamples,2);
+	pChan->pTxInput = ast_calloc(numSamples, 2);
+	pChan->pTxBase = ast_calloc(numSamples, 2);
+	pChan->pTxHpf = ast_calloc(numSamples, 2);
+	pChan->pTxPreEmp = ast_calloc(numSamples, 2);
+	pChan->pTxLimiter = ast_calloc(numSamples, 2);
+	pChan->pTxLsd = ast_calloc(numSamples, 2);
+	pChan->pTxLsdLpf = ast_calloc(numSamples, 2);
+	pChan->pTxComposite = ast_calloc(numSamples, 2);
+	pChan->pSigGen0 = ast_calloc(numSamples, 2);
+	pChan->pSigGen1 = ast_calloc(numSamples, 2);
 
-	pChan->pTxOut		= ast_calloc(numSamples,2*2*6);		// output buffer
-    
+	pChan->prxMeasure = ast_calloc(numSamples, 2);
+
+	pChan->pTxOut = ast_calloc(numSamples, 2 * 2 * 6);	// output buffer
+
 #ifdef HAVE_XPMRX
-	pChan->pLsdEnc		= ast_calloc(sizeof(t_encLsd),1);
+	pChan->pLsdEnc = ast_calloc(sizeof(t_encLsd), 1);
 #endif
 
-	#if XPMR_DEBUG0 == 1
+#if XPMR_DEBUG0 == 1
 	TRACEF(1, "configure tracing\n");
 
-	pChan->pTstTxOut	= ast_calloc(numSamples,2);
-	pChan->pRxLsdCen    = ast_calloc(numSamples,2);
-	pChan->prxDebug0	= ast_calloc(numSamples,2);
-	pChan->prxDebug1	= ast_calloc(numSamples,2);
-	pChan->prxDebug2	= ast_calloc(numSamples,2);
-	pChan->prxDebug3	= ast_calloc(numSamples,2);
-	pChan->ptxDebug0	= ast_calloc(numSamples,2);
-	pChan->ptxDebug1	= ast_calloc(numSamples,2);
-	pChan->ptxDebug2	= ast_calloc(numSamples,2);
-	pChan->ptxDebug3	= ast_calloc(numSamples,2);
-	pChan->pNull		= ast_calloc(numSamples,2);
+	pChan->pTstTxOut = ast_calloc(numSamples, 2);
+	pChan->pRxLsdCen = ast_calloc(numSamples, 2);
+	pChan->prxDebug0 = ast_calloc(numSamples, 2);
+	pChan->prxDebug1 = ast_calloc(numSamples, 2);
+	pChan->prxDebug2 = ast_calloc(numSamples, 2);
+	pChan->prxDebug3 = ast_calloc(numSamples, 2);
+	pChan->ptxDebug0 = ast_calloc(numSamples, 2);
+	pChan->ptxDebug1 = ast_calloc(numSamples, 2);
+	pChan->ptxDebug2 = ast_calloc(numSamples, 2);
+	pChan->ptxDebug3 = ast_calloc(numSamples, 2);
+	pChan->pNull = ast_calloc(numSamples, 2);
 
-	for(i=0;i<numSamples;i++)pChan->pNull[i]=((i%(numSamples/2))*8000)-4000;
+	for (i = 0; i < numSamples; i++)
+		pChan->pNull[i] = ((i % (numSamples / 2)) * 8000) - 4000;
 
-	pChan->rxCtcss->pDebug0=ast_calloc(numSamples,2);
-	pChan->rxCtcss->pDebug1=ast_calloc(numSamples,2);
-	pChan->rxCtcss->pDebug2=ast_calloc(numSamples,2);
-	pChan->rxCtcss->pDebug3=ast_calloc(numSamples,2);
+	pChan->rxCtcss->pDebug0 = ast_calloc(numSamples, 2);
+	pChan->rxCtcss->pDebug1 = ast_calloc(numSamples, 2);
+	pChan->rxCtcss->pDebug2 = ast_calloc(numSamples, 2);
+	pChan->rxCtcss->pDebug3 = ast_calloc(numSamples, 2);
 
-	for(i=0;i<CTCSS_NUM_CODES;i++)
-	{
-		pChan->rxCtcss->tdet[i].pDebug0=ast_calloc(numSamples,2);
-		pChan->rxCtcss->tdet[i].pDebug1=ast_calloc(numSamples,2);
-		pChan->rxCtcss->tdet[i].pDebug2=ast_calloc(numSamples,2);
-		pChan->rxCtcss->tdet[i].pDebug3=ast_calloc(numSamples,2);
+	for (i = 0; i < CTCSS_NUM_CODES; i++) {
+		pChan->rxCtcss->tdet[i].pDebug0 = ast_calloc(numSamples, 2);
+		pChan->rxCtcss->tdet[i].pDebug1 = ast_calloc(numSamples, 2);
+		pChan->rxCtcss->tdet[i].pDebug2 = ast_calloc(numSamples, 2);
+		pChan->rxCtcss->tdet[i].pDebug3 = ast_calloc(numSamples, 2);
 	}
 
 	// buffer, 2 bytes per sample, and 16 channels
-	pChan->prxDebug=ast_calloc(numSamples*16,2);
-	pChan->ptxDebug=ast_calloc(numSamples*16,2);
+	pChan->prxDebug = ast_calloc(numSamples * 16, 2);
+	pChan->ptxDebug = ast_calloc(numSamples * 16, 2);
 
 	// TSCOPE CONFIGURATION SETSCOPE configure debug traces and sources for each channel of the output
-	pChan->sdbg			= (t_sdbg *)ast_calloc(sizeof(t_sdbg),1);
+	pChan->sdbg = (t_sdbg *) ast_calloc(sizeof(t_sdbg), 1);
 
 	for (i = 0; i < XPMR_DEBUG_CHANS; i++) {
 		pChan->sdbg->trace[i] = -1;
@@ -1910,203 +1857,196 @@ t_pmr_chan	*createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 
 	TRACEF(1, "pChan->tracetype = %i\n", pChan->tracetype);
 
-	if(pChan->tracetype==1)				  			// CTCSS DECODE
+	if (pChan->tracetype == 1)	// CTCSS DECODE
 	{
-		pChan->sdbg->source [0]=pChan->pRxDemod;
-		pChan->sdbg->source [1]=pChan->pRxBase;
-		pChan->sdbg->source [2]=pChan->pRxNoise;
-		pChan->sdbg->trace  [3]=RX_NOISE_TRIG;
-		pChan->sdbg->source [4]=pChan->pRxLsd;
-		pChan->sdbg->source [5]=pChan->pRxLsdCen;
-		pChan->sdbg->source [6]=pChan->pRxLsdLimit;
-		pChan->sdbg->source [7]=pChan->rxCtcss->tdet[3].pDebug0;
-		pChan->sdbg->trace  [8]=RX_CTCSS_DECODE;
-		pChan->sdbg->trace  [9]=RX_SMODE;
-		pChan->sdbg->source  [10]=pChan->pRxBase;
-		pChan->sdbg->source  [11]=pChan->pRxSpeaker;
+		pChan->sdbg->source[0] = pChan->pRxDemod;
+		pChan->sdbg->source[1] = pChan->pRxBase;
+		pChan->sdbg->source[2] = pChan->pRxNoise;
+		pChan->sdbg->trace[3] = RX_NOISE_TRIG;
+		pChan->sdbg->source[4] = pChan->pRxLsd;
+		pChan->sdbg->source[5] = pChan->pRxLsdCen;
+		pChan->sdbg->source[6] = pChan->pRxLsdLimit;
+		pChan->sdbg->source[7] = pChan->rxCtcss->tdet[3].pDebug0;
+		pChan->sdbg->trace[8] = RX_CTCSS_DECODE;
+		pChan->sdbg->trace[9] = RX_SMODE;
+		pChan->sdbg->source[10] = pChan->pRxBase;
+		pChan->sdbg->source[11] = pChan->pRxSpeaker;
 	}
-	if(pChan->tracetype==2)							// CTCSS DECODE
+	if (pChan->tracetype == 2)	// CTCSS DECODE
 	{
-		pChan->sdbg->source [0]=pChan->pRxDemod;
-		pChan->sdbg->source [1]=pChan->pRxBase;
-		pChan->sdbg->trace  [2]=RX_NOISE_TRIG;
-		pChan->sdbg->source [3]=pChan->pRxLsd;
-		pChan->sdbg->source [4]=pChan->pRxLsdCen;
-		pChan->sdbg->source [5]=pChan->pRxDcTrack;
-		pChan->sdbg->source [6]=pChan->pRxLsdLimit;
-		pChan->sdbg->source [7]=pChan->rxCtcss->tdet[3].pDebug0;
-		pChan->sdbg->source [8]=pChan->rxCtcss->tdet[3].pDebug1;
-		pChan->sdbg->source [9]=pChan->rxCtcss->tdet[3].pDebug2;
-		pChan->sdbg->source [10]=pChan->rxCtcss->tdet[3].pDebug3;
-		pChan->sdbg->trace  [11]=RX_CTCSS_DECODE;
-		pChan->sdbg->trace  [12]=RX_SMODE;
-		pChan->sdbg->trace  [13]=TX_PTT_IN;
-		pChan->sdbg->trace  [14]=TX_PTT_OUT;
-		pChan->sdbg->source [15]=pChan->pTxLsdLpf;
-	}
-	else if(pChan->tracetype==3)					// DCS DECODE
+		pChan->sdbg->source[0] = pChan->pRxDemod;
+		pChan->sdbg->source[1] = pChan->pRxBase;
+		pChan->sdbg->trace[2] = RX_NOISE_TRIG;
+		pChan->sdbg->source[3] = pChan->pRxLsd;
+		pChan->sdbg->source[4] = pChan->pRxLsdCen;
+		pChan->sdbg->source[5] = pChan->pRxDcTrack;
+		pChan->sdbg->source[6] = pChan->pRxLsdLimit;
+		pChan->sdbg->source[7] = pChan->rxCtcss->tdet[3].pDebug0;
+		pChan->sdbg->source[8] = pChan->rxCtcss->tdet[3].pDebug1;
+		pChan->sdbg->source[9] = pChan->rxCtcss->tdet[3].pDebug2;
+		pChan->sdbg->source[10] = pChan->rxCtcss->tdet[3].pDebug3;
+		pChan->sdbg->trace[11] = RX_CTCSS_DECODE;
+		pChan->sdbg->trace[12] = RX_SMODE;
+		pChan->sdbg->trace[13] = TX_PTT_IN;
+		pChan->sdbg->trace[14] = TX_PTT_OUT;
+		pChan->sdbg->source[15] = pChan->pTxLsdLpf;
+	} else if (pChan->tracetype == 3)	// DCS DECODE
 	{
-		pChan->sdbg->source [0]=pChan->pRxDemod;
-		pChan->sdbg->source [1]=pChan->pRxBase;
-		pChan->sdbg->trace  [2]=RX_NOISE_TRIG;
-		pChan->sdbg->source [3]=pChan->pRxLsd;
-		pChan->sdbg->source [4]=pChan->pRxLsdCen;
-		pChan->sdbg->source [5]=pChan->pRxDcTrack;
-		pChan->sdbg->trace  [6]=RX_DCS_CLK;
-		pChan->sdbg->trace  [7]=RX_DCS_DIN;
-		pChan->sdbg->trace  [8]=RX_DCS_DEC;
-		pChan->sdbg->trace  [9]=RX_SMODE;
-		pChan->sdbg->trace  [10]=TX_PTT_IN;
-		pChan->sdbg->trace  [11]=TX_PTT_OUT;
-		pChan->sdbg->trace  [12]=TX_LSD_CLK;
-		pChan->sdbg->trace  [13]=TX_LSD_DAT;
-		pChan->sdbg->trace  [14]=TX_LSD_GEN;
-		pChan->sdbg->source [14]=pChan->pTxLsd;
-		pChan->sdbg->source [15]=pChan->pTxLsdLpf;
-	}
-	else if(pChan->tracetype==4)			 		// LSD DECODE
+		pChan->sdbg->source[0] = pChan->pRxDemod;
+		pChan->sdbg->source[1] = pChan->pRxBase;
+		pChan->sdbg->trace[2] = RX_NOISE_TRIG;
+		pChan->sdbg->source[3] = pChan->pRxLsd;
+		pChan->sdbg->source[4] = pChan->pRxLsdCen;
+		pChan->sdbg->source[5] = pChan->pRxDcTrack;
+		pChan->sdbg->trace[6] = RX_DCS_CLK;
+		pChan->sdbg->trace[7] = RX_DCS_DIN;
+		pChan->sdbg->trace[8] = RX_DCS_DEC;
+		pChan->sdbg->trace[9] = RX_SMODE;
+		pChan->sdbg->trace[10] = TX_PTT_IN;
+		pChan->sdbg->trace[11] = TX_PTT_OUT;
+		pChan->sdbg->trace[12] = TX_LSD_CLK;
+		pChan->sdbg->trace[13] = TX_LSD_DAT;
+		pChan->sdbg->trace[14] = TX_LSD_GEN;
+		pChan->sdbg->source[14] = pChan->pTxLsd;
+		pChan->sdbg->source[15] = pChan->pTxLsdLpf;
+	} else if (pChan->tracetype == 4)	// LSD DECODE
 	{
-		pChan->sdbg->source [0]=pChan->pRxDemod;
-		pChan->sdbg->source [1]=pChan->pRxBase;
-		pChan->sdbg->trace  [2]=RX_NOISE_TRIG;
-		pChan->sdbg->source [3]=pChan->pRxLsd;
-		pChan->sdbg->source [4]=pChan->pRxLsdCen;
-		pChan->sdbg->source [5]=pChan->pRxDcTrack;
-		pChan->sdbg->trace  [6]=RX_LSD_CLK;
-		pChan->sdbg->trace  [7]=RX_LSD_DAT;
-		pChan->sdbg->trace  [8]=RX_LSD_ERR;
-		pChan->sdbg->trace  [9]=RX_LSD_SYNC;
-		pChan->sdbg->trace  [10]=RX_SMODE;
-		pChan->sdbg->trace  [11]=TX_PTT_IN;
-		pChan->sdbg->trace  [12]=TX_PTT_OUT;
-		pChan->sdbg->trace  [13]=TX_LSD_CLK;
-		pChan->sdbg->trace  [14]=TX_LSD_DAT;
+		pChan->sdbg->source[0] = pChan->pRxDemod;
+		pChan->sdbg->source[1] = pChan->pRxBase;
+		pChan->sdbg->trace[2] = RX_NOISE_TRIG;
+		pChan->sdbg->source[3] = pChan->pRxLsd;
+		pChan->sdbg->source[4] = pChan->pRxLsdCen;
+		pChan->sdbg->source[5] = pChan->pRxDcTrack;
+		pChan->sdbg->trace[6] = RX_LSD_CLK;
+		pChan->sdbg->trace[7] = RX_LSD_DAT;
+		pChan->sdbg->trace[8] = RX_LSD_ERR;
+		pChan->sdbg->trace[9] = RX_LSD_SYNC;
+		pChan->sdbg->trace[10] = RX_SMODE;
+		pChan->sdbg->trace[11] = TX_PTT_IN;
+		pChan->sdbg->trace[12] = TX_PTT_OUT;
+		pChan->sdbg->trace[13] = TX_LSD_CLK;
+		pChan->sdbg->trace[14] = TX_LSD_DAT;
 		//pChan->sdbg->trace  [14]=TX_LSD_GEN;
 		//pChan->sdbg->source [14]=pChan->pTxLsd;
-		pChan->sdbg->source [15]=pChan->pTxLsdLpf;
-	}
-	else if(pChan->tracetype==5)						// LSD LOGIC
+		pChan->sdbg->source[15] = pChan->pTxLsdLpf;
+	} else if (pChan->tracetype == 5)	// LSD LOGIC
 	{
-		pChan->sdbg->source [0]=pChan->pRxBase;
-		pChan->sdbg->trace  [1]=RX_NOISE_TRIG;
-		pChan->sdbg->source [2]=pChan->pRxDcTrack;
-		pChan->sdbg->trace  [3]=RX_LSD_SYNC;
-		pChan->sdbg->trace  [4]=RX_SMODE;
-		pChan->sdbg->trace  [5]=TX_PTT_IN;
-		pChan->sdbg->trace  [6]=TX_PTT_OUT;
-		pChan->sdbg->source [7]=pChan->pTxLsdLpf;
-	}
-	else if(pChan->tracetype==6)
-	{
+		pChan->sdbg->source[0] = pChan->pRxBase;
+		pChan->sdbg->trace[1] = RX_NOISE_TRIG;
+		pChan->sdbg->source[2] = pChan->pRxDcTrack;
+		pChan->sdbg->trace[3] = RX_LSD_SYNC;
+		pChan->sdbg->trace[4] = RX_SMODE;
+		pChan->sdbg->trace[5] = TX_PTT_IN;
+		pChan->sdbg->trace[6] = TX_PTT_OUT;
+		pChan->sdbg->source[7] = pChan->pTxLsdLpf;
+	} else if (pChan->tracetype == 6) {
 		// tx clock skew and jitter buffer
-		pChan->sdbg->source [0]=pChan->pRxDemod;
-		pChan->sdbg->source  [5]=pChan->pTxBase;
-		pChan->sdbg->trace   [6]=TX_DEDRIFT_LEAD;
-		pChan->sdbg->trace   [7]=TX_DEDRIFT_ERR;
-		pChan->sdbg->trace   [8]=TX_DEDRIFT_FACTOR;
-		pChan->sdbg->trace   [9]=TX_DEDRIFT_DRIFT;
-	}
-	else if(pChan->tracetype==7)
-	{
+		pChan->sdbg->source[0] = pChan->pRxDemod;
+		pChan->sdbg->source[5] = pChan->pTxBase;
+		pChan->sdbg->trace[6] = TX_DEDRIFT_LEAD;
+		pChan->sdbg->trace[7] = TX_DEDRIFT_ERR;
+		pChan->sdbg->trace[8] = TX_DEDRIFT_FACTOR;
+		pChan->sdbg->trace[9] = TX_DEDRIFT_DRIFT;
+	} else if (pChan->tracetype == 7) {
 		// tx path
-		pChan->sdbg->source [0]=pChan->pRxBase;
-		pChan->sdbg->trace  [1]=RX_NOISE_TRIG;
-		pChan->sdbg->source [2]=pChan->pRxLsd;
-		pChan->sdbg->trace  [3]=RX_CTCSS_DECODE;
-		pChan->sdbg->source [4]=pChan->pRxHpf;
+		pChan->sdbg->source[0] = pChan->pRxBase;
+		pChan->sdbg->trace[1] = RX_NOISE_TRIG;
+		pChan->sdbg->source[2] = pChan->pRxLsd;
+		pChan->sdbg->trace[3] = RX_CTCSS_DECODE;
+		pChan->sdbg->source[4] = pChan->pRxHpf;
 
-		pChan->sdbg->trace  [5]=TX_PTT_IN;
-		pChan->sdbg->trace  [6]=TX_PTT_OUT;
+		pChan->sdbg->trace[5] = TX_PTT_IN;
+		pChan->sdbg->trace[6] = TX_PTT_OUT;
 
-		pChan->sdbg->source [7]=pChan->pTxBase;
-		pChan->sdbg->source [8]=pChan->pTxHpf;
-		pChan->sdbg->source [9]=pChan->pTxPreEmp;
-		pChan->sdbg->source [10]=pChan->pTxLimiter;
-		pChan->sdbg->source [11]=pChan->pTxComposite;
-		pChan->sdbg->source [12]=pChan->pTxLsdLpf;
+		pChan->sdbg->source[7] = pChan->pTxBase;
+		pChan->sdbg->source[8] = pChan->pTxHpf;
+		pChan->sdbg->source[9] = pChan->pTxPreEmp;
+		pChan->sdbg->source[10] = pChan->pTxLimiter;
+		pChan->sdbg->source[11] = pChan->pTxComposite;
+		pChan->sdbg->source[12] = pChan->pTxLsdLpf;
 	}
 
-	for(i=0;i<XPMR_DEBUG_CHANS;i++){
-		if(pChan->sdbg->trace[i]>=0)pChan->sdbg->point[pChan->sdbg->trace[i]]=i; 	
+	for (i = 0; i < XPMR_DEBUG_CHANS; i++) {
+		if (pChan->sdbg->trace[i] >= 0)
+			pChan->sdbg->point[pChan->sdbg->trace[i]] = i;
 	}
-	pChan->sdbg->mode=1;
- 	#endif
+	pChan->sdbg->mode = 1;
+#endif
 
-	#ifdef XPMRX_H
+#ifdef XPMRX_H
 	// LSD GENERATOR
- 	pSps=pChan->spsLsdGen=createPmrSps(pChan);
-	pSps->source=NULL;
-	pSps->sink=pChan->pTxLsd;
-	pSps->numChanOut=1;
-	pSps->selChanOut=0;
-	pSps->sigProc=LsdGen;
-	pSps->nSamples=pChan->nSamplesTx;
-	pSps->outputGain=(.49*M_Q8);
-	pSps->option=0;
-	pSps->interpolate=1;
-	pSps->decimate=1;
-	pSps->enabled=0;
-	#endif
+	pSps = pChan->spsLsdGen = createPmrSps(pChan);
+	pSps->source = NULL;
+	pSps->sink = pChan->pTxLsd;
+	pSps->numChanOut = 1;
+	pSps->selChanOut = 0;
+	pSps->sigProc = LsdGen;
+	pSps->nSamples = pChan->nSamplesTx;
+	pSps->outputGain = (.49 * M_Q8);
+	pSps->option = 0;
+	pSps->interpolate = 1;
+	pSps->decimate = 1;
+	pSps->enabled = 0;
+#endif
 
 	// General Purpose Function Generator
-	pSps=pChan->spsSigGen1=createPmrSps(pChan);
-	pSps->sink=pChan->pSigGen1;
-	pSps->numChanOut=1;
-	pSps->selChanOut=0;
-	pSps->sigProc=SigGen;
-	pSps->nSamples=pChan->nSamplesTx;
-	pSps->sampleRate=SAMPLE_RATE_NETWORK;
-	pSps->freq=10000; 						// in increments of 0.1 Hz
-	pSps->outputGain=(.25*M_Q8);
-	pSps->option=0;
-	pSps->interpolate=1;
-	pSps->decimate=1;
-	pSps->enabled=0;
-
+	pSps = pChan->spsSigGen1 = createPmrSps(pChan);
+	pSps->sink = pChan->pSigGen1;
+	pSps->numChanOut = 1;
+	pSps->selChanOut = 0;
+	pSps->sigProc = SigGen;
+	pSps->nSamples = pChan->nSamplesTx;
+	pSps->sampleRate = SAMPLE_RATE_NETWORK;
+	pSps->freq = 10000;			// in increments of 0.1 Hz
+	pSps->outputGain = (.25 * M_Q8);
+	pSps->option = 0;
+	pSps->interpolate = 1;
+	pSps->decimate = 1;
+	pSps->enabled = 0;
 
 	// CTCSS ENCODER
 	pSps = pChan->spsSigGen0 = createPmrSps(pChan);
-	pSps->sink=pChan->pTxLsd;
-	pSps->sigProc=SigGen;
-	pSps->numChanOut=1;
-	pSps->selChanOut=0;
-	pSps->nSamples=pChan->nSamplesTx;
-	pSps->sampleRate=SAMPLE_RATE_NETWORK;
-	pSps->freq=1000;	  					// in 0.1 Hz steps
-	pSps->outputGain=(0.5*M_Q8);
-	pSps->option=0;
-	pSps->interpolate=1;
-	pSps->decimate=1;
-	pSps->enabled=0;
+	pSps->sink = pChan->pTxLsd;
+	pSps->sigProc = SigGen;
+	pSps->numChanOut = 1;
+	pSps->selChanOut = 0;
+	pSps->nSamples = pChan->nSamplesTx;
+	pSps->sampleRate = SAMPLE_RATE_NETWORK;
+	pSps->freq = 1000;			// in 0.1 Hz steps
+	pSps->outputGain = (0.5 * M_Q8);
+	pSps->option = 0;
+	pSps->interpolate = 1;
+	pSps->decimate = 1;
+	pSps->enabled = 0;
 
 	// Tx LSD Low Pass Filter
-	pSps=pChan->spsTxLsdLpf=createPmrSps(pChan);
-	pSps->source=pChan->pTxLsd;
-	pSps->sink=pChan->pTxLsdLpf;
-	pSps->sigProc=pmr_gp_fir;
-	pSps->enabled=0;
-	pSps->numChanOut=1;
-	pSps->selChanOut=0;
-	pSps->nSamples=pChan->nSamplesTx;
-	pSps->decimator=pSps->decimate=1;
-	pSps->interpolate=1;
-	pSps->inputGain=(1*M_Q8);
-	pSps->outputGain=(1*M_Q8);
-	 
+	pSps = pChan->spsTxLsdLpf = createPmrSps(pChan);
+	pSps->source = pChan->pTxLsd;
+	pSps->sink = pChan->pTxLsdLpf;
+	pSps->sigProc = pmr_gp_fir;
+	pSps->enabled = 0;
+	pSps->numChanOut = 1;
+	pSps->selChanOut = 0;
+	pSps->nSamples = pChan->nSamplesTx;
+	pSps->decimator = pSps->decimate = 1;
+	pSps->interpolate = 1;
+	pSps->inputGain = (1 * M_Q8);
+	pSps->outputGain = (1 * M_Q8);
+
 	// configure the longer, lower cutoff filter by default
-	pSps->ncoef=taps_fir_lpf_215_9_88;
-	pSps->size_coef=2;
-	pSps->coef=(void*)coef_fir_lpf_215_9_88;
-	pSps->nx=taps_fir_lpf_215_9_88;
-	pSps->size_x=2;
+	pSps->ncoef = taps_fir_lpf_215_9_88;
+	pSps->size_coef = 2;
+	pSps->coef = (void *) coef_fir_lpf_215_9_88;
+	pSps->nx = taps_fir_lpf_215_9_88;
+	pSps->size_x = 2;
 	pSps->x = ast_calloc(pSps->nx, pSps->size_x);
 	if (pSps->x == NULL) {
-		; /* XXX do something here */
+		;						/* XXX do something here */
 	}
-	pSps->calcAdjust=gain_fir_lpf_215_9_88;
+	pSps->calcAdjust = gain_fir_lpf_215_9_88;
 
-	pSps->inputGain=(1*M_Q8);
-	pSps->outputGain=(1*M_Q8);
+	pSps->inputGain = (1 * M_Q8);
+	pSps->outputGain = (1 * M_Q8);
 
 	TRACEF(1, "spsTxLsdLpf = sps \n");
 
@@ -2115,471 +2055,450 @@ t_pmr_chan	*createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 	pSps = NULL;
 
 	// allocate space for first sps and set pointers
-	pSps=pChan->spsRx=createPmrSps(pChan);
-	pSps->source=NULL;					//set when called
-	pSps->sink=pChan->pRxBase;
-	pSps->sigProc=pmr_rx_frontend;
-	pSps->enabled=1;
-	pSps->decimator=pSps->decimate=6;
-	pSps->interpolate=pSps->interpolate=1;
-	pSps->nSamples=pChan->nSamplesRx;
-	pSps->ncoef=fir_rxlpf[pChan->rxlpf].taps;
-	pSps->size_coef=2;
-	pSps->coef=(void*)fir_rxlpf[pChan->rxlpf].coefs;
-	pSps->nx=fir_rxlpf[pChan->rxlpf].taps;
-	pSps->size_x=2;
+	pSps = pChan->spsRx = createPmrSps(pChan);
+	pSps->source = NULL;		//set when called
+	pSps->sink = pChan->pRxBase;
+	pSps->sigProc = pmr_rx_frontend;
+	pSps->enabled = 1;
+	pSps->decimator = pSps->decimate = 6;
+	pSps->interpolate = pSps->interpolate = 1;
+	pSps->nSamples = pChan->nSamplesRx;
+	pSps->ncoef = fir_rxlpf[pChan->rxlpf].taps;
+	pSps->size_coef = 2;
+	pSps->coef = (void *) fir_rxlpf[pChan->rxlpf].coefs;
+	pSps->nx = fir_rxlpf[pChan->rxlpf].taps;
+	pSps->size_x = 2;
 	pSps->x = ast_calloc(pSps->nx, pSps->size_coef);
 	if (pSps->x == NULL) {
-		; /* XXX do something here */
+		;						/* XXX do something here */
 	}
-	pSps->calcAdjust=(fir_rxlpf[pChan->rxlpf].gain*256)/0x0100;
-	pSps->outputGain=(1.0*M_Q8);
-	pSps->discfactor=2;
-	pSps->hyst=pChan->rxCarrierHyst;
-	pSps->setpt=pChan->rxCarrierPoint;
-	pChan->prxSquelchAdjust=&pSps->setpt;
-	#if XPMR_DEBUG0 == 1
-	pSps->debugBuff0=pChan->pRxDemod;
-	pSps->debugBuff1=pChan->pRxNoise;
-	pSps->debugBuff2=pChan->prxDebug0;
-	#endif
-
+	pSps->calcAdjust = (fir_rxlpf[pChan->rxlpf].gain * 256) / 0x0100;
+	pSps->outputGain = (1.0 * M_Q8);
+	pSps->discfactor = 2;
+	pSps->hyst = pChan->rxCarrierHyst;
+	pSps->setpt = pChan->rxCarrierPoint;
+	pChan->prxSquelchAdjust = &pSps->setpt;
+#if XPMR_DEBUG0 == 1
+	pSps->debugBuff0 = pChan->pRxDemod;
+	pSps->debugBuff1 = pChan->pRxNoise;
+	pSps->debugBuff2 = pChan->prxDebug0;
+#endif
 
 	// allocate space for next sps and set pointers
 	// Rx SubAudible Decoder Low Pass Filter
-	pSps=pChan->spsRxLsd=pSps->nextSps=createPmrSps(pChan);
-	pSps->source=pChan->pRxBase;
-	pSps->sink=pChan->pRxLsd;
-	pSps->sigProc=pmr_gp_fir;
-	pSps->enabled=1;
-	pSps->numChanOut=1;
-	pSps->selChanOut=0;
-	pSps->nSamples=pChan->nSamplesRx;
-	pSps->decimator=pSps->decimate=1;
-	pSps->interpolate=1;
+	pSps = pChan->spsRxLsd = pSps->nextSps = createPmrSps(pChan);
+	pSps->source = pChan->pRxBase;
+	pSps->sink = pChan->pRxLsd;
+	pSps->sigProc = pmr_gp_fir;
+	pSps->enabled = 1;
+	pSps->numChanOut = 1;
+	pSps->selChanOut = 0;
+	pSps->nSamples = pChan->nSamplesRx;
+	pSps->decimator = pSps->decimate = 1;
+	pSps->interpolate = 1;
 
 	// configure the the larger, lower cutoff filter by default
-	pSps->ncoef=taps_fir_lpf_215_9_88;
-	pSps->size_coef=2;
-	pSps->coef=(void*)coef_fir_lpf_215_9_88;
-	pSps->nx=taps_fir_lpf_215_9_88;
-	pSps->size_x=2;
+	pSps->ncoef = taps_fir_lpf_215_9_88;
+	pSps->size_coef = 2;
+	pSps->coef = (void *) coef_fir_lpf_215_9_88;
+	pSps->nx = taps_fir_lpf_215_9_88;
+	pSps->size_x = 2;
 	pSps->x = ast_calloc(pSps->nx, pSps->size_x);
 	if (pSps->x == NULL) {
-		; /* XXX do something here */
+		;						/* XXX do something here */
 	}
-	pSps->calcAdjust=gain_fir_lpf_215_9_88;
+	pSps->calcAdjust = gain_fir_lpf_215_9_88;
 
-	pSps->inputGain=(1*M_Q8);
-	pSps->outputGain=(1*M_Q8);
-	pChan->prxCtcssMeasure=pSps->sink;
-	pChan->prxCtcssAdjust=&(pSps->outputGain);
+	pSps->inputGain = (1 * M_Q8);
+	pSps->outputGain = (1 * M_Q8);
+	pChan->prxCtcssMeasure = pSps->sink;
+	pChan->prxCtcssAdjust = &(pSps->outputGain);
 
 	// CTCSS CenterSlicer
-	pSps=pChan->spsRxLsdNrz=pSps->nextSps=createPmrSps(pChan);
-	pSps->source=pChan->pRxLsd;
-	pSps->sink=pChan->pRxDcTrack;
-	pSps->buff=pChan->pRxLsdLimit;
-	pSps->sigProc=CenterSlicer;
-	pSps->nSamples=pChan->nSamplesRx;
-	pSps->discfactor=LSD_DFS;		  		// centering time constant
-	pSps->inputGain=(1*M_Q8);
-	pSps->outputGain=(1*M_Q8);
-	pSps->setpt=4900;	  			// ptp clamp for DC centering
-	pSps->inputGainB=625; 			// peak output limiter clip point
-	pSps->enabled=0;
-
+	pSps = pChan->spsRxLsdNrz = pSps->nextSps = createPmrSps(pChan);
+	pSps->source = pChan->pRxLsd;
+	pSps->sink = pChan->pRxDcTrack;
+	pSps->buff = pChan->pRxLsdLimit;
+	pSps->sigProc = CenterSlicer;
+	pSps->nSamples = pChan->nSamplesRx;
+	pSps->discfactor = LSD_DFS;	// centering time constant
+	pSps->inputGain = (1 * M_Q8);
+	pSps->outputGain = (1 * M_Q8);
+	pSps->setpt = 4900;			// ptp clamp for DC centering
+	pSps->inputGainB = 625;		// peak output limiter clip point
+	pSps->enabled = 0;
 
 	// Rx HPF
-	pSps=pSps->nextSps=createPmrSps(pChan);
-	pChan->spsRxHpf=pSps;
-	pSps->source=pChan->pRxBase;
-	pSps->sink=pChan->pRxHpf;
-	pSps->sigProc=pmr_gp_fir;
-	pSps->enabled=1;
-	pSps->numChanOut=1;
-	pSps->selChanOut=0;
-	pSps->nSamples=pChan->nSamplesRx;
-	pSps->decimator=pSps->decimate=1;
-	pSps->interpolate=1;
-	pSps->ncoef=fir_rxhpf[pChan->rxhpf].taps;
-	pSps->size_coef=2;
-	pSps->coef=(void*)fir_rxhpf[pChan->rxhpf].coefs;
-	pSps->nx=fir_rxhpf[pChan->rxhpf].taps;
-	pSps->size_x=2;
+	pSps = pSps->nextSps = createPmrSps(pChan);
+	pChan->spsRxHpf = pSps;
+	pSps->source = pChan->pRxBase;
+	pSps->sink = pChan->pRxHpf;
+	pSps->sigProc = pmr_gp_fir;
+	pSps->enabled = 1;
+	pSps->numChanOut = 1;
+	pSps->selChanOut = 0;
+	pSps->nSamples = pChan->nSamplesRx;
+	pSps->decimator = pSps->decimate = 1;
+	pSps->interpolate = 1;
+	pSps->ncoef = fir_rxhpf[pChan->rxhpf].taps;
+	pSps->size_coef = 2;
+	pSps->coef = (void *) fir_rxhpf[pChan->rxhpf].coefs;
+	pSps->nx = fir_rxhpf[pChan->rxhpf].taps;
+	pSps->size_x = 2;
 	pSps->x = ast_calloc(pSps->nx, pSps->size_x);
 	if (pSps->x == NULL) {
-		; /* XXX do something here */
+		;						/* XXX do something here */
 	}
-	pSps->calcAdjust=fir_rxhpf[pChan->rxhpf].gain;
-	pSps->inputGain=(1*M_Q8);
-	pSps->outputGain=(1*M_Q8);
-	pChan->prxVoiceAdjust=&(pSps->outputGain);
-	pChan->spsRxOut=pSps;
+	pSps->calcAdjust = fir_rxhpf[pChan->rxhpf].gain;
+	pSps->inputGain = (1 * M_Q8);
+	pSps->outputGain = (1 * M_Q8);
+	pChan->prxVoiceAdjust = &(pSps->outputGain);
+	pChan->spsRxOut = pSps;
 
 	// allocate space for next sps and set pointers
 	// Rx DeEmp
-	if(pChan->rxDeEmpEnable){
-		pSps=pSps->nextSps=createPmrSps(pChan);
-		pChan->spsRxDeEmp=pSps;
-		pSps->source=pChan->pRxHpf;
-		pSps->sink=pChan->pRxSpeaker;
-		pChan->spsRxOut=pSps;					 // OUTPUT STRUCTURE!
-		pSps->sigProc=gp_inte_00;
-		pSps->enabled=1;
-		pSps->nSamples=pChan->nSamplesRx;
+	if (pChan->rxDeEmpEnable) {
+		pSps = pSps->nextSps = createPmrSps(pChan);
+		pChan->spsRxDeEmp = pSps;
+		pSps->source = pChan->pRxHpf;
+		pSps->sink = pChan->pRxSpeaker;
+		pChan->spsRxOut = pSps;	// OUTPUT STRUCTURE!
+		pSps->sigProc = gp_inte_00;
+		pSps->enabled = 1;
+		pSps->nSamples = pChan->nSamplesRx;
 
-		pSps->ncoef=taps_int_lpf_300_1_2;
-		pSps->size_coef=2;
-		pSps->coef=(void*)coef_int_lpf_300_1_2;
+		pSps->ncoef = taps_int_lpf_300_1_2;
+		pSps->size_coef = 2;
+		pSps->coef = (void *) coef_int_lpf_300_1_2;
 
-		pSps->nx=taps_int_lpf_300_1_2;
-		pSps->size_x=4;
+		pSps->nx = taps_int_lpf_300_1_2;
+		pSps->size_x = 4;
 		pSps->x = ast_calloc(pSps->nx, pSps->size_x);
 		if (pSps->x == NULL) {
-			; /* XXX do something here */
+			;					/* XXX do something here */
 		}
-		pSps->calcAdjust=gain_int_lpf_300_1_2/2;
-		pSps->inputGain=(1.0*M_Q8);
-		pSps->outputGain=(1.0*M_Q8);
-		pChan->prxVoiceMeasure=pSps->sink;
-		pChan->prxVoiceAdjust=&(pSps->outputGain);
+		pSps->calcAdjust = gain_int_lpf_300_1_2 / 2;
+		pSps->inputGain = (1.0 * M_Q8);
+		pSps->outputGain = (1.0 * M_Q8);
+		pChan->prxVoiceMeasure = pSps->sink;
+		pChan->prxVoiceAdjust = &(pSps->outputGain);
 	} else {
 		// force delay to be true
 		if (pChan->rxSquelchDelay == 0)
 			pChan->rxSquelchDelay = 30;
 	}
 
-	if(pChan->rxSquelchDelay>RXSQDELAYBUFSIZE/8-1)
-	{
-		pChan->rxSquelchDelay=RXSQDELAYBUFSIZE/8-1;	
+	if (pChan->rxSquelchDelay > RXSQDELAYBUFSIZE / 8 - 1) {
+		pChan->rxSquelchDelay = RXSQDELAYBUFSIZE / 8 - 1;
 	}
-	if(pChan->rxSquelchDelay>0)
-	{
+	if (pChan->rxSquelchDelay > 0) {
 		TRACEF(1, "create rx squelch delay\n");
-		pSps=pChan->spsDelayLine=pSps->nextSps=createPmrSps(pChan);
-		pChan->spsRxSquelchDelay=pSps;
-		pSps->sigProc=DelayLine;
+		pSps = pChan->spsDelayLine = pSps->nextSps = createPmrSps(pChan);
+		pChan->spsRxSquelchDelay = pSps;
+		pSps->sigProc = DelayLine;
 		if (pChan->rxDeEmpEnable)
-			pSps->source=pChan->pRxSpeaker;
+			pSps->source = pChan->pRxSpeaker;
 		else
-			pSps->source=pChan->pRxHpf;
-		pSps->sink=pChan->pRxSpeaker;
-		pChan->spsRxOut=pSps;					 // OUTPUT STRUCTURE!
-		pSps->enabled=1;
-		pSps->b.outzero=0;
-		pSps->inputGain=1*M_Q8;
-		pSps->outputGain=1*M_Q8;
-		pSps->nSamples=pChan->nSamplesRx;
-		pSps->buffSize=RXSQDELAYBUFSIZE;
-		pSps->buff=ast_calloc(RXSQDELAYBUFSIZE,2);	 		 
-		pSps->buffLead = pChan->rxSquelchDelay*8;  // convert ms to samples
-		pSps->buffInIndex=0;
-		pSps->buffOutIndex=0;
+			pSps->source = pChan->pRxHpf;
+		pSps->sink = pChan->pRxSpeaker;
+		pChan->spsRxOut = pSps;	// OUTPUT STRUCTURE!
+		pSps->enabled = 1;
+		pSps->b.outzero = 0;
+		pSps->inputGain = 1 * M_Q8;
+		pSps->outputGain = 1 * M_Q8;
+		pSps->nSamples = pChan->nSamplesRx;
+		pSps->buffSize = RXSQDELAYBUFSIZE;
+		pSps->buff = ast_calloc(RXSQDELAYBUFSIZE, 2);
+		pSps->buffLead = pChan->rxSquelchDelay * 8;	// convert ms to samples
+		pSps->buffInIndex = 0;
+		pSps->buffOutIndex = 0;
 	}
 
-	if(pChan->rxCdType==CD_XPMR_VOX)
-	{
+	if (pChan->rxCdType == CD_XPMR_VOX) {
 		TRACEF(1, "create vox measureblock\n");
-		pChan->prxVoxMeas=ast_calloc(pChan->nSamplesRx,2);
+		pChan->prxVoxMeas = ast_calloc(pChan->nSamplesRx, 2);
 
-		pSps=pChan->spsRxVox=pSps->nextSps=createPmrSps(pChan);
-		pSps->sigProc=MeasureBlock;
-		pSps->parentChan=pChan;
-		pSps->source=pChan->pRxBase;
-		pSps->sink=pChan->prxVoxMeas;
-		pSps->inputGain=1*M_Q8;
-		pSps->outputGain=1*M_Q8;
-		pSps->nSamples=pChan->nSamplesRx;
-		pSps->discfactor=3;
-		if(pChan->rxSqVoxAdj==0)
-			pSps->setpt=(0.011*M_Q15);
+		pSps = pChan->spsRxVox = pSps->nextSps = createPmrSps(pChan);
+		pSps->sigProc = MeasureBlock;
+		pSps->parentChan = pChan;
+		pSps->source = pChan->pRxBase;
+		pSps->sink = pChan->prxVoxMeas;
+		pSps->inputGain = 1 * M_Q8;
+		pSps->outputGain = 1 * M_Q8;
+		pSps->nSamples = pChan->nSamplesRx;
+		pSps->discfactor = 3;
+		if (pChan->rxSqVoxAdj == 0)
+			pSps->setpt = (0.011 * M_Q15);
 		else
-			pSps->setpt=(pChan->rxSqVoxAdj);
-		pSps->hyst=(pSps->setpt/10);
-		pSps->enabled=1;
+			pSps->setpt = (pChan->rxSqVoxAdj);
+		pSps->hyst = (pSps->setpt / 10);
+		pSps->enabled = 1;
 	}
 
 	// tuning measure block
-	pSps=pChan->spsMeasure=pSps->nextSps=createPmrSps(pChan);
-	pSps->source=pChan->spsRx->sink;
-	pSps->sink=pChan->prxMeasure;
-	pSps->sigProc=MeasureBlock;
-	pSps->enabled=0;
-	pSps->nSamples=pChan->nSamplesRx;
-	pSps->discfactor=10;
+	pSps = pChan->spsMeasure = pSps->nextSps = createPmrSps(pChan);
+	pSps->source = pChan->spsRx->sink;
+	pSps->sink = pChan->prxMeasure;
+	pSps->sigProc = MeasureBlock;
+	pSps->enabled = 0;
+	pSps->nSamples = pChan->nSamplesRx;
+	pSps->discfactor = 10;
 
-	pSps->nextSps=NULL;		// last sps in chain RX
-
+	pSps->nextSps = NULL;		// last sps in chain RX
 
 	// CREATE TRANSMIT CHAIN
 	TRACEF(1, "create tx\n");
-	inputTmp=NULL;
+	inputTmp = NULL;
 	pSps = NULL;
 
 	// allocate space for first sps and set pointers
 
 	// Tx HPF SubAudible
-	if(pChan->txHpfEnable)
-	{
-		pSps=createPmrSps(pChan);
-		pChan->spsTx=pSps;
-		pSps->source=pChan->pTxBase;
-		pSps->sink=pChan->pTxHpf;
-		pSps->sigProc=pmr_gp_fir;
-		pSps->enabled=1;
-		pSps->numChanOut=1;
-		pSps->selChanOut=0;
-		pSps->nSamples=pChan->nSamplesTx;
-		pSps->decimator=pSps->decimate=1;
-		pSps->interpolate=1;
-		pSps->ncoef=fir_txhpf[pChan->txhpf].taps;
-		pSps->size_coef=2;
-		pSps->coef=(void*)fir_txhpf[pChan->txhpf].coefs;
-		pSps->nx=fir_txhpf[pChan->txhpf].taps;
-		pSps->size_x=2;
+	if (pChan->txHpfEnable) {
+		pSps = createPmrSps(pChan);
+		pChan->spsTx = pSps;
+		pSps->source = pChan->pTxBase;
+		pSps->sink = pChan->pTxHpf;
+		pSps->sigProc = pmr_gp_fir;
+		pSps->enabled = 1;
+		pSps->numChanOut = 1;
+		pSps->selChanOut = 0;
+		pSps->nSamples = pChan->nSamplesTx;
+		pSps->decimator = pSps->decimate = 1;
+		pSps->interpolate = 1;
+		pSps->ncoef = fir_txhpf[pChan->txhpf].taps;
+		pSps->size_coef = 2;
+		pSps->coef = (void *) fir_txhpf[pChan->txhpf].coefs;
+		pSps->nx = fir_txhpf[pChan->txhpf].taps;
+		pSps->size_x = 2;
 		pSps->x = ast_calloc(pSps->nx, pSps->size_x);
 		if (pSps->x == NULL) {
-			; /* XXX do something here */
+			;					/* XXX do something here */
 		}
-		pSps->calcAdjust=fir_txhpf[pChan->txhpf].gain;
-		pSps->inputGain=(1*M_Q8);
-		pSps->outputGain=(1*M_Q8);
-		inputTmp=pChan->pTxHpf;
+		pSps->calcAdjust = fir_txhpf[pChan->txhpf].gain;
+		pSps->inputGain = (1 * M_Q8);
+		pSps->outputGain = (1 * M_Q8);
+		inputTmp = pChan->pTxHpf;
 	}
 
 	// Tx PreEmphasis
-	if(pChan->txPreEmpEnable)
-	{
-		if(pSps==NULL) pSps=pChan->spsTx=createPmrSps(pChan);
-		else pSps=pSps->nextSps=createPmrSps(pChan);
+	if (pChan->txPreEmpEnable) {
+		if (pSps == NULL)
+			pSps = pChan->spsTx = createPmrSps(pChan);
+		else
+			pSps = pSps->nextSps = createPmrSps(pChan);
 
-		pSps->source=inputTmp;
-		pSps->sink=pChan->pTxPreEmp;
+		pSps->source = inputTmp;
+		pSps->sink = pChan->pTxPreEmp;
 
-		pSps->sigProc=gp_diff;
-		pSps->enabled=1;
-		pSps->nSamples=pChan->nSamplesTx;
+		pSps->sigProc = gp_diff;
+		pSps->enabled = 1;
+		pSps->nSamples = pChan->nSamplesTx;
 
-		pSps->ncoef=taps_int_hpf_4000_1_2;
-		pSps->size_coef=2;
-		pSps->coef=(void*)coef_int_hpf_4000_1_2;
+		pSps->ncoef = taps_int_hpf_4000_1_2;
+		pSps->size_coef = 2;
+		pSps->coef = (void *) coef_int_hpf_4000_1_2;
 
-		pSps->nx=taps_int_hpf_4000_1_2;
-		pSps->size_x=2;
+		pSps->nx = taps_int_hpf_4000_1_2;
+		pSps->size_x = 2;
 		pSps->x = ast_calloc(pSps->nx, pSps->size_x);
 		if (pSps->x == NULL) {
-			; /* XXX do something here */
+			;					/* XXX do something here */
 		}
-		pSps->calcAdjust=gain_int_hpf_4000_1_2;
-		pSps->inputGain=(1*M_Q8);
-		pSps->outputGain=(1*M_Q8);	 // to match flat at 1KHz 
-		inputTmp=pSps->sink;
+		pSps->calcAdjust = gain_int_hpf_4000_1_2;
+		pSps->inputGain = (1 * M_Q8);
+		pSps->outputGain = (1 * M_Q8);	// to match flat at 1KHz 
+		inputTmp = pSps->sink;
 	}
 
 	// Tx Limiter
-	if(pChan->txLimiterEnable)
-	{
-		if(pSps==NULL) pSps=pChan->spsTx=createPmrSps(pChan);
-		else pSps=pSps->nextSps=createPmrSps(pChan);
+	if (pChan->txLimiterEnable) {
+		if (pSps == NULL)
+			pSps = pChan->spsTx = createPmrSps(pChan);
+		else
+			pSps = pSps->nextSps = createPmrSps(pChan);
 		pChan->limiterSpsTx = pSps;
-		pSps->source=inputTmp;
-		pSps->sink=pChan->pTxLimiter;
-		pSps->sigProc=SoftLimiter;
-		pSps->enabled=1;
-		pSps->nSamples=pChan->nSamplesTx;
-		pSps->inputGain=(1*M_Q8);
-		pSps->outputGain=(1*M_Q8);
-		pSps->setpt=12000;			// limiting point for 100 modulation		
-		inputTmp=pSps->sink;
+		pSps->source = inputTmp;
+		pSps->sink = pChan->pTxLimiter;
+		pSps->sigProc = SoftLimiter;
+		pSps->enabled = 1;
+		pSps->nSamples = pChan->nSamplesTx;
+		pSps->inputGain = (1 * M_Q8);
+		pSps->outputGain = (1 * M_Q8);
+		pSps->setpt = 12000;	// limiting point for 100 modulation        
+		inputTmp = pSps->sink;
 	}
 
 	// Composite Mix of Voice and LSD
-	if((pChan->txMixA==TX_OUT_COMPOSITE)||(pChan->txMixB==TX_OUT_COMPOSITE))
-	{
-		if(pSps==NULL)
-			pSps=pChan->spsTx=createPmrSps(pChan);
+	if ((pChan->txMixA == TX_OUT_COMPOSITE) || (pChan->txMixB == TX_OUT_COMPOSITE)) {
+		if (pSps == NULL)
+			pSps = pChan->spsTx = createPmrSps(pChan);
 		else
-			pSps=pSps->nextSps=createPmrSps(pChan);
-		pSps->source=inputTmp;
-		pSps->sourceB=pChan->pTxLsdLpf;		 //asdf ??? !!! maw pTxLsdLpf
-		pSps->sink=pChan->pTxComposite;
-		pSps->sigProc=pmrMixer;
-		pSps->enabled=1;
-		pSps->nSamples=pChan->nSamplesTx;
-		pSps->inputGain=2*M_Q8;
-		pSps->inputGainB=1*M_Q8/8;
-		pSps->outputGain=1*M_Q8;
-		pSps->setpt=0;
-		inputTmp=pSps->sink;
-		pChan->ptxCtcssAdjust=&pSps->inputGainB;
-	}
-	else
-	{
-		if (pChan->b.txboost)
-		{
-			if(pSps==NULL)
-				pSps=pChan->spsTx=createPmrSps(pChan);
+			pSps = pSps->nextSps = createPmrSps(pChan);
+		pSps->source = inputTmp;
+		pSps->sourceB = pChan->pTxLsdLpf;	//asdf ??? !!! maw pTxLsdLpf
+		pSps->sink = pChan->pTxComposite;
+		pSps->sigProc = pmrMixer;
+		pSps->enabled = 1;
+		pSps->nSamples = pChan->nSamplesTx;
+		pSps->inputGain = 2 * M_Q8;
+		pSps->inputGainB = 1 * M_Q8 / 8;
+		pSps->outputGain = 1 * M_Q8;
+		pSps->setpt = 0;
+		inputTmp = pSps->sink;
+		pChan->ptxCtcssAdjust = &pSps->inputGainB;
+	} else {
+		if (pChan->b.txboost) {
+			if (pSps == NULL)
+				pSps = pChan->spsTx = createPmrSps(pChan);
 			else
-				pSps=pSps->nextSps=createPmrSps(pChan);
-			pSps->source=inputTmp;
-			pSps->sourceB=NULL;
-			pSps->sink=pChan->pTxComposite;
-			pSps->sigProc=pmrMixer;
-			pSps->enabled=1;
-			pSps->nSamples=pChan->nSamplesTx;
-			pSps->inputGain=2*M_Q8;
-			pSps->inputGainB=0;
-			pSps->outputGain=1*M_Q8;
-			pSps->setpt=0;
-			inputTmp=pSps->sink;
+				pSps = pSps->nextSps = createPmrSps(pChan);
+			pSps->source = inputTmp;
+			pSps->sourceB = NULL;
+			pSps->sink = pChan->pTxComposite;
+			pSps->sigProc = pmrMixer;
+			pSps->enabled = 1;
+			pSps->nSamples = pChan->nSamplesTx;
+			pSps->inputGain = 2 * M_Q8;
+			pSps->inputGainB = 0;
+			pSps->outputGain = 1 * M_Q8;
+			pSps->setpt = 0;
+			inputTmp = pSps->sink;
 		}
 	}
 
 	// Chan A Upsampler and Filter
-	if(pSps==NULL) pSps=pChan->spsTx=createPmrSps(pChan);
-	else pSps=pSps->nextSps=createPmrSps(pChan);
-
-	pChan->spsTxOutA=pSps;
-	if(!pChan->spsTx)pChan->spsTx=pSps;
-
-	if(pChan->txMixA==TX_OUT_COMPOSITE)
-	{
-		pSps->source=pChan->pTxComposite;
-	}
-	else if(pChan->txMixA==TX_OUT_LSD)
-	{
-		pSps->source=pChan->pTxLsdLpf;
-	}
-	else if(pChan->txMixA==TX_OUT_VOICE)
-	{
-		pSps->source=inputTmp;
-	}
-	else if (pChan->txMixA==TX_OUT_AUX)
-	{
-		pSps->source=pChan->pTxHpf;
-	}
+	if (pSps == NULL)
+		pSps = pChan->spsTx = createPmrSps(pChan);
 	else
-	{
-		pSps->source=NULL;		// maw sph asdf !!!	no blow up
-		pSps->source=inputTmp;
+		pSps = pSps->nextSps = createPmrSps(pChan);
+
+	pChan->spsTxOutA = pSps;
+	if (!pChan->spsTx)
+		pChan->spsTx = pSps;
+
+	if (pChan->txMixA == TX_OUT_COMPOSITE) {
+		pSps->source = pChan->pTxComposite;
+	} else if (pChan->txMixA == TX_OUT_LSD) {
+		pSps->source = pChan->pTxLsdLpf;
+	} else if (pChan->txMixA == TX_OUT_VOICE) {
+		pSps->source = inputTmp;
+	} else if (pChan->txMixA == TX_OUT_AUX) {
+		pSps->source = pChan->pTxHpf;
+	} else {
+		pSps->source = NULL;	// maw sph asdf !!! no blow up
+		pSps->source = inputTmp;
 	}
 
-	pSps->sink=pChan->pTxOut;
-	pSps->sigProc=pmr_gp_fir;
-	pSps->enabled=1;
-	pSps->numChanOut=2;
-	pSps->selChanOut=0;
-	pSps->nSamples=pChan->nSamplesTx;
+	pSps->sink = pChan->pTxOut;
+	pSps->sigProc = pmr_gp_fir;
+	pSps->enabled = 1;
+	pSps->numChanOut = 2;
+	pSps->selChanOut = 0;
+	pSps->nSamples = pChan->nSamplesTx;
 #ifdef	XPMR_VOTER
-	pSps->interpolate=1;
-	pSps->ncoef=taps_fir_lpf_3K_2;
-	pSps->size_coef=2;
-	pSps->coef=(void*)coef_fir_lpf_3K_2;
-	pSps->nx=taps_fir_lpf_3K_2;
-	pSps->calcAdjust=gain_fir_lpf_3K_2;
+	pSps->interpolate = 1;
+	pSps->ncoef = taps_fir_lpf_3K_2;
+	pSps->size_coef = 2;
+	pSps->coef = (void *) coef_fir_lpf_3K_2;
+	pSps->nx = taps_fir_lpf_3K_2;
+	pSps->calcAdjust = gain_fir_lpf_3K_2;
 #else
-	pSps->interpolate=6;
-	pSps->ncoef=fir_txlpf[pChan->txlpf].taps;
-	pSps->size_coef=2;
-	pSps->coef=(void*)fir_txlpf[pChan->txlpf].coefs;
-	pSps->nx=fir_txlpf[pChan->txlpf].taps;
-	pSps->calcAdjust=fir_txlpf[pChan->txlpf].gain;
+	pSps->interpolate = 6;
+	pSps->ncoef = fir_txlpf[pChan->txlpf].taps;
+	pSps->size_coef = 2;
+	pSps->coef = (void *) fir_txlpf[pChan->txlpf].coefs;
+	pSps->nx = fir_txlpf[pChan->txlpf].taps;
+	pSps->calcAdjust = fir_txlpf[pChan->txlpf].gain;
 #endif
-	pSps->size_x=2;
+	pSps->size_x = 2;
 	pSps->x = ast_calloc(pSps->nx, pSps->size_x);
 	if (pSps->x == NULL) {
-		; /* XXX do something here */
+		;						/* XXX do something here */
 	}
-	pSps->inputGain=(1*M_Q8);
-	pSps->outputGain=(1*M_Q8);
-	if(pChan->txMixA==pChan->txMixB)pSps->monoOut=1;
-	else pSps->monoOut=0;
-
+	pSps->inputGain = (1 * M_Q8);
+	pSps->outputGain = (1 * M_Q8);
+	if (pChan->txMixA == pChan->txMixB)
+		pSps->monoOut = 1;
+	else
+		pSps->monoOut = 0;
 
 	// Chan B Upsampler and Filter
-	if((pChan->txMixA!=pChan->txMixB)&&(pChan->txMixB!=TX_OUT_OFF))
-	{
-		if(pSps==NULL) pSps=pChan->spsTx=createPmrSps(pChan);
-		else pSps=pSps->nextSps=createPmrSps(pChan);
-
-		pChan->spsTxOutB=pSps;
-		if(pChan->txMixB==TX_OUT_COMPOSITE)
-		{
-			pSps->source=pChan->pTxComposite;
-		}
-		else if(pChan->txMixB==TX_OUT_LSD)
-		{
-			pSps->source=pChan->pTxLsdLpf;
-			// pChan->ptxCtcssAdjust=&pSps->inputGain;
-		}
-		else if(pChan->txMixB==TX_OUT_VOICE)
-		{
-			pSps->source=inputTmp;
-		}
-		else if(pChan->txMixB==TX_OUT_AUX)
-		{
-			pSps->source=pChan->pTxHpf;
-		}
+	if ((pChan->txMixA != pChan->txMixB) && (pChan->txMixB != TX_OUT_OFF)) {
+		if (pSps == NULL)
+			pSps = pChan->spsTx = createPmrSps(pChan);
 		else
-		{
-			pSps->source=NULL;
+			pSps = pSps->nextSps = createPmrSps(pChan);
+
+		pChan->spsTxOutB = pSps;
+		if (pChan->txMixB == TX_OUT_COMPOSITE) {
+			pSps->source = pChan->pTxComposite;
+		} else if (pChan->txMixB == TX_OUT_LSD) {
+			pSps->source = pChan->pTxLsdLpf;
+			// pChan->ptxCtcssAdjust=&pSps->inputGain;
+		} else if (pChan->txMixB == TX_OUT_VOICE) {
+			pSps->source = inputTmp;
+		} else if (pChan->txMixB == TX_OUT_AUX) {
+			pSps->source = pChan->pTxHpf;
+		} else {
+			pSps->source = NULL;
 		}
 
-		pSps->sink=pChan->pTxOut;
-		pSps->sigProc=pmr_gp_fir;
-		pSps->enabled=1;
-		pSps->numChanOut=2;
-		pSps->selChanOut=1;
-		pSps->mixOut=0;
-		pSps->nSamples=pChan->nSamplesTx;
+		pSps->sink = pChan->pTxOut;
+		pSps->sigProc = pmr_gp_fir;
+		pSps->enabled = 1;
+		pSps->numChanOut = 2;
+		pSps->selChanOut = 1;
+		pSps->mixOut = 0;
+		pSps->nSamples = pChan->nSamplesTx;
 #ifdef	XPMR_VOTER
-		pSps->interpolate=1;
-		pSps->ncoef=taps_fir_lpf_3K_2;
-		pSps->size_coef=2;
-		pSps->coef=(void*)coef_fir_lpf_3K_2;
-		pSps->nx=taps_fir_lpf_3K_2;
-		pSps->calcAdjust=(gain_fir_lpf_3K_2);
+		pSps->interpolate = 1;
+		pSps->ncoef = taps_fir_lpf_3K_2;
+		pSps->size_coef = 2;
+		pSps->coef = (void *) coef_fir_lpf_3K_2;
+		pSps->nx = taps_fir_lpf_3K_2;
+		pSps->calcAdjust = (gain_fir_lpf_3K_2);
 #else
-		pSps->interpolate=6;
-		pSps->ncoef=fir_txlpf[pChan->txlpf].taps;
-		pSps->size_coef=2;
-		pSps->coef=(void*)fir_txlpf[pChan->txlpf].coefs;
-		pSps->nx=fir_txlpf[pChan->txlpf].taps;
-		pSps->calcAdjust=(fir_txlpf[pChan->txlpf].gain);
+		pSps->interpolate = 6;
+		pSps->ncoef = fir_txlpf[pChan->txlpf].taps;
+		pSps->size_coef = 2;
+		pSps->coef = (void *) fir_txlpf[pChan->txlpf].coefs;
+		pSps->nx = fir_txlpf[pChan->txlpf].taps;
+		pSps->calcAdjust = (fir_txlpf[pChan->txlpf].gain);
 #endif
-		pSps->size_x=2;
+		pSps->size_x = 2;
 		pSps->x = ast_calloc(pSps->nx, pSps->size_x);
 		if (pSps->x == NULL) {
-			; /* XXX do something here */
+			;					/* XXX do something here */
 		}
-		pSps->inputGain=(1*M_Q8);
-		pSps->outputGain=(1*M_Q8);
+		pSps->inputGain = (1 * M_Q8);
+		pSps->outputGain = (1 * M_Q8);
 	}
 
-	pSps->nextSps=NULL;
+	pSps->nextSps = NULL;
 
 	// Configure Coded Signaling
 	code_string_parse(pChan);
 
-	pChan->smode=SMODE_NULL;
-	pChan->smodewas=SMODE_NULL;
-	pChan->smodetime=2500;
-	pChan->smodetimer=0;
-	pChan->b.smodeturnoff=0;
+	pChan->smode = SMODE_NULL;
+	pChan->smodewas = SMODE_NULL;
+	pChan->smodetime = 2500;
+	pChan->smodetimer = 0;
+	pChan->b.smodeturnoff = 0;
 
-	pChan->txsettletimer=0;
-	pChan->txrxblankingtimer=0;
+	pChan->txsettletimer = 0;
+	pChan->txrxblankingtimer = 0;
 
 	TRACEF(1, "createPmrChannel() end\n");
 
 	return pChan;
 }
+
 /*
 */
 i16 destroyPmrChannel(t_pmr_chan *pChan)
 {
-	t_pmr_sps  	*pmr_sps, *tmp_sps;
+	t_pmr_sps *pmr_sps, *tmp_sps;
 	i16 i;
 
 	TRACEF(1, "destroyPmrChannel()\n");
@@ -2591,57 +2510,61 @@ i16 destroyPmrChannel(t_pmr_chan *pChan)
 	ast_free(pChan->pRxLsd);
 	ast_free(pChan->pRxSpeaker);
 	ast_free(pChan->pRxDcTrack);
-	if(pChan->pRxLsdLimit)ast_free(pChan->pRxLsdLimit);
+	if (pChan->pRxLsdLimit)
+		ast_free(pChan->pRxLsdLimit);
 	ast_free(pChan->pTxBase);
 	ast_free(pChan->pTxHpf);
 	ast_free(pChan->pTxPreEmp);
 	ast_free(pChan->pTxLimiter);
 	ast_free(pChan->pTxLsd);
 	ast_free(pChan->pTxLsdLpf);
-	if(pChan->pTxComposite)ast_free(pChan->pTxComposite);
+	if (pChan->pTxComposite)
+		ast_free(pChan->pTxComposite);
 	ast_free(pChan->pTxOut);
 
-	if(pChan->prxMeasure)ast_free(pChan->prxMeasure);
-	if(pChan->pSigGen0)ast_free(pChan->pSigGen0);
-	if(pChan->pSigGen1)ast_free(pChan->pSigGen1);
-	 
+	if (pChan->prxMeasure)
+		ast_free(pChan->prxMeasure);
+	if (pChan->pSigGen0)
+		ast_free(pChan->pSigGen0);
+	if (pChan->pSigGen1)
+		ast_free(pChan->pSigGen1);
 
-	#if XPMR_DEBUG0 == 1
+#if XPMR_DEBUG0 == 1
 	//if(pChan->prxDebug)ast_free(pChan->prxDebug);
-	if(pChan->ptxDebug)ast_free(pChan->ptxDebug);
+	if (pChan->ptxDebug)
+		ast_free(pChan->ptxDebug);
 	ast_free(pChan->prxDebug0);
- 	ast_free(pChan->prxDebug1);
+	ast_free(pChan->prxDebug1);
 	ast_free(pChan->prxDebug2);
 	ast_free(pChan->prxDebug3);
 
 	ast_free(pChan->ptxDebug0);
- 	ast_free(pChan->ptxDebug1);
+	ast_free(pChan->ptxDebug1);
 	ast_free(pChan->ptxDebug2);
 	ast_free(pChan->ptxDebug3);
 
 	ast_free(pChan->rxCtcss->pDebug0);
 	ast_free(pChan->rxCtcss->pDebug1);
 
-	for(i=0;i<CTCSS_NUM_CODES;i++)
-	{
+	for (i = 0; i < CTCSS_NUM_CODES; i++) {
 		ast_free(pChan->rxCtcss->tdet[i].pDebug0);
 		ast_free(pChan->rxCtcss->tdet[i].pDebug1);
 		ast_free(pChan->rxCtcss->tdet[i].pDebug2);
 		ast_free(pChan->rxCtcss->tdet[i].pDebug3);
 	}
-	#endif
+#endif
 
-	pChan->dd.option=8;
+	pChan->dd.option = 8;
 	dedrift(pChan);
 
 	ast_free(pChan->pRxCtcss);
 
-	pmr_sps=pChan->spsRx;
+	pmr_sps = pChan->spsRx;
 
-	if(pChan->sdbg)ast_free(pChan->sdbg);
+	if (pChan->sdbg)
+		ast_free(pChan->sdbg);
 
-	while(pmr_sps)
-	{
+	while (pmr_sps) {
 		tmp_sps = pmr_sps;
 		pmr_sps = tmp_sps->nextSps;
 		destroyPmrSps(tmp_sps);
@@ -2651,47 +2574,50 @@ i16 destroyPmrChannel(t_pmr_chan *pChan)
 
 	return 0;
 }
+
 /*
 */
 t_pmr_sps *createPmrSps(t_pmr_chan *pChan)
 {
-	t_pmr_sps  *pSps;
+	t_pmr_sps *pSps;
 
 	TRACEF(1, "createPmrSps()\n");
 
-	pSps = (t_pmr_sps *)ast_calloc(sizeof(t_pmr_sps),1);
+	pSps = (t_pmr_sps *) ast_calloc(sizeof(t_pmr_sps), 1);
 
 	if (!pSps) {
 		ast_log(LOG_ERROR, "Error: createPmrSps()\n");
 	}
 
-	pSps->parentChan=pChan;
-	pSps->index=pChan->spsIndex++;
+	pSps->parentChan = pChan;
+	pSps->index = pChan->spsIndex++;
 
 	return pSps;
 }
+
 /*
 */
-i16 destroyPmrSps(t_pmr_sps  *pSps)
+i16 destroyPmrSps(t_pmr_sps *pSps)
 {
 	TRACEJ(1, "destroyPmrSps(%i)\n", pSps->index);
 
-	if(pSps->x!=NULL)ast_free(pSps->x);
+	if (pSps->x != NULL)
+		ast_free(pSps->x);
 	ast_free(pSps);
 	return 0;
 }
+
 /*
 Set the tx soft limiter set point
 Takes the pmr channel and the new setpoint as arguments
 Returns 0 
 */
- 
+
 i16 SetTxSoftLimiterSetpoint(t_pmr_chan *pChan, i16 setpoint)
 {
 	pChan->limiterSpsTx->setpt = setpoint;
 	return 0;
 }
-
 
 /*
 	PmrTx - takes data from network and holds it for PmrRx
@@ -2703,70 +2629,72 @@ i16 PmrTx(t_pmr_chan *pChan, i16 *input)
 	TRACEF(5, "PmrTx() start %i\n", pChan->frameCountTx);
 
 #if XPMR_PPTP == 99
-	pptp_p2^=1;
-	if(pptp_p2)ioctl(ppdrvdev,PPDRV_IOC_PINSET,LP_PIN02);
-	else ioctl(ppdrvdev,PPDRV_IOC_PINCLEAR,LP_PIN02);
-	#endif
+	pptp_p2 ^= 1;
+	if (pptp_p2)
+		ioctl(ppdrvdev, PPDRV_IOC_PINSET, LP_PIN02);
+	else
+		ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR, LP_PIN02);
+#endif
 
-	if(pChan==NULL){
+	if (pChan == NULL) {
 		ast_log(LOG_ERROR, "PmrTx() pChan == NULL\n");
 		return 1;
 	}
 
-	#if XPMR_DEBUG0 == 1
-	if(pChan->b.rxCapture && pChan->tracetype==5)
-	{
-		memcpy(pChan->pTxInput,input,pChan->nSamplesRx*2);
+#if XPMR_DEBUG0 == 1
+	if (pChan->b.rxCapture && pChan->tracetype == 5) {
+		memcpy(pChan->pTxInput, input, pChan->nSamplesRx * 2);
 	}
-	#endif
+#endif
 
-	dedrift_write(pChan,input);
+	dedrift_write(pChan, input);
 
 	return 0;
 }
+
 /*
 	PmrRx handles a block of data from the usb audio device
 */
 i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 {
-	int i,hit;
-	float f=0;
+	int i, hit;
+	float f = 0;
 	t_pmr_sps *pmr_sps;
 
 	TRACEC(5, "PmrRx(%p %p %p %p)\n", pChan, input, outputrx, outputtx);
 
 #if XPMR_PPTP == 1
-	if(pChan->b.radioactive)
-	{
-		pptp_write(1,pChan->frameCountRx&0x00000001);
+	if (pChan->b.radioactive) {
+		pptp_write(1, pChan->frameCountRx & 0x00000001);
 	}
-	#endif
+#endif
 
-	if(pChan==NULL){
+	if (pChan == NULL) {
 		ast_log(LOG_ERROR, "PmrRx() pChan == NULL\n");
 		return 1;
 	}
 
 	pChan->frameCountRx++;
 
-	#if XPMR_DEBUG0 == 1
-	if(pChan->b.rxCapture)
-	{
+#if XPMR_DEBUG0 == 1
+	if (pChan->b.rxCapture) {
 		//if(pChan->prxDebug)memset((void *)pChan->prxDebug,0,pChan->nSamplesRx*XPMR_DEBUG_CHANS*2);
-		if(pChan->ptxDebug)memset((void *)pChan->ptxDebug,0,pChan->nSamplesRx*XPMR_DEBUG_CHANS*2);
+		if (pChan->ptxDebug)
+			memset((void *) pChan->ptxDebug, 0, pChan->nSamplesRx * XPMR_DEBUG_CHANS * 2);
 
-		memset((void *)pChan->sdbg->buffer,0,pChan->nSamplesRx*XPMR_DEBUG_CHANS*2);
-		pChan->prxDebug=pChan->sdbg->buffer;
+		memset((void *) pChan->sdbg->buffer, 0, pChan->nSamplesRx * XPMR_DEBUG_CHANS * 2);
+		pChan->prxDebug = pChan->sdbg->buffer;
 	}
-	#endif
+#endif
 
 #ifndef XPMR_VOTER
-	pmr_sps=pChan->spsRx;		// first sps
-	pmr_sps->source=input;
+	pmr_sps = pChan->spsRx;		// first sps
+	pmr_sps->source = input;
 
-	if(outputrx!=NULL)pChan->spsRxOut->sink=outputrx;	 //last sps
+	if (outputrx != NULL)
+		pChan->spsRxOut->sink = outputrx;	//last sps
 
-	if(pChan->txrxblankingtimer>0){
+	if (pChan->txrxblankingtimer > 0) {
 		for (i = 0; i < pChan->nSamplesRx * 6; i++)
 			input[i] = 0;
 
@@ -2777,527 +2705,458 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 		}
 	}
 
-	#if 0
-	if(pChan->inputBlanking>0)
-	{
-		pChan->inputBlanking-=pChan->nSamplesRx;
-		if(pChan->inputBlanking<0)pChan->inputBlanking=0;
-		for(i=0;i<pChan->nSamplesRx*6;i++)
-			input[i]=0;
+#if 0
+	if (pChan->inputBlanking > 0) {
+		pChan->inputBlanking -= pChan->nSamplesRx;
+		if (pChan->inputBlanking < 0)
+			pChan->inputBlanking = 0;
+		for (i = 0; i < pChan->nSamplesRx * 6; i++)
+			input[i] = 0;
 	}
-	#endif
+#endif
 
-	if( pChan->rxCpuSaver && !pChan->rxCarrierDetect && 
-	    pChan->smode==SMODE_NULL &&
-	   !pChan->txPttIn && !pChan->txPttOut)
-	{
-		if(!pChan->b.rxhalted)
-		{
-			if(pChan->spsRxHpf)pChan->spsRxHpf->enabled=0;
-			if(pChan->spsRxDeEmp)pChan->spsRxDeEmp->enabled=0;
-			pChan->b.rxhalted=1;
+	if (pChan->rxCpuSaver && !pChan->rxCarrierDetect &&
+		pChan->smode == SMODE_NULL && !pChan->txPttIn && !pChan->txPttOut) {
+		if (!pChan->b.rxhalted) {
+			if (pChan->spsRxHpf)
+				pChan->spsRxHpf->enabled = 0;
+			if (pChan->spsRxDeEmp)
+				pChan->spsRxDeEmp->enabled = 0;
+			pChan->b.rxhalted = 1;
 			TRACEC(1, "PmrRx() rx sps halted\n");
 		}
-	}
-	else if(pChan->b.rxhalted)
-	{
-		if(pChan->spsRxHpf)pChan->spsRxHpf->enabled=1;
-		if(pChan->spsRxDeEmp)pChan->spsRxDeEmp->enabled=1;
-		pChan->b.rxhalted=0;
+	} else if (pChan->b.rxhalted) {
+		if (pChan->spsRxHpf)
+			pChan->spsRxHpf->enabled = 1;
+		if (pChan->spsRxDeEmp)
+			pChan->spsRxDeEmp->enabled = 1;
+		pChan->b.rxhalted = 0;
 		TRACEC(1, "PmrRx() rx sps un-halted\n");
 	}
 
-	i=0;
-	while(pmr_sps!=NULL && pmr_sps!=0)
-	{
+	i = 0;
+	while (pmr_sps != NULL && pmr_sps != 0) {
 		TRACEC(5, "PmrRx() sps %i\n", i++);
 		pmr_sps->sigProc(pmr_sps);
-		pmr_sps = (t_pmr_sps *)(pmr_sps->nextSps);
-		//pmr_sps=NULL;	// sph maw
+		pmr_sps = (t_pmr_sps *) (pmr_sps->nextSps);
+		//pmr_sps=NULL; // sph maw
 	}
 
-	if(pChan->rxCdType==CD_XPMR_VOX)
-	{
-		if(pChan->spsRxVox->compOut)
-		{
-			pChan->rxVoxTimer=pChan->voxHangTime;	/* VOX HangTime in ms */
+	if (pChan->rxCdType == CD_XPMR_VOX) {
+		if (pChan->spsRxVox->compOut) {
+			pChan->rxVoxTimer = pChan->voxHangTime;	/* VOX HangTime in ms */
 		}
-		if(pChan->rxVoxTimer>0)
-		{
-			pChan->rxVoxTimer-=MS_PER_FRAME;
-			pChan->rxCarrierDetect=1;
+		if (pChan->rxVoxTimer > 0) {
+			pChan->rxVoxTimer -= MS_PER_FRAME;
+			pChan->rxCarrierDetect = 1;
+		} else {
+			pChan->rxVoxTimer = 0;
+			pChan->rxCarrierDetect = 0;
 		}
-		else
-		{
-			pChan->rxVoxTimer=0;
-			pChan->rxCarrierDetect=0;
-		}
-	}
-	else
-	{
-		pChan->rxCarrierDetect=!pChan->spsRx->compOut;
-		if(pChan->rxSquelchDelay)
-			pChan->spsRxSquelchDelay->b.outzero=pChan->spsRx->compOut;
+	} else {
+		pChan->rxCarrierDetect = !pChan->spsRx->compOut;
+		if (pChan->rxSquelchDelay)
+			pChan->spsRxSquelchDelay->b.outzero = pChan->spsRx->compOut;
 	}
 
 	// stop and start these engines instead to eliminate falsing
-	if( pChan->b.ctcssRxEnable && 
-	    ( (!pChan->b.rxhalted || 
-		   pChan->rxCtcss->decode!=CTCSS_NULL || pChan->smode==SMODE_CTCSS) &&
-		(pChan->smode!=SMODE_DCS&&pChan->smode!=SMODE_LSD) ) 
-	  )
-	{
+	if (pChan->b.ctcssRxEnable &&
+		((!pChan->b.rxhalted ||
+		  pChan->rxCtcss->decode != CTCSS_NULL || pChan->smode == SMODE_CTCSS) &&
+		 (pChan->smode != SMODE_DCS && pChan->smode != SMODE_LSD))
+		) {
 		ctcss_detect(pChan);
 	}
 
-	#if 1
-	if(pChan->txPttIn!=pChan->b.pttwas)
-	{
-		pChan->b.pttwas=pChan->txPttIn;
+#if 1
+	if (pChan->txPttIn != pChan->b.pttwas) {
+		pChan->b.pttwas = pChan->txPttIn;
 		TRACEC(1, "PmrRx() txPttIn=%i\n", pChan->b.pttwas);
 	}
-	#endif
+#endif
 
-	#ifdef XPMRX_H
-	xpmrx(pChan,XXO_RXDECODE);
-	#endif
+#ifdef XPMRX_H
+	xpmrx(pChan, XXO_RXDECODE);
+#endif
 
-	if(pChan->smodetimer>0 && !pChan->txPttIn)
-	{
-		pChan->smodetimer-=MS_PER_FRAME;
-	 	
-		if(pChan->smodetimer<=0)
-		{
-			pChan->smodetimer=0;
-			pChan->smodewas=pChan->smode;
-			pChan->smode=SMODE_NULL;
-			pChan->b.smodeturnoff=1;
+	if (pChan->smodetimer > 0 && !pChan->txPttIn) {
+		pChan->smodetimer -= MS_PER_FRAME;
+
+		if (pChan->smodetimer <= 0) {
+			pChan->smodetimer = 0;
+			pChan->smodewas = pChan->smode;
+			pChan->smode = SMODE_NULL;
+			pChan->b.smodeturnoff = 1;
 			TRACEC(1, "smode timeout. smode was=%i\n", pChan->smodewas);
 		}
 	}
 
-	if(pChan->rxCtcss->decode > CTCSS_NULL && 
-	   (pChan->smode==SMODE_NULL||pChan->smode==SMODE_CTCSS) )
-	{
-		if(pChan->smode!=SMODE_CTCSS)
-		{
+	if (pChan->rxCtcss->decode > CTCSS_NULL && (pChan->smode == SMODE_NULL || pChan->smode == SMODE_CTCSS)) {
+		if (pChan->smode != SMODE_CTCSS) {
 			TRACEC(1, "smode set=%i  code=%i\n", pChan->smode, pChan->rxCtcss->decode);
-			pChan->smode=pChan->smodewas=SMODE_CTCSS;
+			pChan->smode = pChan->smodewas = SMODE_CTCSS;
 		}
-		pChan->smodetimer=pChan->smodetime;
+		pChan->smodetimer = pChan->smodetime;
 	}
-	if(pChan->smode==SMODE_CTCSS)
-	{
-		if(pChan->rxCtcss->decode != pChan->lastrxdecode)
-		{
+	if (pChan->smode == SMODE_CTCSS) {
+		if (pChan->rxCtcss->decode != pChan->lastrxdecode) {
 			pChan->lastrxdecode = pChan->rxCtcss->decode;
 			f = 0;
-			if(pChan->rxCtcss->decode>CTCSS_NULL)
-			{
-				if(pChan->rxCtcssMap[pChan->rxCtcss->decode]!=CTCSS_RXONLY)
-				{
-					f=freq_ctcss[pChan->rxCtcssMap[pChan->rxCtcss->decode]];
+			if (pChan->rxCtcss->decode > CTCSS_NULL) {
+				if (pChan->rxCtcssMap[pChan->rxCtcss->decode] != CTCSS_RXONLY) {
+					f = freq_ctcss[pChan->rxCtcssMap[pChan->rxCtcss->decode]];
 				}
+			} else {
+				f = pChan->txctcssdefault_value;
 			}
-			else
-			{
-				f=pChan->txctcssdefault_value;	
-			}
-			if (f && pChan->spsSigGen0->freq != f*10)
-			{
-				pChan->spsSigGen0->freq=f*10;
-				pChan->spsSigGen0->option=1;
+			if (f && pChan->spsSigGen0->freq != f * 10) {
+				pChan->spsSigGen0->freq = f * 10;
+				pChan->spsSigGen0->option = 1;
 			}
 		}
-	}
-	else
-	{
+	} else {
 		pChan->lastrxdecode = CTCSS_NULL;
 
 	}
-	#ifdef HAVE_XPMRX
-	xpmrx(pChan,XXO_LSDCTL);
-	#endif
+#ifdef HAVE_XPMRX
+	xpmrx(pChan, XXO_LSDCTL);
+#endif
 
 #endif
 	// TRACEX((1, "PmrRx() tx portion.\n"));
 
 	// handle radio transmitter ptt input
-	hit=0;
-	if( !(pChan->smode==SMODE_DCS||pChan->smode==SMODE_LSD) )
-	{
+	hit = 0;
+	if (!(pChan->smode == SMODE_DCS || pChan->smode == SMODE_LSD)) {
 
-	if( pChan->txPttIn && (pChan->txState==CHAN_TXSTATE_IDLE ))
-	{
-		TRACEC(1,
-			"txPttIn==1 from CHAN_TXSTATE_IDLE && !SMODE_LSD. codeindex=%i  %i \n",
-			pChan->rxCtcss->decode,
-			pChan->rxCtcssMap[pChan->rxCtcss->decode]);
-		pChan->dd.b.doitnow=1;
-		pChan->spsSigGen0->freq=0;
-	    if(pChan->smode==SMODE_CTCSS && !pChan->b.txCtcssInhibit)
-		{
-			if(pChan->rxCtcss->decode>CTCSS_NULL)
-			{
-				if(pChan->rxCtcssMap[pChan->rxCtcss->decode]!=CTCSS_RXONLY)
-				{
-					f=freq_ctcss[pChan->rxCtcssMap[pChan->rxCtcss->decode]];
-				}
-			}
-			else
-			{
-				f=pChan->txctcssdefault_value;	
-			}
-			TRACEC(1, "txPttIn - Start CTCSSGen  %f \n", f);
-			if(f)
-			{
-				t_pmr_sps *pSps;
-	
-				pChan->spsSigGen0->freq=f*10;
-				pSps=pChan->spsTxLsdLpf;
-				pSps->enabled=1;
-
-				#if 0
-				if(f>203.0)
-				{
-					pSps->ncoef=taps_fir_lpf_250_9_66;
-					pSps->size_coef=2;
-					pSps->coef=(void*)coef_fir_lpf_250_9_66;
-					pSps->nx=taps_fir_lpf_250_9_66;
-					pSps->size_x=2;
-					pSps->x= ast_calloc(pSps->nx,pSps->size_x);
-					if (pSps->x == NULL) {
-						; /* XXX do something here */
+		if (pChan->txPttIn && (pChan->txState == CHAN_TXSTATE_IDLE)) {
+			TRACEC(1,
+				   "txPttIn==1 from CHAN_TXSTATE_IDLE && !SMODE_LSD. codeindex=%i  %i \n",
+				   pChan->rxCtcss->decode, pChan->rxCtcssMap[pChan->rxCtcss->decode]);
+			pChan->dd.b.doitnow = 1;
+			pChan->spsSigGen0->freq = 0;
+			if (pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit) {
+				if (pChan->rxCtcss->decode > CTCSS_NULL) {
+					if (pChan->rxCtcssMap[pChan->rxCtcss->decode] != CTCSS_RXONLY) {
+						f = freq_ctcss[pChan->rxCtcssMap[pChan->rxCtcss->decode]];
 					}
-
-					pSps->calcAdjust=gain_fir_lpf_250_9_66;
+				} else {
+					f = pChan->txctcssdefault_value;
 				}
-				else
-				{
-					pSps->ncoef=taps_fir_lpf_215_9_88;
-					pSps->size_coef=2;
-					pSps->coef=(void*)coef_fir_lpf_215_9_88;
-					pSps->nx=taps_fir_lpf_215_9_88;
-					pSps->size_x=2;
-					pSps->x= ast_calloc(pSps->nx,pSps->size_x);
-					if (pSps->x == NULL) {
-						; /* XXX do something here */
+				TRACEC(1, "txPttIn - Start CTCSSGen  %f \n", f);
+				if (f) {
+					t_pmr_sps *pSps;
+
+					pChan->spsSigGen0->freq = f * 10;
+					pSps = pChan->spsTxLsdLpf;
+					pSps->enabled = 1;
+
+#if 0
+					if (f > 203.0) {
+						pSps->ncoef = taps_fir_lpf_250_9_66;
+						pSps->size_coef = 2;
+						pSps->coef = (void *) coef_fir_lpf_250_9_66;
+						pSps->nx = taps_fir_lpf_250_9_66;
+						pSps->size_x = 2;
+						pSps->x = ast_calloc(pSps->nx, pSps->size_x);
+						if (pSps->x == NULL) {
+							;	/* XXX do something here */
+						}
+
+						pSps->calcAdjust = gain_fir_lpf_250_9_66;
+					} else {
+						pSps->ncoef = taps_fir_lpf_215_9_88;
+						pSps->size_coef = 2;
+						pSps->coef = (void *) coef_fir_lpf_215_9_88;
+						pSps->nx = taps_fir_lpf_215_9_88;
+						pSps->size_x = 2;
+						pSps->x = ast_calloc(pSps->nx, pSps->size_x);
+						if (pSps->x == NULL) {
+							;	/* XXX do something here */
+						}
+						pSps->calcAdjust = gain_fir_lpf_215_9_88;
 					}
-					pSps->calcAdjust=gain_fir_lpf_215_9_88;
+#endif
+
+					pChan->spsSigGen0->option = 1;
+					pChan->spsSigGen0->enabled = 1;
+					pChan->spsSigGen0->discounterl = 0;
 				}
-				#endif
-
-				pChan->spsSigGen0->option=1;
-				pChan->spsSigGen0->enabled=1;
-			    pChan->spsSigGen0->discounterl=0;
-		    }
-		}
-		else if(pChan->smode==SMODE_NULL && pChan->txcodedefaultsmode==SMODE_CTCSS && !pChan->b.txCtcssInhibit)
-		{
-			TRACEC(1, "txPtt Encode txcodedefaultsmode==SMODE_CTCSS %f\n", pChan->txctcssdefault_value);
-			f=pChan->txctcssdefault_value;
-			pChan->spsSigGen0->freq=f*10;
-			pChan->spsSigGen0->option=1;
-		    pChan->spsSigGen0->enabled=1;
-			pChan->spsSigGen0->discounterl=0;
-			pChan->smode=SMODE_CTCSS;
-			pChan->smodetimer=pChan->smodetime;
-		}
-		else if(pChan->txcodedefaultsmode==SMODE_NULL||pChan->b.txCtcssInhibit)
-		{
-			TRACEC(1, "txPtt Encode txcodedefaultsmode==SMODE_NULL\n");
-		}
-		else
-		{
-			TRACEC(1, "txPttIn=%i NOT HANDLED PROPERLY.\n", pChan->txPttIn);
-		}
-
-		memset(pChan->txctcssfreq,0,sizeof(pChan->txctcssfreq));
-		sprintf(pChan->txctcssfreq,"%.1f",f);
-		pChan->b.txCtcssReady = 1;
-
-		pChan->txState = CHAN_TXSTATE_ACTIVE;
-		pChan->txPttOut=1;
-
-		pChan->txsettletimer=pChan->txsettletime;
-
-		if(pChan->spsTxOutA)pChan->spsTxOutA->enabled=1;
-		if(pChan->spsTxOutB)pChan->spsTxOutB->enabled=1;
-		if(pChan->spsTxLsdLpf)pChan->spsTxLsdLpf->enabled=1;
-		if(pChan->txfreq)pChan->b.reprog=1;
-		TRACEC(1, "PmrRx() TxOn\n");
-	}
-	else if(pChan->txPttIn && pChan->txState==CHAN_TXSTATE_ACTIVE)
-	{
-		// pChan->smode=SMODE_CTCSS;
-		pChan->smodetimer=pChan->smodetime;
-	}
-	else if(!pChan->txPttIn && pChan->txState==CHAN_TXSTATE_ACTIVE)
-	{
-		TRACEC(1, "txPttIn==0 from CHAN_TXSTATE_ACTIVE\n");
-		if(pChan->smode==SMODE_CTCSS && !pChan->b.txCtcssInhibit)
-		{
-			if( pChan->txTocType==TOC_NONE || !pChan->b.ctcssTxEnable )
-			{
-				TRACEC(1, "Tx Off Immediate.\n");
-				pChan->spsSigGen0->option=3;
-				pChan->txBufferClear=3;
-				pChan->txState=CHAN_TXSTATE_FINISHING;
-	        }
-			else if(pChan->txTocType==TOC_NOTONE)
-			{
-				pChan->txState=CHAN_TXSTATE_TOC;
-				pChan->txHangTime=TOC_NOTONE_TIME/MS_PER_FRAME;
-				pChan->spsSigGen0->option=3;
-				TRACEC(1, "Tx Turn Off No Tone Start.\n");
+			} else if (pChan->smode == SMODE_NULL && pChan->txcodedefaultsmode == SMODE_CTCSS
+					   && !pChan->b.txCtcssInhibit) {
+				TRACEC(1, "txPtt Encode txcodedefaultsmode==SMODE_CTCSS %f\n", pChan->txctcssdefault_value);
+				f = pChan->txctcssdefault_value;
+				pChan->spsSigGen0->freq = f * 10;
+				pChan->spsSigGen0->option = 1;
+				pChan->spsSigGen0->enabled = 1;
+				pChan->spsSigGen0->discounterl = 0;
+				pChan->smode = SMODE_CTCSS;
+				pChan->smodetimer = pChan->smodetime;
+			} else if (pChan->txcodedefaultsmode == SMODE_NULL || pChan->b.txCtcssInhibit) {
+				TRACEC(1, "txPtt Encode txcodedefaultsmode==SMODE_NULL\n");
+			} else {
+				TRACEC(1, "txPttIn=%i NOT HANDLED PROPERLY.\n", pChan->txPttIn);
 			}
-	 		else
-			{
-				pChan->txState=CHAN_TXSTATE_TOC;
-				pChan->txHangTime=0;
-				pChan->spsSigGen0->option=2;
-				TRACEC(1, "Tx Turn Off Phase Shift Start.\n");
-			}
-	    }
-		else
-		{
-		    pChan->txBufferClear=3;
-			pChan->txState=CHAN_TXSTATE_FINISHING;
-			TRACEC(1, "Tx Off No SMODE to Finish.\n");
-		}
-	}
-	else if(pChan->txState==CHAN_TXSTATE_TOC)
-	{
-		if( pChan->txPttIn && pChan->smode==SMODE_CTCSS )
-		{
-			TRACEC(1, "Tx Key During HangTime\n");
+
+			memset(pChan->txctcssfreq, 0, sizeof(pChan->txctcssfreq));
+			sprintf(pChan->txctcssfreq, "%.1f", f);
+			pChan->b.txCtcssReady = 1;
+
 			pChan->txState = CHAN_TXSTATE_ACTIVE;
-			pChan->spsSigGen0->option=1;
-			pChan->spsSigGen0->enabled=1;
-			pChan->spsSigGen0->discounterl=0;
-			hit=0;
-		}
-		else if(pChan->txHangTime)
-		{
-			if(--pChan->txHangTime==0)pChan->txState=CHAN_TXSTATE_FINISHING;
-		}
-		else if(pChan->txHangTime<=0 && pChan->spsSigGen0->state==0)
-		{
-			pChan->txBufferClear=3;
-			pChan->txState=CHAN_TXSTATE_FINISHING;
-			TRACEC(1, "Tx Off TOC.\n");
-		}
-	}
-	else if(pChan->txState==CHAN_TXSTATE_FINISHING)
-	{
-		if(--pChan->txBufferClear<=0)
-			pChan->txState=CHAN_TXSTATE_COMPLETE;
-	}
-	else if(pChan->txState==CHAN_TXSTATE_COMPLETE)
-	{
-		hit=1;	
-	}
-	}	// end of if SMODE==LSD
+			pChan->txPttOut = 1;
 
-	if(hit)
-	{
-		pChan->txPttOut=0;
-		pChan->spsSigGen0->option=3;
-		pChan->txrxblankingtimer=pChan->txrxblankingtime;
+			pChan->txsettletimer = pChan->txsettletime;
+
+			if (pChan->spsTxOutA)
+				pChan->spsTxOutA->enabled = 1;
+			if (pChan->spsTxOutB)
+				pChan->spsTxOutB->enabled = 1;
+			if (pChan->spsTxLsdLpf)
+				pChan->spsTxLsdLpf->enabled = 1;
+			if (pChan->txfreq)
+				pChan->b.reprog = 1;
+			TRACEC(1, "PmrRx() TxOn\n");
+		} else if (pChan->txPttIn && pChan->txState == CHAN_TXSTATE_ACTIVE) {
+			// pChan->smode=SMODE_CTCSS;
+			pChan->smodetimer = pChan->smodetime;
+		} else if (!pChan->txPttIn && pChan->txState == CHAN_TXSTATE_ACTIVE) {
+			TRACEC(1, "txPttIn==0 from CHAN_TXSTATE_ACTIVE\n");
+			if (pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit) {
+				if (pChan->txTocType == TOC_NONE || !pChan->b.ctcssTxEnable) {
+					TRACEC(1, "Tx Off Immediate.\n");
+					pChan->spsSigGen0->option = 3;
+					pChan->txBufferClear = 3;
+					pChan->txState = CHAN_TXSTATE_FINISHING;
+				} else if (pChan->txTocType == TOC_NOTONE) {
+					pChan->txState = CHAN_TXSTATE_TOC;
+					pChan->txHangTime = TOC_NOTONE_TIME / MS_PER_FRAME;
+					pChan->spsSigGen0->option = 3;
+					TRACEC(1, "Tx Turn Off No Tone Start.\n");
+				} else {
+					pChan->txState = CHAN_TXSTATE_TOC;
+					pChan->txHangTime = 0;
+					pChan->spsSigGen0->option = 2;
+					TRACEC(1, "Tx Turn Off Phase Shift Start.\n");
+				}
+			} else {
+				pChan->txBufferClear = 3;
+				pChan->txState = CHAN_TXSTATE_FINISHING;
+				TRACEC(1, "Tx Off No SMODE to Finish.\n");
+			}
+		} else if (pChan->txState == CHAN_TXSTATE_TOC) {
+			if (pChan->txPttIn && pChan->smode == SMODE_CTCSS) {
+				TRACEC(1, "Tx Key During HangTime\n");
+				pChan->txState = CHAN_TXSTATE_ACTIVE;
+				pChan->spsSigGen0->option = 1;
+				pChan->spsSigGen0->enabled = 1;
+				pChan->spsSigGen0->discounterl = 0;
+				hit = 0;
+			} else if (pChan->txHangTime) {
+				if (--pChan->txHangTime == 0)
+					pChan->txState = CHAN_TXSTATE_FINISHING;
+			} else if (pChan->txHangTime <= 0 && pChan->spsSigGen0->state == 0) {
+				pChan->txBufferClear = 3;
+				pChan->txState = CHAN_TXSTATE_FINISHING;
+				TRACEC(1, "Tx Off TOC.\n");
+			}
+		} else if (pChan->txState == CHAN_TXSTATE_FINISHING) {
+			if (--pChan->txBufferClear <= 0)
+				pChan->txState = CHAN_TXSTATE_COMPLETE;
+		} else if (pChan->txState == CHAN_TXSTATE_COMPLETE) {
+			hit = 1;
+		}
+	}							// end of if SMODE==LSD
+
+	if (hit) {
+		pChan->txPttOut = 0;
+		pChan->spsSigGen0->option = 3;
+		pChan->txrxblankingtimer = pChan->txrxblankingtime;
 		TRACEC(1, "PmrRx() txrxblankingtimer=%i\n", pChan->txrxblankingtimer);
-		pChan->txState=CHAN_TXSTATE_IDLE;
-		if(pChan->spsTxLsdLpf)pChan->spsTxLsdLpf->option=3;
-		if(pChan->spsTxOutA)pChan->spsTxOutA->option=3;
-		if(pChan->spsTxOutB)pChan->spsTxOutB->option=3;
-		if(pChan->rxfreq||pChan->txfreq)pChan->b.reprog=1;
-		memset(pChan->txctcssfreq,0,sizeof(pChan->txctcssfreq));
+		pChan->txState = CHAN_TXSTATE_IDLE;
+		if (pChan->spsTxLsdLpf)
+			pChan->spsTxLsdLpf->option = 3;
+		if (pChan->spsTxOutA)
+			pChan->spsTxOutA->option = 3;
+		if (pChan->spsTxOutB)
+			pChan->spsTxOutB->option = 3;
+		if (pChan->rxfreq || pChan->txfreq)
+			pChan->b.reprog = 1;
+		memset(pChan->txctcssfreq, 0, sizeof(pChan->txctcssfreq));
 		pChan->b.txCtcssReady = 1;
 		TRACEC(1, "Tx Off hit.\n");
 	}
-			  
-	if(pChan->b.reprog)
-	{
-		pChan->b.reprog=0;	
+
+	if (pChan->b.reprog) {
+		pChan->b.reprog = 0;
 		progdtx(pChan);
 	}
 
-	if(pChan->txsettletimer && pChan->txPttHid )
-	{
-		pChan->txsettletimer-=MS_PER_FRAME;
-		if(pChan->txsettletimer<0)pChan->txsettletimer=0;
+	if (pChan->txsettletimer && pChan->txPttHid) {
+		pChan->txsettletimer -= MS_PER_FRAME;
+		if (pChan->txsettletimer < 0)
+			pChan->txsettletimer = 0;
 	}
 
 	// enable this after we know everything else is working
-	if( pChan->txCpuSaver && 
-	    !pChan->txPttIn && !pChan->txPttOut && 
-	    pChan->txState==CHAN_TXSTATE_IDLE &&
-	    !pChan->dd.b.doitnow 
-	    ) 
-	{
-		if(!pChan->b.txhalted)
-		{
-			pChan->b.txhalted=1;
+	if (pChan->txCpuSaver &&
+		!pChan->txPttIn && !pChan->txPttOut && pChan->txState == CHAN_TXSTATE_IDLE && !pChan->dd.b.doitnow) {
+		if (!pChan->b.txhalted) {
+			pChan->b.txhalted = 1;
 			TRACEC(1, "PmrRx() tx sps halted\n");
 		}
-	}
-	else if(pChan->b.txhalted)
-	{
-		pChan->dd.b.doitnow=1;
-		pChan->b.txhalted=0;
+	} else if (pChan->b.txhalted) {
+		pChan->dd.b.doitnow = 1;
+		pChan->b.txhalted = 0;
 		TRACEC(1, "PmrRx() tx sps un-halted\n");
 	}
 
-	if(pChan->b.txhalted)return(1);
+	if (pChan->b.txhalted)
+		return (1);
 
-	if(pChan->b.startSpecialTone)
-	{
-		pChan->b.startSpecialTone=0;
-		pChan->spsSigGen1->option=1;
-		pChan->spsSigGen1->enabled=1;
-		pChan->b.doingSpecialTone=1;
-	} 
-	else if(pChan->b.stopSpecialTone)
-	{
-		pChan->b.stopSpecialTone=0;
-		pChan->spsSigGen1->option=0;
-		pChan->b.doingSpecialTone=0;
-		pChan->spsSigGen1->enabled=0;
-	} 
-	else if(pChan->b.doingSpecialTone)
-	{
-		pChan->spsSigGen1->sink=outputtx;
+	if (pChan->b.startSpecialTone) {
+		pChan->b.startSpecialTone = 0;
+		pChan->spsSigGen1->option = 1;
+		pChan->spsSigGen1->enabled = 1;
+		pChan->b.doingSpecialTone = 1;
+	} else if (pChan->b.stopSpecialTone) {
+		pChan->b.stopSpecialTone = 0;
+		pChan->spsSigGen1->option = 0;
+		pChan->b.doingSpecialTone = 0;
+		pChan->spsSigGen1->enabled = 0;
+	} else if (pChan->b.doingSpecialTone) {
+		pChan->spsSigGen1->sink = outputtx;
 		pChan->spsSigGen1->sigProc(pChan->spsSigGen1);
-		for(i=0;i<(pChan->nSamplesTx*2*6);i+=2)outputtx[i+1]=outputtx[i];
+		for (i = 0; i < (pChan->nSamplesTx * 2 * 6); i += 2)
+			outputtx[i + 1] = outputtx[i];
 		return 0;
 	}
 
-	if(pChan->spsSigGen0 && pChan->spsSigGen0->enabled)
-	{
+	if (pChan->spsSigGen0 && pChan->spsSigGen0->enabled) {
 		pChan->spsSigGen0->b.mute = pChan->b.txCtcssOff;
 		pChan->spsSigGen0->sigProc(pChan->spsSigGen0);
 	}
 
-	if(pChan->spsSigGen1 && pChan->spsSigGen1->enabled)
-	{
+	if (pChan->spsSigGen1 && pChan->spsSigGen1->enabled) {
 		pChan->spsSigGen1->sigProc(pChan->spsSigGen1);
 	}
 
-	#ifdef XPMRX_H
+#ifdef XPMRX_H
 	pChan->spsLsdGen->sigProc(pChan->spsLsdGen);	// maw sph ???
-	#endif
+#endif
 
 	// Do Low Speed Data Low Pass Filter
 	pChan->spsTxLsdLpf->sigProc(pChan->spsTxLsdLpf);
 
 	// Do Voice
-	pmr_sps=pChan->spsTx;
+	pmr_sps = pChan->spsTx;
 
 	// get tx data from de-drift process
-	pChan->dd.option=0;
-	pChan->dd.ptr=pChan->pTxBase;
+	pChan->dd.option = 0;
+	pChan->dd.ptr = pChan->pTxBase;
 	dedrift(pChan);
 
 	// tx process
-	if(!pChan->spsSigGen1->enabled)
-	{
-		pmr_sps->source=pChan->pTxBase;
-	}
-	else input=pmr_sps->source;
+	if (!pChan->spsSigGen1->enabled) {
+		pmr_sps->source = pChan->pTxBase;
+	} else
+		input = pmr_sps->source;
 
-	if(outputtx!=NULL)
-	{
-		if(pChan->spsTxOutA)pChan->spsTxOutA->sink=outputtx;
-		if(pChan->spsTxOutB)pChan->spsTxOutB->sink=outputtx;
+	if (outputtx != NULL) {
+		if (pChan->spsTxOutA)
+			pChan->spsTxOutA->sink = outputtx;
+		if (pChan->spsTxOutB)
+			pChan->spsTxOutB->sink = outputtx;
 	}
 
-	i=0;
-	while(pmr_sps!=NULL && pmr_sps!=0)
-	{
+	i = 0;
+	while (pmr_sps != NULL && pmr_sps != 0) {
 		// TRACEF(1,"PmrTx() sps %i\n",i++);
 		pmr_sps->sigProc(pmr_sps);
-		pmr_sps = (t_pmr_sps *)(pmr_sps->nextSps);
+		pmr_sps = (t_pmr_sps *) (pmr_sps->nextSps);
 	}
 
 	// TRACEF(1,"PmrTx() - outputs \n");
-	if(pChan->txMixA==TX_OUT_OFF || !pChan->txPttOut){
-		for(i=0;i<pChan->nSamplesTx*2*6;i+=2)outputtx[i]=0;
+	if (pChan->txMixA == TX_OUT_OFF || !pChan->txPttOut) {
+		for (i = 0; i < pChan->nSamplesTx * 2 * 6; i += 2)
+			outputtx[i] = 0;
 	}
 
-	if(pChan->txMixB==TX_OUT_OFF || !pChan->txPttOut ){
-		for(i=0;i<pChan->nSamplesTx*2*6;i+=2)outputtx[i+1]=0;
+	if (pChan->txMixB == TX_OUT_OFF || !pChan->txPttOut) {
+		for (i = 0; i < pChan->nSamplesTx * 2 * 6; i += 2)
+			outputtx[i + 1] = 0;
 	}
 
-	#if XPMR_PPTP == 1
-	if(	pChan->b.radioactive && pChan->b.pptp_p1!=pChan->txPttOut)
-	{
-		pChan->b.pptp_p1=pChan->txPttOut;
-		pptp_write(0,pChan->b.pptp_p1);
+#if XPMR_PPTP == 1
+	if (pChan->b.radioactive && pChan->b.pptp_p1 != pChan->txPttOut) {
+		pChan->b.pptp_p1 = pChan->txPttOut;
+		pptp_write(0, pChan->b.pptp_p1);
 	}
-	#endif
+#endif
 
-	#if XPMR_DEBUG0 == 1
+#if XPMR_DEBUG0 == 1
 	// TRACEF(1,"PmrRx() - debug outputs \n");
-	if(pChan->b.rxCapture){
-		for(i=0;i<pChan->nSamplesRx;i++)
-		{
-			pChan->pRxDemod[i]=input[i*2*6];
-			pChan->pTstTxOut[i]=outputtx[i*2*6+0]; // txa
+	if (pChan->b.rxCapture) {
+		for (i = 0; i < pChan->nSamplesRx; i++) {
+			pChan->pRxDemod[i] = input[i * 2 * 6];
+			pChan->pTstTxOut[i] = outputtx[i * 2 * 6 + 0];	// txa
 			//pChan->pTstTxOut[i]=outputtx[i*2*6+1]; // txb
-			TSCOPE((RX_NOISE_TRIG, pChan->sdbg, i, (pChan->rxCarrierDetect*XPMR_TRACE_AMP)-XPMR_TRACE_AMP/2));
-			TSCOPE((RX_CTCSS_DECODE, pChan->sdbg, i, pChan->rxCtcss->decode*(M_Q14/CTCSS_NUM_CODES)));
-			TSCOPE((RX_SMODE, pChan->sdbg, i, pChan->smode*(XPMR_TRACE_AMP/4)));
-			TSCOPE((TX_PTT_IN, pChan->sdbg, i, (pChan->txPttIn*XPMR_TRACE_AMP)-XPMR_TRACE_AMP/2));
-			TSCOPE((TX_PTT_OUT, pChan->sdbg, i, (pChan->txPttOut*XPMR_TRACE_AMP)-XPMR_TRACE_AMP/2));
-			TSCOPE((TX_DEDRIFT_LEAD, pChan->sdbg, i, pChan->dd.lead*8));
-			TSCOPE((TX_DEDRIFT_ERR, pChan->sdbg, i, pChan->dd.err*16));
-			TSCOPE((TX_DEDRIFT_FACTOR, pChan->sdbg, i, pChan->dd.factor*16));
-			TSCOPE((TX_DEDRIFT_DRIFT, pChan->sdbg, i, pChan->dd.drift*16));
+			TSCOPE((RX_NOISE_TRIG, pChan->sdbg, i, (pChan->rxCarrierDetect * XPMR_TRACE_AMP) - XPMR_TRACE_AMP / 2));
+			TSCOPE((RX_CTCSS_DECODE, pChan->sdbg, i, pChan->rxCtcss->decode * (M_Q14 / CTCSS_NUM_CODES)));
+			TSCOPE((RX_SMODE, pChan->sdbg, i, pChan->smode * (XPMR_TRACE_AMP / 4)));
+			TSCOPE((TX_PTT_IN, pChan->sdbg, i, (pChan->txPttIn * XPMR_TRACE_AMP) - XPMR_TRACE_AMP / 2));
+			TSCOPE((TX_PTT_OUT, pChan->sdbg, i, (pChan->txPttOut * XPMR_TRACE_AMP) - XPMR_TRACE_AMP / 2));
+			TSCOPE((TX_DEDRIFT_LEAD, pChan->sdbg, i, pChan->dd.lead * 8));
+			TSCOPE((TX_DEDRIFT_ERR, pChan->sdbg, i, pChan->dd.err * 16));
+			TSCOPE((TX_DEDRIFT_FACTOR, pChan->sdbg, i, pChan->dd.factor * 16));
+			TSCOPE((TX_DEDRIFT_DRIFT, pChan->sdbg, i, pChan->dd.drift * 16));
 		}
-    }
-	#endif
+	}
+#endif
 
 	strace2(pChan->sdbg);
 	TRACEC(5,
-		"PmrRx() return  cd=%i smode=%i  txPttIn=%i  txPttOut=%i \n",
-		pChan->rxCarrierDetect,
-		pChan->smode,
-		pChan->txPttIn,
-		pChan->txPttOut);
+		   "PmrRx() return  cd=%i smode=%i  txPttIn=%i  txPttOut=%i \n",
+		   pChan->rxCarrierDetect, pChan->smode, pChan->txPttIn, pChan->txPttOut);
 	return 0;
 }
+
 /*
 	parallel binary programming of an RF Transceiver*/
 
-void	ppbinout	(u8 chan)
+void ppbinout(u8 chan)
 {
 #if(DTX_PROG == 1)
-	i32	i;
+	i32 i;
 
 	if (ppdrvdev == 0)
-    	ppdrvdev = open("/dev/ppdrv_device", 0);
+		ppdrvdev = open("/dev/ppdrv_device", 0);
 
-    if (ppdrvdev < 0)
-    {
+	if (ppdrvdev < 0) {
 		ast_debug(LOG_ERROR, "open /dev/ppdrv_ppdrvdev returned %i\n", ppdrvdev);
 		return;
 	}
 
-	i=0;
-	if(chan&0x01)i|=BIN_PROG_0;
-	if(chan&0x02)i|=BIN_PROG_1;
-	if(chan&0x04)i|=BIN_PROG_2;
-	if(chan&0x08)i|=BIN_PROG_3;
+	i = 0;
+	if (chan & 0x01)
+		i |= BIN_PROG_0;
+	if (chan & 0x02)
+		i |= BIN_PROG_1;
+	if (chan & 0x04)
+		i |= BIN_PROG_2;
+	if (chan & 0x08)
+		i |= BIN_PROG_3;
 
-	ioctl(ppdrvdev, PPDRV_IOC_PINMODE_OUT, BIN_PROG_3|BIN_PROG_2|BIN_PROG_1|BIN_PROG_0);
+	ioctl(ppdrvdev, PPDRV_IOC_PINMODE_OUT, BIN_PROG_3 | BIN_PROG_2 | BIN_PROG_1 | BIN_PROG_0);
 	//ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR,    BIN_PROG_3|BIN_PROG_2|BIN_PROG_1|BIN_PROG_0);
 	//ioctl(ppdrvdev, PPDRV_IOC_PINSET, i );
-	ioctl(ppdrvdev, PPDRV_IOC_PINSET,    BIN_PROG_3|BIN_PROG_2|BIN_PROG_1|BIN_PROG_0);
-	ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR, i );
+	ioctl(ppdrvdev, PPDRV_IOC_PINSET, BIN_PROG_3 | BIN_PROG_2 | BIN_PROG_1 | BIN_PROG_0);
+	ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR, i);
 
-    // ioctl(ppdrvdev, PPDRV_IOC_PINSET, BIN_PROG_3|BIN_PROG_2|BIN_PROG_1|BIN_PROG_0 ); 
-    ast_log(LOG_NOTICE, "mask=%i 0x%x\n",i,i); 
+	// ioctl(ppdrvdev, PPDRV_IOC_PINSET, BIN_PROG_3|BIN_PROG_2|BIN_PROG_1|BIN_PROG_0 ); 
+	ast_log(LOG_NOTICE, "mask=%i 0x%x\n", i, i);
 #endif
 }
+
 /*
 	SPI Programming of an RF Transceiver
 	need to add permissions check and mutex
@@ -3305,66 +3164,62 @@ void	ppbinout	(u8 chan)
 /*
 	need to add permissions check and mutex
 */
-void	ppspiout	(u32 spidata)
+void ppspiout(u32 spidata)
 {
 #if(DTX_PROG == 1)
-	static char firstrun=0;
-	i32	i,ii;
-	u32	bitselect;
+	static char firstrun = 0;
+	i32 i, ii;
+	u32 bitselect;
 
-    if (ppdrvdev < 0)
-    {
+	if (ppdrvdev < 0) {
 		ast_debug(LOG_ERROR, "no parallel port permission ppdrvdev %i\n", ppdrvdev);
 		exit(0);
 	}
 
-	ioctl(ppdrvdev, PPDRV_IOC_PINMODE_OUT, DTX_CLK | DTX_DATA | DTX_ENABLE | DTX_TXPWR | DTX_TX );
-	ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR, DTX_CLK | DTX_DATA | DTX_ENABLE | DTX_TXPWR | DTX_TX );
+	ioctl(ppdrvdev, PPDRV_IOC_PINMODE_OUT, DTX_CLK | DTX_DATA | DTX_ENABLE | DTX_TXPWR | DTX_TX);
+	ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR, DTX_CLK | DTX_DATA | DTX_ENABLE | DTX_TXPWR | DTX_TX);
 
-	if(firstrun==0)
-	{
-		firstrun=1;
-		for(ii=0;ii<PP_BIT_TIME*200;ii++);	
-	}
-	else
-	{
-		for(ii=0;ii<PP_BIT_TIME*4;ii++);
+	if (firstrun == 0) {
+		firstrun = 1;
+		for (ii = 0; ii < PP_BIT_TIME * 200; ii++);
+	} else {
+		for (ii = 0; ii < PP_BIT_TIME * 4; ii++);
 	}
 
-	bitselect=0x00080000;
+	bitselect = 0x00080000;
 
-	for(i=0;i<(PP_REG_LEN-12);i++)
-	{
-		if((bitselect&spidata))
-			ioctl(ppdrvdev, PPDRV_IOC_PINSET, DTX_DATA );
+	for (i = 0; i < (PP_REG_LEN - 12); i++) {
+		if ((bitselect & spidata))
+			ioctl(ppdrvdev, PPDRV_IOC_PINSET, DTX_DATA);
 		else
-			ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR, DTX_DATA );
+			ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR, DTX_DATA);
 
-		for(ii=0;ii<PP_BIT_TIME;ii++);
+		for (ii = 0; ii < PP_BIT_TIME; ii++);
 
-		ioctl(ppdrvdev, PPDRV_IOC_PINSET, DTX_CLK );
-		for(ii=0;ii<PP_BIT_TIME;ii++);
-		ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR, DTX_CLK );
-		for(ii=0;ii<PP_BIT_TIME;ii++);
+		ioctl(ppdrvdev, PPDRV_IOC_PINSET, DTX_CLK);
+		for (ii = 0; ii < PP_BIT_TIME; ii++);
+		ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR, DTX_CLK);
+		for (ii = 0; ii < PP_BIT_TIME; ii++);
 
-		bitselect=(bitselect>>1);
+		bitselect = (bitselect >> 1);
 	}
-	ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR, DTX_CLK | DTX_DATA );
-	ioctl(ppdrvdev, PPDRV_IOC_PINSET, DTX_ENABLE );
-	for(ii=0;ii<PP_BIT_TIME;ii++);
-	ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR, DTX_ENABLE );
+	ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR, DTX_CLK | DTX_DATA);
+	ioctl(ppdrvdev, PPDRV_IOC_PINSET, DTX_ENABLE);
+	for (ii = 0; ii < PP_BIT_TIME; ii++);
+	ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR, DTX_ENABLE);
 #endif
 }
+
 /*
 	mutex needed
 	now assumes calling thread secures permissions
 	could set up a separate thread to program the radio? yuck!
 
 */
-void	progdtx(t_pmr_chan *pChan)
+void progdtx(t_pmr_chan *pChan)
 {
-#if(DTX_PROG == 1)	
-	//static u32	progcount=0;
+#if(DTX_PROG == 1)
+	//static u32    progcount=0;
 
 	u32 reffreq;
 	u32 stepfreq;
@@ -3376,55 +3231,49 @@ void	progdtx(t_pmr_chan *pChan)
 	TRACEC(1, "\nprogdtx() %i %i %i\n", pChan->rxfreq, pChan->txfreq, 0);
 
 	if (ppdrvdev == 0)
-    	ppdrvdev = open("/dev/ppdrv_device", 0);
+		ppdrvdev = open("/dev/ppdrv_device", 0);
 
-    if (ppdrvdev < 0)
-    {
+	if (ppdrvdev < 0) {
 		ast_debug(LOG_ERROR, "open /dev/ppdrv_ppdrvdev returned %i\n", ppdrvdev);
 		exit(0);
 	}
 
-	if(pChan->rxfreq>200000000)
-	{
-		reffreq=16012500;
-		stepfreq=12500;
-		rxiffreq=21400000;
-	}
-	else
-	{
-		reffreq=16000000;
-		stepfreq=5000;
-		rxiffreq=10700000;
+	if (pChan->rxfreq > 200000000) {
+		reffreq = 16012500;
+		stepfreq = 12500;
+		rxiffreq = 21400000;
+	} else {
+		reffreq = 16000000;
+		stepfreq = 5000;
+		rxiffreq = 10700000;
 	}
 
-	shiftreg=(reffreq/stepfreq)<<1;
-	shiftreg=shiftreg|0x00000001;
+	shiftreg = (reffreq / stepfreq) << 1;
+	shiftreg = shiftreg | 0x00000001;
 
 	ppspiout(shiftreg);
 
-	if(pChan->txPttOut)
-		synthfreq=pChan->txfreq;
+	if (pChan->txPttOut)
+		synthfreq = pChan->txfreq;
 	else
-		synthfreq=pChan->rxfreq-rxiffreq;
+		synthfreq = pChan->rxfreq - rxiffreq;
 
-	shiftreg=(synthfreq/stepfreq)<<1;
-	tmp=(shiftreg&0xFFFFFF80)<<1;
-	shiftreg=tmp+(shiftreg&0x0000007F);
+	shiftreg = (synthfreq / stepfreq) << 1;
+	tmp = (shiftreg & 0xFFFFFF80) << 1;
+	shiftreg = tmp + (shiftreg & 0x0000007F);
 
 	ppspiout(shiftreg);
 
-	ioctl(ppdrvdev, PPDRV_IOC_PINMODE_OUT, DTX_CLK | DTX_DATA | DTX_ENABLE | DTX_TXPWR | DTX_TX );
-	ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR, DTX_CLK | DTX_DATA | DTX_ENABLE );
+	ioctl(ppdrvdev, PPDRV_IOC_PINMODE_OUT, DTX_CLK | DTX_DATA | DTX_ENABLE | DTX_TXPWR | DTX_TX);
+	ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR, DTX_CLK | DTX_DATA | DTX_ENABLE);
 
-	if(pChan->txPttOut)
-	{
-		ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR, DTX_TXPWR );
-		ioctl(ppdrvdev, PPDRV_IOC_PINSET, DTX_TX );
-		if(pChan->txpower && 0) ioctl(ppdrvdev, PPDRV_IOC_PINSET, DTX_TXPWR );
-	}
-	else
-	{
-		ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR, DTX_TX | DTX_TXPWR );
+	if (pChan->txPttOut) {
+		ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR, DTX_TXPWR);
+		ioctl(ppdrvdev, PPDRV_IOC_PINSET, DTX_TX);
+		if (pChan->txpower && 0)
+			ioctl(ppdrvdev, PPDRV_IOC_PINSET, DTX_TXPWR);
+	} else {
+		ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR, DTX_TX | DTX_TXPWR);
 	}
 #endif
 }
@@ -3440,156 +3289,137 @@ void dedrift(t_pmr_chan *pChan)
 {
 	TRACEC(5, "dedrift()\n");
 
-	if(pChan->dd.option==9)
-	{
+	if (pChan->dd.option == 9) {
 		TRACEF(1, "dedrift(9)\n");
-		pChan->dd.framesize=DDB_FRAME_SIZE;
-		pChan->dd.frames=DDB_FRAMES_IN_BUFF;
+		pChan->dd.framesize = DDB_FRAME_SIZE;
+		pChan->dd.frames = DDB_FRAMES_IN_BUFF;
 		pChan->dd.buffersize = pChan->dd.frames * pChan->dd.framesize;
-		pChan->dd.buff=ast_calloc(DDB_FRAME_SIZE*DDB_FRAMES_IN_BUFF,2);
-		pChan->dd.modulus=DDB_ERR_MODULUS;
-		pChan->dd.inputindex=0;
-		pChan->dd.outputindex=0;
-		pChan->dd.skew = pChan->dd.lead=0;
-		pChan->dd.z1=0;
-		pChan->dd.debug=0;
-		pChan->dd.debugcnt=0;
-		pChan->dd.lock=pChan->dd.b.txlock=pChan->dd.b.rxlock=0;
-		pChan->dd.initcnt=2;
-		pChan->dd.timer=10000/20;
-		pChan->dd.drift=0;
-		pChan->dd.factor=pChan->dd.x1 = pChan->dd.x0 = pChan->dd.y1 = pChan->dd.y0 = 0;
-		pChan->dd.txframecnt=pChan->dd.rxframecnt=0;
+		pChan->dd.buff = ast_calloc(DDB_FRAME_SIZE * DDB_FRAMES_IN_BUFF, 2);
+		pChan->dd.modulus = DDB_ERR_MODULUS;
+		pChan->dd.inputindex = 0;
+		pChan->dd.outputindex = 0;
+		pChan->dd.skew = pChan->dd.lead = 0;
+		pChan->dd.z1 = 0;
+		pChan->dd.debug = 0;
+		pChan->dd.debugcnt = 0;
+		pChan->dd.lock = pChan->dd.b.txlock = pChan->dd.b.rxlock = 0;
+		pChan->dd.initcnt = 2;
+		pChan->dd.timer = 10000 / 20;
+		pChan->dd.drift = 0;
+		pChan->dd.factor = pChan->dd.x1 = pChan->dd.x0 = pChan->dd.y1 = pChan->dd.y0 = 0;
+		pChan->dd.txframecnt = pChan->dd.rxframecnt = 0;
 		// clear the buffer too!
 		return;
-	}
-	else if(pChan->dd.option==8)
-	{
+	} else if (pChan->dd.option == 8) {
 		ast_free(pChan->dd.buff);
-		pChan->dd.lock=0;
-		pChan->dd.b.txlock=pChan->dd.b.rxlock=0;
+		pChan->dd.lock = 0;
+		pChan->dd.b.txlock = pChan->dd.b.rxlock = 0;
 		return;
-	}
-	else if(pChan->dd.initcnt==0)
-	{
+	} else if (pChan->dd.initcnt == 0) {
 		void *vptr;
 		i16 inputindex;
 		i16 indextweak;
-	    i32 accum;
+		i32 accum;
 
 		// WinFilter, IIR Fs=50, Fc=0.1
-		const i32 a0 =  26231;
-		const i32 a1 =  26231;
-		const i32 b0 =  32768;
+		const i32 a0 = 26231;
+		const i32 a1 = 26231;
+		const i32 b0 = 32768;
 		const i32 b1 = -32358;
-		const i32 dg =	128;
+		const i32 dg = 128;
 
 		inputindex = pChan->dd.inputindex;
-		pChan->dd.skew = pChan->dd.txframecnt-pChan->dd.rxframecnt;
+		pChan->dd.skew = pChan->dd.txframecnt - pChan->dd.rxframecnt;
 		pChan->dd.rxframecnt++;
 
 		// pull data from buffer
-		if( (pChan->dd.outputindex + pChan->dd.framesize) > pChan->dd.buffersize )
-		{
-			i16 dofirst,donext;
+		if ((pChan->dd.outputindex + pChan->dd.framesize) > pChan->dd.buffersize) {
+			i16 dofirst, donext;
 
 			dofirst = pChan->dd.buffersize - pChan->dd.outputindex;
-		    donext = pChan->dd.framesize - dofirst;
-			vptr = (void*)(pChan->dd.ptr);
-			memcpy(vptr,(void*)(pChan->dd.buff + pChan->dd.outputindex),dofirst*2);
-			vptr=(void*)(pChan->dd.ptr + dofirst);
-			memcpy(vptr,(void*)(pChan->dd.buff),donext*2);
+			donext = pChan->dd.framesize - dofirst;
+			vptr = (void *) (pChan->dd.ptr);
+			memcpy(vptr, (void *) (pChan->dd.buff + pChan->dd.outputindex), dofirst * 2);
+			vptr = (void *) (pChan->dd.ptr + dofirst);
+			memcpy(vptr, (void *) (pChan->dd.buff), donext * 2);
+		} else {
+			memcpy(pChan->dd.ptr, (void *) (pChan->dd.buff + pChan->dd.outputindex), pChan->dd.framesize * 2);
 		}
-		else
-		{
-			memcpy(pChan->dd.ptr,(void*)(pChan->dd.buff + pChan->dd.outputindex),pChan->dd.framesize*2);
-		}
-		
+
 		// compute clock error and correction factor
-		if(pChan->dd.outputindex > inputindex)
-		{
+		if (pChan->dd.outputindex > inputindex) {
 			pChan->dd.lead = (inputindex + pChan->dd.buffersize) - pChan->dd.outputindex;
-		}
-	    else
-		{
+		} else {
 			pChan->dd.lead = inputindex - pChan->dd.outputindex;
 		}
-		pChan->dd.err = pChan->dd.lead - (pChan->dd.buffersize/2);
+		pChan->dd.err = pChan->dd.lead - (pChan->dd.buffersize / 2);
 
 		pChan->dd.x1 = pChan->dd.x0;
-	    pChan->dd.y1 = pChan->dd.y0;
+		pChan->dd.y1 = pChan->dd.y0;
 		pChan->dd.x0 = pChan->dd.err;
-	    pChan->dd.y0 = a0 * pChan->dd.x0;
-	    pChan->dd.y0 += (a1 * pChan->dd.x1 - (b1 * pChan->dd.y1));
-	    pChan->dd.y0 /= b0;
-		accum = pChan->dd.y0/dg;
+		pChan->dd.y0 = a0 * pChan->dd.x0;
+		pChan->dd.y0 += (a1 * pChan->dd.x1 - (b1 * pChan->dd.y1));
+		pChan->dd.y0 /= b0;
+		accum = pChan->dd.y0 / dg;
 
-		pChan->dd.factor=accum;
-		indextweak=0;
+		pChan->dd.factor = accum;
+		indextweak = 0;
 
-		#if 1
+#if 1
 		// event sync'd correction
-		if(pChan->dd.b.doitnow)
-		{
-		    pChan->dd.b.doitnow=0;	
-			indextweak=pChan->dd.factor;
+		if (pChan->dd.b.doitnow) {
+			pChan->dd.b.doitnow = 0;
+			indextweak = pChan->dd.factor;
 			pChan->dd.factor = pChan->dd.x1 = pChan->dd.x0 = pChan->dd.y1 = pChan->dd.y0 = 0;
-			pChan->dd.timer=20000/MS_PER_FRAME;
+			pChan->dd.timer = 20000 / MS_PER_FRAME;
 		}
 		// coarse lead adjustment if really far out of range
-		else if( pChan->dd.lead >= pChan->dd.framesize*(DDB_FRAMES_IN_BUFF-2) )
-		{
+		else if (pChan->dd.lead >= pChan->dd.framesize * (DDB_FRAMES_IN_BUFF - 2)) {
 			pChan->dd.factor = pChan->dd.x1 = pChan->dd.x0 = pChan->dd.y1 = pChan->dd.y0 = 0;
-			indextweak += (pChan->dd.framesize*5/4);
-		}
-		else if(pChan->dd.lead <= pChan->dd.framesize*2 )
-		{
+			indextweak += (pChan->dd.framesize * 5 / 4);
+		} else if (pChan->dd.lead <= pChan->dd.framesize * 2) {
 			pChan->dd.factor = pChan->dd.x1 = pChan->dd.x0 = pChan->dd.y1 = pChan->dd.y0 = 0;
-			indextweak -= (pChan->dd.framesize*5/4);
+			indextweak -= (pChan->dd.framesize * 5 / 4);
 		}
-	    #endif
+#endif
 
-		#if 1
-		if(pChan->dd.timer>0)pChan->dd.timer--;
-		if(pChan->dd.timer==0 && abs(pChan->dd.factor)>=16)
-		{
-			indextweak=pChan->dd.factor;
+#if 1
+		if (pChan->dd.timer > 0)
+			pChan->dd.timer--;
+		if (pChan->dd.timer == 0 && abs(pChan->dd.factor) >= 16) {
+			indextweak = pChan->dd.factor;
 			pChan->dd.factor = pChan->dd.x1 = pChan->dd.x0 = pChan->dd.y1 = pChan->dd.y0 = 0;
-			pChan->dd.timer=20000/MS_PER_FRAME;
+			pChan->dd.timer = 20000 / MS_PER_FRAME;
 		}
-		#endif
+#endif
 
-		#if XPMR_DEBUG0 == 1
+#if XPMR_DEBUG0 == 1
 		if (indextweak != 0)
 			TRACEF(4,
-				"%08i indextweak  %+4i  %+4i  %+5i  %5i  %5i  %5i  %+4i\n",
-				pChan->dd.rxframecnt,
-				indextweak,
-				pChan->dd.err,
-				accum,
-				inputindex,
-				pChan->dd.outputindex,
-				pChan->dd.lead,
-				pChan->dd.skew);
+				   "%08i indextweak  %+4i  %+4i  %+5i  %5i  %5i  %5i  %+4i\n",
+				   pChan->dd.rxframecnt,
+				   indextweak, pChan->dd.err, accum, inputindex, pChan->dd.outputindex, pChan->dd.lead, pChan->dd.skew);
 #endif
 
 		// set the output index based on lead and clock offset
-		pChan->dd.outputindex = (pChan->dd.outputindex + pChan->dd.framesize + indextweak)%pChan->dd.buffersize;
+		pChan->dd.outputindex = (pChan->dd.outputindex + pChan->dd.framesize + indextweak) % pChan->dd.buffersize;
 	}
 }
+
 /*
 */
-void dedrift_write(t_pmr_chan *pChan, i16 *src )
+void dedrift_write(t_pmr_chan *pChan, i16 *src)
 {
 	void *vptr;
 
 	TRACEF(5, "dedrift_write()\n");
 	vptr = pChan->dd.buff + pChan->dd.inputindex;
-	memcpy(vptr, src, pChan->dd.framesize*2);
+	memcpy(vptr, src, pChan->dd.framesize * 2);
 	pChan->dd.inputindex = (pChan->dd.inputindex + pChan->dd.framesize) % pChan->dd.buffersize;
 	pChan->dd.txframecnt++;
-	if(pChan->dd.initcnt!=0)pChan->dd.initcnt--;
-	pChan->dd.accum+=pChan->dd.framesize;
+	if (pChan->dd.initcnt != 0)
+		pChan->dd.initcnt--;
+	pChan->dd.accum += pChan->dd.framesize;
 }
 
 #if GCC_VERSION > 40600

--- a/channels/xpmr/xpmr.c
+++ b/channels/xpmr/xpmr.c
@@ -56,15 +56,13 @@
 
 // XPMR_FILE_VERSION(__FILE__, "$Revision: 491 $")
 
-#define GCC_VERSION (__GNUC__ * 10000 \
-                               + __GNUC_MINOR__ * 100 \
-                               + __GNUC_PATCHLEVEL__)
+#define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #if GCC_VERSION > 40600
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsequence-point"
 #endif
 
-#define N_FMT(duf) "%30" #duf	/* Maximum sscanf conversion to numeric strings */
+#define N_FMT(duf) "%30" #duf /* Maximum sscanf conversion to numeric strings */
 #include "asterisk.h"
 
 #include <stdio.h>
@@ -82,10 +80,10 @@
 #include "xpmr_coef.h"
 #include "sinetabx.h"
 
-static i16 pmrChanIndex = 0;	// count of created pmr instances
-//static i16 pmrSpsIndex=0;
+static i16 pmrChanIndex = 0; // count of created pmr instances
+// static i16 pmrSpsIndex=0;
 
-#if (DTX_PROG == 1) || 	XPMR_PPTP == 1
+#if (DTX_PROG == 1) || XPMR_PPTP == 1
 static int ppdrvdev = 0;
 #endif
 
@@ -136,7 +134,7 @@ void pptp_init(void)
 }
 
 /*
-*/
+ */
 void pptp_write(i16 bit, i16 state)
 {
 	if (bit == 0) {
@@ -228,7 +226,7 @@ i16 code_string_parse(t_pmr_chan *pChan)
 	TRACEF(1, "pChan->pTxCodeSrc %s \n", pChan->pTxCodeSrc);
 	TRACEF(1, "pChan->pTxCodeDefault %s \n", pChan->pTxCodeDefault);
 
-	//printf("code_string_parse() %s / %s / %s / %s \n",pChan->name, pChan->pTxCodeDefault,pChan->pTxCodeSrc,pChan->pRxCodeSrc);
+	// printf("code_string_parse() %s / %s / %s / %s \n",pChan->name, pChan->pTxCodeDefault,pChan->pTxCodeSrc,pChan->pRxCodeSrc);
 
 	maxctcssindex = CTCSS_NULL;
 	maxctcsstxfreq = CTCSS_NULL;
@@ -265,7 +263,7 @@ i16 code_string_parse(t_pmr_chan *pChan)
 	if (!pChan->rxCtcss->testIndex)
 		pChan->rxCtcss->testIndex = 3;
 
-	pChan->rxctcssfreq[0] = 0;	// decode now   CTCSS_RXONLY
+	pChan->rxctcssfreq[0] = 0; // decode now   CTCSS_RXONLY
 
 	for (i = 0; i < CTCSS_NUM_CODES; i++) {
 		pChan->rxctcss[i] = 0;
@@ -299,12 +297,12 @@ i16 code_string_parse(t_pmr_chan *pChan)
 				maxctcssindex = ri;
 			}
 
-			if (i < pChan->numtxcodes) {	/* more rx codes than tx codes */
+			if (i < pChan->numtxcodes) { /* more rx codes than tx codes */
 				sscanf(pChan->pTxCode[i], N_FMT(f), &f);
 				ti = CtcssFreqIndex(f);
 				if (ti == CTCSS_NULL) {
 					if (f != 0.0) {
-						f = -1.0;	/* tone freq not valid */
+						f = -1.0; /* tone freq not valid */
 						ast_log(LOG_ERROR, "Invalid TX CTCSS code detected and ignored. %i %s\n", i, pChan->pTxCode[i]);
 					}
 				} else if (f > maxctcsstxfreq) {
@@ -312,7 +310,7 @@ i16 code_string_parse(t_pmr_chan *pChan)
 				}
 			} else {
 				ti = CTCSS_NULL;
-				f = -1.0;		/* tone freq not provided */
+				f = -1.0; /* tone freq not provided */
 				ast_log(LOG_ERROR, "Invalid CTCSS configuration. Number of rx codes > number of tx codes\n");
 			}
 
@@ -356,9 +354,9 @@ i16 code_string_parse(t_pmr_chan *pChan)
 		ptdet = &(pChan->rxCtcss->tdet[i]);
 		ptdet->counterFactor = coef_ctcss_div[i];
 		ptdet->state = 1;
-		ptdet->setpt = (M_Q15 * 0.041);	// 0.069
+		ptdet->setpt = (M_Q15 * 0.041); // 0.069
 		ptdet->hyst = (M_Q15 * 0.0130);
-		ptdet->binFactor = (M_Q15 * 0.135);	// was 0.140
+		ptdet->binFactor = (M_Q15 * 0.135); // was 0.140
 		ptdet->fudgeFactor = 8;
 	}
 
@@ -403,7 +401,7 @@ i16 code_string_parse(t_pmr_chan *pChan)
 		pSps->size_x = 2;
 		pSps->x = ast_calloc(pSps->nx, pSps->size_x);
 		if (pSps->x == NULL) {
-			;					/* XXX do something here */
+			; /* XXX do something here */
 		}
 		pSps->calcAdjust = gain_fir_lpf_250_9_66;
 		TRACEF(1, "code_string_parse() Tx Filter Freq High\n");
@@ -415,7 +413,7 @@ i16 code_string_parse(t_pmr_chan *pChan)
 		pSps->size_x = 2;
 		pSps->x = ast_calloc(pSps->nx, pSps->size_x);
 		if (pSps->x == NULL) {
-			;					/* XXX do something here */
+			; /* XXX do something here */
 		}
 		pSps->calcAdjust = gain_fir_lpf_215_9_88;
 		TRACEF(1, "code_string_parse() Tx Filter Freq Low\n");
@@ -440,7 +438,7 @@ i16 code_string_parse(t_pmr_chan *pChan)
 		pSps->size_x = 2;
 		pSps->x = ast_calloc(pSps->nx, pSps->size_x);
 		if (pSps->x == NULL) {
-			;					/* XXX do something here */
+			; /* XXX do something here */
 		}
 		pSps->calcAdjust = gain_fir_lpf_250_9_66;
 		TRACEF(1, "code_string_parse() Rx Filter Freq High\n");
@@ -452,7 +450,7 @@ i16 code_string_parse(t_pmr_chan *pChan)
 		pSps->size_x = 2;
 		pSps->x = ast_calloc(pSps->nx, pSps->size_x);
 		if (pSps->x == NULL) {
-			;					/* XXX do something here */
+			; /* XXX do something here */
 		}
 		pSps->calcAdjust = gain_fir_lpf_215_9_88;
 		TRACEF(1, "code_string_parse() Rx Filter Freq Low\n");
@@ -509,7 +507,7 @@ i16 CtcssFreqIndex(float freq)
 */
 i16 pmr_rx_frontend(t_pmr_sps *mySps)
 {
-#define DCgainBpfNoise 	65536
+#define DCgainBpfNoise 65536
 
 	i16 samples, nx, iOutput, *input, *output, *noutput;
 	i16 *x;
@@ -553,7 +551,7 @@ i16 pmr_rx_frontend(t_pmr_sps *mySps)
 	for (i = 0; i < samples; i++) {
 		i16 n;
 
-		//shift the old samples
+		// shift the old samples
 #if 0
 		for (n = nx - 1; n > 0; n--)
 			x[n] = x[n - 1];
@@ -562,13 +560,13 @@ i16 pmr_rx_frontend(t_pmr_sps *mySps)
 #endif
 		x[0] = input[i * 2];
 
-#if	XPMR_TRACE_FRONTEND == 1
+#if XPMR_TRACE_FRONTEND == 1
 		y = 0;
 		for (n = 0; n < nx; n++)
 			y += fir_rxlpf[mySps->parentChan->rxlpf].coefs[n] * x[n];
 
 		y = ((y / calcAdjust) * outputGain) / M_Q8;
-		input[i * 2] = y;		// debug output LowPass at 48KS/s
+		input[i * 2] = y; // debug output LowPass at 48KS/s
 #endif
 
 		if (doNoise) {
@@ -583,12 +581,11 @@ i16 pmr_rx_frontend(t_pmr_sps *mySps)
 					naccum += coef_fir_bpf_noise_2[n] * x[n];
 				naccum /= gain_fir_bpf_noise_2;
 			}
-#if	XPMR_TRACE_FRONTEND == 1
-			input[i * 2 + 1] = naccum;	// output noise filter results
+#if XPMR_TRACE_FRONTEND == 1
+			input[i * 2 + 1] = naccum; // output noise filter results
 #endif
 			npwr += naccum * naccum;
 		}
-
 
 		--decimator;
 
@@ -601,7 +598,7 @@ i16 pmr_rx_frontend(t_pmr_sps *mySps)
 
 			y = ((y / calcAdjust) * outputGain) / M_Q8;
 
-#if	XPMR_TRACE_OVFLW == 1
+#if XPMR_TRACE_OVFLW == 1
 			if (y > 32767) {
 				y = 32767;
 				ast_log(LOG_ERROR, "pmr_rx_frontend() OVRFLW \n");
@@ -615,9 +612,9 @@ i16 pmr_rx_frontend(t_pmr_sps *mySps)
 			else if (y < -32767)
 				y = -32767;
 #endif
-			output[iOutput++] = y;	// Rx Baseband decimated
+			output[iOutput++] = y; // Rx Baseband decimated
 
-		}						// if decimator
+		} // if decimator
 	}
 
 	if (doNoise) {
@@ -627,10 +624,7 @@ i16 pmr_rx_frontend(t_pmr_sps *mySps)
 		if (mySps->blanking)
 			mySps->blanking--;
 		mySps->blanking = 0;
-		if (!mySps->compOut &&
-			((npwr > (mySps->setpt + mySps->hyst)) || ((mySps->apeak < (mySps->setpt / 4)) && (npwr > mySps->setpt))
-			)
-			) {
+		if (!mySps->compOut && ((npwr > (mySps->setpt + mySps->hyst)) || ((mySps->apeak < (mySps->setpt / 4)) && (npwr > mySps->setpt)))) {
 			if (!mySps->compOut) {
 				mySps->blanking = 2;
 				mySps->compOut = 1;
@@ -639,7 +633,7 @@ i16 pmr_rx_frontend(t_pmr_sps *mySps)
 			mySps->compOut = 0;
 		}
 
-#if	XPMR_DEBUG0 == 1
+#if XPMR_DEBUG0 == 1
 		if (mySps->parentChan->tracetype) {
 			for (i = 0; i < mySps->nSamples; i++) {
 				noutput[i] = npwr;
@@ -751,7 +745,7 @@ i16 pmr_gp_fir(t_pmr_sps *mySps)
 			y = ((y / calcAdjust) * outputGain) / M_Q8;
 
 			if (y > 32767)
-				y = 32767;		// overflow
+				y = 32767; // overflow
 			else if (y < -32767)
 				y = -32767;
 
@@ -923,22 +917,22 @@ i16 CenterSlicer(t_pmr_sps *mySps)
 	i32 i;
 	i32 accum;
 
-	i32 amax;					// buffer amplitude maximum
-	i32 amin;					// buffer amplitude minimum
-	i32 apeak;					// buffer amplitude peak
+	i32 amax;  // buffer amplitude maximum
+	i32 amin;  // buffer amplitude minimum
+	i32 apeak; // buffer amplitude peak
 	i32 center;
-	i32 setpt;					// amplitude set point for peak tracking
+	i32 setpt; // amplitude set point for peak tracking
 
-	i32 discounteru;			// amplitude detector integrator discharge counter upper
-	i32 discounterl;			// amplitude detector integrator discharge counter lower
-	i32 discfactor;				// amplitude detector integrator discharge factor
+	i32 discounteru; // amplitude detector integrator discharge counter upper
+	i32 discounterl; // amplitude detector integrator discharge counter lower
+	i32 discfactor;	 // amplitude detector integrator discharge factor
 
 	TRACEJ(5, "CenterSlicer() %i\n", mySps->enabled);
 	if (!mySps->enabled)
 		return (1);
 
 	input = mySps->source;
-	output = mySps->sink;		// limited output
+	output = mySps->sink; // limited output
 	buff = mySps->buff;
 
 	npoints = mySps->nSamples;
@@ -999,7 +993,7 @@ i16 CenterSlicer(t_pmr_sps *mySps)
 		center = (amax + amin) / 2;
 		accum = accum - center;
 
-		output[i] = accum;		// sink output unlimited/centered.
+		output[i] = accum; // sink output unlimited/centered.
 
 		// do limiter function
 		if (accum > inputGainB)
@@ -1013,7 +1007,7 @@ i16 CenterSlicer(t_pmr_sps *mySps)
 		mySps->parentChan->pRxLsdCen[i] = center;	// trace center ref
 #else
 		tfx = 0;
-		if ((tfx++ / 8) & 1)	// trace min/max levels
+		if ((tfx++ / 8) & 1) // trace min/max levels
 			mySps->parentChan->pRxLsdCen[i] = amax;
 		else
 			mySps->parentChan->pRxLsdCen[i] = amin;
@@ -1048,14 +1042,14 @@ i16 MeasureBlock(t_pmr_sps *mySps)
 	i32 i;
 	i32 accum;
 
-	i16 amax;					// buffer amplitude maximum
-	i16 amin;					// buffer amplitude minimum
-	i16 apeak = 0;				// buffer amplitude peak (peak to peak)/2
-	i16 setpt;					// amplitude set point for amplitude comparator
+	i16 amax;	   // buffer amplitude maximum
+	i16 amin;	   // buffer amplitude minimum
+	i16 apeak = 0; // buffer amplitude peak (peak to peak)/2
+	i16 setpt;	   // amplitude set point for amplitude comparator
 
-	i32 discounteru;			// amplitude detector integrator discharge counter upper
-	i32 discounterl;			// amplitude detector integrator discharge counter lower
-	i32 discfactor;				// amplitude detector integrator discharge factor
+	i32 discounteru; // amplitude detector integrator discharge counter upper
+	i32 discounterl; // amplitude detector integrator discharge counter lower
+	i32 discfactor;	 // amplitude detector integrator discharge factor
 
 	TRACEJ(5, "MeasureBlock() %i\n", mySps->enabled);
 
@@ -1125,7 +1119,7 @@ i16 MeasureBlock(t_pmr_sps *mySps)
 i16 SoftLimiter(t_pmr_sps *mySps)
 {
 	i16 npoints;
-	//i16 samples, lhit,uhit;
+	// i16 samples, lhit,uhit;
 	i16 *input, *output;
 
 	i32 outputGain;
@@ -1133,10 +1127,10 @@ i16 SoftLimiter(t_pmr_sps *mySps)
 	i32 accum;
 	i32 tmp;
 
-	i32 amax;					// buffer amplitude maximum
-	i32 amin;					// buffer amplitude minimum
-	//i32  apeak;       // buffer amplitude peak
-	i32 setpt;					// amplitude set point for amplitude comparator
+	i32 amax; // buffer amplitude maximum
+	i32 amin; // buffer amplitude minimum
+	// i32  apeak;       // buffer amplitude peak
+	i32 setpt; // amplitude set point for amplitude comparator
 
 	input = mySps->source;
 	output = mySps->sink;
@@ -1153,7 +1147,7 @@ i16 SoftLimiter(t_pmr_sps *mySps)
 
 	for (i = 0; i < npoints; i++) {
 		accum = input[i];
-		//accum=input[i]*mySps->inputGain/256;
+		// accum=input[i]*mySps->inputGain/256;
 
 		if (accum > setpt) {
 			tmp = ((accum - setpt) * 4) / 128;
@@ -1186,7 +1180,7 @@ i16 SoftLimiter(t_pmr_sps *mySps)
 */
 i16 SigGen(t_pmr_sps *mySps)
 {
-#define PH_FRACT_FACT	128
+#define PH_FRACT_FACT 128
 
 	i32 ph;
 	i16 i, outputgain, waveform, numChanOut, selChanOut;
@@ -1217,13 +1211,12 @@ i16 SigGen(t_pmr_sps *mySps)
 		// phase shift request
 		mySps->option = 0;
 		mySps->state = 2;
-		mySps->discounterl = CTCSS_TURN_OFF_TIME - (2 * MS_PER_FRAME);	//
+		mySps->discounterl = CTCSS_TURN_OFF_TIME - (2 * MS_PER_FRAME); //
 
 		mySps->discounteru =
-			(mySps->discounteru +
-			 (((SAMPLES_PER_SINE * shiftfactor) / 360) * PH_FRACT_FACT)) % (SAMPLES_PER_SINE * PH_FRACT_FACT);
-		//printf("shiftfactor = %i\n",shiftfactor);
-		//shiftfactor+=10;
+			(mySps->discounteru + (((SAMPLES_PER_SINE * shiftfactor) / 360) * PH_FRACT_FACT)) % (SAMPLES_PER_SINE * PH_FRACT_FACT);
+		// printf("shiftfactor = %i\n",shiftfactor);
+		// shiftfactor+=10;
 	} else if (mySps->option == 3) {
 		// stop it and clear the output buffer
 		mySps->option = 0;
@@ -1249,7 +1242,7 @@ i16 SigGen(t_pmr_sps *mySps)
 	for (i = 0; i < mySps->nSamples; i++) {
 		if (!waveform) {
 			// sine
-			//tmp=(sinetablex[ph/PH_FRACT_FACT]*amplitude)/M_Q16;
+			// tmp=(sinetablex[ph/PH_FRACT_FACT]*amplitude)/M_Q16;
 			accum = sinetablex[ph / PH_FRACT_FACT];
 			accum = (accum * outputgain) / M_Q8;
 		} else {
@@ -1285,8 +1278,8 @@ i16 pmrMixer(t_pmr_sps *mySps)
 {
 	i32 accum;
 	i16 i, *input, *inputB, *output;
-	i16 inputGain, inputGainB;	// apply to input data   in Q7.8 format
-	i16 outputGain;				// apply to output data  in Q7.8 format
+	i16 inputGain, inputGainB; // apply to input data   in Q7.8 format
+	i16 outputGain;			   // apply to output data  in Q7.8 format
 	i16 discounteru, discounterl, amax, amin, setpt, discfactor;
 	i16 npoints, uhit, lhit, apeak, measPeak;
 
@@ -1426,8 +1419,7 @@ i16 ctcss_detect(t_pmr_chan *pChan)
 	i16 points = 0;
 	i16 indexWas = 0;
 
-	TRACEF(5, "ctcss_detect(%p) %i %i %i %i\n", pChan, pChan->rxCtcss->enabled, 0, pChan->rxCtcss->testIndex,
-		   pChan->rxCtcss->decode);
+	TRACEF(5, "ctcss_detect(%p) %i %i %i %i\n", pChan, pChan->rxCtcss->enabled, 0, pChan->rxCtcss->testIndex, pChan->rxCtcss->decode);
 
 	if (!pChan->rxCtcss->enabled)
 		return (1);
@@ -1446,11 +1438,9 @@ i16 ctcss_detect(t_pmr_chan *pChan)
 		i16 binFactor;
 
 		TRACEF(6, " ctcss_detect() tnum=%i %i\n", tnum, pChan->rxCtcssMap[tnum]);
-		//if(tnum==14)printf("ctcss_detect() %i %i %i\n",tnum,pChan->rxCtcssMap[tnum], pChan->rxCtcss->decode );
+		// if(tnum==14)printf("ctcss_detect() %i %i %i\n",tnum,pChan->rxCtcssMap[tnum], pChan->rxCtcss->decode );
 
-		if ((pChan->rxCtcssMap[tnum] == CTCSS_NULL) ||
-			(pChan->rxCtcss->decode > CTCSS_NULL && (tnum != pChan->rxCtcss->decode))
-			)
+		if ((pChan->rxCtcssMap[tnum] == CTCSS_NULL) || (pChan->rxCtcss->decode > CTCSS_NULL && (tnum != pChan->rxCtcss->decode)))
 			continue;
 
 		TRACEF(6, " ctcss_detect() tnum=%i\n", tnum);
@@ -1469,7 +1459,7 @@ i16 ctcss_detect(t_pmr_chan *pChan)
 
 			ptdet->counter += ptdet->counterFactor;
 
-			accum = pInput[indexNow - 1];	// duuuude's major bug fix!
+			accum = pInput[indexNow - 1]; // duuuude's major bug fix!
 
 			ptdet->z[ptdet->zIndex] += (((accum - ptdet->z[ptdet->zIndex]) * binFactor) / M_Q15);
 
@@ -1486,7 +1476,7 @@ i16 ctcss_detect(t_pmr_chan *pChan)
 				i32 temp0, temp1;
 				i16 x0;
 
-				//differentiate
+				// differentiate
 				x0 = ptdet->zd;
 				temp0 = x0 * a1;
 				ptdet->zd = ptdet->peak;
@@ -1622,7 +1612,7 @@ i16 TxTestTone(t_pmr_chan *pChan, i16 function)
 	if (function == 1) {
 		pChan->spsSigGen1->enabled = 1;
 		pChan->spsSigGen1->option = 1;
-		pChan->spsSigGen1->outputGain = (.23125 * M_Q8);	// to match *99 level
+		pChan->spsSigGen1->outputGain = (.23125 * M_Q8); // to match *99 level
 		pChan->spsTx->source = pChan->spsSigGen1->sink;
 	} else {
 		pChan->spsSigGen1->option = 3;
@@ -1634,7 +1624,7 @@ i16 TxTestTone(t_pmr_chan *pChan, i16 function)
 	assumes:
 	sampling rate is 48KS/s
 	samples are all 16 bits
-    samples are filtered and decimated by 1/6th
+	samples are filtered and decimated by 1/6th
 */
 t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 {
@@ -1748,7 +1738,6 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 		ast_log(LOG_NOTICE, "xpmr rxhpf: %d\n", pChan->rxhpf);
 		ast_log(LOG_NOTICE, "xpmr txlpf: %d\n", pChan->txlpf);
 		ast_log(LOG_NOTICE, "xpmr txhpf: %d\n", pChan->txhpf);
-
 	}
 
 	if (pChan->rxCarrierHyst == 0)
@@ -1764,7 +1753,7 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 		pChan->rxDeEmpEnable = 1;
 
 	pChan->rxCarrierPoint = (pChan->rxSquelchPoint * 32767) / 100;
-	pChan->rxCarrierHyst = 3000;	//pChan->rxCarrierPoint/15;
+	pChan->rxCarrierHyst = 3000; // pChan->rxCarrierPoint/15;
 
 	pChan->rxDcsDecodeEnable = 0;
 
@@ -1809,7 +1798,7 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 
 	pChan->prxMeasure = ast_calloc(numSamples, 2);
 
-	pChan->pTxOut = ast_calloc(numSamples, 2 * 2 * 6);	// output buffer
+	pChan->pTxOut = ast_calloc(numSamples, 2 * 2 * 6); // output buffer
 
 #ifdef HAVE_XPMRX
 	pChan->pLsdEnc = ast_calloc(sizeof(t_encLsd), 1);
@@ -1858,7 +1847,7 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 
 	TRACEF(1, "pChan->tracetype = %i\n", pChan->tracetype);
 
-	if (pChan->tracetype == 1)	// CTCSS DECODE
+	if (pChan->tracetype == 1) // CTCSS DECODE
 	{
 		pChan->sdbg->source[0] = pChan->pRxDemod;
 		pChan->sdbg->source[1] = pChan->pRxBase;
@@ -1873,7 +1862,7 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 		pChan->sdbg->source[10] = pChan->pRxBase;
 		pChan->sdbg->source[11] = pChan->pRxSpeaker;
 	}
-	if (pChan->tracetype == 2)	// CTCSS DECODE
+	if (pChan->tracetype == 2) // CTCSS DECODE
 	{
 		pChan->sdbg->source[0] = pChan->pRxDemod;
 		pChan->sdbg->source[1] = pChan->pRxBase;
@@ -1891,7 +1880,7 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 		pChan->sdbg->trace[13] = TX_PTT_IN;
 		pChan->sdbg->trace[14] = TX_PTT_OUT;
 		pChan->sdbg->source[15] = pChan->pTxLsdLpf;
-	} else if (pChan->tracetype == 3)	// DCS DECODE
+	} else if (pChan->tracetype == 3) // DCS DECODE
 	{
 		pChan->sdbg->source[0] = pChan->pRxDemod;
 		pChan->sdbg->source[1] = pChan->pRxBase;
@@ -1910,7 +1899,7 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 		pChan->sdbg->trace[14] = TX_LSD_GEN;
 		pChan->sdbg->source[14] = pChan->pTxLsd;
 		pChan->sdbg->source[15] = pChan->pTxLsdLpf;
-	} else if (pChan->tracetype == 4)	// LSD DECODE
+	} else if (pChan->tracetype == 4) // LSD DECODE
 	{
 		pChan->sdbg->source[0] = pChan->pRxDemod;
 		pChan->sdbg->source[1] = pChan->pRxBase;
@@ -1927,10 +1916,10 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 		pChan->sdbg->trace[12] = TX_PTT_OUT;
 		pChan->sdbg->trace[13] = TX_LSD_CLK;
 		pChan->sdbg->trace[14] = TX_LSD_DAT;
-		//pChan->sdbg->trace  [14]=TX_LSD_GEN;
-		//pChan->sdbg->source [14]=pChan->pTxLsd;
+		// pChan->sdbg->trace  [14]=TX_LSD_GEN;
+		// pChan->sdbg->source [14]=pChan->pTxLsd;
 		pChan->sdbg->source[15] = pChan->pTxLsdLpf;
-	} else if (pChan->tracetype == 5)	// LSD LOGIC
+	} else if (pChan->tracetype == 5) // LSD LOGIC
 	{
 		pChan->sdbg->source[0] = pChan->pRxBase;
 		pChan->sdbg->trace[1] = RX_NOISE_TRIG;
@@ -1998,7 +1987,7 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 	pSps->sigProc = SigGen;
 	pSps->nSamples = pChan->nSamplesTx;
 	pSps->sampleRate = SAMPLE_RATE_NETWORK;
-	pSps->freq = 10000;			// in increments of 0.1 Hz
+	pSps->freq = 10000; // in increments of 0.1 Hz
 	pSps->outputGain = (.25 * M_Q8);
 	pSps->option = 0;
 	pSps->interpolate = 1;
@@ -2013,7 +2002,7 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 	pSps->selChanOut = 0;
 	pSps->nSamples = pChan->nSamplesTx;
 	pSps->sampleRate = SAMPLE_RATE_NETWORK;
-	pSps->freq = 1000;			// in 0.1 Hz steps
+	pSps->freq = 1000; // in 0.1 Hz steps
 	pSps->outputGain = (0.5 * M_Q8);
 	pSps->option = 0;
 	pSps->interpolate = 1;
@@ -2042,7 +2031,7 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 	pSps->size_x = 2;
 	pSps->x = ast_calloc(pSps->nx, pSps->size_x);
 	if (pSps->x == NULL) {
-		;						/* XXX do something here */
+		; /* XXX do something here */
 	}
 	pSps->calcAdjust = gain_fir_lpf_215_9_88;
 
@@ -2057,7 +2046,7 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 
 	// allocate space for first sps and set pointers
 	pSps = pChan->spsRx = createPmrSps(pChan);
-	pSps->source = NULL;		//set when called
+	pSps->source = NULL; // set when called
 	pSps->sink = pChan->pRxBase;
 	pSps->sigProc = pmr_rx_frontend;
 	pSps->enabled = 1;
@@ -2071,7 +2060,7 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 	pSps->size_x = 2;
 	pSps->x = ast_calloc(pSps->nx, pSps->size_coef);
 	if (pSps->x == NULL) {
-		;						/* XXX do something here */
+		; /* XXX do something here */
 	}
 	pSps->calcAdjust = (fir_rxlpf[pChan->rxlpf].gain * 256) / 0x0100;
 	pSps->outputGain = (1.0 * M_Q8);
@@ -2106,7 +2095,7 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 	pSps->size_x = 2;
 	pSps->x = ast_calloc(pSps->nx, pSps->size_x);
 	if (pSps->x == NULL) {
-		;						/* XXX do something here */
+		; /* XXX do something here */
 	}
 	pSps->calcAdjust = gain_fir_lpf_215_9_88;
 
@@ -2122,11 +2111,11 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 	pSps->buff = pChan->pRxLsdLimit;
 	pSps->sigProc = CenterSlicer;
 	pSps->nSamples = pChan->nSamplesRx;
-	pSps->discfactor = LSD_DFS;	// centering time constant
+	pSps->discfactor = LSD_DFS; // centering time constant
 	pSps->inputGain = (1 * M_Q8);
 	pSps->outputGain = (1 * M_Q8);
-	pSps->setpt = 4900;			// ptp clamp for DC centering
-	pSps->inputGainB = 625;		// peak output limiter clip point
+	pSps->setpt = 4900;		// ptp clamp for DC centering
+	pSps->inputGainB = 625; // peak output limiter clip point
 	pSps->enabled = 0;
 
 	// Rx HPF
@@ -2148,7 +2137,7 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 	pSps->size_x = 2;
 	pSps->x = ast_calloc(pSps->nx, pSps->size_x);
 	if (pSps->x == NULL) {
-		;						/* XXX do something here */
+		; /* XXX do something here */
 	}
 	pSps->calcAdjust = fir_rxhpf[pChan->rxhpf].gain;
 	pSps->inputGain = (1 * M_Q8);
@@ -2163,7 +2152,7 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 		pChan->spsRxDeEmp = pSps;
 		pSps->source = pChan->pRxHpf;
 		pSps->sink = pChan->pRxSpeaker;
-		pChan->spsRxOut = pSps;	// OUTPUT STRUCTURE!
+		pChan->spsRxOut = pSps; // OUTPUT STRUCTURE!
 		pSps->sigProc = gp_inte_00;
 		pSps->enabled = 1;
 		pSps->nSamples = pChan->nSamplesRx;
@@ -2176,7 +2165,7 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 		pSps->size_x = 4;
 		pSps->x = ast_calloc(pSps->nx, pSps->size_x);
 		if (pSps->x == NULL) {
-			;					/* XXX do something here */
+			; /* XXX do something here */
 		}
 		pSps->calcAdjust = gain_int_lpf_300_1_2 / 2;
 		pSps->inputGain = (1.0 * M_Q8);
@@ -2202,7 +2191,7 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 		else
 			pSps->source = pChan->pRxHpf;
 		pSps->sink = pChan->pRxSpeaker;
-		pChan->spsRxOut = pSps;	// OUTPUT STRUCTURE!
+		pChan->spsRxOut = pSps; // OUTPUT STRUCTURE!
 		pSps->enabled = 1;
 		pSps->b.outzero = 0;
 		pSps->inputGain = 1 * M_Q8;
@@ -2210,7 +2199,7 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 		pSps->nSamples = pChan->nSamplesRx;
 		pSps->buffSize = RXSQDELAYBUFSIZE;
 		pSps->buff = ast_calloc(RXSQDELAYBUFSIZE, 2);
-		pSps->buffLead = pChan->rxSquelchDelay * 8;	// convert ms to samples
+		pSps->buffLead = pChan->rxSquelchDelay * 8; // convert ms to samples
 		pSps->buffInIndex = 0;
 		pSps->buffOutIndex = 0;
 	}
@@ -2245,7 +2234,7 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 	pSps->nSamples = pChan->nSamplesRx;
 	pSps->discfactor = 10;
 
-	pSps->nextSps = NULL;		// last sps in chain RX
+	pSps->nextSps = NULL; // last sps in chain RX
 
 	// CREATE TRANSMIT CHAIN
 	TRACEF(1, "create tx\n");
@@ -2274,7 +2263,7 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 		pSps->size_x = 2;
 		pSps->x = ast_calloc(pSps->nx, pSps->size_x);
 		if (pSps->x == NULL) {
-			;					/* XXX do something here */
+			; /* XXX do something here */
 		}
 		pSps->calcAdjust = fir_txhpf[pChan->txhpf].gain;
 		pSps->inputGain = (1 * M_Q8);
@@ -2304,11 +2293,11 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 		pSps->size_x = 2;
 		pSps->x = ast_calloc(pSps->nx, pSps->size_x);
 		if (pSps->x == NULL) {
-			;					/* XXX do something here */
+			; /* XXX do something here */
 		}
 		pSps->calcAdjust = gain_int_hpf_4000_1_2;
 		pSps->inputGain = (1 * M_Q8);
-		pSps->outputGain = (1 * M_Q8);	// to match flat at 1KHz 
+		pSps->outputGain = (1 * M_Q8); // to match flat at 1KHz
 		inputTmp = pSps->sink;
 	}
 
@@ -2326,7 +2315,7 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 		pSps->nSamples = pChan->nSamplesTx;
 		pSps->inputGain = (1 * M_Q8);
 		pSps->outputGain = (1 * M_Q8);
-		pSps->setpt = 12000;	// limiting point for 100 modulation        
+		pSps->setpt = 12000; // limiting point for 100 modulation
 		inputTmp = pSps->sink;
 	}
 
@@ -2337,7 +2326,7 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 		else
 			pSps = pSps->nextSps = createPmrSps(pChan);
 		pSps->source = inputTmp;
-		pSps->sourceB = pChan->pTxLsdLpf;	//asdf ??? !!! maw pTxLsdLpf
+		pSps->sourceB = pChan->pTxLsdLpf; // asdf ??? !!! maw pTxLsdLpf
 		pSps->sink = pChan->pTxComposite;
 		pSps->sigProc = pmrMixer;
 		pSps->enabled = 1;
@@ -2387,7 +2376,7 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 	} else if (pChan->txMixA == TX_OUT_AUX) {
 		pSps->source = pChan->pTxHpf;
 	} else {
-		pSps->source = NULL;	// maw sph asdf !!! no blow up
+		pSps->source = NULL; // maw sph asdf !!! no blow up
 		pSps->source = inputTmp;
 	}
 
@@ -2397,7 +2386,7 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 	pSps->numChanOut = 2;
 	pSps->selChanOut = 0;
 	pSps->nSamples = pChan->nSamplesTx;
-#ifdef	XPMR_VOTER
+#ifdef XPMR_VOTER
 	pSps->interpolate = 1;
 	pSps->ncoef = taps_fir_lpf_3K_2;
 	pSps->size_coef = 2;
@@ -2415,7 +2404,7 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 	pSps->size_x = 2;
 	pSps->x = ast_calloc(pSps->nx, pSps->size_x);
 	if (pSps->x == NULL) {
-		;						/* XXX do something here */
+		; /* XXX do something here */
 	}
 	pSps->inputGain = (1 * M_Q8);
 	pSps->outputGain = (1 * M_Q8);
@@ -2452,7 +2441,7 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 		pSps->selChanOut = 1;
 		pSps->mixOut = 0;
 		pSps->nSamples = pChan->nSamplesTx;
-#ifdef	XPMR_VOTER
+#ifdef XPMR_VOTER
 		pSps->interpolate = 1;
 		pSps->ncoef = taps_fir_lpf_3K_2;
 		pSps->size_coef = 2;
@@ -2470,7 +2459,7 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 		pSps->size_x = 2;
 		pSps->x = ast_calloc(pSps->nx, pSps->size_x);
 		if (pSps->x == NULL) {
-			;					/* XXX do something here */
+			; /* XXX do something here */
 		}
 		pSps->inputGain = (1 * M_Q8);
 		pSps->outputGain = (1 * M_Q8);
@@ -2496,7 +2485,7 @@ t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples)
 }
 
 /*
-*/
+ */
 i16 destroyPmrChannel(t_pmr_chan *pChan)
 {
 	t_pmr_sps *pmr_sps, *tmp_sps;
@@ -2531,7 +2520,7 @@ i16 destroyPmrChannel(t_pmr_chan *pChan)
 		ast_free(pChan->pSigGen1);
 
 #if XPMR_DEBUG0 == 1
-	//if(pChan->prxDebug)ast_free(pChan->prxDebug);
+	// if(pChan->prxDebug)ast_free(pChan->prxDebug);
 	if (pChan->ptxDebug)
 		ast_free(pChan->ptxDebug);
 	ast_free(pChan->prxDebug0);
@@ -2577,7 +2566,7 @@ i16 destroyPmrChannel(t_pmr_chan *pChan)
 }
 
 /*
-*/
+ */
 t_pmr_sps *createPmrSps(t_pmr_chan *pChan)
 {
 	t_pmr_sps *pSps;
@@ -2597,7 +2586,7 @@ t_pmr_sps *createPmrSps(t_pmr_chan *pChan)
 }
 
 /*
-*/
+ */
 i16 destroyPmrSps(t_pmr_sps *pSps)
 {
 	TRACEJ(1, "destroyPmrSps(%i)\n", pSps->index);
@@ -2616,7 +2605,7 @@ Returns 0 if successful. -1 if the setpoint is out of bounds or the pChan isn't 
 
 i16 SetTxSoftLimiterSetpoint(t_pmr_chan *pChan, i16 setpoint)
 {
-	if(!pChan) {
+	if (!pChan) {
 		return -1;
 	}
 
@@ -2625,16 +2614,15 @@ i16 SetTxSoftLimiterSetpoint(t_pmr_chan *pChan, i16 setpoint)
 		TRACEF(1, "Request to set limiter setpoint ignored. Limiter not enabled\n");
 		return 0;
 	}
-	
+
 	/* Bounds check setpoint to ensure it is within range */
 	if ((setpoint < 5000) || (setpoint > 13000)) {
 		return -1;
 	}
-	
+
 	pChan->spsLimiterTx->setpt = setpoint;
 	return 0;
 }
-
 
 /*
 	PmrTx - takes data from network and holds it for PmrRx
@@ -2695,7 +2683,7 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 
 #if XPMR_DEBUG0 == 1
 	if (pChan->b.rxCapture) {
-		//if(pChan->prxDebug)memset((void *)pChan->prxDebug,0,pChan->nSamplesRx*XPMR_DEBUG_CHANS*2);
+		// if(pChan->prxDebug)memset((void *)pChan->prxDebug,0,pChan->nSamplesRx*XPMR_DEBUG_CHANS*2);
 		if (pChan->ptxDebug)
 			memset((void *) pChan->ptxDebug, 0, pChan->nSamplesRx * XPMR_DEBUG_CHANS * 2);
 
@@ -2705,11 +2693,11 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 #endif
 
 #ifndef XPMR_VOTER
-	pmr_sps = pChan->spsRx;		// first sps
+	pmr_sps = pChan->spsRx; // first sps
 	pmr_sps->source = input;
 
 	if (outputrx != NULL)
-		pChan->spsRxOut->sink = outputrx;	//last sps
+		pChan->spsRxOut->sink = outputrx; // last sps
 
 	if (pChan->txrxblankingtimer > 0) {
 		for (i = 0; i < pChan->nSamplesRx * 6; i++)
@@ -2732,8 +2720,7 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 	}
 #endif
 
-	if (pChan->rxCpuSaver && !pChan->rxCarrierDetect &&
-		pChan->smode == SMODE_NULL && !pChan->txPttIn && !pChan->txPttOut) {
+	if (pChan->rxCpuSaver && !pChan->rxCarrierDetect && pChan->smode == SMODE_NULL && !pChan->txPttIn && !pChan->txPttOut) {
 		if (!pChan->b.rxhalted) {
 			if (pChan->spsRxHpf)
 				pChan->spsRxHpf->enabled = 0;
@@ -2756,12 +2743,12 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 		TRACEC(5, "PmrRx() sps %i\n", i++);
 		pmr_sps->sigProc(pmr_sps);
 		pmr_sps = (t_pmr_sps *) (pmr_sps->nextSps);
-		//pmr_sps=NULL; // sph maw
+		// pmr_sps=NULL; // sph maw
 	}
 
 	if (pChan->rxCdType == CD_XPMR_VOX) {
 		if (pChan->spsRxVox->compOut) {
-			pChan->rxVoxTimer = pChan->voxHangTime;	/* VOX HangTime in ms */
+			pChan->rxVoxTimer = pChan->voxHangTime; /* VOX HangTime in ms */
 		}
 		if (pChan->rxVoxTimer > 0) {
 			pChan->rxVoxTimer -= MS_PER_FRAME;
@@ -2777,11 +2764,8 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 	}
 
 	// stop and start these engines instead to eliminate falsing
-	if (pChan->b.ctcssRxEnable &&
-		((!pChan->b.rxhalted ||
-		  pChan->rxCtcss->decode != CTCSS_NULL || pChan->smode == SMODE_CTCSS) &&
-		 (pChan->smode != SMODE_DCS && pChan->smode != SMODE_LSD))
-		) {
+	if (pChan->b.ctcssRxEnable && ((!pChan->b.rxhalted || pChan->rxCtcss->decode != CTCSS_NULL || pChan->smode == SMODE_CTCSS) &&
+									  (pChan->smode != SMODE_DCS && pChan->smode != SMODE_LSD))) {
 		ctcss_detect(pChan);
 	}
 
@@ -2833,7 +2817,6 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 		}
 	} else {
 		pChan->lastrxdecode = CTCSS_NULL;
-
 	}
 #ifdef HAVE_XPMRX
 	xpmrx(pChan, XXO_LSDCTL);
@@ -2845,11 +2828,9 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 	// handle radio transmitter ptt input
 	hit = 0;
 	if (!(pChan->smode == SMODE_DCS || pChan->smode == SMODE_LSD)) {
-
 		if (pChan->txPttIn && (pChan->txState == CHAN_TXSTATE_IDLE)) {
-			TRACEC(1,
-				   "txPttIn==1 from CHAN_TXSTATE_IDLE && !SMODE_LSD. codeindex=%i  %i \n",
-				   pChan->rxCtcss->decode, pChan->rxCtcssMap[pChan->rxCtcss->decode]);
+			TRACEC(1, "txPttIn==1 from CHAN_TXSTATE_IDLE && !SMODE_LSD. codeindex=%i  %i \n", pChan->rxCtcss->decode,
+				pChan->rxCtcssMap[pChan->rxCtcss->decode]);
 			pChan->dd.b.doitnow = 1;
 			pChan->spsSigGen0->freq = 0;
 			if (pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit) {
@@ -2899,8 +2880,7 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 					pChan->spsSigGen0->enabled = 1;
 					pChan->spsSigGen0->discounterl = 0;
 				}
-			} else if (pChan->smode == SMODE_NULL && pChan->txcodedefaultsmode == SMODE_CTCSS
-					   && !pChan->b.txCtcssInhibit) {
+			} else if (pChan->smode == SMODE_NULL && pChan->txcodedefaultsmode == SMODE_CTCSS && !pChan->b.txCtcssInhibit) {
 				TRACEC(1, "txPtt Encode txcodedefaultsmode==SMODE_CTCSS %f\n", pChan->txctcssdefault_value);
 				f = pChan->txctcssdefault_value;
 				pChan->spsSigGen0->freq = f * 10;
@@ -2982,7 +2962,7 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 		} else if (pChan->txState == CHAN_TXSTATE_COMPLETE) {
 			hit = 1;
 		}
-	}							// end of if SMODE==LSD
+	} // end of if SMODE==LSD
 
 	if (hit) {
 		pChan->txPttOut = 0;
@@ -3015,8 +2995,7 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 	}
 
 	// enable this after we know everything else is working
-	if (pChan->txCpuSaver &&
-		!pChan->txPttIn && !pChan->txPttOut && pChan->txState == CHAN_TXSTATE_IDLE && !pChan->dd.b.doitnow) {
+	if (pChan->txCpuSaver && !pChan->txPttIn && !pChan->txPttOut && pChan->txState == CHAN_TXSTATE_IDLE && !pChan->dd.b.doitnow) {
 		if (!pChan->b.txhalted) {
 			pChan->b.txhalted = 1;
 			TRACEC(1, "PmrRx() tx sps halted\n");
@@ -3058,7 +3037,7 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 	}
 
 #ifdef XPMRX_H
-	pChan->spsLsdGen->sigProc(pChan->spsLsdGen);	// maw sph ???
+	pChan->spsLsdGen->sigProc(pChan->spsLsdGen); // maw sph ???
 #endif
 
 	// Do Low Speed Data Low Pass Filter
@@ -3115,8 +3094,8 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 	if (pChan->b.rxCapture) {
 		for (i = 0; i < pChan->nSamplesRx; i++) {
 			pChan->pRxDemod[i] = input[i * 2 * 6];
-			pChan->pTstTxOut[i] = outputtx[i * 2 * 6 + 0];	// txa
-			//pChan->pTstTxOut[i]=outputtx[i*2*6+1]; // txb
+			pChan->pTstTxOut[i] = outputtx[i * 2 * 6 + 0]; // txa
+			// pChan->pTstTxOut[i]=outputtx[i*2*6+1]; // txb
 			TSCOPE((RX_NOISE_TRIG, pChan->sdbg, i, (pChan->rxCarrierDetect * XPMR_TRACE_AMP) - XPMR_TRACE_AMP / 2));
 			TSCOPE((RX_CTCSS_DECODE, pChan->sdbg, i, pChan->rxCtcss->decode * (M_Q14 / CTCSS_NUM_CODES)));
 			TSCOPE((RX_SMODE, pChan->sdbg, i, pChan->smode * (XPMR_TRACE_AMP / 4)));
@@ -3131,9 +3110,8 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 #endif
 
 	strace2(pChan->sdbg);
-	TRACEC(5,
-		   "PmrRx() return  cd=%i smode=%i  txPttIn=%i  txPttOut=%i \n",
-		   pChan->rxCarrierDetect, pChan->smode, pChan->txPttIn, pChan->txPttOut);
+	TRACEC(5, "PmrRx() return  cd=%i smode=%i  txPttIn=%i  txPttOut=%i \n", pChan->rxCarrierDetect, pChan->smode, pChan->txPttIn,
+		pChan->txPttOut);
 	return 0;
 }
 
@@ -3142,7 +3120,7 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 
 void ppbinout(u8 chan)
 {
-#if(DTX_PROG == 1)
+#if (DTX_PROG == 1)
 	i32 i;
 
 	if (ppdrvdev == 0)
@@ -3164,12 +3142,12 @@ void ppbinout(u8 chan)
 		i |= BIN_PROG_3;
 
 	ioctl(ppdrvdev, PPDRV_IOC_PINMODE_OUT, BIN_PROG_3 | BIN_PROG_2 | BIN_PROG_1 | BIN_PROG_0);
-	//ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR,    BIN_PROG_3|BIN_PROG_2|BIN_PROG_1|BIN_PROG_0);
-	//ioctl(ppdrvdev, PPDRV_IOC_PINSET, i );
+	// ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR,    BIN_PROG_3|BIN_PROG_2|BIN_PROG_1|BIN_PROG_0);
+	// ioctl(ppdrvdev, PPDRV_IOC_PINSET, i );
 	ioctl(ppdrvdev, PPDRV_IOC_PINSET, BIN_PROG_3 | BIN_PROG_2 | BIN_PROG_1 | BIN_PROG_0);
 	ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR, i);
 
-	// ioctl(ppdrvdev, PPDRV_IOC_PINSET, BIN_PROG_3|BIN_PROG_2|BIN_PROG_1|BIN_PROG_0 ); 
+	// ioctl(ppdrvdev, PPDRV_IOC_PINSET, BIN_PROG_3|BIN_PROG_2|BIN_PROG_1|BIN_PROG_0 );
 	ast_log(LOG_NOTICE, "mask=%i 0x%x\n", i, i);
 #endif
 }
@@ -3183,7 +3161,7 @@ void ppbinout(u8 chan)
 */
 void ppspiout(u32 spidata)
 {
-#if(DTX_PROG == 1)
+#if (DTX_PROG == 1)
 	static char firstrun = 0;
 	i32 i, ii;
 	u32 bitselect;
@@ -3198,9 +3176,11 @@ void ppspiout(u32 spidata)
 
 	if (firstrun == 0) {
 		firstrun = 1;
-		for (ii = 0; ii < PP_BIT_TIME * 200; ii++);
+		for (ii = 0; ii < PP_BIT_TIME * 200; ii++)
+			;
 	} else {
-		for (ii = 0; ii < PP_BIT_TIME * 4; ii++);
+		for (ii = 0; ii < PP_BIT_TIME * 4; ii++)
+			;
 	}
 
 	bitselect = 0x00080000;
@@ -3211,18 +3191,22 @@ void ppspiout(u32 spidata)
 		else
 			ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR, DTX_DATA);
 
-		for (ii = 0; ii < PP_BIT_TIME; ii++);
+		for (ii = 0; ii < PP_BIT_TIME; ii++)
+			;
 
 		ioctl(ppdrvdev, PPDRV_IOC_PINSET, DTX_CLK);
-		for (ii = 0; ii < PP_BIT_TIME; ii++);
+		for (ii = 0; ii < PP_BIT_TIME; ii++)
+			;
 		ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR, DTX_CLK);
-		for (ii = 0; ii < PP_BIT_TIME; ii++);
+		for (ii = 0; ii < PP_BIT_TIME; ii++)
+			;
 
 		bitselect = (bitselect >> 1);
 	}
 	ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR, DTX_CLK | DTX_DATA);
 	ioctl(ppdrvdev, PPDRV_IOC_PINSET, DTX_ENABLE);
-	for (ii = 0; ii < PP_BIT_TIME; ii++);
+	for (ii = 0; ii < PP_BIT_TIME; ii++)
+		;
 	ioctl(ppdrvdev, PPDRV_IOC_PINCLEAR, DTX_ENABLE);
 #endif
 }
@@ -3235,8 +3219,8 @@ void ppspiout(u32 spidata)
 */
 void progdtx(t_pmr_chan *pChan)
 {
-#if(DTX_PROG == 1)
-	//static u32    progcount=0;
+#if (DTX_PROG == 1)
+	// static u32    progcount=0;
 
 	u32 reffreq;
 	u32 stepfreq;
@@ -3296,8 +3280,8 @@ void progdtx(t_pmr_chan *pChan)
 }
 
 /*	dedrift
-	reconciles clock differences between the usb adapter and 
-	asterisk's frame rate clock	
+	reconciles clock differences between the usb adapter and
+	asterisk's frame rate clock
 	take out all accumulated drift error on these events:
 	before transmitter on
 	when ptt release from mobile units detected
@@ -3412,10 +3396,8 @@ void dedrift(t_pmr_chan *pChan)
 
 #if XPMR_DEBUG0 == 1
 		if (indextweak != 0)
-			TRACEF(4,
-				   "%08i indextweak  %+4i  %+4i  %+5i  %5i  %5i  %5i  %+4i\n",
-				   pChan->dd.rxframecnt,
-				   indextweak, pChan->dd.err, accum, inputindex, pChan->dd.outputindex, pChan->dd.lead, pChan->dd.skew);
+			TRACEF(4, "%08i indextweak  %+4i  %+4i  %+5i  %5i  %5i  %5i  %+4i\n", pChan->dd.rxframecnt, indextweak, pChan->dd.err,
+				accum, inputindex, pChan->dd.outputindex, pChan->dd.lead, pChan->dd.skew);
 #endif
 
 		// set the output index based on lead and clock offset
@@ -3424,7 +3406,7 @@ void dedrift(t_pmr_chan *pChan)
 }
 
 /*
-*/
+ */
 void dedrift_write(t_pmr_chan *pChan, i16 *src)
 {
 	void *vptr;

--- a/channels/xpmr/xpmr.h
+++ b/channels/xpmr/xpmr.h
@@ -1,26 +1,26 @@
 /*
  * xpmr.h - for Xelatec Private Mobile Radio Processes
- * 
+ *
  * All Rights Reserved. Copyright (C)2007, Xelatec, LLC
- * 
+ *
  * 20070808 1235 Steven Henke, W9SH, sph@xelatec.com
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
- * 		 
+ *
  * This version may be optionally licenced under the GNU LGPL licence.
- *													
+ *
  * A license has been granted to Digium (via disclaimer) for the use of
  * this code.
  *
@@ -34,50 +34,58 @@
  * \author Steven Henke, W9SH <sph@xelatec.com> Xelatec, LLC
  */
 
-#ifndef  XPMR_H
-#define  XPMR_H					1
+#ifndef XPMR_H
+#define XPMR_H 1
 
-#define  XPMR_DEV   			0	// when running in test mode
+#define XPMR_DEV 0 // when running in test mode
 
-#define  XPMR_TRACE_OVFLW   	0
-#define  XPMR_TRACE_FRONTEND	0
+#define XPMR_TRACE_OVFLW 0
+#define XPMR_TRACE_FRONTEND 0
 
-#define  XPMR_TRACE_LEVEL		0
+#define XPMR_TRACE_LEVEL 0
 
-#ifdef	 RADIO_RTX
-#define	 DTX_PROG				1	// rf transceiver module
-#define  XPMR_PPTP				0	// parallel port test probe
+#ifdef RADIO_RTX
+#define DTX_PROG 1	// rf transceiver module
+#define XPMR_PPTP 0 // parallel port test probe
 #else
-#define	 DTX_PROG				0
-#define  XPMR_PPTP				0
+#define DTX_PROG 0
+#define XPMR_PPTP 0
 #endif
 
-#if (DTX_PROG == 1) || 	XPMR_PPTP == 1
+#if (DTX_PROG == 1) || XPMR_PPTP == 1
 #include <parapindriver.h>
 #endif
 
-#ifdef	CHAN_USBRADIO
-#define XPMR_DEBUG0		1
-#define XPMR_TRACE		1
-#define TRACEO(level,a) { if ( o && (o->tracelevel >= level) ) {printf a;} }
+#ifdef CHAN_USBRADIO
+#define XPMR_DEBUG0 1
+#define XPMR_TRACE 1
+#define TRACEO(level, a) \
+	{ \
+		if (o && (o->tracelevel >= level)) { \
+			printf a; \
+		} \
+	}
 #else
-#define XPMR_DEBUG0		1
-#define XPMR_TRACE		1
-#define TRACEO(level,a)
+#define XPMR_DEBUG0 1
+#define XPMR_TRACE 1
+#define TRACEO(level, a)
 #endif
 
-#define LSD_DFS			5
-#define LSD_DFD			1
+#define LSD_DFS 5
+#define LSD_DFD 1
 
-#if(XPMR_DEBUG0 == 1)
-#define XPMR_DEBUG_CHANS	16
-#define TSCOPE(a) {strace a;}
+#if (XPMR_DEBUG0 == 1)
+#define XPMR_DEBUG_CHANS 16
+#define TSCOPE(a) \
+	{ \
+		strace a; \
+	}
 #else
-#define XPMR_DEBUG_CHANS	0
+#define XPMR_DEBUG_CHANS 0
 #define TSCOPE(a)
 #endif
 
-#define	XPMR_TRACE_AMP		8192
+#define XPMR_TRACE_AMP 8192
 
 #if (XPMR_TRACE == 1)
 #define TRACEX(a) \
@@ -110,119 +118,119 @@
 #define TRACEJ(level, a)
 #endif
 
-#define i8  	int8_t
-#define u8  	u_int8_t
-#define i16		int16_t
-#define u16 	u_int16_t
-#define i32		int32_t
-#define u32 	u_int32_t
-#define i64 	int64_t
-#define u64 	u_int64_t
+#define i8 int8_t
+#define u8 u_int8_t
+#define i16 int16_t
+#define u16 u_int16_t
+#define i32 int32_t
+#define u32 u_int32_t
+#define i64 int64_t
+#define u64 u_int64_t
 
-#define M_Q31			0x80000000	//
-#define M_Q30			0x40000000	//
-#define M_Q29			0x20000000	//
-#define M_Q28			0x10000000	//
-#define M_Q27			0x08000000	//
-#define M_Q26			0x04000000	//
-#define M_Q25			0x02000000	//
-#define M_Q24			0x01000000	//
-#define M_Q23			0x00800000	//
-#define M_Q22			0x00400000	//
-#define M_Q21			0x00200000	// undsoweiter
-#define M_Q20			0x00100000	// 1048576
-#define M_Q19			0x00080000	// 524288
-#define M_Q18			0x00040000	// 262144
-#define M_Q17           0x00020000	// 131072
-#define M_Q16           0x00010000	// 65536
-#define M_Q15           0x00008000	// 32768
-#define M_Q14           0x00004000	// 16384
-#define M_Q13           0x00002000	// 8182
-#define M_Q12           0x00001000	// 4096
-#define M_Q11           0x00000800	// 2048
-#define M_Q10           0x00000400	// 1024
-#define M_Q9            0x00000200	// 512
-#define M_Q8            0x00000100	// 256
-#define M_Q7            0x00000080	// 128
-#define M_Q6            0x00000040	// 64
-#define M_Q5            0x00000020	// 32
-#define M_Q4            0x00000010	// 16
-#define M_Q3            0x00000008	// 16
-#define M_Q2            0x00000004	// 16
-#define M_Q1            0x00000002	// 16
-#define M_Q0            0x00000001	// 16
+#define M_Q31 0x80000000 //
+#define M_Q30 0x40000000 //
+#define M_Q29 0x20000000 //
+#define M_Q28 0x10000000 //
+#define M_Q27 0x08000000 //
+#define M_Q26 0x04000000 //
+#define M_Q25 0x02000000 //
+#define M_Q24 0x01000000 //
+#define M_Q23 0x00800000 //
+#define M_Q22 0x00400000 //
+#define M_Q21 0x00200000 // undsoweiter
+#define M_Q20 0x00100000 // 1048576
+#define M_Q19 0x00080000 // 524288
+#define M_Q18 0x00040000 // 262144
+#define M_Q17 0x00020000 // 131072
+#define M_Q16 0x00010000 // 65536
+#define M_Q15 0x00008000 // 32768
+#define M_Q14 0x00004000 // 16384
+#define M_Q13 0x00002000 // 8182
+#define M_Q12 0x00001000 // 4096
+#define M_Q11 0x00000800 // 2048
+#define M_Q10 0x00000400 // 1024
+#define M_Q9 0x00000200	 // 512
+#define M_Q8 0x00000100	 // 256
+#define M_Q7 0x00000080	 // 128
+#define M_Q6 0x00000040	 // 64
+#define M_Q5 0x00000020	 // 32
+#define M_Q4 0x00000010	 // 16
+#define M_Q3 0x00000008	 // 16
+#define M_Q2 0x00000004	 // 16
+#define M_Q1 0x00000002	 // 16
+#define M_Q0 0x00000001	 // 16
 
-#define RADIANS_PER_CYCLE		(2*M_PI)
+#define RADIANS_PER_CYCLE (2 * M_PI)
 
-#define SAMPLE_RATE_INPUT       48000
-#define SAMPLE_RATE_NETWORK     8000
+#define SAMPLE_RATE_INPUT 48000
+#define SAMPLE_RATE_NETWORK 8000
 
-#define SAMPLES_PER_BLOCK       160
-#define MS_PER_FRAME            20
-#define SAMPLES_PER_MS          8
+#define SAMPLES_PER_BLOCK 160
+#define MS_PER_FRAME 20
+#define SAMPLES_PER_MS 8
 
-#define RXSQDELAYBUFSIZE		4096
+#define RXSQDELAYBUFSIZE 4096
 
-#define CTCSS_NULL              -1
-#define CTCSS_RXONLY            -2
-#define CTCSS_NUM_CODES			38	// 0 - 37
-#define CTCSS_SCOUNT_MUL		100
-#define CTCSS_INTEGRATE	  		3932	// 32767*.120 // 120/1000  // 0.120
-#define CTCSS_INPUT_LIMIT	  	1000
-#define CTCSS_DETECT_POINT	  	1989
-#define CTCSS_HYSTERSIS	  	    200
+#define CTCSS_NULL -1
+#define CTCSS_RXONLY -2
+#define CTCSS_NUM_CODES 38 // 0 - 37
+#define CTCSS_SCOUNT_MUL 100
+#define CTCSS_INTEGRATE 3932 // 32767*.120 // 120/1000  // 0.120
+#define CTCSS_INPUT_LIMIT 1000
+#define CTCSS_DETECT_POINT 1989
+#define CTCSS_HYSTERSIS 200
 
-#define CTCSS_TURN_OFF_TIME		160	// ms
-#define CTCSS_TURN_OFF_SHIFT    240	// degrees
-#define TOC_NOTONE_TIME			600	// ms
+#define CTCSS_TURN_OFF_TIME 160	 // ms
+#define CTCSS_TURN_OFF_SHIFT 240 // degrees
+#define TOC_NOTONE_TIME 600		 // ms
 
-#define	DDB_FRAME_SIZE			160	// clock de-drift defaults
-#define DDB_FRAMES_IN_BUFF		8
-#define DDB_ERR_MODULUS 		10000
+#define DDB_FRAME_SIZE 160 // clock de-drift defaults
+#define DDB_FRAMES_IN_BUFF 8
+#define DDB_ERR_MODULUS 10000
 
-#define DCS_TURN_OFF_TIME       180
+#define DCS_TURN_OFF_TIME 180
 
-#define	NUM_TXLSD_FRAMEBUFFERS	4
+#define NUM_TXLSD_FRAMEBUFFERS 4
 
-#define CHAN_TXSTATE_IDLE		0
-#define CHAN_TXSTATE_ACTIVE		1
-#define CHAN_TXSTATE_TOC		2
-#define CHAN_TXSTATE_HANGING    3
-#define CHAN_TXSTATE_FINISHING  4
-#define CHAN_TXSTATE_COMPLETE	5
-#define CHAN_TXSTATE_USURPED	9
+#define CHAN_TXSTATE_IDLE 0
+#define CHAN_TXSTATE_ACTIVE 1
+#define CHAN_TXSTATE_TOC 2
+#define CHAN_TXSTATE_HANGING 3
+#define CHAN_TXSTATE_FINISHING 4
+#define CHAN_TXSTATE_COMPLETE 5
+#define CHAN_TXSTATE_USURPED 9
 
-#define SMODE_NULL				0
-#define SMODE_CARRIER			1
-#define SMODE_CTCSS				2
-#define SMODE_DCS       		3
-#define SMODE_LSD				4
-#define SMODE_MPT				5
-#define SMODE_DST				6
-#define SMODE_P25				7
-#define SMODE_MDC				8
+#define SMODE_NULL 0
+#define SMODE_CARRIER 1
+#define SMODE_CTCSS 2
+#define SMODE_DCS 3
+#define SMODE_LSD 4
+#define SMODE_MPT 5
+#define SMODE_DST 6
+#define SMODE_P25 7
+#define SMODE_MDC 8
 
-#define SPS_OPT_START			1
-#define SPS_OPT_STOP			2
-#define SPS_OPT_TURNOFF         3
-#define SPS_OPT_STOPNOW			4
+#define SPS_OPT_START 1
+#define SPS_OPT_STOP 2
+#define SPS_OPT_TURNOFF 3
+#define SPS_OPT_STOPNOW 4
 
-#define SPS_STAT_STOPPED		0
-#define SPS_STAT_STARTING		1
-#define SPS_STAT_RUNNING		2
-#define SPS_STAT_HALTING		3
+#define SPS_STAT_STOPPED 0
+#define SPS_STAT_STARTING 1
+#define SPS_STAT_RUNNING 2
+#define SPS_STAT_HALTING 3
 
-#define PP_BIT_TEST		6
-#define PP_REG_LEN		32
-#define PP_BIT_TIME		100000
+#define PP_BIT_TEST 6
+#define PP_REG_LEN 32
+#define PP_BIT_TIME 100000
 
-#define DTX_CLK 	LP_PIN02
-#define DTX_DATA 	LP_PIN03
-#define DTX_ENABLE 	LP_PIN04
-#define DTX_TX 	    LP_PIN05	// only used on older mods
-#define DTX_TXPWR 	LP_PIN06	// not used
-#define DTX_TP1 	LP_PIN07	// not used
-#define DTX_TP2 	LP_PIN08	// not used
+#define DTX_CLK LP_PIN02
+#define DTX_DATA LP_PIN03
+#define DTX_ENABLE LP_PIN04
+#define DTX_TX LP_PIN05	   // only used on older mods
+#define DTX_TXPWR LP_PIN06 // not used
+#define DTX_TP1 LP_PIN07   // not used
+#define DTX_TP2 LP_PIN08   // not used
 
 #define BIN_PROG_0 LP_PIN06
 #define BIN_PROG_1 LP_PIN07
@@ -303,13 +311,13 @@ typedef struct {
 	i16 trace[16];
 	i16 scale[16];
 	i16 offset[16];
-	i16 buffer[16 * SAMPLES_PER_BLOCK];	// allocate for rx and tx
+	i16 buffer[16 * SAMPLES_PER_BLOCK]; // allocate for rx and tx
 	i16 *source[16];
 } t_sdbg;
 
 typedef struct {
 	i16 lock;
-	i16 option;					// 1 = data in, 0 = data out
+	i16 option; // 1 = data in, 0 = data out
 	i16 debug;
 	i16 debugcnt;
 	i32 rxframecnt;
@@ -331,7 +339,7 @@ typedef struct {
 	i16 err;
 	i16 accum;
 
-	i16 *ptr;					// source or destination
+	i16 *ptr; // source or destination
 	i16 *buff;
 
 	i16 inputcnt;
@@ -350,17 +358,17 @@ typedef struct {
 } t_dedrift;
 
 /*
-	one structure for each ctcss tone to decode 
+	one structure for each ctcss tone to decode
 */
 typedef struct {
-	i16 counter;				// counter to next sample
-	i16 counterFactor;			// full divisor used to increment counter
+	i16 counter;	   // counter to next sample
+	i16 counterFactor; // full divisor used to increment counter
 	i16 binFactor;
 	i16 fudgeFactor;
-	i16 peak;					// peak amplitude now   maw sph now
+	i16 peak; // peak amplitude now   maw sph now
 	i16 enabled;
-	i16 state;					// dead, running, error              
-	i16 zIndex;					// z bucket index
+	i16 state;	// dead, running, error
+	i16 zIndex; // z bucket index
 	i16 z[4];
 	i16 zi;
 	i16 dvu;
@@ -378,20 +386,20 @@ typedef struct {
 	i16 lasttv2;
 	i16 lasttv3;
 
-	i16 *pDebug0;				// pointer to debug output
-	i16 *pDebug1;				// pointer to debug output
-	i16 *pDebug2;				// pointer to debug output
-	i16 *pDebug3;				// pointer to debug output
+	i16 *pDebug0; // pointer to debug output
+	i16 *pDebug1; // pointer to debug output
+	i16 *pDebug2; // pointer to debug output
+	i16 *pDebug3; // pointer to debug output
 #endif
 
 } t_tdet;
 
 typedef struct {
-	i16 enabled;				// if 0 none, 0xFFFF all tones, or single tone
-	i16 *input;					// source data
+	i16 enabled; // if 0 none, 0xFFFF all tones, or single tone
+	i16 *input;	 // source data
 	i16 clamplitude;
 	i16 center;
-	i16 decode;					// current ctcss decode index
+	i16 decode; // current ctcss decode index
 	i32 BlankingTimer;
 	u32 TurnOffTimer;
 	i16 gain;
@@ -408,7 +416,7 @@ typedef struct {
 
 	i8 numrxcodes;
 	i16 rxCtcssMap[CTCSS_NUM_CODES];
-	char *rxctcss[CTCSS_NUM_CODES];	// pointers to each tone in string above
+	char *rxctcss[CTCSS_NUM_CODES]; // pointers to each tone in string above
 	char *txctcss[CTCSS_NUM_CODES];
 
 	i32 txctcssdefault_index;
@@ -422,66 +430,66 @@ typedef struct {
 /*
 	Low Speed Data
 */
-/* 
-	general purpose pmr signal processing element 
+/*
+	general purpose pmr signal processing element
 */
 
 struct t_pmr_chan;
 
 typedef struct t_pmr_sps {
-	i16 index;					// unique to each instance
+	i16 index; // unique to each instance
 
-	i16 enabled;				// enabled/disabled
+	i16 enabled; // enabled/disabled
 
 	struct t_pmr_chan *parentChan;
-	i16 *source;				// source buffer
-	i16 *sourceB;				// source buffer B
-	i16 *sink;					// sink buffer
+	i16 *source;  // source buffer
+	i16 *sourceB; // source buffer B
+	i16 *sink;	  // sink buffer
 
-	i16 numChanOut;				// allows output direct to interleaved buffer
+	i16 numChanOut; // allows output direct to interleaved buffer
 	i16 selChanOut;
 
 	i32 ticks;
 	i32 timer;
 	i32 count;
 
-	void *buff;					// this structure's internal buffer
+	void *buff; // this structure's internal buffer
 
-	i16 *debugBuff0;			// debug buffer
-	i16 *debugBuff1;			// debug buffer
-	i16 *debugBuff2;			// debug buffer
-	i16 *debugBuff3;			// debug buffer
+	i16 *debugBuff0; // debug buffer
+	i16 *debugBuff1; // debug buffer
+	i16 *debugBuff2; // debug buffer
+	i16 *debugBuff3; // debug buffer
 
-	i16 nSamples;				// number of samples in the buffer
+	i16 nSamples; // number of samples in the buffer
 
-	u32 buffSize;				// buffer maximum index
-	u32 buffInIndex;			// index to current input point
-	u32 buffOutIndex;			// index to current output point
-	u32 buffLead;				// lead of input over output through cb
+	u32 buffSize;	  // buffer maximum index
+	u32 buffInIndex;  // index to current input point
+	u32 buffOutIndex; // index to current output point
+	u32 buffLead;	  // lead of input over output through cb
 
-	i16 decimate;				// decimation or interpolation factor (could be put in coef's)
+	i16 decimate; // decimation or interpolation factor (could be put in coef's)
 	i16 interpolate;
-	i16 decimator;				// like the state this must be saved between calls (could be put in x's)
+	i16 decimator; // like the state this must be saved between calls (could be put in x's)
 
-	u32 sampleRate;				// in Hz for elements in this structure
-	u32 freq;					// in 0.1 Hz
+	u32 sampleRate; // in Hz for elements in this structure
+	u32 freq;		// in 0.1 Hz
 
-	i16 measPeak;				// do measure Peak
-	i16 amax;					// buffer amplitude maximum
-	i16 amin;					// buffer amplitude minimum
-	i16 apeak;					// buffer amplitude peak value (peak to peak)/2
-	i16 setpt;					// amplitude set point for amplitude comparator
-	i16 hyst;					// hysterysis for amplitude comparator
-	i16 compOut;				// amplitude comparator output
-	i16 blanking;				// blanking timer in frames
+	i16 measPeak; // do measure Peak
+	i16 amax;	  // buffer amplitude maximum
+	i16 amin;	  // buffer amplitude minimum
+	i16 apeak;	  // buffer amplitude peak value (peak to peak)/2
+	i16 setpt;	  // amplitude set point for amplitude comparator
+	i16 hyst;	  // hysterysis for amplitude comparator
+	i16 compOut;  // amplitude comparator output
+	i16 blanking; // blanking timer in frames
 
-	i32 discounteru;			// amplitude detector integrator discharge counter upper
-	i32 discounterl;			// amplitude detector integrator discharge counter lower
-	i32 discfactor;				// amplitude detector integrator discharge factor
+	i32 discounteru; // amplitude detector integrator discharge counter upper
+	i32 discounterl; // amplitude detector integrator discharge counter lower
+	i32 discfactor;	 // amplitude detector integrator discharge factor
 
-	i16 err;					// error condition
-	i16 option;					// option / request zero
-	i16 state;					// stopped, start, stopped assumes zero'd
+	i16 err;	// error condition
+	i16 option; // option / request zero
+	i16 state;	// stopped, start, stopped assumes zero'd
 
 	i16 pending;
 
@@ -508,70 +516,71 @@ typedef struct t_pmr_sps {
 		unsigned mute:1;
 	} b;
 
-	i16 cleared;				// output buffer cleared
+	i16 cleared; // output buffer cleared
 
 	i16 delay;
 	i16 decode;
 
-	i32 inputGain;				// apply to input data   ? in Q7.8 format
-	i32 inputGainB;				// apply to input data   ? in Q7.8 format
-	i32 outputGain;				// apply to output data  ? in Q7.8 format
+	i32 inputGain;	// apply to input data   ? in Q7.8 format
+	i32 inputGainB; // apply to input data   ? in Q7.8 format
+	i32 outputGain; // apply to output data  ? in Q7.8 format
 	i16 mixOut;
 	i16 monoOut;
 
-	i16 filterType;				// iir, fir, 1, 2, 3, 4 ...
+	i16 filterType; // iir, fir, 1, 2, 3, 4 ...
 
-	 i16(*sigProc) (struct t_pmr_sps * sps);	// function to call
+	i16 (*sigProc)(struct t_pmr_sps *sps); // function to call
 
-	i32 calcAdjust;				// final adjustment
-	i16 nx;						// number of x history elements
-	i16 ncoef;					// number of coefficients
-	i16 size_x;					// size of each x history element
-	i16 size_coef;				// size of each coefficient
-	void *x;					// history registers
-	void *x2;					// history registers, 2nd bank 
+	i32 calcAdjust; // final adjustment
+	i16 nx;			// number of x history elements
+	i16 ncoef;		// number of coefficients
+	i16 size_x;		// size of each x history element
+	i16 size_coef;	// size of each coefficient
+	void *x;		// history registers
+	void *x2;		// history registers, 2nd bank
 	void *coef;
 
-	void *y;					// history registers, y bank 
+	void *y; // history registers, y bank
 	void *coefa;
 	void *coefb;
 
-	void *nextSps;				// next Sps function
+	void *nextSps; // next Sps function
 
 } t_pmr_sps;
 
 struct t_dec_dcs;
 struct t_lsd_control;
-struct t_decLsd;;
+struct t_decLsd;
+;
 struct t_encLsd;
 
 /*
 	pmr channel
 */
 typedef struct t_pmr_chan {
-	i16 index;					// which one
-	i16 devicenum;				// belongs to
+	i16 index;	   // which one
+	i16 devicenum; // belongs to
 
 	char *name;
 
-	i16 enabled;				// enabled/disabled
-	i16 status;					// ok, error, busy, idle, initializing
+	i16 enabled; // enabled/disabled
+	i16 status;	 // ok, error, busy, idle, initializing
 
 	i16 tracelevel;
 	i16 tracetype;
 	u32 tracemask;
 
-	i16 nSamplesRx;				// max frame size
+	i16 nSamplesRx; // max frame size
 	i16 nSamplesTx;
 
-	i32 inputSampleRate;		// in S/s  48000
-	i32 baseSampleRate;			// in S/s   8000 
+	i32 inputSampleRate; // in S/s  48000
+	i32 baseSampleRate;	 // in S/s   8000
 
 	i16 inputGain;
 	i16 inputOffset;
 
-	i32 ticks;					// time ticks
-	u32 frameCountRx;			// number processed
+	i32 ticks;		  // time ticks
+	u32 frameCountRx; // number processed
 	u32 frameCountTx;
 
 	i8 txframelock;
@@ -585,23 +594,23 @@ typedef struct t_pmr_chan {
 	u32 rxfreq;
 	i8 txpower;
 
-	i32 txsettletime;			/* in samples */
+	i32 txsettletime; /* in samples */
 	i32 txsettletimer;
 
-	i16 txrxblankingtime;		/* in milli-seconds */
+	i16 txrxblankingtime; /* in milli-seconds */
 	i16 txrxblankingtimer;
 
-	i16 rxDC;					/* average DC value of input */
-	i16 rxSqSet;				/* carrier squelch threshold */
-	i16 rxSqHyst;				/* carrier squelch hysterysis */
-	i16 rxRssi;					/* current Rssi level */
-	i16 rxQuality;				/* signal quality metric */
-	i16 rxCarrierDetect;		/* carrier detect */
+	i16 rxDC;			 /* average DC value of input */
+	i16 rxSqSet;		 /* carrier squelch threshold */
+	i16 rxSqHyst;		 /* carrier squelch hysterysis */
+	i16 rxRssi;			 /* current Rssi level */
+	i16 rxQuality;		 /* signal quality metric */
+	i16 rxCarrierDetect; /* carrier detect */
 	enum radio_carrier_detect rxCdType;
-	i16 voxHangTime;			/* if rxCdType=CD_XPMR_VOX, time to wait for RX audio before setting CD=0 */
+	i16 voxHangTime; /* if rxCdType=CD_XPMR_VOX, time to wait for RX audio before setting CD=0 */
 	i16 rxSqVoxAdj;
 	i16 rxExtCarrierDetect;
-	i32 inputBlanking;			/* Tx pulse eliminator */
+	i32 inputBlanking; /* Tx pulse eliminator */
 
 	enum radio_rx_audio rxDemod;
 	i16 txMod;
@@ -629,28 +638,28 @@ typedef struct t_pmr_chan {
 	char *pStr;
 
 	//      start channel signaling codes source
-	char *pRxCodeSrc;			// source
-	char *pTxCodeSrc;			// source
-	char *pTxCodeDefault;		// source
+	char *pRxCodeSrc;	  // source
+	char *pTxCodeSrc;	  // source
+	char *pTxCodeDefault; // source
 	//      end channel signaling codes source
 
 	//      start signaling code info derived from source
 	i16 numrxcodes;
 	i16 numtxcodes;
-	char *pRxCodeStr;			// copied and cut up
-	char **pRxCode;				// pointers to subs
+	char *pRxCodeStr; // copied and cut up
+	char **pRxCode;	  // pointers to subs
 	char *pTxCodeStr;
 	char **pTxCode;
 
-	char txctcssdefault[16];	// codes from higher level
+	char txctcssdefault[16]; // codes from higher level
 
-	char *rxctcssfreqs;			// rest are derived from this 
+	char *rxctcssfreqs; // rest are derived from this
 	char *txctcssfreqs;
 
 	char numrxctcssfreqs;
 	char numtxctcssfreqs;
 
-	char *rxctcss[CTCSS_NUM_CODES];	// pointers to each tone in string above
+	char *rxctcss[CTCSS_NUM_CODES]; // pointers to each tone in string above
 	char *txctcss[CTCSS_NUM_CODES];
 
 	i16 rxCtcssMap[CTCSS_NUM_CODES];
@@ -659,8 +668,8 @@ typedef struct t_pmr_chan {
 	i16 txctcssdefault_index;
 	float txctcssdefault_value;
 
-	char txctcssfreq[32];		// encode now for upper layers
-	char rxctcssfreq[32];		// decode now
+	char txctcssfreq[32]; // encode now for upper layers
+	char rxctcssfreq[32]; // decode now
 	//      end most of signaling code info derived from source
 
 	struct t_lsd_control *pLsdCtl;
@@ -691,7 +700,7 @@ typedef struct t_pmr_chan {
 	i16 rxCpuSaver;
 	i16 txCpuSaver;
 
-	i8 rxSqMode;				// 0 open, 1 carrier, 2 coded
+	i8 rxSqMode; // 0 open, 1 carrier, 2 coded
 
 	i8 cdMethod;
 
@@ -704,11 +713,11 @@ typedef struct t_pmr_chan {
 	i16 txCtcssTocTime;
 	i8 txTocType;
 
-	i16 smode;					// ctcss, dcs, lsd
+	i16 smode; // ctcss, dcs, lsd
 	i16 smodecode;
-	i16 smodewas;				// ctcss, dcs, lsd
-	i32 smodetimer;				// in ms
-	i32 smodetime;				// to set in ms
+	i16 smodewas;	// ctcss, dcs, lsd
+	i32 smodetimer; // in ms
+	i32 smodetime;	// to set in ms
 
 	t_dec_ctcss *rxCtcss;
 	struct t_dec_dcs *decDcs;
@@ -718,63 +727,63 @@ typedef struct t_pmr_chan {
 	i16 clamplitudeDcs;
 	i16 centerDcs;
 	u32 dcsBlankingTimer;
-	i16 dcsDecode;				// current dcs decode value
+	i16 dcsDecode; // current dcs decode value
 
 	i16 clamplitudeLsd;
 	i16 centerLsd;
 
-	i16 txPttIn;				// from external request
-	i16 txPttOut;				// to radio hardware
+	i16 txPttIn;  // from external request
+	i16 txPttOut; // to radio hardware
 	i16 txPttHid;
 
-	i16 bandwidth;				// wide/narrow
-	i16 txCompand;				// type
-	i16 rxCompand;				// 
+	i16 bandwidth; // wide/narrow
+	i16 txCompand; // type
+	i16 rxCompand; //
 
-	i16 txEqRight;				// muted, flat, pre-emp limited filtered
+	i16 txEqRight; // muted, flat, pre-emp limited filtered
 	i16 txEqLeft;
 
-	i16 txPotRight;				// 
-	i16 txPotLeft;				//
+	i16 txPotRight; //
+	i16 txPotLeft;	//
 
-	i16 rxPotRight;				// 
-	i16 rxPotLeft;				//
+	i16 rxPotRight; //
+	i16 rxPotLeft;	//
 
 	i16 function;
 
-	i16 txState;				// off,settling,on,hangtime,turnoff
+	i16 txState; // off,settling,on,hangtime,turnoff
 
 	i16 spsIndex;
 
 	i16 lastrxdecode;
 
-	t_pmr_sps *spsMeasure;		// measurement block
+	t_pmr_sps *spsMeasure; // measurement block
 
-	t_pmr_sps *spsRx;			// 1st signal processing struct
+	t_pmr_sps *spsRx; // 1st signal processing struct
 	t_pmr_sps *spsRxLsd;
 	t_pmr_sps *spsRxLsdNrz;
 	t_pmr_sps *spsRxDeEmp;
 	t_pmr_sps *spsRxHpf;
 	t_pmr_sps *spsRxVox;
-	t_pmr_sps *spsDelayLine;	// Last signal processing struct
+	t_pmr_sps *spsDelayLine; // Last signal processing struct
 	t_pmr_sps *spsRxSquelchDelay;
-	t_pmr_sps *spsRxOut;		// Last signal processing struct
+	t_pmr_sps *spsRxOut; // Last signal processing struct
 
-	t_pmr_sps *spsTx;			// 1st  signal processing struct
+	t_pmr_sps *spsTx; // 1st  signal processing struct
 
-	t_pmr_sps *spsTxOutA;		// Last signal processing struct
-	t_pmr_sps *spsTxOutB;		// Last signal processing struct
+	t_pmr_sps *spsTxOutA; // Last signal processing struct
+	t_pmr_sps *spsTxOutB; // Last signal processing struct
 
-	t_pmr_sps *spsSigGen0;		// ctcss
-	t_pmr_sps *spsSigGen1;		// test and other tones
+	t_pmr_sps *spsSigGen0; // ctcss
+	t_pmr_sps *spsSigGen1; // test and other tones
 	t_pmr_sps *spsLsdGen;
 	t_pmr_sps *spsTxLsdLpf;
 
-	t_pmr_sps *spsLimiterTx;	// Pointer to limiter signal processing struct
+	t_pmr_sps *spsLimiterTx; // Pointer to limiter signal processing struct
 
 	// tune tweaks
 
-	i32 rxVoxTimer;				// Vox Hang Timer
+	i32 rxVoxTimer; // Vox Hang Timer
 
 	i16 *prxSquelchAdjust;
 
@@ -787,10 +796,10 @@ typedef struct t_pmr_chan {
 	i16 *prxCtcssMeasure;
 	i32 *prxCtcssAdjust;
 
-	i16 *ptxVoiceAdjust;		// from calling application
-	i32 *ptxCtcssAdjust;		// from calling application
+	i16 *ptxVoiceAdjust; // from calling application
+	i32 *ptxCtcssAdjust; // from calling application
 
-	i32 *ptxLimiterAdjust;		// from calling application
+	i32 *ptxLimiterAdjust; // from calling application
 
 	struct {
 		unsigned pmrNoiseSquelch:1;
@@ -847,31 +856,31 @@ typedef struct t_pmr_chan {
 		unsigned txboost:1;
 	} b;
 
-	i16 *pRxDemod;				// buffers
-	i16 *pRxBase;				// decimated lpf input
+	i16 *pRxDemod; // buffers
+	i16 *pRxBase;  // decimated lpf input
 	i16 *pRxNoise;
-	i16 *pRxLsd;				// subaudible only 
-	i16 *pRxHpf;				// subaudible removed
-	i16 *pRxDeEmp;				// EIA Audio
-	i16 *pRxSpeaker;			// EIA Audio
-	i16 *pRxDcTrack;			// DC Restored LSD
-	i16 *pRxLsdLimit;			// LSD Limited
-	i16 *pRxCtcss;				//
+	i16 *pRxLsd;	  // subaudible only
+	i16 *pRxHpf;	  // subaudible removed
+	i16 *pRxDeEmp;	  // EIA Audio
+	i16 *pRxSpeaker;  // EIA Audio
+	i16 *pRxDcTrack;  // DC Restored LSD
+	i16 *pRxLsdLimit; // LSD Limited
+	i16 *pRxCtcss;	  //
 	i16 *pRxSquelch;
 	i16 *prxVoxMeas;
 	i16 *prxMeasure;
 
-	i16 *pTxInput;				// input data
-	i16 *pTxBase;				// input data
+	i16 *pTxInput; // input data
+	i16 *pTxBase;  // input data
 	i16 *pTxHpf;
 	i16 *pTxPreEmp;
 	i16 *pTxLimiter;
 	i16 *pTxLsd;
 	i16 *pTxLsdLpf;
 	i16 *pTxComposite;
-	i16 *pTxMod;				// upsampled, low pass filtered
+	i16 *pTxMod; // upsampled, low pass filtered
 
-	i16 *pTxOut;				// 
+	i16 *pTxOut; //
 
 	i16 *pSigGen0;
 	i16 *pSigGen1;
@@ -887,8 +896,8 @@ typedef struct t_pmr_chan {
 
 	i16 *pTstTxOut;
 
-	i16 *prxDebug;				// consolidated debug buffer
-	i16 *ptxDebug;				// consolidated debug buffer
+	i16 *prxDebug; // consolidated debug buffer
+	i16 *ptxDebug; // consolidated debug buffer
 
 	i16 *prxDebug0;
 	i16 *prxDebug1;
@@ -914,49 +923,49 @@ typedef struct t_pmr_chan {
 /*
 	function prototype declarations
 */
-void strace(i16 point, t_sdbg * sdbg, i16 index, i16 value);
-void strace2(t_sdbg * sdbg);
+void strace(i16 point, t_sdbg *sdbg, i16 index, i16 value);
+void strace2(t_sdbg *sdbg);
 
-t_pmr_chan *createPmrChannel(t_pmr_chan * tChan, i16 numSamples);
-t_pmr_sps *createPmrSps(t_pmr_chan * pChan);
-i16 destroyPmrChannel(t_pmr_chan * pChan);
-i16 destroyPmrSps(t_pmr_sps * pSps);
-i16 pmr_rx_frontend(t_pmr_sps * mySps);
-i16 pmr_gp_fir(t_pmr_sps * mySps);
-i16 pmr_gp_iir(t_pmr_sps * mySps);
-i16 gp_inte_00(t_pmr_sps * mySps);
-i16 gp_diff(t_pmr_sps * mySps);
-i16 CenterSlicer(t_pmr_sps * mySps);
-i16 ctcss_detect(t_pmr_chan * pmrChan);
-i16 SoftLimiter(t_pmr_sps * mySps);
-i16 SigGen(t_pmr_sps * mySps);
-i16 pmrMixer(t_pmr_sps * mySps);
-i16 DelayLine(t_pmr_sps * mySps);
+t_pmr_chan *createPmrChannel(t_pmr_chan *tChan, i16 numSamples);
+t_pmr_sps *createPmrSps(t_pmr_chan *pChan);
+i16 destroyPmrChannel(t_pmr_chan *pChan);
+i16 destroyPmrSps(t_pmr_sps *pSps);
+i16 pmr_rx_frontend(t_pmr_sps *mySps);
+i16 pmr_gp_fir(t_pmr_sps *mySps);
+i16 pmr_gp_iir(t_pmr_sps *mySps);
+i16 gp_inte_00(t_pmr_sps *mySps);
+i16 gp_diff(t_pmr_sps *mySps);
+i16 CenterSlicer(t_pmr_sps *mySps);
+i16 ctcss_detect(t_pmr_chan *pmrChan);
+i16 SoftLimiter(t_pmr_sps *mySps);
+i16 SigGen(t_pmr_sps *mySps);
+i16 pmrMixer(t_pmr_sps *mySps);
+i16 DelayLine(t_pmr_sps *mySps);
 
-i16 PmrRx(t_pmr_chan * PmrChan, i16 * input, i16 * outputrx, i16 * outputtx);
-i16 PmrTx(t_pmr_chan * PmrChan, i16 * input);
+i16 PmrRx(t_pmr_chan *PmrChan, i16 *input, i16 *outputrx, i16 *outputtx);
+i16 PmrTx(t_pmr_chan *PmrChan, i16 *input);
 
 i16 string_parse(char *src, char **dest, char ***ptrs);
-i16 code_string_parse(t_pmr_chan * pChan);
+i16 code_string_parse(t_pmr_chan *pChan);
 
 i16 CtcssFreqIndex(float freq);
-i16 MeasureBlock(t_pmr_sps * mySps);
+i16 MeasureBlock(t_pmr_sps *mySps);
 
-void dedrift(t_pmr_chan * pChan);
-void dedrift_write(t_pmr_chan * pChan, i16 * src);
+void dedrift(t_pmr_chan *pChan);
+void dedrift_write(t_pmr_chan *pChan, i16 *src);
 
 void ppspiout(u32 spidata);
-void progdtx(t_pmr_chan * pChan);
+void progdtx(t_pmr_chan *pChan);
 void ppbinout(u8 chan);
 
-i16 TxTestTone(t_pmr_chan * pChan, i16 function);
-i16 SetTxSoftLimiterSetpoint(t_pmr_chan * pChan, i16 setpoint);
+i16 TxTestTone(t_pmr_chan *pChan, i16 function);
+i16 SetTxSoftLimiterSetpoint(t_pmr_chan *pChan, i16 setpoint);
 
 #if XPMR_PPTP == 1
 void pptp_init(void);
 void pptp_write(i16 bit, i16 state);
 #endif
 
-#endif							/* ! XPMR_H */
+#endif /* ! XPMR_H */
 
 /* end of file */

--- a/channels/xpmr/xpmr.h
+++ b/channels/xpmr/xpmr.h
@@ -37,7 +37,7 @@
 #ifndef  XPMR_H
 #define  XPMR_H					1
 
-#define  XPMR_DEV   			0 			// when running in test mode
+#define  XPMR_DEV   			0	// when running in test mode
 
 #define  XPMR_TRACE_OVFLW   	0
 #define  XPMR_TRACE_FRONTEND	0
@@ -45,11 +45,11 @@
 #define  XPMR_TRACE_LEVEL		0
 
 #ifdef	 RADIO_RTX
-#define	 DTX_PROG				1			// rf transceiver module
-#define  XPMR_PPTP				0 			// parallel port test probe
+#define	 DTX_PROG				1	// rf transceiver module
+#define  XPMR_PPTP				0	// parallel port test probe
 #else
 #define	 DTX_PROG				0
-#define  XPMR_PPTP				0 			
+#define  XPMR_PPTP				0
 #endif
 
 #if (DTX_PROG == 1) || 	XPMR_PPTP == 1
@@ -66,7 +66,6 @@
 #define TRACEO(level,a)
 #endif
 
-
 #define LSD_DFS			5
 #define LSD_DFD			1
 
@@ -76,7 +75,7 @@
 #else
 #define XPMR_DEBUG_CHANS	0
 #define TSCOPE(a)
-#endif  
+#endif
 
 #define	XPMR_TRACE_AMP		8192
 
@@ -120,38 +119,38 @@
 #define i64 	int64_t
 #define u64 	u_int64_t
 
-#define M_Q31			0x80000000		//
-#define M_Q30			0x40000000		//
-#define M_Q29			0x20000000		//
-#define M_Q28			0x10000000		//
-#define M_Q27			0x08000000		//
-#define M_Q26			0x04000000		//
-#define M_Q25			0x02000000		//			
-#define M_Q24			0x01000000		//
-#define M_Q23			0x00800000		//
-#define M_Q22			0x00400000		//					
-#define M_Q21			0x00200000		// undsoweiter  		
-#define M_Q20			0x00100000		// 1048576
-#define M_Q19			0x00080000		// 524288		   
-#define M_Q18			0x00040000		// 262144
-#define M_Q17           0x00020000		// 131072
-#define M_Q16           0x00010000		// 65536
-#define M_Q15           0x00008000		// 32768
-#define M_Q14           0x00004000		// 16384
-#define M_Q13           0x00002000		// 8182
-#define M_Q12           0x00001000		// 4096
-#define M_Q11           0x00000800		// 2048
-#define M_Q10           0x00000400		// 1024
-#define M_Q9            0x00000200		// 512
-#define M_Q8            0x00000100		// 256
-#define M_Q7            0x00000080		// 128
-#define M_Q6            0x00000040		// 64
-#define M_Q5            0x00000020		// 32
-#define M_Q4            0x00000010		// 16
-#define M_Q3            0x00000008		// 16
-#define M_Q2            0x00000004		// 16
-#define M_Q1            0x00000002		// 16
-#define M_Q0            0x00000001		// 16
+#define M_Q31			0x80000000	//
+#define M_Q30			0x40000000	//
+#define M_Q29			0x20000000	//
+#define M_Q28			0x10000000	//
+#define M_Q27			0x08000000	//
+#define M_Q26			0x04000000	//
+#define M_Q25			0x02000000	//
+#define M_Q24			0x01000000	//
+#define M_Q23			0x00800000	//
+#define M_Q22			0x00400000	//
+#define M_Q21			0x00200000	// undsoweiter
+#define M_Q20			0x00100000	// 1048576
+#define M_Q19			0x00080000	// 524288
+#define M_Q18			0x00040000	// 262144
+#define M_Q17           0x00020000	// 131072
+#define M_Q16           0x00010000	// 65536
+#define M_Q15           0x00008000	// 32768
+#define M_Q14           0x00004000	// 16384
+#define M_Q13           0x00002000	// 8182
+#define M_Q12           0x00001000	// 4096
+#define M_Q11           0x00000800	// 2048
+#define M_Q10           0x00000400	// 1024
+#define M_Q9            0x00000200	// 512
+#define M_Q8            0x00000100	// 256
+#define M_Q7            0x00000080	// 128
+#define M_Q6            0x00000040	// 64
+#define M_Q5            0x00000020	// 32
+#define M_Q4            0x00000010	// 16
+#define M_Q3            0x00000008	// 16
+#define M_Q2            0x00000004	// 16
+#define M_Q1            0x00000002	// 16
+#define M_Q0            0x00000001	// 16
 
 #define RADIANS_PER_CYCLE		(2*M_PI)
 
@@ -166,18 +165,18 @@
 
 #define CTCSS_NULL              -1
 #define CTCSS_RXONLY            -2
-#define CTCSS_NUM_CODES			38 			// 0 - 37
+#define CTCSS_NUM_CODES			38	// 0 - 37
 #define CTCSS_SCOUNT_MUL		100
-#define CTCSS_INTEGRATE	  		3932       // 32767*.120 // 120/1000  // 0.120
+#define CTCSS_INTEGRATE	  		3932	// 32767*.120 // 120/1000  // 0.120
 #define CTCSS_INPUT_LIMIT	  	1000
 #define CTCSS_DETECT_POINT	  	1989
 #define CTCSS_HYSTERSIS	  	    200
 
-#define CTCSS_TURN_OFF_TIME		160			// ms
-#define CTCSS_TURN_OFF_SHIFT    240			// degrees
-#define TOC_NOTONE_TIME			600			// ms
+#define CTCSS_TURN_OFF_TIME		160	// ms
+#define CTCSS_TURN_OFF_SHIFT    240	// degrees
+#define TOC_NOTONE_TIME			600	// ms
 
-#define	DDB_FRAME_SIZE			160		   	// clock de-drift defaults
+#define	DDB_FRAME_SIZE			160	// clock de-drift defaults
 #define DDB_FRAMES_IN_BUFF		8
 #define DDB_ERR_MODULUS 		10000
 
@@ -203,7 +202,6 @@
 #define SMODE_P25				7
 #define SMODE_MDC				8
 
-
 #define SPS_OPT_START			1
 #define SPS_OPT_STOP			2
 #define SPS_OPT_TURNOFF         3
@@ -214,18 +212,17 @@
 #define SPS_STAT_RUNNING		2
 #define SPS_STAT_HALTING		3
 
- 
 #define PP_BIT_TEST		6
 #define PP_REG_LEN		32
 #define PP_BIT_TIME		100000
-					  	
+
 #define DTX_CLK 	LP_PIN02
 #define DTX_DATA 	LP_PIN03
 #define DTX_ENABLE 	LP_PIN04
-#define DTX_TX 	    LP_PIN05		// only used on older mods
-#define DTX_TXPWR 	LP_PIN06		// not used
-#define DTX_TP1 	LP_PIN07		// not used
-#define DTX_TP2 	LP_PIN08		// not used
+#define DTX_TX 	    LP_PIN05	// only used on older mods
+#define DTX_TXPWR 	LP_PIN06	// not used
+#define DTX_TP1 	LP_PIN07	// not used
+#define DTX_TP2 	LP_PIN08	// not used
 
 #define BIN_PROG_0 LP_PIN06
 #define BIN_PROG_1 LP_PIN07
@@ -300,19 +297,17 @@ enum dbg_pts {
 	NUM_DEBUG_PTS
 };
 
-typedef struct
-{
+typedef struct {
 	i16 mode;
-	i16	point[NUM_DEBUG_PTS];
+	i16 point[NUM_DEBUG_PTS];
 	i16 trace[16];
 	i16 scale[16];
 	i16 offset[16];
-	i16 buffer[16 * SAMPLES_PER_BLOCK];  // allocate for rx and tx
+	i16 buffer[16 * SAMPLES_PER_BLOCK];	// allocate for rx and tx
 	i16 *source[16];
 } t_sdbg;
 
-typedef struct
-{
+typedef struct {
 	i16 lock;
 	i16 option;					// 1 = data in, 0 = data out
 	i16 debug;
@@ -327,8 +322,8 @@ typedef struct
 	i16 buffersize;
 
 	i32 timer;
-	
-	i32 x0,x1,y0,y1;
+
+	i32 x0, x1, y0, y1;
 
 	i16 inputindex;
 	i16 outputindex;
@@ -337,38 +332,36 @@ typedef struct
 	i16 accum;
 
 	i16 *ptr;					// source or destination
-	i16	*buff;
-	
+	i16 *buff;
+
 	i16 inputcnt;
 	i16 initcnt;
 
 	i32 factor;
 	i32 drift;
 	i32 modulus;
-	i32	z1;
+	i32 z1;
 	struct {
 		unsigned rxlock:1;
 		unsigned txlock:1;
 		unsigned twiddle:1;
 		unsigned doitnow:1;
-	}b;
-}
-t_dedrift;
+	} b;
+} t_dedrift;
 
 /*
 	one structure for each ctcss tone to decode 
 */
-typedef struct
-{
-	i16 counter;			// counter to next sample
-	i16 counterFactor;		// full divisor used to increment counter
+typedef struct {
+	i16 counter;				// counter to next sample
+	i16 counterFactor;			// full divisor used to increment counter
 	i16 binFactor;
 	i16 fudgeFactor;
-	i16 peak;				// peak amplitude now	maw sph now
+	i16 peak;					// peak amplitude now   maw sph now
 	i16 enabled;
-	i16 state;				// dead, running, error				 
-	i16 zIndex;				// z bucket index
-	i16 z[4];	  			 
+	i16 state;					// dead, running, error              
+	i16 zIndex;					// z bucket index
+	i16 z[4];
 	i16 zi;
 	i16 dvu;
 	i16 dvd;
@@ -377,29 +370,28 @@ typedef struct
 	i16 hyst;
 	i16 decode;
 	i16 diffpeak;
-	i16 debug;				 
+	i16 debug;
 
-	#if XPMR_DEBUG0 == 1
+#if XPMR_DEBUG0 == 1
 	i16 lasttv0;
 	i16 lasttv1;
 	i16 lasttv2;
 	i16 lasttv3;
 
-	i16 *pDebug0;			// pointer to debug output
-	i16 *pDebug1;			// pointer to debug output
-	i16 *pDebug2;			// pointer to debug output
-	i16 *pDebug3;			// pointer to debug output
-	#endif
+	i16 *pDebug0;				// pointer to debug output
+	i16 *pDebug1;				// pointer to debug output
+	i16 *pDebug2;				// pointer to debug output
+	i16 *pDebug3;				// pointer to debug output
+#endif
 
 } t_tdet;
 
-typedef struct
-{
-	i16 enabled;						// if 0 none, 0xFFFF all tones, or single tone
-	i16 *input;							// source data
+typedef struct {
+	i16 enabled;				// if 0 none, 0xFFFF all tones, or single tone
+	i16 *input;					// source data
 	i16 clamplitude;
 	i16 center;
-	i16 decode;		  					// current ctcss decode index
+	i16 decode;					// current ctcss decode index
 	i32 BlankingTimer;
 	u32 TurnOffTimer;
 	i16 gain;
@@ -414,17 +406,17 @@ typedef struct
 	i8 relax;
 	t_tdet tdet[CTCSS_NUM_CODES];
 
-	i8 		numrxcodes;
-	i16 	rxCtcssMap[CTCSS_NUM_CODES];
-	char    *rxctcss[CTCSS_NUM_CODES];		// pointers to each tone in string above
-	char    *txctcss[CTCSS_NUM_CODES];
+	i8 numrxcodes;
+	i16 rxCtcssMap[CTCSS_NUM_CODES];
+	char *rxctcss[CTCSS_NUM_CODES];	// pointers to each tone in string above
+	char *txctcss[CTCSS_NUM_CODES];
 
-	i32		txctcssdefault_index;
-	float 	txctcssdefault_value;
+	i32 txctcssdefault_index;
+	float txctcssdefault_value;
 
-	struct{
+	struct {
 		unsigned valid:1;
-	}b;
+	} b;
 } t_dec_ctcss;
 
 /*
@@ -436,63 +428,62 @@ typedef struct
 
 struct t_pmr_chan;
 
-typedef struct t_pmr_sps
-{
-	i16  index;		  	// unique to each instance
+typedef struct t_pmr_sps {
+	i16 index;					// unique to each instance
 
-	i16  enabled;		// enabled/disabled
+	i16 enabled;				// enabled/disabled
 
-	struct t_pmr_chan *parentChan;	
-	i16  *source;		// source buffer
-	i16  *sourceB;		// source buffer B
-	i16  *sink;			// sink buffer
+	struct t_pmr_chan *parentChan;
+	i16 *source;				// source buffer
+	i16 *sourceB;				// source buffer B
+	i16 *sink;					// sink buffer
 
-	i16  numChanOut;	// allows output direct to interleaved buffer
-	i16  selChanOut;
+	i16 numChanOut;				// allows output direct to interleaved buffer
+	i16 selChanOut;
 
-	i32  ticks;			
-	i32  timer;
-	i32  count;
+	i32 ticks;
+	i32 timer;
+	i32 count;
 
-	void *buff;			// this structure's internal buffer
+	void *buff;					// this structure's internal buffer
 
-	i16  *debugBuff0;	// debug buffer
-	i16  *debugBuff1;	// debug buffer
-	i16  *debugBuff2;	// debug buffer
-	i16  *debugBuff3;	// debug buffer
+	i16 *debugBuff0;			// debug buffer
+	i16 *debugBuff1;			// debug buffer
+	i16 *debugBuff2;			// debug buffer
+	i16 *debugBuff3;			// debug buffer
 
-	i16  nSamples;		// number of samples in the buffer
+	i16 nSamples;				// number of samples in the buffer
 
-	u32	 buffSize;		// buffer maximum index
-	u32  buffInIndex;	// index to current input point
-	u32  buffOutIndex;	// index to current output point
-	u32  buffLead;		// lead of input over output through cb
+	u32 buffSize;				// buffer maximum index
+	u32 buffInIndex;			// index to current input point
+	u32 buffOutIndex;			// index to current output point
+	u32 buffLead;				// lead of input over output through cb
 
-	i16  decimate;		// decimation or interpolation factor (could be put in coef's)
-	i16  interpolate;
-	i16	 decimator;		// like the state this must be saved between calls (could be put in x's)
+	i16 decimate;				// decimation or interpolation factor (could be put in coef's)
+	i16 interpolate;
+	i16 decimator;				// like the state this must be saved between calls (could be put in x's)
 
-	u32  sampleRate;    // in Hz for elements in this structure
-	u32  freq;			// in 0.1 Hz
+	u32 sampleRate;				// in Hz for elements in this structure
+	u32 freq;					// in 0.1 Hz
 
-	i16  measPeak;		// do measure Peak
-	i16  amax;			// buffer amplitude maximum
-	i16  amin;			// buffer amplitude minimum
-	i16  apeak;			// buffer amplitude peak value (peak to peak)/2
-	i16  setpt;			// amplitude set point for amplitude comparator
-	i16  hyst;			// hysterysis for amplitude comparator
-	i16  compOut;		// amplitude comparator output
-	i16  blanking;      // blanking timer in frames
+	i16 measPeak;				// do measure Peak
+	i16 amax;					// buffer amplitude maximum
+	i16 amin;					// buffer amplitude minimum
+	i16 apeak;					// buffer amplitude peak value (peak to peak)/2
+	i16 setpt;					// amplitude set point for amplitude comparator
+	i16 hyst;					// hysterysis for amplitude comparator
+	i16 compOut;				// amplitude comparator output
+	i16 blanking;				// blanking timer in frames
 
-	i32  discounteru;	// amplitude detector integrator discharge counter upper
-	i32  discounterl;	// amplitude detector integrator discharge counter lower
-	i32  discfactor;	// amplitude detector integrator discharge factor
+	i32 discounteru;			// amplitude detector integrator discharge counter upper
+	i32 discounterl;			// amplitude detector integrator discharge counter lower
+	i32 discfactor;				// amplitude detector integrator discharge factor
 
-	i16  err;			// error condition
-	i16  option;		// option / request zero
-	i16  state;         // stopped, start, stopped assumes zero'd
-	
-	i16  pending;
+	i16 err;					// error condition
+	i16 option;					// option / request zero
+	i16 state;					// stopped, start, stopped assumes zero'd
+
+	i16 pending;
 
 	struct {
 		unsigned hit:1;
@@ -515,104 +506,102 @@ typedef struct t_pmr_sps
 		unsigned syncing:1;
 		unsigned dirty:1;
 		unsigned mute:1;
-	}b;
+	} b;
 
-	i16  cleared;		// output buffer cleared
+	i16 cleared;				// output buffer cleared
 
-	i16  delay;
-	i16  decode;
+	i16 delay;
+	i16 decode;
 
-	i32  inputGain;	  	// apply to input data	 ? in Q7.8 format
-	i32  inputGainB;	// apply to input data	 ? in Q7.8 format
-	i32  outputGain;	// apply to output data  ? in Q7.8 format
-	i16  mixOut;
-	i16  monoOut;
+	i32 inputGain;				// apply to input data   ? in Q7.8 format
+	i32 inputGainB;				// apply to input data   ? in Q7.8 format
+	i32 outputGain;				// apply to output data  ? in Q7.8 format
+	i16 mixOut;
+	i16 monoOut;
 
-	i16  filterType;	// iir, fir, 1, 2, 3, 4 ...
+	i16 filterType;				// iir, fir, 1, 2, 3, 4 ...
 
-	i16 (*sigProc)(struct t_pmr_sps *sps);	// function to call
+	 i16(*sigProc) (struct t_pmr_sps * sps);	// function to call
 
-	i32	 calcAdjust;	// final adjustment
-	i16	 nx;	 		// number of x history elements
-	i16  ncoef;			// number of coefficients
-	i16  size_x;		// size of each x history element
-	i16  size_coef;		// size of each coefficient
-	void  *x;			// history registers
-	void  *x2;			// history registers, 2nd bank 
-	void  *coef;
+	i32 calcAdjust;				// final adjustment
+	i16 nx;						// number of x history elements
+	i16 ncoef;					// number of coefficients
+	i16 size_x;					// size of each x history element
+	i16 size_coef;				// size of each coefficient
+	void *x;					// history registers
+	void *x2;					// history registers, 2nd bank 
+	void *coef;
 
-	void  *y;			// history registers, y bank 
- 	void  *coefa;
-	void  *coefb;
+	void *y;					// history registers, y bank 
+	void *coefa;
+	void *coefb;
 
-	void  *nextSps;		// next Sps function
+	void *nextSps;				// next Sps function
 
 } t_pmr_sps;
 
-
 struct t_dec_dcs;
 struct t_lsd_control;
-struct t_decLsd;;	
+struct t_decLsd;;
 struct t_encLsd;
 
 /*
 	pmr channel
 */
-typedef struct	t_pmr_chan
-{
-	i16 index;				// which one
-	i16 devicenum;			// belongs to
+typedef struct t_pmr_chan {
+	i16 index;					// which one
+	i16 devicenum;				// belongs to
 
 	char *name;
 
-	i16 enabled;			// enabled/disabled
-	i16 status;				// ok, error, busy, idle, initializing
-	
-	i16  tracelevel;
-	i16  tracetype;
-	u32  tracemask;
+	i16 enabled;				// enabled/disabled
+	i16 status;					// ok, error, busy, idle, initializing
 
-	i16 nSamplesRx;			// max frame size
+	i16 tracelevel;
+	i16 tracetype;
+	u32 tracemask;
+
+	i16 nSamplesRx;				// max frame size
 	i16 nSamplesTx;
 
-	i32 inputSampleRate;	// in S/s  48000
-	i32 baseSampleRate;		// in S/s   8000 
+	i32 inputSampleRate;		// in S/s  48000
+	i32 baseSampleRate;			// in S/s   8000 
 
 	i16 inputGain;
 	i16 inputOffset;
 
-	i32  ticks;				// time ticks
-	u32  frameCountRx;		// number processed
-	u32  frameCountTx;
+	i32 ticks;					// time ticks
+	u32 frameCountRx;			// number processed
+	u32 frameCountTx;
 
-	i8   txframelock;
+	i8 txframelock;
 
-	i32  txHangTime;
-	i32  txHangTimer;
-	i32  txTurnOff;
-	i16  txBufferClear;
+	i32 txHangTime;
+	i32 txHangTimer;
+	i32 txTurnOff;
+	i16 txBufferClear;
 
 	u32 txfreq;
 	u32 rxfreq;
-	i8  txpower;
+	i8 txpower;
 
-	i32 txsettletime; /* in samples */
+	i32 txsettletime;			/* in samples */
 	i32 txsettletimer;
 
-	i16 txrxblankingtime; /* in milli-seconds */
+	i16 txrxblankingtime;		/* in milli-seconds */
 	i16 txrxblankingtimer;
 
-	i16 rxDC;			 /* average DC value of input */
-	i16 rxSqSet;		 /* carrier squelch threshold */
-	i16 rxSqHyst;		 /* carrier squelch hysterysis */
-	i16 rxRssi;			 /* current Rssi level */
-	i16 rxQuality;		 /* signal quality metric */
-	i16 rxCarrierDetect; /* carrier detect */
+	i16 rxDC;					/* average DC value of input */
+	i16 rxSqSet;				/* carrier squelch threshold */
+	i16 rxSqHyst;				/* carrier squelch hysterysis */
+	i16 rxRssi;					/* current Rssi level */
+	i16 rxQuality;				/* signal quality metric */
+	i16 rxCarrierDetect;		/* carrier detect */
 	enum radio_carrier_detect rxCdType;
-	i16 voxHangTime; /* if rxCdType=CD_XPMR_VOX, time to wait for RX audio before setting CD=0 */
+	i16 voxHangTime;			/* if rxCdType=CD_XPMR_VOX, time to wait for RX audio before setting CD=0 */
 	i16 rxSqVoxAdj;
 	i16 rxExtCarrierDetect;
-	i32 inputBlanking; /* Tx pulse eliminator */
+	i32 inputBlanking;			/* Tx pulse eliminator */
 
 	enum radio_rx_audio rxDemod;
 	i16 txMod;
@@ -632,59 +621,59 @@ typedef struct	t_pmr_chan
 
 	char radioDuplex;
 	char rxNoiseFilType;
-    int	 rxlpf;
-    int	 rxhpf;
-    int	 txlpf;
-    int	 txhpf;
+	int rxlpf;
+	int rxhpf;
+	int txlpf;
+	int txhpf;
 
-	char    *pStr;
+	char *pStr;
 
-	// 		start channel signaling codes source
-	char 	*pRxCodeSrc;					// source
-	char 	*pTxCodeSrc;					// source
-	char 	*pTxCodeDefault;				// source
-	// 		end channel signaling codes source
+	//      start channel signaling codes source
+	char *pRxCodeSrc;			// source
+	char *pTxCodeSrc;			// source
+	char *pTxCodeDefault;		// source
+	//      end channel signaling codes source
 
-	// 		start signaling code info derived from source
-	i16  	numrxcodes;
-	i16  	numtxcodes;
-	char 	*pRxCodeStr;					// copied and cut up
-	char 	**pRxCode;						// pointers to subs
-	char 	*pTxCodeStr;					 
-	char 	**pTxCode;
+	//      start signaling code info derived from source
+	i16 numrxcodes;
+	i16 numtxcodes;
+	char *pRxCodeStr;			// copied and cut up
+	char **pRxCode;				// pointers to subs
+	char *pTxCodeStr;
+	char **pTxCode;
 
-	char 	txctcssdefault[16];				// codes from higher level
+	char txctcssdefault[16];	// codes from higher level
 
-	char	*rxctcssfreqs; 					// rest are derived from this 
-	char    *txctcssfreqs;
-	
-	char    numrxctcssfreqs;
-	char    numtxctcssfreqs;
+	char *rxctcssfreqs;			// rest are derived from this 
+	char *txctcssfreqs;
 
-	char    *rxctcss[CTCSS_NUM_CODES];		// pointers to each tone in string above
-	char    *txctcss[CTCSS_NUM_CODES];
+	char numrxctcssfreqs;
+	char numtxctcssfreqs;
 
-	i16 	rxCtcssMap[CTCSS_NUM_CODES];
+	char *rxctcss[CTCSS_NUM_CODES];	// pointers to each tone in string above
+	char *txctcss[CTCSS_NUM_CODES];
 
-	i8		txcodedefaultsmode;
-	i16		txctcssdefault_index;
-	float 	txctcssdefault_value;
+	i16 rxCtcssMap[CTCSS_NUM_CODES];
 
-	char	txctcssfreq[32];				// encode now for upper layers
-	char    rxctcssfreq[32];				// decode now
-	// 		end most of signaling code info derived from source
+	i8 txcodedefaultsmode;
+	i16 txctcssdefault_index;
+	float txctcssdefault_value;
 
-	struct t_lsd_control	*pLsdCtl;
+	char txctcssfreq[32];		// encode now for upper layers
+	char rxctcssfreq[32];		// decode now
+	//      end most of signaling code info derived from source
 
-	i16  rptnum;
-	i16  area;
+	struct t_lsd_control *pLsdCtl;
+
+	i16 rptnum;
+	i16 area;
 	char *ukey;
-	u32  idleinterval;
+	u32 idleinterval;
 	char turnoffs;
 
 	char pplock;
 
-	t_dedrift	dd;
+	t_dedrift dd;
 
 	i16 dummy;
 
@@ -702,55 +691,54 @@ typedef struct	t_pmr_chan
 	i16 rxCpuSaver;
 	i16 txCpuSaver;
 
-	i8	rxSqMode;			// 0 open, 1 carrier, 2 coded
+	i8 rxSqMode;				// 0 open, 1 carrier, 2 coded
 
-	i8	cdMethod;
+	i8 cdMethod;
 
-	i16	rxSquelchPoint;
+	i16 rxSquelchPoint;
 
 	i16 rxCarrierPoint;
 	i16 rxCarrierHyst;
-	
+
 	i16 txCtcssTocShift;
 	i16 txCtcssTocTime;
-	i8	txTocType;
+	i8 txTocType;
 
-	i16 smode;	  							// ctcss, dcs, lsd
+	i16 smode;					// ctcss, dcs, lsd
 	i16 smodecode;
-	i16 smodewas;	  						// ctcss, dcs, lsd
-	i32 smodetimer;	  						// in ms
-	i32 smodetime;							// to set in ms
+	i16 smodewas;				// ctcss, dcs, lsd
+	i32 smodetimer;				// in ms
+	i32 smodetime;				// to set in ms
 
-	t_dec_ctcss			*rxCtcss;
-	struct t_dec_dcs	*decDcs;
-	struct t_decLsd 	*decLsd;		 				
-	struct t_encLsd		*pLsdEnc;
+	t_dec_ctcss *rxCtcss;
+	struct t_dec_dcs *decDcs;
+	struct t_decLsd *decLsd;
+	struct t_encLsd *pLsdEnc;
 
 	i16 clamplitudeDcs;
 	i16 centerDcs;
 	u32 dcsBlankingTimer;
-	i16 dcsDecode;							// current dcs decode value
+	i16 dcsDecode;				// current dcs decode value
 
 	i16 clamplitudeLsd;
 	i16 centerLsd;
 
-
-	i16 txPttIn;	 		// from external request
-	i16 txPttOut;			// to radio hardware
+	i16 txPttIn;				// from external request
+	i16 txPttOut;				// to radio hardware
 	i16 txPttHid;
 
-	i16 bandwidth;			// wide/narrow
-	i16 txCompand;			// type
-	i16 rxCompand;			// 
-	
-	i16 txEqRight;			// muted, flat, pre-emp limited filtered
+	i16 bandwidth;				// wide/narrow
+	i16 txCompand;				// type
+	i16 rxCompand;				// 
+
+	i16 txEqRight;				// muted, flat, pre-emp limited filtered
 	i16 txEqLeft;
 
-	i16 txPotRight;			// 
-	i16 txPotLeft;			//
+	i16 txPotRight;				// 
+	i16 txPotLeft;				//
 
-	i16 rxPotRight;			// 
-	i16 rxPotLeft;			//
+	i16 rxPotRight;				// 
+	i16 rxPotLeft;				//
 
 	i16 function;
 
@@ -773,7 +761,7 @@ typedef struct	t_pmr_chan
 	t_pmr_sps *spsRxOut;		// Last signal processing struct
 
 	t_pmr_sps *spsTx;			// 1st  signal processing struct
-	
+
 	t_pmr_sps *spsTxOutA;		// Last signal processing struct
 	t_pmr_sps *spsTxOutB;		// Last signal processing struct
 
@@ -781,28 +769,28 @@ typedef struct	t_pmr_chan
 	t_pmr_sps *spsSigGen1;		// test and other tones
 	t_pmr_sps *spsLsdGen;
 	t_pmr_sps *spsTxLsdLpf;
-	
-	t_pmr_sps *limiterSpsTx;    // Pointer to limiter signal processing struct
+
+	t_pmr_sps *limiterSpsTx;	// Pointer to limiter signal processing struct
 
 	// tune tweaks
 
 	i32 rxVoxTimer;				// Vox Hang Timer
 
-	i16	*prxSquelchAdjust;
+	i16 *prxSquelchAdjust;
 
-	// i16	*prxNoiseMeasure;	// for autotune
-	// i32	*prxNoiseAdjust;
+	// i16  *prxNoiseMeasure;   // for autotune
+	// i32  *prxNoiseAdjust;
 
-	i16	*prxVoiceMeasure;
-	i32	*prxVoiceAdjust;	
-	
-	i16	*prxCtcssMeasure;
-	i32	*prxCtcssAdjust;		 
-	
-	i16	*ptxVoiceAdjust;		// from calling application
-	i32	*ptxCtcssAdjust;		// from calling application
+	i16 *prxVoiceMeasure;
+	i32 *prxVoiceAdjust;
 
-	i32	*ptxLimiterAdjust;		// from calling application
+	i16 *prxCtcssMeasure;
+	i32 *prxCtcssAdjust;
+
+	i16 *ptxVoiceAdjust;		// from calling application
+	i32 *ptxCtcssAdjust;		// from calling application
+
+	i32 *ptxLimiterAdjust;		// from calling application
 
 	struct {
 		unsigned pmrNoiseSquelch:1;
@@ -857,20 +845,20 @@ typedef struct	t_pmr_chan
 		unsigned tuning:1;
 		unsigned pttwas:1;
 		unsigned txboost:1;
-	}b;
+	} b;
 
 	i16 *pRxDemod;				// buffers
-	i16 *pRxBase;	 			// decimated lpf input
-	i16 *pRxNoise;   
+	i16 *pRxBase;				// decimated lpf input
+	i16 *pRxNoise;
 	i16 *pRxLsd;				// subaudible only 
 	i16 *pRxHpf;				// subaudible removed
-	i16 *pRxDeEmp;        		// EIA Audio
-	i16 *pRxSpeaker;        	// EIA Audio
+	i16 *pRxDeEmp;				// EIA Audio
+	i16 *pRxSpeaker;			// EIA Audio
 	i16 *pRxDcTrack;			// DC Restored LSD
-	i16 *pRxLsdLimit;         	// LSD Limited
+	i16 *pRxLsdLimit;			// LSD Limited
 	i16 *pRxCtcss;				//
 	i16 *pRxSquelch;
-	i16 *prxVoxMeas;				
+	i16 *prxVoxMeas;
 	i16 *prxMeasure;
 
 	i16 *pTxInput;				// input data
@@ -881,26 +869,26 @@ typedef struct	t_pmr_chan
 	i16 *pTxLsd;
 	i16 *pTxLsdLpf;
 	i16 *pTxComposite;
-	i16 *pTxMod;			// upsampled, low pass filtered
-	
-	i16 *pTxOut;			// 
+	i16 *pTxMod;				// upsampled, low pass filtered
 
-	i16	*pSigGen0;
-	i16	*pSigGen1;
+	i16 *pTxOut;				// 
+
+	i16 *pSigGen0;
+	i16 *pSigGen1;
 
 	i16 *pAlt0;
 	i16 *pAlt1;
 
 	i16 *pNull;
 
-	#if XPMR_DEBUG0 == 1
+#if XPMR_DEBUG0 == 1
 
 	i16 *pRxLsdCen;
 
 	i16 *pTstTxOut;
 
-	i16 *prxDebug;			// consolidated debug buffer
-	i16 *ptxDebug;			// consolidated debug buffer
+	i16 *prxDebug;				// consolidated debug buffer
+	i16 *ptxDebug;				// consolidated debug buffer
 
 	i16 *prxDebug0;
 	i16 *prxDebug1;
@@ -912,11 +900,11 @@ typedef struct	t_pmr_chan
 	i16 *ptxDebug2;
 	i16 *ptxDebug3;
 
-	#endif
+#endif
 
 	i16 numDebugChannels;
 
-	t_sdbg	*sdbg;
+	t_sdbg *sdbg;
 
 	i16 fever;
 	i16 tx_limiter_setpoint;
@@ -926,53 +914,49 @@ typedef struct	t_pmr_chan
 /*
 	function prototype declarations
 */
-void 		strace(i16 point, t_sdbg *sdbg, i16 index, i16 value);
-void 		strace2(t_sdbg *sdbg);
+void strace(i16 point, t_sdbg * sdbg, i16 index, i16 value);
+void strace2(t_sdbg * sdbg);
 
-t_pmr_chan	*createPmrChannel(t_pmr_chan *tChan, i16 numSamples);
-t_pmr_sps 	*createPmrSps(t_pmr_chan *pChan);
-i16			destroyPmrChannel(t_pmr_chan *pChan);
-i16			destroyPmrSps(t_pmr_sps  *pSps);
-i16 		pmr_rx_frontend(t_pmr_sps *mySps);
-i16 		pmr_gp_fir(t_pmr_sps *mySps);
-i16 		pmr_gp_iir(t_pmr_sps *mySps);
-i16 		gp_inte_00(t_pmr_sps *mySps);
-i16 		gp_diff(t_pmr_sps *mySps);
-i16 		CenterSlicer(t_pmr_sps *mySps);
-i16 		ctcss_detect(t_pmr_chan *pmrChan);
-i16 		SoftLimiter(t_pmr_sps *mySps);
-i16			SigGen(t_pmr_sps *mySps);
-i16 		pmrMixer(t_pmr_sps *mySps);
-i16 		DelayLine(t_pmr_sps *mySps);
+t_pmr_chan *createPmrChannel(t_pmr_chan * tChan, i16 numSamples);
+t_pmr_sps *createPmrSps(t_pmr_chan * pChan);
+i16 destroyPmrChannel(t_pmr_chan * pChan);
+i16 destroyPmrSps(t_pmr_sps * pSps);
+i16 pmr_rx_frontend(t_pmr_sps * mySps);
+i16 pmr_gp_fir(t_pmr_sps * mySps);
+i16 pmr_gp_iir(t_pmr_sps * mySps);
+i16 gp_inte_00(t_pmr_sps * mySps);
+i16 gp_diff(t_pmr_sps * mySps);
+i16 CenterSlicer(t_pmr_sps * mySps);
+i16 ctcss_detect(t_pmr_chan * pmrChan);
+i16 SoftLimiter(t_pmr_sps * mySps);
+i16 SigGen(t_pmr_sps * mySps);
+i16 pmrMixer(t_pmr_sps * mySps);
+i16 DelayLine(t_pmr_sps * mySps);
 
-i16			PmrRx(t_pmr_chan *PmrChan, i16 *input, i16 *outputrx, i16 *outputtx );
-i16			PmrTx(t_pmr_chan *PmrChan, i16 *input);
+i16 PmrRx(t_pmr_chan * PmrChan, i16 * input, i16 * outputrx, i16 * outputtx);
+i16 PmrTx(t_pmr_chan * PmrChan, i16 * input);
 
-i16 		string_parse(char *src, char **dest, char ***ptrs);
-i16 		code_string_parse(t_pmr_chan *pChan);
+i16 string_parse(char *src, char **dest, char ***ptrs);
+i16 code_string_parse(t_pmr_chan * pChan);
 
-i16 		CtcssFreqIndex(float freq);
-i16 		MeasureBlock(t_pmr_sps *mySps);
+i16 CtcssFreqIndex(float freq);
+i16 MeasureBlock(t_pmr_sps * mySps);
 
-void		dedrift			(t_pmr_chan *pChan);
-void 		dedrift_write	(t_pmr_chan *pChan, i16 *src);
+void dedrift(t_pmr_chan * pChan);
+void dedrift_write(t_pmr_chan * pChan, i16 * src);
 
-void		ppspiout	(u32 spidata);
-void		progdtx		(t_pmr_chan *pChan);
-void		ppbinout	(u8 chan);
+void ppspiout(u32 spidata);
+void progdtx(t_pmr_chan * pChan);
+void ppbinout(u8 chan);
 
-i16		    TxTestTone(t_pmr_chan *pChan, i16 function);
-i16         SetTxSoftLimiterSetpoint(t_pmr_chan *pChan, i16 setpoint);
-
+i16 TxTestTone(t_pmr_chan * pChan, i16 function);
+i16 SetTxSoftLimiterSetpoint(t_pmr_chan * pChan, i16 setpoint);
 
 #if XPMR_PPTP == 1
-void		pptp_init 		(void);
-void		pptp_write		(i16 bit, i16 state);
+void pptp_init(void);
+void pptp_write(i16 bit, i16 state);
 #endif
 
-#endif /* ! XPMR_H */
+#endif							/* ! XPMR_H */
 
 /* end of file */
-
-
-


### PR DESCRIPTION
With some users not dialing in their RX audio levels and/or not tapping off audio before de-emphasis, you get wildly varying audio levels depending upon what you're listening to. If your node is using the txprelim setting, I've noticed that some users are so loud that they cause the deviation to exceed 5 kHz and therefore the users of the adjacent channel could experience interference.

Some background: The txprelim setting is used when you want to use pre-emphasized and limited  "flat audio". In my case, I used Motorola CDM 1250's with the audio input on the rear connector set to flat audio with no limiting. In versions of the chan_usbradio.c and xpmr.c  source code prior to this pull request the tx soft limiter was hardcoded to a value of 12000. What I noticed with this hard coded value is that the deviation was exceeding 5 kHz when some loud users were talking.

In order to resolve this issue, I made some changes to allow the soft limiter to be adjusted using radio tune txslimsp XXXXX and radio tune menu-support Lxxxxx. The TX soft limiter can now have its setpoint set to a value between 5000 and 13000 from these menus.  The setting is also able to be written to the usbradio.conf file using the write commands from the main menu and the menu-support menu facilities.

Steve WA6ZFT