### PR TITLE
app_rpt.c: Handle `duplex=0` with `linktolink=yes`

### DIFF
--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -182,7 +182,7 @@ int altlink1(struct rpt *myrpt, struct rpt_link *mylink)
 			tlist = tlist->next;
 		}
 	}
-	if ((!myrpt->p.duplex) || (!nonlocals)) {
+	if ((!myrpt->p.duplex && !myrpt->p.linktolink) || (!nonlocals)) {
 		return 0;
 	}
 	if (!mylink->phonemode &&


### PR DESCRIPTION
Allowing cli rpt playback to send audio out the links as expected.

Fixes #773 

This one appears to have been around since ASL2.  Further testing to confirm it doesn't break anything else would be appreciated as I'm not sure I completely understand what this configuration is doing.