### PR TITLE
app_rpt: prevent html in logfile, add "words" to http codes

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -1004,12 +1004,18 @@ static const char *http_status_text(long code)
 		return "Created";
 	case 204:
 		return "No Content";
+	case 206:
+		return "Partial Content";
 	case 301:
 		return "Moved Permanently";
 	case 302:
 		return "Found";
 	case 304:
 		return "Not Modified";
+	case 307:
+		return "Temporary Redirect";
+	case 308:
+		return "Permanent Redirect";
 	case 400:
 		return "Bad Request";
 	case 401:
@@ -1018,12 +1024,22 @@ static const char *http_status_text(long code)
 		return "Forbidden";
 	case 404:
 		return "Not Found";
+	case 405:
+		return "Method Not Allowed";
+	case 408:
+		return "Request Timeout";
+	case 429:
+		return "Too Many Requests";
 	case 500:
 		return "Internal Server Error";
+	case 501:
+		return "Not Implemented";
 	case 502:
 		return "Bad Gateway";
 	case 503:
 		return "Service Unavailable";
+	case 504:
+		return "Gateway Timeout";
 	default:
 		return "Unknown Status";
 	}


### PR DESCRIPTION
The goal was to improve debug info on a CURL failure, html is not what we hoped for.
Added a text translation for HTTP error codes to "assist" users.
Fixes #701 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized HTTP status text is now used in error messages for non-2xx responses.
  * Error logs present clearer, more consistent human-readable status descriptions, making diagnosis of failed requests easier for users and operators.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->