### PR TITLE
Fix random key ups and telemetry messages being sent after a time out condition

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -5095,21 +5095,42 @@ static void *rpt(void *this)
 
 		/* Main TX control */
 
-		/* let telemetry transmit anyway (regardless of timeout) */
-		if (myrpt->p.duplex > 0)
-			totx = totx || (myrpt->tele.next != &myrpt->tele);
+		/* Handling  of telemetry during a time out condition */
+		if (myrpt->p.duplex > 0) {
+			/* If timed out, we only want to keep the TX keyed if there
+			 * is a message queued which is configured to override
+			 *  the time out condition 
+			 */
+			if ((!myrpt->totimer) || myrpt->tounkeyed)  {
+				totx = totx || tot_override_message_pending(myrpt);
+			}
+			else {
+				/* Not in time out condition. Keep TX keyed for all telemetry */
+				totx = totx || (myrpt->tele.next != &myrpt->tele);
+			}
+			
+		}
+		
+			
+			
+		/* Control op tx disable overrides everything prior to this. */	
 		totx = totx && !myrpt->p.s[myrpt->p.sysstate_cur].txdisable;
+		/* Save a copy of the "real" tx state */
 		myrpt->txrealkeyed = totx;
+		/*  Hold up the TX as long as there are frames in the tx queue */
 		totx = totx || (!AST_LIST_EMPTY(&myrpt->txq));
 		/* if in 1/2 or 3/4 duplex, give rx priority */
 		if ((myrpt->p.duplex < 2) && (!myrpt->p.linktolink) && (!myrpt->p.dias) && (myrpt->keyed))
 			totx = 0;
+	    // Disable TX if Elke timer is enabled and it expires.
 		if (myrpt->p.elke && (myrpt->elketimer > myrpt->p.elke))
 			totx = 0;
+		/* Log unkeyed to keyed transition point */
 		if (totx && !lasttx) {
 			log_keyed(myrpt);
 			lasttx = 1;
 		}
+		/* Log keyed to unkeyed transition point */
 		if (!totx && lasttx) {
 			lasttx = 0;
 			log_unkeyed(myrpt);

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -493,6 +493,33 @@ done:
 	return 0;
 }
 
+int tot_override_message_pending(struct rpt *myrpt)
+{
+	struct rpt_tele *telem;
+	int pending = 0;
+	
+	if (!myrpt) {
+		return 0;
+	}
+	
+	ast_debug(3, "Check for tot override message pending");
+	rpt_mutex_lock(&myrpt->lock);
+	telem = myrpt->tele.next;
+	/* Traverse the telemetry list looking for override_tot flag */
+	while (telem != &myrpt->tele) {
+		/*
+		 * Add more telemetry modes here if they need
+		 * to be sent during a time out condition
+		 */
+		if(telem->mode == TIMEOUT) {
+			pending = 1;
+		}
+		telem = telem->next;
+	}
+	rpt_mutex_unlock(&myrpt->lock);
+	return pending;
+}
+
 void flush_telem(struct rpt *myrpt)
 {
 	struct rpt_tele *telem;

--- a/apps/app_rpt/rpt_telemetry.h
+++ b/apps/app_rpt/rpt_telemetry.h
@@ -2,6 +2,9 @@
 
 void rpt_telem_select(struct rpt *myrpt, int command_source, struct rpt_link *mylink);
 
+/*! \brief Routine checks to see if there's a message pending which needs to override a time out condition */
+int tot_override_message_pending(struct rpt *myrpt);
+
 void flush_telem(struct rpt *myrpt);
 
 /*! \brief Routine that hangs up all links and frees all threads related to them hence taking a "bird bath".  Makes a lot of noise/cleans up the mess */


### PR DESCRIPTION
The current code does not make any distinction between the a time out message and all other types of telemetry. This pull request resolves that. When in the time out condition, the only messages which can be sent are those identified in the tot_override_message_pending() function in rpt_telemetry.c

The previous revisions of app_rpt didn't care what type of telemetry messages were in the queue, and kept the TX keyed for all of them. This version specifically looks for the TIMEOUT message and if it is present in the queue, then the TX will be keyed for as long as it is in the queue.

Other telemetry modes could conceivable be added to the tot_override_message_pending() in the future.

This will resolve the random key ups and telemetry messages seen after the node enters the time out condition.

