### PR TITLE
app_rpt: restore `noduck` functionality

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -5287,18 +5287,20 @@ static void *rpt(void *this)
 			}
 		}
 		/* If we have a new active telemetry message and a channel */
-		if (myrpt->active_telem && myrpt->active_telem->chan) {
+		if (!myrpt->noduck && myrpt->active_telem && myrpt->active_telem->chan) {
 			/* If we have a new telmetry message or we have changed keyup state to keyup */
 			if (((myrpt->active_telem != last_telem) || !lastduck) && (myrpt->keyed || myrpt->remrx)) {
 				if (ast_audiohook_volume_set_float(myrpt->active_telem->chan, AST_AUDIOHOOK_DIRECTION_WRITE, myrpt->p.telemduckgain)) {
-					ast_debug(7, "Setting the volume on channel %s to %2.2f", ast_channel_name(myrpt->tele.next->chan), myrpt->p.telemduckgain);
+					ast_debug(7, "Setting the volume on channel %s to %2.2f", ast_channel_name(myrpt->active_telem->chan),
+						myrpt->p.telemduckgain);
 				}
 				lastduck = 1;
 			}
 			/* If we have a new telemetry message or we have already adjusted ducking and we are not keyed up */
 			if (((myrpt->active_telem != last_telem) || lastduck) && !myrpt->keyed && !myrpt->remrx) {
 				if (ast_audiohook_volume_set_float(myrpt->active_telem->chan, AST_AUDIOHOOK_DIRECTION_WRITE, myrpt->p.telemnomgain)) {
-					ast_debug(7, "Setting the volume on channel %s to %2.2f", ast_channel_name(myrpt->tele.next->chan), myrpt->p.telemnomgain);
+					ast_debug(7, "Setting the volume on channel %s to %2.2f", ast_channel_name(myrpt->active_telem->chan),
+						myrpt->p.telemnomgain);
 				}
 				lastduck = 0;
 			}


### PR DESCRIPTION
Reviewing the audiohook / ducking replacement code, missed the `!noduck` condition in the conversion.
Also addressing debug using incorrect channel name.