### PR TITLE
chan_voter: Additional debug message changes for easier troubleshooting

### DIFF
--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -3884,7 +3884,8 @@ static void *voter_reader(void *data)
 					.subclass.integer = AST_CONTROL_RADIO_UNKEY,
 					.src = __PRETTY_FUNCTION__,
 				};
-				ast_debug(3, "VOTER client %s was receiving but now has stopped (RX_TIMEOUT_MS)!\n", ((client) ? client->name : "UNKNOWN"));
+				ast_debug(3, "VOTER client %s was receiving but now has stopped (RX_TIMEOUT_MS)!\n",
+					(client && client->name) ? client->name : "UNKNOWN");
 				ast_queue_frame(p->owner, &wf);
 				p->rxkey = 0;
 				p->lastwon = NULL;
@@ -3905,7 +3906,7 @@ static void *voter_reader(void *data)
 		}
 		vph = (VOTER_PACKET_HEADER *) buf;
 		ast_debug(7, "Got RX packet, len %d payload %d challenge %s digest %08x from client %s\n", (int) recvlen,
-			ntohs(vph->payload_type), vph->challenge, ntohl(vph->digest), ((client) ? client->name : "UNKNOWN"));
+			ntohs(vph->payload_type), vph->challenge, ntohl(vph->digest), (client && client->name) ? client->name : "UNKNOWN");
 		client = NULL;
 		if ((!check_client_sanity) && master_port) {
 			sin.sin_port = htons(master_port);


### PR DESCRIPTION
-Clean up grammar in debug messages for clarity
-Add context to "out of bounds" debug message for mix clients -Add and log a more descriptive error when bufflen too small for mix mode clients -First pass at adding client name to additional debug strings (note it can't seem to resolve client names reliably in normal (voting) mode, but resolves fine in mix mode) -Revise TX On/TX Off from debug level 2 to debug level 1 for consistency with like messages -Spelling corrections in comments
-Change debug around line 3906 to level 7 (it is WAY too chatty) -Add debug level 3 message when a client appears to have stopped receiving (RX_TIMEOUT_MS (200ms) detected) -Change disconnect (timeout) messages from verbose 3 to log notice per Issue 334 and Issue 122 which will also help diag which function is asserting the notice (there are two different parts of the code). Note that a client designated as a "master" will timeout in 100ms, versus a regular client which has 3s before it times out. Hence why a master MUST be on the same LAN as the host -Change debug lines at around 4207 to level 7, they are very chatty, and of limited use

Resolves: #334 #122

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized capitalization and terminology in log and status messages for improved clarity and consistency throughout the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->