### PR TITLE
app_rpt: initialize last_thread_time[] in rpt_master()

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -5658,7 +5658,7 @@ static void *rpt_master(void *ignore)
 {
 	int i;
 	bool thread_hung[MAXRPTS] = { false };
-	time_t last_thread_time[MAXRPTS];
+	time_t last_thread_time[MAXRPTS] = { 0 };
 	time_t current_time = rpt_time_monotonic();
 	/* init nodelog queue */
 	nodelog.next = nodelog.prev = &nodelog;


### PR DESCRIPTION
Valgrind testing shows the following warning on asterisk startup:

==106769== Thread 43:
==106769== Conditional jump or move depends on uninitialised value(s)
==106769==    at 0xCF3B48E: rpt_master (app_rpt.c:5730)
==106769==    by 0x41EE114: dummy_start (utils.c:1607)
==106769==    by 0x5ECCB7A: start_thread (pthread_create.c:448)
==106769==    by 0x5F4A5EF: clone (clone.S:100)
==106769==

due to the last_thread_time[] array not being initializd. This patch does so.