### PR TITLE
app_rpt: address race setting `myrpt->calldigittimer`

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -1380,7 +1380,6 @@ void *rpt_call(void *this)
 	congstarted = 0;
 	dialtimer = 0;
 	lastcidx = 0;
-	myrpt->calldigittimer = 0;
 	aborted = 0;
 
 	/* Reverse engineering of callmode Mar 2023 NA
@@ -2587,6 +2586,7 @@ static void local_dtmf_helper(struct rpt *myrpt, char c_in)
 			myrpt->patchquiet = 0;
 			myrpt->patchfarenddisconnect = 0;
 			myrpt->patchdialtime = 0;
+			myrpt->calldigittimer = 0;
 			ast_copy_string(myrpt->patchcontext, myrpt->p.ourcontext, MAXPATCHCONTEXT - 1);
 			myrpt->cidx = 0;
 			myrpt->exten[myrpt->cidx] = 0;


### PR DESCRIPTION
When calling a number from the command line with a partial match ex: `rpt fun 1999 *612345` where 2345 is a valid extension with a partial match, there is a race between the extension check setting `myrpt->calldigittimer = 1` and the `rpt_call()` thread setting `myrpt->calldigittimer = 0`.  This prevents a partial match extension from dialing and always ends in a patch timeout. The idea behind `myrpt->calldigittimer = 0` is to prevent digit timing until the first digit is received.  If a user dials *61, the patch timer should start, but the inter digit timers should wait until the first extension digit is dialed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Modified patch dialing timeout behavior. The digit entry timeout now resets at the start of dialing and during digit handling, rather than on every call entry, adjusting the available window for entering dialing digits.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->