### PR TITLE
simpleusb.conf: Remove invalid options txmixa and txmixb. Update definitions.

### DIFF
--- a/configs/rpt/simpleusb.conf
+++ b/configs/rpt/simpleusb.conf
@@ -6,6 +6,8 @@
 ;
 ; SimpleUSB channel driver Configuration File
 ;
+; See https://allstarlink.github.io/config/simpleusb_conf/ for full option documentation.
+;
 ;;;;;                 New to ASL3                 ;;;;;
 ;;;;; The SimpleUSB "tune" settings have moved to ;;;;;
 ;;;;; this file. The simpleusb_tune_usb_1999.conf ;;;;;
@@ -49,8 +51,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 eeprom = 0                          ; EEPROM installed: 0,1
-                                    ; 0 = no (default)
-                                    ; 1 = yes
+                                    ; 0 = no (use 0, unless you know your radio interface has an EEPROM)
+                                    ; 1 = yes (default)
 
 hdwtype = 0                         ; Leave this set to 0 for USB sound fobs designed for app_rpt
                                     ; or modified cmxxx sound fobs.
@@ -81,27 +83,24 @@ deemphasis = no                     ; enable de-emphasis (input from discriminat
 
 plfilter = yes                      ; enable PL filter
 
-rxondelay = 0               		; Number of 20mSec intervals following the release of PTT.
-                                    ; Uncomment and/or adjust for simplex nodes to eliminate "Ping Ponging"
-                                    ; or "Relay Racing". A positive value here will instruct the usbradio
-                                    ; driver to ignore the COR line for a specified number of 20mSec
-                                    ; intervals following the release of PTT. Use this ONLY on simplex
-                                    ; nodes, and leave commented out for repeaters or other full duplex nodes.
+rxondelay = 0                       ; Number of 20ms audio frames to delay after the hardware COR goes active, 
+                                    ; before the signal is considered valid and COR is asserted to app_rpt. 
+                                    ; If txoffdelay is also set (non-zero), then the transmitter has to be off 
+                                    ; for txoffdelay AND COR has to be active for rxondelay before COR is 
+                                    ; asserted to app_rpt. The default is 0. Use this ONLY on simplex nodes, 
+                                    ; to eliminate "Ping Ponging". Leave commented out for repeaters or 
+                                    ; other full duplex nodes.
 
-txoffdelay = 0              		; Ignore the receiver for a specified number of 20 millisecond
-                                    ; intervals after the transmitter unkeys.
+txoffdelay = 0                      ; Number of 20ms audio frames the transmitter has to be un-keyed before a 
+                                    ; hardware COR signal is considered valid, and COR is asserted to app_rpt. 
+                                    ; If rxondelay is also set (non-zero), then the transmitter has to be off 
+                                    ; for txoffdelay AND* COR has to be active for rxondelay before COR is 
+                                    ; asserted to app_rpt. The default is 0. Leave commented out for normal 
+                                    ; repeaters or other full duplex nodes.
                                     ; This is useful when setting up a half-duplex link with an existing
                                     ; repeater, where you need to ignore the repeater's hangtime.
 
 ; Transmitter parameters
-txmixa = voice                      ; Left channel output (A): no,voice
-                                    ; no - Do not output anything
-                                    ; voice - output voice only
-
-txmixb = no                         ; Right channel output (B): no,voice
-                                    ; no - Do not output anything
-                                    ; voice - output voice only
-
 invertptt = no                      ; Invert PTT: no,yes
                                     ; no  - ground to transmit
                                     ; yes - open to transmit

--- a/configs/rpt/simpleusb.conf
+++ b/configs/rpt/simpleusb.conf
@@ -51,7 +51,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 eeprom = 0                          ; EEPROM installed: 0,1
-                                    ; 0 = no (use 0, unless you know your radio interface has an EEPROM)
+                                    ; 0 = no (radio interface does not have an EEPROM)
                                     ; 1 = yes (default)
 
 hdwtype = 0                         ; Leave this set to 0 for USB sound fobs designed for app_rpt
@@ -94,7 +94,7 @@ rxondelay = 0                       ; Number of 20ms audio frames to delay after
 txoffdelay = 0                      ; Number of 20ms audio frames the transmitter has to be un-keyed before a 
                                     ; hardware COR signal is considered valid, and COR is asserted to app_rpt. 
                                     ; If rxondelay is also set (non-zero), then the transmitter has to be off 
-                                    ; for txoffdelay AND* COR has to be active for rxondelay before COR is 
+                                    ; for txoffdelay AND COR has to be active for rxondelay before COR is 
                                     ; asserted to app_rpt. The default is 0. Leave commented out for normal 
                                     ; repeaters or other full duplex nodes.
                                     ; This is useful when setting up a half-duplex link with an existing


### PR DESCRIPTION
Remove invalid options `txmixa` and `txmixb`. Update definitions.

`txmixa` and `txmixb` are not valid options for `chan_simpleusb`. Remove them from the default .conf file. Update descriptions of `rxondelay` and `txoffdelay` for better clarity of what they do, and how they interact with each other. Correct description that default option for `eeprom` is `1` (not `0`). Add link to ASL3 Manual page for `simpleusb.conf`. 

Closes #746 