### PR TITLE
app_rpt: Update all mutex calls to `myrpt->lock` to use `rpt_mutex_*`

### DIFF
--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -673,7 +673,7 @@ enum rpt_function_response function_remote(struct rpt *myrpt, char *param, char 
 		cp = ast_strdup(param);
 		cp1 = strchr(cp, ',');
 		if (cp1) {
-			ast_mutex_lock(&myrpt->lock);
+			rpt_mutex_lock(&myrpt->lock);
 			*cp1 = 0;
 			cp2 = strchr(cp1 + 1, ',');
 			if (cp2) {
@@ -681,7 +681,7 @@ enum rpt_function_response function_remote(struct rpt *myrpt, char *param, char 
 				ast_copy_string(myrpt->loginlevel, cp2 + 1, sizeof(myrpt->loginlevel));
 			}
 			ast_copy_string(myrpt->loginuser, cp1 + 1, sizeof(myrpt->loginuser) - 1);
-			ast_mutex_unlock(&myrpt->lock);
+			rpt_mutex_unlock(&myrpt->lock);
 			donodelog_fmt(myrpt, "LOGIN,%s,%s", myrpt->loginuser, myrpt->loginlevel);
 			ast_debug(1, "loginuser %s level %s\n", myrpt->loginuser, myrpt->loginlevel);
 			rpt_telemetry(myrpt, REMLOGIN, NULL);

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -562,9 +562,9 @@ void rpt_update_links(struct rpt *myrpt)
 		return;
 	}
 
-	ast_mutex_lock(&myrpt->lock);
+	rpt_mutex_lock(&myrpt->lock);
 	n = __mklinklist(myrpt, NULL, &buf, 1);
-	ast_mutex_unlock(&myrpt->lock);
+	rpt_mutex_unlock(&myrpt->lock);
 	/* parse em */
 	if (n) {
 		ast_str_set(&obuf, 0, "%d,%s", n, ast_str_buffer(buf));
@@ -576,9 +576,9 @@ void rpt_update_links(struct rpt *myrpt)
 	rpt_manager_trigger(myrpt, "RPT_NUMALINKS", ast_str_buffer(obuf));
 
 	ast_str_reset(buf);
-	ast_mutex_lock(&myrpt->lock);
+	rpt_mutex_lock(&myrpt->lock);
 	n = __mklinklist(myrpt, NULL, &buf, 0);
-	ast_mutex_unlock(&myrpt->lock);
+	rpt_mutex_unlock(&myrpt->lock);
 	if (n) {
 		ast_str_set(&obuf, 0, "%d,%s", n, ast_str_buffer(buf));
 	}


### PR DESCRIPTION
Allows APP_RPT_LOCK_DEBUG to function correctly.