### PR TITLE
app_rpt: log warning when audiohook fails to adjust volume

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -5293,16 +5293,16 @@ static void *rpt(void *this)
 			/* If we have a new telmetry message or we have changed keyup state to keyup */
 			if (((myrpt->active_telem != last_telem) || !lastduck) && (myrpt->keyed || myrpt->remrx)) {
 				if (ast_audiohook_volume_set_float(myrpt->active_telem->chan, AST_AUDIOHOOK_DIRECTION_WRITE, myrpt->p.telemduckgain)) {
-					ast_debug(7, "Setting the volume on channel %s to %2.2f", ast_channel_name(myrpt->active_telem->chan),
-						myrpt->p.telemduckgain);
+					ast_log(LOG_WARNING, "Setting the volume on channel %s to %2.2f failed",
+						ast_channel_name(myrpt->active_telem->chan), myrpt->p.telemduckgain);
 				}
 				lastduck = 1;
 			}
 			/* If we have a new telemetry message or we have already adjusted ducking and we are not keyed up */
 			if (((myrpt->active_telem != last_telem) || lastduck) && !myrpt->keyed && !myrpt->remrx) {
 				if (ast_audiohook_volume_set_float(myrpt->active_telem->chan, AST_AUDIOHOOK_DIRECTION_WRITE, myrpt->p.telemnomgain)) {
-					ast_debug(7, "Setting the volume on channel %s to %2.2f", ast_channel_name(myrpt->active_telem->chan),
-						myrpt->p.telemnomgain);
+					ast_log(LOG_WARNING, "Setting the volume on channel %s to %2.2f failed",
+						ast_channel_name(myrpt->active_telem->chan), myrpt->p.telemnomgain);
 				}
 				lastduck = 0;
 			}

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -1331,7 +1331,7 @@ void *rpt_tele_thread(void *this)
 			break;
 	}
 	if (ast_audiohook_volume_set_float(mychannel, AST_AUDIOHOOK_DIRECTION_WRITE, myrpt->p.telemnomgain)) {
-		ast_debug(7, "Setting the volume on channel %s to %2.2f", ast_channel_name(mychannel), myrpt->p.telemnomgain);
+		ast_log(LOG_WARNING, "Setting the volume on channel %s to %2.2f failed", ast_channel_name(mychannel), myrpt->p.telemnomgain);
 	}
 
 	if (rpt_conf_add(mychannel, myrpt, type, RPT_CONF_CONFANN)) {


### PR DESCRIPTION
These "debug" messages are actually failure to set the audiohook.