### PR TITLE
.clang-format: Remove duplicate BasedOnStyle directive

### DIFF
--- a/.dev/.clang-format
+++ b/.dev/.clang-format
@@ -51,7 +51,6 @@ EmptyLineAfterAccessModifier: Never
 EmptyLineBeforeAccessModifier: LogicalBlock
 ExperimentalAutoDetectBinPacking: false
 PackConstructorInitializers: Never
-BasedOnStyle:    ''
 AllowAllConstructorInitializersOnNextLine: true
 FixNamespaceComments: true
 ForEachMacros:


### PR DESCRIPTION
The duplicate causes clang-format to fail during git pre-commit processing. Desired style is LLVM.