### PR TITLE
app_rpt.c: Fix "spewing" tot overide debug message

### DIFF
--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -528,7 +528,7 @@ int priority_telemetry_pending(struct rpt *myrpt)
 		 */
 		switch (telem->mode) {
 		case TIMEOUT:
-			ast_debug(3, "tot override message pending.");
+			ast_debug(3, "Transmit override: Priority telemetry message pending (TIMEOUT).");
 			pending = 1;
 			break;
 		default:


### PR DESCRIPTION
Seems like we only really care if it finds an override? 
Fixes #853

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved diagnostic logging with updated debug messages for timeout detection scenarios in telemetry monitoring.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->