### PR TITLE
app_rpt: Remove now unused teleconf from dahdiconf struct

### DIFF
--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -733,7 +733,6 @@ struct rpt_conf {
 	struct {
 		int conf;
 		int txconf;
-		int teleconf; /*!< \brief telemetry conference id */
 	} dahdiconf;
 };
 


### PR DESCRIPTION
teleconf was removed in PR#563