### PR TITLE
app_rpt: Add timeout reset delay via `toresettime` parameter.

### DIFF
--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -465,9 +465,10 @@ struct rpt_chan_stat {
 #define	MSWAIT 20
 #define	HANGTIME 5000
 #define SLEEPTIME 900		/* default # of seconds for of no activity before entering sleep mode */
-#define	TOTIME 180000
-#define	IDTIME 300000
-#define	MAXRPTS 500
+#define TOTIME 180000		/* default timeout time to 180000ms (3 minutes) */
+#define TORESETTIME 1000	/* default timeout reset time to 1000ms (1 second) */
+#define IDTIME 300000
+#define MAXRPTS 500
 #define MAX_STAT_LINKS 256
 #define POLITEID 30000
 #define FUNCTDELAY 1500
@@ -782,6 +783,7 @@ struct rpt {
 		int hangtime;
 		int althangtime;
 		int totime;
+		int toresettime;
 		int idtime;
 		int tailmessagetime;
 		int tailsquashedtime;
@@ -936,7 +938,7 @@ struct rpt {
 	time_t dtmf_time,rem_dtmf_time,dtmf_time_rem;
 	int calldigittimer;
 	struct rpt_conf rptconf;
-	int tailtimer, totimer, idtimer, cidx, scantimer, tmsgtimer, skedtimer, linkactivitytimer, elketimer;
+	int tailtimer, totimer, toresettimer, idtimer, cidx, scantimer, tmsgtimer, skedtimer, linkactivitytimer, elketimer;
 	enum patch_call_mode callmode;
 	int mustid,tailid;
 	int rptinacttimer;

--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -857,6 +857,7 @@ void load_rpt_vars(int n, int init)
 	}
 
 	RPT_CONFIG_VAR_INT_DEFAULT(totime, "totime", (ISRANGER(rpt_vars[n].name) ? 9999999 : TOTIME));
+	RPT_CONFIG_VAR_INT_DEFAULT(toresettime, "toresettime", (ISRANGER(rpt_vars[n].name) ? 10000 : TORESETTIME));
 	RPT_CONFIG_VAR_INT_DEFAULT(voxtimeout_ms, "voxtimeout", VOX_TIMEOUT_MS);
 	RPT_CONFIG_VAR_INT_DEFAULT(voxrecover_ms, "voxrecover", VOX_RECOVER_MS);
 	RPT_CONFIG_VAR_INT_DEFAULT(simplexpatchdelay, "simplexpatchdelay", SIMPLEX_PATCH_DELAY);

--- a/configs/rpt/rpt.conf
+++ b/configs/rpt/rpt.conf
@@ -127,8 +127,8 @@ accountcode = RADIO                 ; account code (optional)
 
 hangtime = 2000                     ; squelch tail hang time (in ms) (optional, default 5 seconds, 5000 ms)
 althangtime = 4000                  ; longer squelch tail
-totime = 180000                     ; transmit time-out time (in ms) (optional, default 3 minutes 180000 ms)
-
+totime = 180000                     ; transmit time-out time (in ms) (optional, default to 180000 ms (3 minutes), maximum 9999999 ms (166 minutes))
+toresettime = 1000                  ; transmit time-out reset time (in ms) (optional, default to 1000ms (1 second), maximum 10000 ms (10 seconds))
 idrecording = |iNOTSET              ; id recording or morse string
 ;idtalkover =                       ; Talkover ID (optional) default is none
 idtime = 540000                     ; id interval time (in ms) (optional) Default 5 minutes (300000 ms)


### PR DESCRIPTION
Picket fencing on a stuck key causes timeout to reset too quickly.  Need a bit of delay on unkey before resetting the Timeout Timer and rekeying the machine.
This can be disabled to match previous behavior.