### PR TITLE
app_rpt: Use ast_opt macro instead of ast_test_flag for options

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -5665,7 +5665,7 @@ static void *rpt_master(void *ignore)
 	/* go thru all the specified repeaters */
 
 	/* wait until asterisk starts */
-	while (!ast_test_flag(&ast_options, AST_OPT_FLAG_FULLY_BOOTED)) {
+	while (!ast_fully_booted) {
 		usleep(250000);
 	}
 


### PR DESCRIPTION
Asterisk commit https://github.com/asterisk/asterisk/commit/a8a3ba97b1d8dc813a99b6d2f02060615174d908 changed the ast_options structure from 32-bit to 64-bit, which means ast_test_flag64 must now be used instead of ast_test_flag. Use the macros defined in include/asterisk/options.h to automatically use the appropriate flag test macro for a system.