### PR TITLE
app_rpt.c: Clear `active_telem` when flushing telemetry

### DIFF
--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -546,8 +546,8 @@ int priority_telemetry_pending(struct rpt *myrpt)
  */
 #define telem_done(myrpt, telem) \
 	if (myrpt->active_telem == telem) { \
-		myrpt->active_telem = NULL; \
 		ast_debug(5, "Ending telemetry, active_telem = %p, mytele = %p\n", myrpt->active_telem, telem); \
+		myrpt->active_telem = NULL; \
 	} else { \
 		ast_log(LOG_WARNING, "Attempting to clear active_telem %p when telem is %p", myrpt->active_telem, telem); \
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Telemetry shutdown and cleanup now only clears the currently active telemetry, preventing incorrect termination in normal and abort paths and improving stability.
  * Improved logging for termination paths to aid diagnostics during shutdown and flush operations.

* **Refactor**
  * Centralized active-telemetry state handling for more consistent and reliable cleanup across code paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->