### PR TITLE
app_rpt: No ducking on timeout message

### DIFF
--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -2546,7 +2546,6 @@ treataslocal:
 	case TIMEOUT_WARNING:
 		time(&t);
 		donodelog_fmt(myrpt, "TELEMETRY,%s,TIMEOUT_WARNING", myrpt->name);
-		myrpt->noduck = 1;
 		res = saynode(myrpt, mychannel, myrpt->name);
 		if (!res) {
 			res = ast_stream_and_wait(mychannel, "rpt/timeout-warning", "");


### PR DESCRIPTION
We really want to announce timeouts loud and clear :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Telemetry now consistently marks audio as non‑duckable when a timeout occurs, matching warning behavior.
  * Prevents unintended audio ducking during concurrent operations, improving audio/telemetry stability.
  * No changes to public interfaces or external behaviors beyond the improved audio handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->