### PR TITLE
app_rpt: prevent null pointer when calling `softhangup()`, observed in issue #763

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4796,16 +4796,8 @@ static void *rpt(void *this)
 		}
 
 		if (myrpt->reload) {
-			struct rpt_tele *telem;
-
-			rpt_mutex_lock(&myrpt->lock);
-			telem = myrpt->tele.next;
-			while (telem != &myrpt->tele) {
-				ast_softhangup(telem->chan, AST_SOFTHANGUP_DEV);
-				telem = telem->next;
-			}
+			flush_telem(myrpt);
 			myrpt->reload = 0;
-			rpt_mutex_unlock(&myrpt->lock);
 			usleep(10000);
 			load_rpt_vars_by_rpt(myrpt, 1);
 		}

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -546,7 +546,7 @@ void flush_telem(struct rpt *myrpt)
 	rpt_mutex_lock(&myrpt->lock);
 	telem = myrpt->tele.next;
 	while (telem != &myrpt->tele) {
-		if (telem->mode != SETREMOTE) {
+		if (telem->mode != SETREMOTE && telem->chan) {
 			ast_softhangup(telem->chan, AST_SOFTHANGUP_DEV);
 		}
 		telem = telem->next;


### PR DESCRIPTION
The first core dump while trying to reload the repeater found in issue #763 : Attempted to `softhangup()` with a null channel pointer.  
 