### PR TITLE
chan_usbradio & chan_simpleusb: add limits.

### DIFF
--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -130,6 +130,8 @@ static struct ast_jb_conf global_jbconf;
 #define	QUEUE_SIZE	5			/* 100 milliseconds of sound card output buffer */
 
 #define CONFIG	"simpleusb.conf"				/* default config file */
+#define RX_ON_DELAY_MAX 3000					/* 20ms ticks = 60000ms, 60 seconds, 1 minute */
+#define TX_OFF_DELAY_MAX 3000					/* 20ms ticks = 60000ms, 60 seconds, 1 minute */
 
 /* file handles for writing debug audio packets */
 static FILE *frxcapraw = NULL;
@@ -2286,8 +2288,8 @@ static struct ast_frame *simpleusb_read(struct ast_channel *c)
 			o->txoffcnt = 0;		/* If keyed, set this to zero. */
 		} else {
 			o->txoffcnt++;
-			if (o->txoffcnt > 50000) {
-				o->txoffcnt = 20000;	/* Cap this timer at 20000 - 400 seconds */
+			if (o->txoffcnt > TX_OFF_DELAY_MAX) {
+				o->txoffcnt = TX_OFF_DELAY_MAX; /* Cap this timer at 20000 - 400 seconds */
 			}
 		}
 	}
@@ -3549,6 +3551,9 @@ static void tune_menusupport(int fd, struct chan_simpleusb_pvt *o, const char *c
 	case 't':					/* change rx on delay */
 		if (cmd[1]) {
 			o->rxondelay = atoi(&cmd[1]);
+			if (o->rxondelay > RX_ON_DELAY_MAX) {
+				o->rxondelay = RX_ON_DELAY_MAX;
+			}
 			ast_cli(fd, "RX On Delay From changed to %d\n", o->rxondelay);
 		} else {
 			ast_cli(fd, "RX On Delay is currently %d\n", o->rxondelay);
@@ -3557,6 +3562,9 @@ static void tune_menusupport(int fd, struct chan_simpleusb_pvt *o, const char *c
 	case 'u':					/* change tx off delay */
 		if (cmd[1]) {
 			o->txoffdelay = atoi(&cmd[1]);
+			if (o->txoffdelay > TX_OFF_DELAY_MAX) {
+				o->txoffdelay = TX_OFF_DELAY_MAX;
+			}
 			ast_cli(fd, "TX Off Delay From changed to %d\n", o->txoffdelay);
 		} else {
 			ast_cli(fd, "TX Off Delay is currently %d\n", o->txoffdelay);
@@ -3762,7 +3770,13 @@ static struct chan_simpleusb_pvt *store_config(const struct ast_config *cfg, con
 		CV_UINT("hdwtype", o->hdwtype);
 		CV_UINT("eeprom", o->wanteeprom);
 		CV_UINT("rxondelay", o->rxondelay);
+		if (o->rxondelay > RX_ON_DELAY_MAX) {
+			o->rxondelay = RX_ON_DELAY_MAX;
+		}
 		CV_UINT("txoffdelay", o->txoffdelay);
+		if (o->txoffdelay > TX_OFF_DELAY_MAX) {
+			o->txoffdelay = TX_OFF_DELAY_MAX;
+		}
 		CV_F("pager", store_pager(o, (char *) v->value));
 		CV_BOOL("plfilter", o->plfilter);
 		CV_BOOL("deemphasis", o->deemphasis);

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -130,8 +130,9 @@ static struct ast_jb_conf global_jbconf;
 #define	QUEUE_SIZE	5			/* 100 milliseconds of sound card output buffer */
 
 #define CONFIG	"simpleusb.conf"				/* default config file */
-#define RX_ON_DELAY_MAX 3000					/* 20ms ticks = 60000ms, 60 seconds, 1 minute */
-#define TX_OFF_DELAY_MAX 3000					/* 20ms ticks = 60000ms, 60 seconds, 1 minute */
+#define RX_ON_DELAY_MAX 60000					/* in ms, 60000ms, 60 seconds, 1 minute */
+#define TX_OFF_DELAY_MAX 60000					/* in ms, 60000ms, 60 seconds, 1 minute */
+#define MS_TO_20MS_TICKS(ms) ((ms) / 20)
 
 /* file handles for writing debug audio packets */
 static FILE *frxcapraw = NULL;
@@ -2288,8 +2289,8 @@ static struct ast_frame *simpleusb_read(struct ast_channel *c)
 			o->txoffcnt = 0;		/* If keyed, set this to zero. */
 		} else {
 			o->txoffcnt++;
-			if (o->txoffcnt > TX_OFF_DELAY_MAX) {
-				o->txoffcnt = TX_OFF_DELAY_MAX; /* Cap this timer at 20000 - 400 seconds */
+			if (o->txoffcnt > MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX)) {
+				o->txoffcnt = MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX); /* Cap this timer at 20000 - 400 seconds */
 			}
 		}
 	}
@@ -3551,8 +3552,8 @@ static void tune_menusupport(int fd, struct chan_simpleusb_pvt *o, const char *c
 	case 't':					/* change rx on delay */
 		if (cmd[1]) {
 			o->rxondelay = atoi(&cmd[1]);
-			if (o->rxondelay > RX_ON_DELAY_MAX) {
-				o->rxondelay = RX_ON_DELAY_MAX;
+			if (o->rxondelay > MS_TO_20MS_TICKS(RX_ON_DELAY_MAX)) {
+				o->rxondelay = MS_TO_20MS_TICKS(RX_ON_DELAY_MAX);
 			}
 			ast_cli(fd, "RX On Delay From changed to %d\n", o->rxondelay);
 		} else {
@@ -3562,8 +3563,8 @@ static void tune_menusupport(int fd, struct chan_simpleusb_pvt *o, const char *c
 	case 'u':					/* change tx off delay */
 		if (cmd[1]) {
 			o->txoffdelay = atoi(&cmd[1]);
-			if (o->txoffdelay > TX_OFF_DELAY_MAX) {
-				o->txoffdelay = TX_OFF_DELAY_MAX;
+			if (o->txoffdelay > MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX)) {
+				o->txoffdelay = MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX);
 			}
 			ast_cli(fd, "TX Off Delay From changed to %d\n", o->txoffdelay);
 		} else {
@@ -3770,12 +3771,12 @@ static struct chan_simpleusb_pvt *store_config(const struct ast_config *cfg, con
 		CV_UINT("hdwtype", o->hdwtype);
 		CV_UINT("eeprom", o->wanteeprom);
 		CV_UINT("rxondelay", o->rxondelay);
-		if (o->rxondelay > RX_ON_DELAY_MAX) {
-			o->rxondelay = RX_ON_DELAY_MAX;
+		if (o->rxondelay > MS_TO_20MS_TICKS(RX_ON_DELAY_MAX)) {
+			o->rxondelay = MS_TO_20MS_TICKS(RX_ON_DELAY_MAX);
 		}
 		CV_UINT("txoffdelay", o->txoffdelay);
-		if (o->txoffdelay > TX_OFF_DELAY_MAX) {
-			o->txoffdelay = TX_OFF_DELAY_MAX;
+		if (o->txoffdelay > MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX)) {
+			o->txoffdelay = MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX);
 		}
 		CV_F("pager", store_pager(o, (char *) v->value));
 		CV_BOOL("plfilter", o->plfilter);

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -129,10 +129,11 @@ static struct ast_jb_conf global_jbconf;
 
 #define	QUEUE_SIZE	5			/* 100 milliseconds of sound card output buffer */
 
-#define CONFIG	"simpleusb.conf"				/* default config file */
-#define RX_ON_DELAY_MAX 60000					/* in ms, 60000ms, 60 seconds, 1 minute */
-#define TX_OFF_DELAY_MAX 60000					/* in ms, 60000ms, 60 seconds, 1 minute */
-#define MS_TO_20MS_TICKS(ms) ((ms) / 20)
+#define CONFIG "simpleusb.conf"				   /* default config file */
+#define RX_ON_DELAY_MAX 60000				   /* in ms, 60000ms, 60 seconds, 1 minute */
+#define TX_OFF_DELAY_MAX 60000				   /* in ms, 60000ms, 60 seconds, 1 minute */
+#define MS_PER_FRAME 20						   /* 20 ms frames */
+#define MS_TO_FRAMES(ms) ((ms) / MS_PER_FRAME) /* convert ms to frames */
 
 /* file handles for writing debug audio packets */
 static FILE *frxcapraw = NULL;
@@ -2289,8 +2290,8 @@ static struct ast_frame *simpleusb_read(struct ast_channel *c)
 			o->txoffcnt = 0;		/* If keyed, set this to zero. */
 		} else {
 			o->txoffcnt++;
-			if (o->txoffcnt > MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX)) {
-				o->txoffcnt = MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX); /* limit count */
+			if (o->txoffcnt > MS_TO_FRAMES(TX_OFF_DELAY_MAX)) {
+				o->txoffcnt = MS_TO_FRAMES(TX_OFF_DELAY_MAX); /* limit count */
 			}
 		}
 	}
@@ -3552,8 +3553,8 @@ static void tune_menusupport(int fd, struct chan_simpleusb_pvt *o, const char *c
 	case 't':					/* change rx on delay */
 		if (cmd[1]) {
 			o->rxondelay = atoi(&cmd[1]);
-			if (o->rxondelay > MS_TO_20MS_TICKS(RX_ON_DELAY_MAX)) {
-				o->rxondelay = MS_TO_20MS_TICKS(RX_ON_DELAY_MAX);
+			if (o->rxondelay > MS_TO_FRAMES(RX_ON_DELAY_MAX)) {
+				o->rxondelay = MS_TO_FRAMES(RX_ON_DELAY_MAX);
 			}
 			ast_cli(fd, "RX On Delay From changed to %d\n", o->rxondelay);
 		} else {
@@ -3563,8 +3564,8 @@ static void tune_menusupport(int fd, struct chan_simpleusb_pvt *o, const char *c
 	case 'u':					/* change tx off delay */
 		if (cmd[1]) {
 			o->txoffdelay = atoi(&cmd[1]);
-			if (o->txoffdelay > MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX)) {
-				o->txoffdelay = MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX);
+			if (o->txoffdelay > MS_TO_FRAMES(TX_OFF_DELAY_MAX)) {
+				o->txoffdelay = MS_TO_FRAMES(TX_OFF_DELAY_MAX);
 			}
 			ast_cli(fd, "TX Off Delay From changed to %d\n", o->txoffdelay);
 		} else {
@@ -3771,12 +3772,12 @@ static struct chan_simpleusb_pvt *store_config(const struct ast_config *cfg, con
 		CV_UINT("hdwtype", o->hdwtype);
 		CV_UINT("eeprom", o->wanteeprom);
 		CV_UINT("rxondelay", o->rxondelay);
-		if (o->rxondelay > MS_TO_20MS_TICKS(RX_ON_DELAY_MAX)) {
-			o->rxondelay = MS_TO_20MS_TICKS(RX_ON_DELAY_MAX);
+		if (o->rxondelay > MS_TO_FRAMES(RX_ON_DELAY_MAX)) {
+			o->rxondelay = MS_TO_FRAMES(RX_ON_DELAY_MAX);
 		}
 		CV_UINT("txoffdelay", o->txoffdelay);
-		if (o->txoffdelay > MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX)) {
-			o->txoffdelay = MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX);
+		if (o->txoffdelay > MS_TO_FRAMES(TX_OFF_DELAY_MAX)) {
+			o->txoffdelay = MS_TO_FRAMES(TX_OFF_DELAY_MAX);
 		}
 		CV_F("pager", store_pager(o, (char *) v->value));
 		CV_BOOL("plfilter", o->plfilter);

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -2290,7 +2290,7 @@ static struct ast_frame *simpleusb_read(struct ast_channel *c)
 		} else {
 			o->txoffcnt++;
 			if (o->txoffcnt > MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX)) {
-				o->txoffcnt = MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX); /* Cap this timer at 20000 - 400 seconds */
+				o->txoffcnt = MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX); /* limit count */
 			}
 		}
 	}

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -90,6 +90,8 @@
 #define RPT_TO_STRING(x) #x
 #define S_FMT(x) "%" RPT_TO_STRING(x) "s "
 #define N_FMT(duf) "%30" #duf /* Maximum sscanf conversion to numeric strings */
+#define RX_ON_DELAY_MAX 3000  /* 20ms ticks = 60000ms, 60 seconds, 1 minute */
+#define TX_OFF_DELAY_MAX 3000 /* 20ms ticks = 60000ms, 60 seconds, 1 minute */
 
 #include "./xpmr/xpmr.h"
 #ifdef HAVE_XPMRX
@@ -2303,8 +2305,8 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 			o->txoffcnt = 0; /* If keyed, set this to zero. */
 		} else {
 			o->txoffcnt++;
-			if (o->txoffcnt > 50000) {
-				o->txoffcnt = 20000; /* Cap this timer at 20000 - 400 seconds */
+			if (o->txoffcnt > TX_OFF_DELAY_MAX) {
+				o->txoffcnt = TX_OFF_DELAY_MAX; /* Cap this timer at 3000 - 60 seconds */
 			}
 		}
 	}
@@ -4181,6 +4183,9 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 	case 'q': /* change rx on delay */
 		if (cmd[1]) {
 			o->rxondelay = atoi(&cmd[1]);
+			if (o->rxondelay > RX_ON_DELAY_MAX) {
+				o->rxondelay = RX_ON_DELAY_MAX;
+			}
 			ast_cli(fd, "RX On Delay From changed to %d\n", o->rxondelay);
 		} else {
 			ast_cli(fd, "RX On Delay is currently %d\n", o->rxondelay);
@@ -4189,6 +4194,9 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 	case 'r': /* change tx off delay */
 		if (cmd[1]) {
 			o->txoffdelay = atoi(&cmd[1]);
+			if (o->txoffdelay > TX_OFF_DELAY_MAX) {
+				o->txoffdelay = TX_OFF_DELAY_MAX;
+			}
 			ast_cli(fd, "TX Off Delay From changed to %d\n", o->txoffdelay);
 		} else {
 			ast_cli(fd, "TX Off Delay is currently %d\n", o->txoffdelay);
@@ -5022,7 +5030,13 @@ static struct chan_usbradio_pvt *store_config(const struct ast_config *cfg, cons
 		CV_UINT("tracetype", o->tracetype);
 		CV_UINT("tracelevel", o->tracelevel);
 		CV_UINT("rxondelay", o->rxondelay);
+		if (o->rxondelay > RX_ON_DELAY_MAX) {
+			o->rxondelay = RX_ON_DELAY_MAX;
+		}
 		CV_UINT("txoffdelay", o->txoffdelay);
+		if (o->txoffdelay > TX_OFF_DELAY_MAX) {
+			o->txoffdelay = TX_OFF_DELAY_MAX;
+		}
 		CV_UINT("area", o->area);
 		CV_STR("ukey", o->ukey);
 		CV_UINT("duplex3", o->duplex3);

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -2307,7 +2307,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 		} else {
 			o->txoffcnt++;
 			if (o->txoffcnt > MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX)) {
-				o->txoffcnt = MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX); /* Cap this timer at 3000 - 60 seconds */
+				o->txoffcnt = MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX); /* Limit the count */
 			}
 		}
 	}

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -89,10 +89,11 @@
 #define PP_IOPORT 0x378
 #define RPT_TO_STRING(x) #x
 #define S_FMT(x) "%" RPT_TO_STRING(x) "s "
-#define N_FMT(duf) "%30" #duf /* Maximum sscanf conversion to numeric strings */
-#define RX_ON_DELAY_MAX 60000 /* in ms, 60000ms, 60 seconds, 1 minute */
-#define TX_OFF_DELAY_MAX 60000 /* in ms 60000ms, 60 seconds, 1 minute */
-#define MS_TO_20MS_TICKS(ms) ((ms) / 20)
+#define N_FMT(duf) "%30" #duf				   /* Maximum sscanf conversion to numeric strings */
+#define RX_ON_DELAY_MAX 60000				   /* in ms, 60000ms, 60 seconds, 1 minute */
+#define TX_OFF_DELAY_MAX 60000				   /* in ms 60000ms, 60 seconds, 1 minute */
+#define MS_PER_FRAME 20						   /* 20 ms frames */
+#define MS_TO_FRAMES(ms) ((ms) / MS_PER_FRAME) /* convert ms to frames */
 
 #include "./xpmr/xpmr.h"
 #ifdef HAVE_XPMRX
@@ -2306,8 +2307,8 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 			o->txoffcnt = 0; /* If keyed, set this to zero. */
 		} else {
 			o->txoffcnt++;
-			if (o->txoffcnt > MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX)) {
-				o->txoffcnt = MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX); /* Limit the count */
+			if (o->txoffcnt > MS_TO_FRAMES(TX_OFF_DELAY_MAX)) {
+				o->txoffcnt = MS_TO_FRAMES(TX_OFF_DELAY_MAX); /* Limit the count */
 			}
 		}
 	}
@@ -4184,8 +4185,8 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 	case 'q': /* change rx on delay */
 		if (cmd[1]) {
 			o->rxondelay = atoi(&cmd[1]);
-			if (o->rxondelay > MS_TO_20MS_TICKS(RX_ON_DELAY_MAX)) {
-				o->rxondelay = MS_TO_20MS_TICKS(RX_ON_DELAY_MAX);
+			if (o->rxondelay > MS_TO_FRAMES(RX_ON_DELAY_MAX)) {
+				o->rxondelay = MS_TO_FRAMES(RX_ON_DELAY_MAX);
 			}
 			ast_cli(fd, "RX On Delay From changed to %d\n", o->rxondelay);
 		} else {
@@ -4195,8 +4196,8 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 	case 'r': /* change tx off delay */
 		if (cmd[1]) {
 			o->txoffdelay = atoi(&cmd[1]);
-			if (o->txoffdelay > MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX)) {
-				o->txoffdelay = MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX);
+			if (o->txoffdelay > MS_TO_FRAMES(TX_OFF_DELAY_MAX)) {
+				o->txoffdelay = MS_TO_FRAMES(TX_OFF_DELAY_MAX);
 			}
 			ast_cli(fd, "TX Off Delay From changed to %d\n", o->txoffdelay);
 		} else {
@@ -5031,12 +5032,12 @@ static struct chan_usbradio_pvt *store_config(const struct ast_config *cfg, cons
 		CV_UINT("tracetype", o->tracetype);
 		CV_UINT("tracelevel", o->tracelevel);
 		CV_UINT("rxondelay", o->rxondelay);
-		if (o->rxondelay > MS_TO_20MS_TICKS(RX_ON_DELAY_MAX)) {
-			o->rxondelay = MS_TO_20MS_TICKS(RX_ON_DELAY_MAX);
+		if (o->rxondelay > MS_TO_FRAMES(RX_ON_DELAY_MAX)) {
+			o->rxondelay = MS_TO_FRAMES(RX_ON_DELAY_MAX);
 		}
 		CV_UINT("txoffdelay", o->txoffdelay);
-		if (o->txoffdelay > MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX)) {
-			o->txoffdelay = MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX);
+		if (o->txoffdelay > MS_TO_FRAMES(TX_OFF_DELAY_MAX)) {
+			o->txoffdelay = MS_TO_FRAMES(TX_OFF_DELAY_MAX);
 		}
 		CV_UINT("area", o->area);
 		CV_STR("ukey", o->ukey);

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -90,8 +90,9 @@
 #define RPT_TO_STRING(x) #x
 #define S_FMT(x) "%" RPT_TO_STRING(x) "s "
 #define N_FMT(duf) "%30" #duf /* Maximum sscanf conversion to numeric strings */
-#define RX_ON_DELAY_MAX 3000  /* 20ms ticks = 60000ms, 60 seconds, 1 minute */
-#define TX_OFF_DELAY_MAX 3000 /* 20ms ticks = 60000ms, 60 seconds, 1 minute */
+#define RX_ON_DELAY_MAX 60000 /* in ms, 60000ms, 60 seconds, 1 minute */
+#define TX_OFF_DELAY_MAX 60000 /* in ms 60000ms, 60 seconds, 1 minute */
+#define MS_TO_20MS_TICKS(ms) ((ms) / 20)
 
 #include "./xpmr/xpmr.h"
 #ifdef HAVE_XPMRX
@@ -2305,8 +2306,8 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 			o->txoffcnt = 0; /* If keyed, set this to zero. */
 		} else {
 			o->txoffcnt++;
-			if (o->txoffcnt > TX_OFF_DELAY_MAX) {
-				o->txoffcnt = TX_OFF_DELAY_MAX; /* Cap this timer at 3000 - 60 seconds */
+			if (o->txoffcnt > MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX)) {
+				o->txoffcnt = MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX); /* Cap this timer at 3000 - 60 seconds */
 			}
 		}
 	}
@@ -4183,8 +4184,8 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 	case 'q': /* change rx on delay */
 		if (cmd[1]) {
 			o->rxondelay = atoi(&cmd[1]);
-			if (o->rxondelay > RX_ON_DELAY_MAX) {
-				o->rxondelay = RX_ON_DELAY_MAX;
+			if (o->rxondelay > MS_TO_20MS_TICKS(RX_ON_DELAY_MAX)) {
+				o->rxondelay = MS_TO_20MS_TICKS(RX_ON_DELAY_MAX);
 			}
 			ast_cli(fd, "RX On Delay From changed to %d\n", o->rxondelay);
 		} else {
@@ -4194,8 +4195,8 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 	case 'r': /* change tx off delay */
 		if (cmd[1]) {
 			o->txoffdelay = atoi(&cmd[1]);
-			if (o->txoffdelay > TX_OFF_DELAY_MAX) {
-				o->txoffdelay = TX_OFF_DELAY_MAX;
+			if (o->txoffdelay > MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX)) {
+				o->txoffdelay = MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX);
 			}
 			ast_cli(fd, "TX Off Delay From changed to %d\n", o->txoffdelay);
 		} else {
@@ -5030,12 +5031,12 @@ static struct chan_usbradio_pvt *store_config(const struct ast_config *cfg, cons
 		CV_UINT("tracetype", o->tracetype);
 		CV_UINT("tracelevel", o->tracelevel);
 		CV_UINT("rxondelay", o->rxondelay);
-		if (o->rxondelay > RX_ON_DELAY_MAX) {
-			o->rxondelay = RX_ON_DELAY_MAX;
+		if (o->rxondelay > MS_TO_20MS_TICKS(RX_ON_DELAY_MAX)) {
+			o->rxondelay = MS_TO_20MS_TICKS(RX_ON_DELAY_MAX);
 		}
 		CV_UINT("txoffdelay", o->txoffdelay);
-		if (o->txoffdelay > TX_OFF_DELAY_MAX) {
-			o->txoffdelay = TX_OFF_DELAY_MAX;
+		if (o->txoffdelay > MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX)) {
+			o->txoffdelay = MS_TO_20MS_TICKS(TX_OFF_DELAY_MAX);
 		}
 		CV_UINT("area", o->area);
 		CV_STR("ukey", o->ukey);


### PR DESCRIPTION
chan_simpleusb:
address incorrect limit on o->txoffcnt.
Add limits to txoffdelay and rxondelay.

Fixes #745 
Seems like 1 minute on/off delay is plenty of time for this configuration.