### PR TITLE
app_rpt: on update_parrot() and update_timers() failure, add missing call to rpt_mutex_unlock()

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -5368,6 +5368,7 @@ static void *rpt(void *this)
 		rpt_mutex_lock(&myrpt->lock);
 		periodic_process_links(myrpt, elap);
 		if (update_timers(myrpt, elap, totx)) {
+			rpt_mutex_unlock(&myrpt->lock);
 			break;
 		}
 		if (!ms) {
@@ -5378,6 +5379,7 @@ static void *rpt(void *this)
 		}
 		if ((myrpt->p.parrotmode || myrpt->parrotonce) && myrpt->parrotstate == 1 && myrpt->parrottimer <= 0) {
 			if (update_parrot(myrpt)) {
+				rpt_mutex_unlock(&myrpt->lock);
 				break;
 			}
 		}


### PR DESCRIPTION
It appears we are locked at these locations and should unlock before leaving the while loop.  Of course this only causes trouble when things "fail" and we try to shut down the repeater thread.