### PR TITLE
chan_voter: Ignore clients when no asterisk channel is setup

### DIFF
--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -2635,6 +2635,7 @@ static struct ast_channel *voter_request(const char *type, struct ast_format_cap
 		}
 		ast_mutex_unlock(&voter_lock);
 	}
+	ast_config_destroy(cfg);
 	ast_pthread_create(&p->xmit_thread, NULL, voter_xmit, p);
 	if (SEND_PRIMARY(p)) {
 		ast_pthread_create(&p->primary_thread, NULL, voter_primary_client, p);


### PR DESCRIPTION
If a repeater is disabled, or if voter.conf has mismatched node id,
the RTCM will continually connect/disconnect cycle generating the
CW ID over and over.  Simply dereferencing the "known" client if we don't have a channel prevents the cycle.
This is essentially the same as not finding a valid client in `voter.conf`.
This  closes #786 

Handle killing threads when `hangup()` is called.
Create additional thread handle in the private data to allow killing both threads: `voter_primary_client()` and `voter_xmit()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-instance controls with separate primary and transmit threads for voter instances to improve isolation and shutdown behavior.

* **Bug Fixes**
  * Threads now terminate cleanly per instance on hangup/shutdown to prevent hangs and leaks.
  * Incoming UDP packets without a matching channel are skipped to avoid needless processing.

* **Documentation**
  * Clarified thread lifecycle and roles for maintainability.

* **Logging**
  * Improved node-centric messages and explicit checks to avoid misleading responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->