### PR TITLE
chan_usbradio: remove unnecessary code

### DIFF
--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -3735,18 +3735,13 @@ static void mixer_write(struct chan_simpleusb_pvt *o)
 		ast_radio_make_spkr_playback_value(o->spkrmax, o->txmixaset, o->devtype),
 		ast_radio_make_spkr_playback_value(o->spkrmax, o->txmixbset, o->devtype));
 	/* adjust settings based on the device */
-	switch (o->devtype) {
-		case C119B_PRODUCT_ID:
-			mic_setting =  o->rxmixerset * o->micmax / C119B_ADJUSTMENT;
-			/* get interval step size */
-			f = C119B_ADJUSTMENT / (float) o->micmax;
-			o->rxboost = 1;		/*rxboost is always set for this device */
-			break;
-		default:
-			mic_setting =  o->rxmixerset * o->micmax / 1000;
-			/* get interval step size */
-			f = 1000.0 / (float) o->micmax;
+	if (o->devtype == C119B_PRODUCT_ID) {
+		o->rxboost = 1; /*rxboost is always set for this device */
 	}
+	mic_setting = o->rxmixerset * o->micmax / AUDIO_ADJUSTMENT;
+	/* get interval step size */
+	f = AUDIO_ADJUSTMENT / (float) o->micmax;
+
 	ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL, mic_setting, 0);
 	ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_BOOST, o->rxboost, 0);
 	ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_CAPTURE_SW, 1, 0);

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -78,7 +78,7 @@
  *	This adjustment factor is used for both microphone and
  *	speaker calculations.
  */
-#define C119B_ADJUSTMENT	1000
+#define AUDIO_ADJUSTMENT 1000
 
 /*!
  * \brief EEPROM memory layout

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -116,21 +116,7 @@ long ast_radio_lround(double x)
 
 int ast_radio_make_spkr_playback_value(int spkrmax, int request_value, int devtype)
 {
-	int v;
-	
-	switch (devtype) {
-		case C108_PRODUCT_ID:
-			v = (request_value * spkrmax) / 1000;
-			return v;
-			
-		case C119B_PRODUCT_ID:
-			v = (request_value * spkrmax) / C119B_ADJUSTMENT;
-			return v;
-			
-		default:
-			v = (request_value * spkrmax) / 1000;
-			return v;
-	}
+	return (request_value * spkrmax) / AUDIO_ADJUSTMENT;
 }
 
 int ast_radio_amixer_max(int devnum, char *param)


### PR DESCRIPTION
chan_simpleusb: remove unnecessary code.
The C119B_ADJUSTMENT is 1000.  Each case switch for the C119B_PRODUCT_ID decided between C119B_ADJUSTMENT and a magic number of 1000 -> solving to the same result.
There remains 1 device specific configuration related to `o->rxboost = 1` for the C119B_PRODUCT_ID
Resolves https://github.com/AllStarLink/app_rpt/issues/760

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated audio calibration logic for improved consistency across USB radio device types
  * Unified microphone capture volume, squelch, and voice tone adjustment calculations
  * Simplified speaker playback value derivation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->