### PR TITLE
Update README to use clang-format for code prettification

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,13 @@ Thank you!
 
 Note: This is an optional step. If you are touching existing code in a few places, then it is best to skip prettifying and just let the commit checker check for conformance to the coding standards. 
 
-If `clang-format` isn't already installed, install `clang-format` on your development system.  
+After installing clang-format and codespell, set up the pre-commit workflow.
 
-From the top level project directory run:
+From the top level project directory, execute:
 
-`clang-format -style file:.dev/.clang-format your_file > your_prettified_file`
+`cp ./.dev/pre-commit ./.git/hooks/pre-commit`
 
+This will enable coding standards to be checked locally.
 
 # Installing
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If 'clang_format' isn't already installed, install `clang_format` on your develo
 
 From the top level project directory run:
 
-`clang_format -style file:.dev/.clang_format your_file > your_prettified_file`
+`clang-format -style file:.dev/.clang-format your_file > your_prettified_file`
 
 
 # Installing

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Thank you!
 
 Note: This is an optional step. If you are touching existing code in a few places, then it is best to skip prettifying and just let the commit checker check for conformance to the coding standards. 
 
-If 'clang_format' isn't already installed, install `clang_format` on your development system.  
+If `clang-format` isn't already installed, install `clang-format` on your development system.  
 
 From the top level project directory run:
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,14 @@ Thank you!
 
 ## Prettifying
 
-`indent --k-and-r-style --use-tabs --tab-size4 --braces-on-if-line --cuddle-else --dont-break-function-decl-args --line-length120 --swallow-optional-blank-lines apps/app_rpt.c`
+Note: This is an optional step. If you are touching existing code in a few places, then it is best to skip prettifying and just let the commit checker check for conformance to the coding standards. 
+
+If 'clang_format' isn't already installed, install `clang_format` on your development system.  
+
+From the top level project directory run:
+
+`clang_format -style file:.dev/.clang_format your_file > your_prettified_file`
+
 
 # Installing
 


### PR DESCRIPTION
I thought it might be good to update README.md file on code prettifying, as running the indent command was not the correct thing to do.

I updated this section of the README.md to use clang-format instead. I also added a note not to do prettification if there are only a few lines of code being touched.