### PR TITLE
Channel drivers, tune utilities: add Tx Audio Stats, fix issue 791

### DIFF
--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -327,7 +327,7 @@ struct chan_simpleusb_pvt {
 
 	struct audiostatistics rxaudiostats;
 	struct audiostatistics txaudiostats;
-	
+
 	int legacyaudioscaling;
 
 	ast_mutex_t usblock;

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -325,7 +325,8 @@ struct chan_simpleusb_pvt {
 	char *gpios[GPIO_PINCOUNT];
 	char *pps[32];
 
-	struct rxaudiostatistics rxaudiostats;
+	struct audiostatistics rxaudiostats;
+	struct audiostatistics txaudiostats;
 	
 	int legacyaudioscaling;
 
@@ -2145,7 +2146,18 @@ static struct ast_frame *simpleusb_read(struct ast_channel *c)
 						*sp1++ = (doleft) ? v : 0;
 						*sp1++ = (doright) ? v : 0;
 					}
+
 					soundcard_writeframe(o, outbuf);
+
+					/* Check Tx audio statistics. FRAME_SIZE define refers to 8Ksps mono which is 160 samples
+					 * per 20mS USB frame. ast_radio_check_audio() takes the write buffer (48K stereo),
+					 * extracts the mono 48K channel, checks amplitude and distortion characteristics,
+					 * and returns true if clipping was detected. If local Tx audio is clipped it might be
+					 * nice to log a warning but as this does not relate to outgoing network audio it's not
+					 * a major issue. User can check the Tx Audio Stats utility if desired.
+					 */
+					ast_radio_check_audio(outbuf, &o->txaudiostats, 12 * FRAME_SIZE);
+
 					src += l;
 					o->simpleusb_write_dst = 0;
 					if (o->waspager && (!ispager)) {
@@ -2317,11 +2329,11 @@ static struct ast_frame *simpleusb_read(struct ast_channel *c)
 
 	/* Check for ADC clipping and input audio statistics before any filtering is done.
 	 * FRAME_SIZE define refers to 8Ksps mono which is 160 samples per 20mS USB frame.
-	 * ast_radio_check_rx_audio() takes the read buffer as received (48K stereo),
+	 * ast_radio_check_audio() takes the read buffer as received (48K stereo),
 	 * extracts the mono 48K channel, checks amplitude and distortion characteristics,
 	 * and returns true if clipping was detected.
 	 */
-	if (ast_radio_check_rx_audio((short *) o->simpleusb_read_buf, &o->rxaudiostats, 12 * FRAME_SIZE)) {
+	if (ast_radio_check_audio((short *) o->simpleusb_read_buf, &o->rxaudiostats, 12 * FRAME_SIZE)) {
 		if (o->clipledgpio) {
 			/* Set Clip LED GPIO pulsetimer if not already set */
 			if (!o->hid_gpio_pulsetimer[o->clipledgpio - 1]) {
@@ -3373,6 +3385,7 @@ static void tune_write(struct chan_simpleusb_pvt *o)
  *		u - change tx off delay
  *		v - view cos, ctcss and ptt status
  *		y - receive audio statistics display
+ *		z - transmit audio statistics display
  *
  * \param fd			Asterisk CLI fd
  * \param o				Private struct.
@@ -3592,8 +3605,24 @@ static void tune_menusupport(int fd, struct chan_simpleusb_pvt *o, const char *c
 			break;
 		}
 		for (;;) {
-			ast_radio_print_rx_audio_stats(fd, &o->rxaudiostats);
+			ast_radio_print_audio_stats(fd, &o->rxaudiostats, "Rx");
 			if (cmd[0] == 'Y') {
+				break;
+			}
+			if (ast_radio_poll_input(fd, 1000)) {
+				break;
+			}
+		}
+		break;
+	case 'z': /* display transmit audio statistics (interactive) */
+	case 'Z': /* display transmit audio statistics (once only) */
+		if (!o->hasusb) {
+			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
+			break;
+		}
+		for (;;) {
+			ast_radio_print_audio_stats(fd, &o->txaudiostats, "Tx");
+			if (cmd[0] == 'Z') {
 				break;
 			}
 			if (ast_radio_poll_input(fd, 1000)) {

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -4290,8 +4290,15 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 			ast_cli(fd, USB_UNASSIGNED_FMT, o->name, o->devstr);
 			break;
 		}
+		x = 1;
 		for (;;) {
-			ast_radio_print_audio_stats(fd, &o->txaudiostats, "Tx");
+			if (o->txkeyed) {
+				ast_radio_print_audio_stats(fd, &o->txaudiostats, "Tx");
+				x = 1;
+			} else if (x == 1) {
+				ast_cli(fd, "Tx not keyed\n");
+				x = 0;
+			}
 			if (cmd[0] == 'Z') {
 				break;
 			}

--- a/channels/xpmr/xpmr.c
+++ b/channels/xpmr/xpmr.c
@@ -684,8 +684,6 @@ i16 pmr_gp_fir(t_pmr_sps *mySps)
 	setpt = mySps->setpt;
 	compOut = mySps->compOut;
 
-	inputGain = mySps->inputGain;
-	outputGain = mySps->outputGain;
 	numChanOut = mySps->numChanOut;
 	selChanOut = mySps->selChanOut;
 	mixOut = mySps->mixOut;
@@ -1312,6 +1310,14 @@ i16 pmrMixer(t_pmr_sps *mySps)
 			accum = (input[i] * inputGain) / M_Q8;
 		}
 		accum = (accum * outputGain) / M_Q8;
+
+		// Check for overflows
+		if (accum > 32767) {
+			accum = 32767;
+		} else if (accum < -32767) {
+			accum = -32767;
+		}
+
 		output[i] = accum;
 
 		if (measPeak) {

--- a/channels/xpmr/xpmr.c
+++ b/channels/xpmr/xpmr.c
@@ -1311,7 +1311,7 @@ i16 pmrMixer(t_pmr_sps *mySps)
 		}
 		accum = (accum * outputGain) / M_Q8;
 
-		// Check for overflows
+		/* Check for overflows */
 		if (accum > 32767) {
 			accum = 32767;
 		} else if (accum < -32767) {

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -181,11 +181,11 @@ struct usbecho {
 	short data[FRAME_SIZE];
 };
 
-/* Rx audio (ADC) statistics variables. tune-menu "R" command displays
+/* Audio statistics variables. tune-menu "R" and "X" commands display
  * stats data (peak, average, min, max levels and clipped sample count).
  */
 #define AUDIO_STATS_LEN 50 	                	/* number of 20mS frames. 50 => 1 second buf len */
-struct rxaudiostatistics {
+struct audiostatistics {
 	unsigned short maxbuf[AUDIO_STATS_LEN]; 	/* peak sample value per frame */
 	unsigned short clipbuf[AUDIO_STATS_LEN];	/* number of clipped samples per frame */
 	unsigned int pwrbuf[AUDIO_STATS_LEN];   	/* total RMS power per frame */
@@ -479,7 +479,7 @@ struct timeval ast_radio_tvnow(void);
  * \return 	    	1 if clipping detected, 0 otherwise
  */
 #define CLIP_LED_HOLD_TIME_MS  500
-int ast_radio_check_rx_audio(short *sbuf, struct rxaudiostatistics *o, short len);
+int ast_radio_check_audio(short *sbuf, struct audiostatistics *o, short len);
 
 /*!
  * \brief Display receive audio statistics.
@@ -503,4 +503,4 @@ int ast_radio_check_rx_audio(short *sbuf, struct rxaudiostatistics *o, short len
  * \param o 		Channel data structure
  * \return  		None
  */
-void ast_radio_print_rx_audio_stats(int fd, struct rxaudiostatistics *o);
+void ast_radio_print_audio_stats(int fd, struct audiostatistics *o, const char *prefix_text);

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -872,8 +872,7 @@ void ast_radio_print_audio_stats(int fd, struct audiostatistics *o, const char *
 	dmin = minpwr ? 10 * log10(minpwr * scale) : -96.0;
 	dmax = maxpwr ? 10 * log10(maxpwr * scale) : -96.0;
 	/* Print stats */
-	sprintf(s1, "%sAudioStats: Pk %5.1f  Avg Pwr %3.0f  Min %3.0f  Max %3.0f  dBFS  ClipCnt %u",
-		prefix_text, dpk, tpwr, dmin, dmax, clipcnt);
+	sprintf(s1, "%sAudioStats: Pk %5.1f  Avg Pwr %3.0f  Min %3.0f  Max %3.0f  dBFS  ClipCnt %u", prefix_text, dpk, tpwr, dmin, dmax, clipcnt);
 	if (fd >= 0) {
 		ast_cli(fd, "%s\n", s1);
 	} else {

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -873,7 +873,7 @@ void ast_radio_print_audio_stats(int fd, struct audiostatistics *o, const char *
 	dmax = maxpwr ? 10 * log10(maxpwr * scale) : -96.0;
 	/* Print stats */
 	sprintf(s1, "%sAudioStats: Pk %5.1f  Avg Pwr %3.0f  Min %3.0f  Max %3.0f  dBFS  ClipCnt %u",
-			prefix_text, dpk, tpwr, dmin, dmax, clipcnt);
+		prefix_text, dpk, tpwr, dmin, dmax, clipcnt);
 	if (fd >= 0) {
 		ast_cli(fd, "%s\n", s1);
 	} else {

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -795,7 +795,7 @@ struct timeval ast_radio_tvnow(void)
 
 #define CLIP_SAMP_THRESH       0x7eb0
 #define CLIP_EVENT_MIN_SAMPLES 3
-int ast_radio_check_rx_audio(short *sbuf, struct rxaudiostatistics *o, short len)
+int ast_radio_check_audio(short *sbuf, struct audiostatistics *o, short len)
 {
 	unsigned short i, j, val, max = 0, seq_clips = 0;
 	double pwr = 0.0;
@@ -839,7 +839,7 @@ int ast_radio_check_rx_audio(short *sbuf, struct rxaudiostatistics *o, short len
 	return (seq_clips >= CLIP_EVENT_MIN_SAMPLES);
 }
 
-void ast_radio_print_rx_audio_stats(int fd, struct rxaudiostatistics *o)
+void ast_radio_print_audio_stats(int fd, struct audiostatistics *o, const char *prefix_text)
 {
 	unsigned int i, pk = 0, pwr = 0, minpwr = 0x40000000, maxpwr = 0, clipcnt = 0;
 	double dpk, dmin, dmax, scale, tpwr = 0.0;
@@ -872,8 +872,8 @@ void ast_radio_print_rx_audio_stats(int fd, struct rxaudiostatistics *o)
 	dmin = minpwr ? 10 * log10(minpwr * scale) : -96.0;
 	dmax = maxpwr ? 10 * log10(maxpwr * scale) : -96.0;
 	/* Print stats */
-	sprintf(s1, "RxAudioStats: Pk %5.1f  Avg Pwr %3.0f  Min %3.0f  Max %3.0f  dBFS  ClipCnt %u",
-			dpk, tpwr, dmin, dmax, clipcnt);
+	sprintf(s1, "%sAudioStats: Pk %5.1f  Avg Pwr %3.0f  Min %3.0f  Max %3.0f  dBFS  ClipCnt %u",
+			prefix_text, dpk, tpwr, dmin, dmax, clipcnt);
 	if (fd >= 0) {
 		ast_cli(fd, "%s\n", s1);
 	} else {

--- a/utils/radio-tune-menu.c
+++ b/utils/radio-tune-menu.c
@@ -1105,6 +1105,7 @@ static void options_menu(void)
 		printf("T) Toggle Transmit Test Tone/Keying (currently '%s')\n", (keying) ? "enabled" : "disabled");
 		printf("V) View COS, CTCSS and PTT Status\n");
 		printf("W) Write (Save) Current Parameter Values\n");
+		printf("X) View Tx Audio Statistics\n");
 		printf("0) Exit Menu\n");
 		printf("\nPlease enter your selection now: ");
 
@@ -1236,6 +1237,10 @@ static void options_menu(void)
 			if (astgetresp(COMMAND_PREFIX "tune menu-support j")) {
 				exit(255);
 			}
+			break;
+		case 'x':				/* display transmit audio statistics */
+		case 'X':
+			astgetresp(COMMAND_PREFIX "tune menu-support z");
 			break;
 		default:
 			printf("Invalid Entry, try again\n");

--- a/utils/radio-tune-menu.c
+++ b/utils/radio-tune-menu.c
@@ -1238,7 +1238,7 @@ static void options_menu(void)
 				exit(255);
 			}
 			break;
-		case 'x':				/* display transmit audio statistics */
+		case 'x': /* display transmit audio statistics */
 		case 'X':
 			astgetresp(COMMAND_PREFIX "tune menu-support z");
 			break;

--- a/utils/simpleusb-tune-menu.c
+++ b/utils/simpleusb-tune-menu.c
@@ -1035,7 +1035,7 @@ int main(int argc, char *argv[])
 				exit(255);
 			}
 			break;
-		case 'x':				/* display transmit audio statistics */
+		case 'x': /* display transmit audio statistics */
 		case 'X':
 			astgetresp(COMMAND_PREFIX "tune menu-support z");
 			break;

--- a/utils/simpleusb-tune-menu.c
+++ b/utils/simpleusb-tune-menu.c
@@ -870,6 +870,7 @@ int main(int argc, char *argv[])
 		printf("T) Toggle Transmit Test Tone/Keying (currently '%s')\n", keying ? "enabled" : "disabled");
 		printf("V) View COS, CTCSS and PTT Status\n");
 		printf("W) Write (Save) Current Parameter Values\n");
+		printf("X) View Tx Audio Statistics\n");
 		printf("0) Exit Menu\n");
 		printf("\nPlease enter your selection now: ");
 
@@ -1033,6 +1034,10 @@ int main(int argc, char *argv[])
 			if (astgetresp(COMMAND_PREFIX "tune menu-support j")) {
 				exit(255);
 			}
+			break;
+		case 'x':				/* display transmit audio statistics */
+		case 'X':
+			astgetresp(COMMAND_PREFIX "tune menu-support z");
 			break;
 		default:
 			printf("Invalid Entry, try again\n");


### PR DESCRIPTION
Fix issue 791 in xpmr.c. Add Tx Audio Stats utility. See https://github.com/AllStarLink/app_rpt/issues/791 for details. As noted in one of my comments there this is a somewhat major issue that will affect all nodes using USBRadio channel driver, regardless of if txboost is on or off or other usbradio.conf settings.

I have included the Tx Audio Stats utility with this as it was very helpful in testing an is a very simple change extending the already existing Rx Audio Stats utility to now also be able to look at Tx audio.