### PR TITLE
app_rpt.c: Warn when using pipe delimiter in dialplan instead of comma

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -6097,7 +6097,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 	use_pipe = strchr(tmp, '|');
 	if (use_pipe) {
 		separator = "|";
-		ast_log(LOG_WARNING, "Using pipes as a delimiter is deprecated and support will be removed in a future version of Asterisk. Please use commas instead.\n");
+		ast_log(LOG_WARNING, "Pipe (|) delimiter is deprecated and will be removed in a future release, please use comma (,).\n");
 	} else {
 		separator = ",";
 	}


### PR DESCRIPTION
The pipe (`|`) delimiter was previously used in OLD Asterisk. The current delimiter is the comma (`,`). We currently support either, but the plan is to stop supporting the pipe at sometime in the future.

This change warns users that there is a pipe in their dialplan (in extensions.conf) and reminds them to change it.

UpgradeNote: Users should update calls to Rpt to use the comma delimiter to prevent future errors.