### PR TITLE
app_rpt.c: add mutex_lock when setting audiohooks

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -5294,6 +5294,7 @@ static void *rpt(void *this)
 			}
 		}
 		/* If we have a new active telemetry message and a channel */
+		rpt_mutex_lock(&myrpt->lock);
 		if (!myrpt->noduck && myrpt->active_telem && myrpt->active_telem->chan) {
 			/* If we have a new telmetry message or we have changed keyup state to keyup */
 			if (((myrpt->active_telem != last_telem) || !lastduck) && (myrpt->keyed || myrpt->remrx)) {
@@ -5313,6 +5314,7 @@ static void *rpt(void *this)
 			}
 		}
 		last_telem = myrpt->active_telem;
+		rpt_mutex_unlock(&myrpt->lock);
 
 		n = 0;
 		cs[n++] = myrpt->rxchannel;


### PR DESCRIPTION
I have been watching this one for a bit. Looks like the telemetry thread can pull the rug out from the audio adjustment mid evaluation.  Since we expect `myrpt->active_telem` to remain "the same" non NULL value for the if statement, there should be a lock to prevent the race.
https://github.com/AllStarLink/app_rpt/blob/992a245bb05a3a9b06372dcc401ed658115e07e9/apps/app_rpt.c#L5297-L5314
Closes #789