### PR TITLE
chan_voter: Fix module reload chan_voter not detecting client type change

### DIFF
--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -424,9 +424,6 @@ int maxpvtorder = 0;
  */
 int puckit = 0;
 
-/* this variable doesn't seem to be used, delete?*/
-double dnsec;
-
 static pthread_t voter_reader_thread = 0;
 static pthread_t voter_timer_thread = 0;
 
@@ -4138,6 +4135,8 @@ static int reload(void)
 			client->donulaw = 0;
 			client->nodeemp = 0;
 			client->mix = 0;
+			client->curmaster = 0;
+			client->ismaster = 0;
 			client->noplfilter = 0;
 			client->prio = 0;
 			client->gpsid = 0;


### PR DESCRIPTION
Changing to/from master to mix client in voter.conf and doing a module reload chan_voter did not pick up the config file change.

client->ismaster and client->curmaster were not being reset on reload to detect the change.

Resolves: #857

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed state handling during client reconfiguration to ensure proper reset of client status flags when reloading or reconfiguring clients, improving reliability of master/client selection behavior.

* **Chores**
  * Removed unused code declarations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->