### PR TITLE
app_rpt: Remove dependency on DAHDI

### DIFF
--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -741,12 +741,13 @@ struct rpt_cmd_struct {
 	enum rpt_command_source command_source;
 };
 
+struct ast_bridge; /* Forward declaration */
+
+/*! \brief Structure used to manage conference bridges */
 struct rpt_conf {
-	/* DAHDI conference numbers */
-	struct {
-		int conf;
-		int txconf;
-	} dahdiconf;
+	/* Conference bridge channels */
+	struct ast_bridge *conf;
+	struct ast_bridge *txconf;
 };
 
 /*! \brief Populate rpt structure with data */
@@ -941,16 +942,21 @@ struct rpt {
 	int  parrottimer;
 	unsigned int parrotcnt;
 	int telemmode;
-	struct ast_channel *rxchannel,*txchannel, *monchannel, *parrotchannel;
-	struct ast_channel *pchannel,*txpchannel, *dahdirxchannel, *dahditxchannel;
-	struct ast_channel *voxchannel;
+	struct ast_channel *rxchannel;		/*!< Channel connected to physical hardware, can be bi-directional */
+	struct ast_channel *txchannel;		/*!< Channel connect to physical hardware if separate otherwise equal to rxchannel */
+	struct ast_channel *monchannel;		/*!< Monitor channel used to record activity on the TXCONF */
+	struct ast_channel *pchannel;		/*!< Channel used to copy CONF bridge audio into txpchannel */
+	struct ast_channel *rxpchannel;		/*!< Channel used to copy RX audio into CONF bridge */
+	struct ast_channel *txpchannel;		/*!< Channel used to receive RX audio into the TXCONF bridge */
+	struct ast_channel *localrxchannel; /*!< Channel used when in remote configuration for rx, may be set equal to pchannel */
+	struct ast_channel *localtxchannel; /*!< Channel used to receive audio from the TXCONF bridge into the txchannel */
 	struct rpt_frame_queue frame_queue;
 	struct rpt_tele tele;
 	struct timeval lasttv,curtv;
-	pthread_t rpt_call_thread,rpt_thread;
-	time_t dtmf_time,rem_dtmf_time,dtmf_time_rem;
-	int calldigittimer;
 	struct rpt_conf rptconf;
+	pthread_t rpt_call_thread, rpt_thread;
+	time_t dtmf_time, rem_dtmf_time, dtmf_time_rem;
+	int calldigittimer;
 	int tailtimer, totimer, idtimer, cidx, scantimer, tmsgtimer, skedtimer, linkactivitytimer, elketimer;
 	int remote_time_out_reset_unkey_interval_timer, time_out_reset_unkey_interval_timer;
 	enum patch_call_mode callmode;
@@ -1024,6 +1030,7 @@ struct rpt {
 	int lastkeytimer;
 	enum newkey rpt_newkey;
 	int rxlingertimer;
+	rpt_bool patch_talking:1;
 	rpt_bool inpadtest:1;
 	rpt_bool localoverride:1;
 	rpt_bool wasvox:1;
@@ -1106,6 +1113,9 @@ struct statpost {
 
 #define IS_PSEUDO(c) (!strncasecmp(ast_channel_name(c), "DAHDI/pseudo", 12))
 #define IS_PSEUDO_NAME(c) (!strncasecmp(c, "DAHDI/pseudo", 12))
+
+#define IS_LOCAL(c) (!strncasecmp(ast_channel_name(c), "Local", 5))
+#define IS_LOCAL_NAME(c) (!strncasecmp(c, "Local", 5))
 
 int rpt_debug_level(void);
 int rpt_set_debug_level(int newlevel);

--- a/apps/app_rpt/rpt_bridging.c
+++ b/apps/app_rpt/rpt_bridging.c
@@ -27,17 +27,22 @@
 #include "asterisk.h"
 
 #include <dahdi/user.h>
-#include <dahdi/tonezone.h>		/* use tone_zone_set_zone */
 
+#include "asterisk/bridge.h"
+#include "asterisk/core_unreal.h"
 #include "asterisk/channel.h"
 #include "asterisk/indications.h"
 #include "asterisk/format_cache.h" /* use ast_format_slin */
+#include "asterisk/audiohook.h"
 
 #include "app_rpt.h"
 
 #include "rpt_bridging.h"
 #include "rpt_call.h"
 
+/*!
+ *	\brief used to display "words" in debug messages.
+ */
 static const char *rpt_chan_type_str(enum rpt_chan_type chantype)
 {
 	switch (chantype) {
@@ -47,16 +52,14 @@ static const char *rpt_chan_type_str(enum rpt_chan_type chantype)
 		return "txchan";
 	case RPT_PCHAN:
 		return "pchan";
-	case RPT_DAHDITXCHAN:
-		return "dahditxchan";
+	case RPT_LOCALTXCHAN:
+		return "localtxchan";
 	case RPT_MONCHAN:
 		return "monchan";
-	case RPT_PARROTCHAN:
-		return "parrotchan";
-	case RPT_VOXCHAN:
-		return "voxchan";
 	case RPT_TXPCHAN:
 		return "txpchan";
+	case RPT_RXPCHAN:
+		return "rxpchan";
 	}
 	ast_assert(0);
 	return NULL;
@@ -70,11 +73,10 @@ static const char *rpt_chan_name(struct rpt *myrpt, enum rpt_chan_type chantype)
 	case RPT_TXCHAN:
 		return myrpt->txchanname;
 	case RPT_PCHAN:
-	case RPT_DAHDITXCHAN:
+	case RPT_LOCALTXCHAN:
 	case RPT_MONCHAN:
-	case RPT_PARROTCHAN:
-	case RPT_VOXCHAN:
 	case RPT_TXPCHAN:
+	case RPT_RXPCHAN:
 		return NULL;
 	}
 	ast_assert(0);
@@ -91,16 +93,14 @@ static struct ast_channel **rpt_chan_channel(struct rpt *myrpt, struct rpt_link 
 			return &myrpt->txchannel;
 		case RPT_PCHAN:
 			return &myrpt->pchannel;
-		case RPT_DAHDITXCHAN:
-			return &myrpt->dahditxchannel;
+		case RPT_LOCALTXCHAN:
+			return &myrpt->localtxchannel;
 		case RPT_MONCHAN:
 			return &myrpt->monchannel;
-		case RPT_PARROTCHAN:
-			return &myrpt->parrotchannel;
-		case RPT_VOXCHAN:
-			return &myrpt->voxchannel;
 		case RPT_TXPCHAN:
 			return &myrpt->txpchannel;
+		case RPT_RXPCHAN:
+			return &myrpt->rxpchannel;
 		}
 	} else if (link) {
 		switch (chantype) {
@@ -114,7 +114,7 @@ static struct ast_channel **rpt_chan_channel(struct rpt *myrpt, struct rpt_link 
 	return NULL;
 }
 
-#define RPT_DIAL_TIME 999
+#define RPT_DIAL_DURATION 999 /*! \brief Wait timeout for ast_call() executions (asterisk may not be using) */
 
 void rpt_hangup(struct rpt *myrpt, enum rpt_chan_type chantype)
 {
@@ -139,6 +139,10 @@ void rpt_hangup(struct rpt *myrpt, enum rpt_chan_type chantype)
 			ast_debug(2, "Also resetting rxchannel\n");
 			myrpt->rxchannel = NULL;
 		}
+		if (myrpt->localtxchannel && myrpt->localtxchannel == *chanptr) {
+			ast_debug(2, "Also resetting localtxchannel\n");
+			myrpt->localtxchannel = NULL;
+		}
 		break;
 	default:
 		break;
@@ -153,15 +157,14 @@ static const char *rpt_chan_app(enum rpt_chan_type chantype, enum rpt_chan_flags
 {
 	switch (chantype) {
 	case RPT_RXCHAN:
-		return flags & RPT_LINK_CHAN ? "(Link Rx)" : "(Repeater Rx)";
+		return flags & RPT_LINK_CHAN ? "Link Rx" : "Repeater Rx";
 	case RPT_TXCHAN:
-		return flags & RPT_LINK_CHAN ? "(Link Tx)" : "(Repeater Tx)";
+		return flags & RPT_LINK_CHAN ? "Link Tx" : "Repeater Tx";
 	case RPT_PCHAN:
-	case RPT_DAHDITXCHAN:
+	case RPT_LOCALTXCHAN:
 	case RPT_MONCHAN:
-	case RPT_PARROTCHAN:
-	case RPT_VOXCHAN:
 	case RPT_TXPCHAN:
+	case RPT_RXPCHAN:
 		return NULL;
 	}
 	ast_assert(0);
@@ -176,11 +179,10 @@ static const char *rpt_chan_app_data(enum rpt_chan_type chantype)
 	case RPT_TXCHAN:
 		return "Tx";
 	case RPT_PCHAN:
-	case RPT_DAHDITXCHAN:
+	case RPT_LOCALTXCHAN:
 	case RPT_MONCHAN:
-	case RPT_PARROTCHAN:
-	case RPT_VOXCHAN:
 	case RPT_TXPCHAN:
+	case RPT_RXPCHAN:
 		return NULL;
 	}
 	ast_assert(0);
@@ -224,21 +226,13 @@ int __rpt_request(void *data, struct ast_format_cap *cap, enum rpt_chan_type cha
 		return -1;
 	}
 
-	/* XXX
-	 * Note: Removed in refactoring:
-	 * inside rpt_make_call, we should rpt_mutex_unlock(&myrpt->lock);
-	 * before ast_call
-	 * and
-	 * rpt_mutex_lock(&myrpt->lock);
-	 * afterwards,
-	 * if flags & RPT_LINK_CHAN.
-	 * This might not be necessary, but if it is, this should be re-added. */
-
-	rpt_make_call(chan, device, RPT_DIAL_TIME, tech, rpt_chan_app(chantype, flags), rpt_chan_app_data(chantype), myrpt->name);
-	if (ast_channel_state(chan) != AST_STATE_UP) {
-		ast_log(LOG_ERROR, "Requested channel %s not up?\n", ast_channel_name(chan));
-		ast_hangup(chan);
-		return -1;
+	if (!IS_LOCAL_NAME(tech)) {
+		rpt_make_call(chan, device, RPT_DIAL_DURATION, tech, rpt_chan_app(chantype, flags), rpt_chan_app_data(chantype), myrpt->name);
+		if (ast_channel_state(chan) != AST_STATE_UP) {
+			ast_log(LOG_ERROR, "Requested channel %s not up?\n", ast_channel_name(chan));
+			ast_hangup(chan);
+			return -1;
+		}
 	}
 
 	chanptr = rpt_chan_channel(myrpt, NULL, chantype);
@@ -246,15 +240,10 @@ int __rpt_request(void *data, struct ast_format_cap *cap, enum rpt_chan_type cha
 
 	switch (chantype) {
 	case RPT_RXCHAN:
-		myrpt->dahdirxchannel = !strcasecmp(tech, "DAHDI") ? chan : NULL;
+		myrpt->localrxchannel = IS_LOCAL_NAME(tech) ? chan : NULL;
 		break;
 	case RPT_TXCHAN:
-		if (flags & RPT_LINK_CHAN) {
-			/* XXX Dunno if this difference is really necessary, but this is a literal refactor of existing logic... */
-			myrpt->dahditxchannel = !strcasecmp(tech, "DAHDI") ? chan : NULL;
-		} else {
-			myrpt->dahditxchannel = !strcasecmp(tech, "DAHDI") && strcasecmp(device, "pseudo") ? chan : NULL;
-		}
+		myrpt->localtxchannel = IS_LOCAL_NAME(tech) ? chan : NULL;
 		break;
 	default:
 		break;
@@ -263,19 +252,62 @@ int __rpt_request(void *data, struct ast_format_cap *cap, enum rpt_chan_type cha
 	return 0;
 }
 
-struct ast_channel *rpt_request_pseudo_chan(struct ast_format_cap *cap)
+static const char *rpt_bridge_chan_type_name(enum rpt_bridge_chan_type type)
 {
-	struct ast_channel *chan = ast_request("DAHDI", cap, NULL, NULL, "pseudo", NULL);
+	switch (type) {
+	case RPT_LOCAL:
+		return "Local";
+	case RPT_TELEMETRY:
+		return "Announcer";
+	case RPT_MONITOR:
+		return "Recorder";
+	}
+	ast_assert(0);
+	return NULL;
+}
+
+static const char *rpt_chan_type_name(enum rpt_chan_type type, enum rpt_chan_flags flags)
+{
+	if (flags & RPT_LINK_CHAN) {
+		return "Announcer";
+	}
+
+	switch (type) {
+	case RPT_MONCHAN:
+	case RPT_PCHAN:
+		return "Recorder";
+	case RPT_RXPCHAN:
+	case RPT_TXPCHAN:
+		return "Announcer";
+	default:
+		return "Local";
+	}
+}
+
+struct ast_channel *__rpt_request_local_chan(struct ast_format_cap *cap, const char *exten, enum rpt_bridge_chan_type type)
+{
+	struct ast_channel *chan;
+
+	chan = ast_request(rpt_bridge_chan_type_name(type), cap, NULL, NULL, exten, NULL);
 	if (!chan) {
-		ast_log(LOG_ERROR, "Failed to request pseudo channel\n");
+		ast_log(LOG_ERROR, "Failed to request local channel\n");
 		return NULL;
 	}
-	rpt_disable_cdr(chan);
-	ast_answer(chan);
+
+	ast_debug(1, "Requesting channel %s setup\n", ast_channel_name(chan));
+	ast_set_read_format(chan, ast_format_slin);
+	ast_set_write_format(chan, ast_format_slin);
+	if (type == RPT_LOCAL) {
+		/* Local channel needs to be answered.
+		 * Announcer channels auto answer on creation.
+		 */
+		rpt_disable_cdr(chan);
+		ast_debug(1, "Requested channel %s cdr disabled\n", ast_channel_name(chan));
+	}
 	return chan;
 }
 
-int __rpt_request_pseudo(void *data, struct ast_format_cap *cap, enum rpt_chan_type chantype, enum rpt_chan_flags flags)
+int __rpt_request_local(void *data, struct ast_format_cap *cap, enum rpt_chan_type chantype, enum rpt_chan_flags flags, const char *exten)
 {
 	struct rpt *myrpt = NULL;
 	struct rpt_link *link = NULL;
@@ -286,30 +318,25 @@ int __rpt_request_pseudo(void *data, struct ast_format_cap *cap, enum rpt_chan_t
 	} else {
 		myrpt = data;
 	}
-
-	chan = ast_request("DAHDI", cap, NULL, NULL, "pseudo", NULL);
+	chan = ast_request(rpt_chan_type_name(chantype, flags), cap, NULL, NULL, exten, NULL);
 	if (!chan) {
-		ast_log(LOG_ERROR, "Failed to request pseudo channel\n");
+		ast_log(LOG_ERROR, "Failed to request local channel\n");
 		return -1;
 	}
-
-	ast_debug(1, "Requested channel %s\n", ast_channel_name(chan));
-
-	/* A subset of what rpt_make_call does... */
 	ast_set_read_format(chan, ast_format_slin);
 	ast_set_write_format(chan, ast_format_slin);
 	rpt_disable_cdr(chan);
-	ast_answer(chan);
-
 	chanptr = rpt_chan_channel(myrpt, link, chantype);
 	*chanptr = chan;
 
 	switch (chantype) {
+	case RPT_MONCHAN:
+		break; /* WE don't need to answer MONCHAN */
 	case RPT_PCHAN:
 		if (!(flags & RPT_LINK_CHAN)) {
 			ast_assert(myrpt != NULL);
-			if (!myrpt->dahdirxchannel) {
-				myrpt->dahdirxchannel = chan;
+			if (!myrpt->localrxchannel) {
+				myrpt->localrxchannel = chan;
 			}
 		}
 		break;
@@ -320,322 +347,119 @@ int __rpt_request_pseudo(void *data, struct ast_format_cap *cap, enum rpt_chan_t
 	return 0;
 }
 
-#define join_dahdiconf(chan, ci) __join_dahdiconf(chan, ci, __FILE__, __LINE__, __PRETTY_FUNCTION__)
-
-static int __join_dahdiconf(struct ast_channel *chan, struct dahdi_confinfo *ci, const char *file, int line, const char *function)
+int __rpt_conf_create(struct rpt *myrpt, enum rpt_conf_type type, const char *file, int line)
 {
-	ci->chan = 0;
-
-	/* First put the channel on the conference in proper mode */
-	if (ioctl(ast_channel_fd(chan, 0), DAHDI_SETCONF, ci) == -1) {
-		ast_log(LOG_WARNING, "%s:%d (%s) Unable to set conference mode on %s\n", file, line, function, ast_channel_name(chan));
-		return -1;
-	}
-	return 0;
-}
-
-static int dahdi_conf_create(struct ast_channel *chan, int *confno, int mode)
-{
-	int res;
-	struct dahdi_confinfo ci;	/* conference info */
-
-	ci.confno = -1;
-	ci.confmode = mode;
-
-	res = join_dahdiconf(chan, &ci);
-	if (res) {
-		ast_log(LOG_WARNING, "Failed to join DAHDI conf (mode: %d)\n", mode);
-	} else {
-		*confno = ci.confno;
-	}
-	return res;
-}
-
-static int dahdi_conf_add(struct ast_channel *chan, int confno, int mode)
-{
-	int res;
-	struct dahdi_confinfo ci;	/* conference info */
-
-	ci.confno = confno;
-	ci.confmode = mode;
-	
-	ast_debug(2, "Channel %s joining conference %i", ast_channel_name(chan), confno);
-
-	res = join_dahdiconf(chan, &ci);
-	if (res) {
-		ast_log(LOG_WARNING, "Failed to join DAHDI conf (mode: %d)\n", mode);
-	}
-	return res;
-}
-
-#define RPT_DAHDI_FLAG(r, d) \
-	if (rflags & r) { \
-		dflags |= d; \
-	}
-
-static int dahdi_conf_flags(enum rpt_conf_flags rflags)
-{
-	int dflags = 0;
-
-	RPT_DAHDI_FLAG(RPT_CONF_NORMAL, DAHDI_CONF_NORMAL);
-	RPT_DAHDI_FLAG(RPT_CONF_MONITOR, DAHDI_CONF_MONITOR);
-	RPT_DAHDI_FLAG(RPT_CONF_MONITORTX, DAHDI_CONF_MONITORTX);
-	RPT_DAHDI_FLAG(RPT_CONF_CONF, DAHDI_CONF_CONF);
-	RPT_DAHDI_FLAG(RPT_CONF_CONFANN, DAHDI_CONF_CONFANN);
-	RPT_DAHDI_FLAG(RPT_CONF_CONFMON, DAHDI_CONF_CONFMON);
-	RPT_DAHDI_FLAG(RPT_CONF_CONFANNMON, DAHDI_CONF_CONFANNMON);
-	RPT_DAHDI_FLAG(RPT_CONF_LISTENER, DAHDI_CONF_LISTENER);
-	RPT_DAHDI_FLAG(RPT_CONF_TALKER, DAHDI_CONF_TALKER);
-
-	return dflags;
-}
-
-static int *dahdi_confno(struct rpt *myrpt, enum rpt_conf_type type)
-{
+	struct ast_bridge *conf = NULL, **confptr;
+	const char *conference_name = "";
 	switch (type) {
 	case RPT_CONF:
-		return &myrpt->rptconf.dahdiconf.conf;
+		conference_name = RPT_CONF_NAME;
+		confptr = &myrpt->rptconf.conf;
+		break;
 	case RPT_TXCONF:
-		return &myrpt->rptconf.dahdiconf.txconf;
+		conference_name = RPT_TXCONF_NAME;
+		confptr = &myrpt->rptconf.txconf;
+		break;
+	default:
+		__builtin_unreachable();
+		return -1;
 	}
-	ast_assert(0);
-	return NULL;
-}
-
-/*!
- * \brief Get the channel number of a DAHDI channel
- * \param chan DAHDI channel
- * \retval -1 on failure, conference number on success
- */
-static int dahdi_conf_get_channo(struct ast_channel *chan)
-{
-	struct dahdi_confinfo ci = {0};
-
-	if (ioctl(ast_channel_fd(chan, 0), DAHDI_CHANNO, &ci.chan)) {
-		ast_log(LOG_WARNING, "DAHDI_CHANNO failed: %s\n", strerror(errno));
+	ast_debug(3, "Setting up conference '%s' mixing bridge \n", conference_name);
+	conf = ast_bridge_base_new(AST_BRIDGE_CAPABILITY_MULTIMIX,
+		AST_BRIDGE_FLAG_MASQUERADE_ONLY | AST_BRIDGE_FLAG_TRANSFER_BRIDGE_ONLY, "app_rpt", conference_name, NULL);
+	if (!conf) {
+		ast_log(LOG_ERROR, "Conference '%s' mixing bridge could not be created.\n", conference_name);
 		return -1;
 	}
 
-	return ci.chan;
-}
-
-int __rpt_conf_create(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_type type, enum rpt_conf_flags flags, const char *file, int line)
-{
-	int *confno, dflags;
-	/* Convert RPT conf flags to DAHDI conf flags... for now. */
-	dflags = dahdi_conf_flags(flags);
-	confno = dahdi_confno(myrpt, type);
-	if (dahdi_conf_create(chan, confno, dflags)) {
-		ast_log(LOG_ERROR, "%s:%d: Failed to create conference using chan type %d\n", file, line, type);
-		return -1;
-	}
+	*confptr = conf;
 	return 0;
 }
 
-int rpt_equate_tx_conf(struct rpt *myrpt)
+int __rpt_conf_add(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_type type, const char *file, int line)
 {
-	/* save pseudo channel conference number */
-	myrpt->rptconf.dahdiconf.conf = myrpt->rptconf.dahdiconf.txconf;
-	return 0;
-}
-
-int __rpt_conf_add(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_type type, enum rpt_conf_flags flags, const char *file, int line)
-{
-	/* Convert RPT conf flags to DAHDI conf flags... for now. */
-	int *confno, dflags;
-
-	dflags = dahdi_conf_flags(flags);
-	confno = dahdi_confno(myrpt, type);
-
-	if (dahdi_conf_add(chan, *confno, dflags)) {
-		ast_log(LOG_ERROR, "%s:%d: Failed to add to conference using chan type %d\n", file, line, type);
-		return -1;
-	}
-	return 0;
-}
-
-int rpt_call_bridge_setup(struct rpt *myrpt, struct ast_channel *mychannel)
-{
+	struct ast_bridge *conf = NULL;
+	const char *conference_name = "";
+	struct ast_unreal_pvt *p;
 	int res;
 
-	/* Put pchannel back on the conference in speaker mode */
-	if (myrpt->p.duplex == 4 || myrpt->p.duplex == 3) {
-		if (rpt_conf_add_speaker(myrpt->pchannel, myrpt)) {
-			return -1;
-		}
-	}
-
-	/* get its conference number */
-	res = dahdi_conf_get_channo(mychannel);
-	if (res < 0) {
-		ast_log(LOG_WARNING, "Unable to get autopatch channel number\n");
-		/* Put pchannel back on the conference in announce mode */
-		if (myrpt->p.duplex == 4 || myrpt->p.duplex == 3) {
-			rpt_conf_add_announcer_monitor(myrpt->pchannel, myrpt);
-		}
+	switch (type) {
+	case RPT_CONF:
+		conference_name = RPT_CONF_NAME;
+		conf = myrpt->rptconf.conf;
+		break;
+	case RPT_TXCONF:
+		conference_name = RPT_TXCONF_NAME;
+		conf = myrpt->rptconf.txconf;
+		break;
+	default:
+		__builtin_unreachable();
 		return -1;
 	}
-
-	/* put vox channel monitoring on the channel  
-	 *
-	 * This uses the internal DAHDI channel number to create the 
-	 * monitor conference.  This code will hang here when trying to 
-	 * join the conference when the underlying version of DAHDI in use
-	 * is missing a patch that allows the DAHDI_CONF_MONITOR option
-	 * to monitor a pseudo channel.  This patch prevents the hardware
-	 * pre-echo routines from acting on a pseudo channel.  It also
-	 * prevents the DAHDI check conference routine from acting
-	 * on a channel number being used as a conference.
-	 */
-	if (dahdi_conf_add(myrpt->voxchannel, res, DAHDI_CONF_MONITOR)) {
-		/* Put pchannel back on the conference in announce mode */
-		if (myrpt->p.duplex == 4 || myrpt->p.duplex == 3) {
-			rpt_conf_add_announcer_monitor(myrpt->pchannel, myrpt);
-		}
+	if (!conf) {
+		ast_log(LOG_ERROR, "Conference '%s' mixing bridge doesn't exist, can't add channel %s\n", conference_name, ast_channel_name(chan));
 		return -1;
 	}
-	return 0;
-}
-
-int rpt_mon_setup(struct rpt *myrpt)
-{
-	int res;
-
-	if (!IS_PSEUDO(myrpt->txchannel) && myrpt->dahditxchannel == myrpt->txchannel) {
-		int confno = dahdi_conf_get_channo(myrpt->txchannel); /* get tx channel's port number */
-		if (confno < 0) {
-			return -1;
-		}
-		res = dahdi_conf_add(myrpt->monchannel, confno, DAHDI_CONF_MONITORTX);
-	} else {
-		/* first put the channel on the conference in announce mode */
-		res = rpt_conf_add(myrpt->monchannel, myrpt, RPT_TXCONF, RPT_CONF_CONFANNMON);
+	ast_debug(3, "Adding channel %s to conference '%s' mixing bridge \n", ast_channel_name(chan), conference_name);
+	res = ast_unreal_channel_push_to_bridge(chan, conf, AST_BRIDGE_CHANNEL_FLAG_IMMOVABLE);
+	if (res) {
+		ast_log(LOG_ERROR, "Failed to add channel %s to conference '%s'\n", ast_channel_name(chan), conference_name);
+		return res;
+	}
+	p = ast_channel_tech_pvt(chan);
+	if (p && p->chan) {
+		ast_raw_answer(p->chan); /* We can not wait 500ms for media to start flowing */
 	}
 	return res;
-}
-
-int rpt_parrot_add(struct rpt *myrpt)
-{
-	/* first put the channel on the conference in announce mode */
-	if (dahdi_conf_add(myrpt->parrotchannel, 0, DAHDI_CONF_NORMAL)) {
-		return -1;
-	}
-	return 0;
-}
-
-static int dahdi_conf_get_muted(struct ast_channel *chan)
-{
-	int muted;
-
-	if (!CHAN_TECH(chan, "DAHDI")) {
-		return 0;
-	}
-
-	if (ioctl(ast_channel_fd(chan, 0), DAHDI_GETCONFMUTE, &muted) == -1) {
-		ast_log(LOG_WARNING, "Couldn't get mute status on %s: %s\n", ast_channel_name(chan), strerror(errno));
-		muted = 0;
-	}
-	return muted;
 }
 
 int rpt_conf_get_muted(struct ast_channel *chan, struct rpt *myrpt)
 {
-	return dahdi_conf_get_muted(chan);
+	/*! \todo: Do we need to check mute? What should it do?*/
+	return 0;
 }
 
-/*!
- * \param chan
- * \param tone DAHDI_TONE_DIALTONE, DAHDI_TONE_CONGESTION, or -1 to stop tone
- * \retval 0 on success, -1 on failure
- */
-static int rpt_play_tone(struct ast_channel *chan, int tone)
+int rpt_play_tone(struct ast_channel *chan, const char *tone)
 {
-	if (tone_zone_play_tone(ast_channel_fd(chan, 0), tone)) {
+	int res = 0;
+	struct ast_tone_zone *zone = ast_channel_zone(chan);
+	struct ast_tone_zone_sound *ts = ast_get_indication_tone(zone, tone);
+	if (ts) {
+		res = ast_playtones_start(chan, 0, ts->data, 0);
+		ts = ast_tone_zone_sound_unref(ts);
+	} else {
+		ast_log(LOG_WARNING, "No tone '%s' found in zone '%s'\n", tone, (zone && zone->country[0]) ? zone->country : "default");
+		return -1;
+	}
+
+	if (res) {
 		ast_log(LOG_WARNING, "Cannot start tone on %s\n", ast_channel_name(chan));
 		return -1;
 	}
 	return 0;
 }
 
-int rpt_play_dialtone(struct ast_channel *chan)
-{
-	return rpt_play_tone(chan, DAHDI_TONE_DIALTONE);
-}
-
-int rpt_play_congestion(struct ast_channel *chan)
-{
-	return rpt_play_tone(chan, DAHDI_TONE_CONGESTION);
-}
-
 int rpt_stop_tone(struct ast_channel *chan)
 {
-	return rpt_play_tone(chan, -1);
+	ast_playtones_stop(chan);
+	return 0;
 }
 
 int rpt_set_tone_zone(struct ast_channel *chan, const char *tz)
 {
-	if (tone_zone_set_zone(ast_channel_fd(chan, 0), (char*) tz) == -1) {
-		ast_log(LOG_WARNING, "Unable to set tone zone %s on %s\n", tz, ast_channel_name(chan));
+	struct ast_tone_zone *new_zone;
+	if (!(new_zone = ast_get_indication_zone(tz))) {
+		ast_log(LOG_ERROR, "Unknown country code '%s' for tonezone. Check indications.conf for available country codes.\n", tz);
 		return -1;
 	}
-	return 0;
-}
 
-int dahdi_write_wait(struct ast_channel *chan)
-{
-	int res, i, flags;
-
-	for (i = 0; i < 20; i++) {
-		flags = DAHDI_IOMUX_WRITEEMPTY | DAHDI_IOMUX_NOWAIT;
-		res = ioctl(ast_channel_fd(chan, 0), DAHDI_IOMUX, &flags);
-		if (res) {
-			ast_log(LOG_WARNING, "DAHDI_IOMUX failed: %s\n", strerror(errno));
-			break;
-		}
-		if (flags & DAHDI_IOMUX_WRITEEMPTY) {
-			break;
-		}
-		if (ast_safe_sleep(chan, 50)) {
-			res = -1;
-			break;
-		}
+	ast_channel_lock(chan);
+	if (ast_channel_zone(chan)) {
+		ast_channel_zone_set(chan, ast_tone_zone_unref(ast_channel_zone(chan)));
 	}
-	return res;
-}
-
-int dahdi_flush(struct ast_channel *chan)
-{
-	int i = DAHDI_FLUSH_EVENT;
-	if (ioctl(ast_channel_fd(chan, 0), DAHDI_FLUSH, &i) == -1) {
-		ast_log(LOG_ERROR, "Can't flush events on %s: %s", ast_channel_name(chan), strerror(errno));
-		return -1;
-	}
-	return 0;
-}
-
-int dahdi_bump_buffers(struct ast_channel *chan, int samples)
-{
-	struct dahdi_bufferinfo bi;
-
-	/* This is a miserable kludge. For some unknown reason, which I dont have
-	   time to properly research, buffer settings do not get applied to dahdi
-	   pseudo-channels. So, if we have a need to fit more then 1 160 sample
-	   buffer into the psuedo-channel at a time, and there currently is not
-	   room, it increases the number of buffers to accommodate the larger number
-	   of samples (version 0.257 9/3/10) */
-	memset(&bi, 0, sizeof(bi));
-
-	if (ioctl(ast_channel_fd(chan, 0), DAHDI_GET_BUFINFO, &bi) == -1) {
-		ast_log(LOG_ERROR, "Failed to get buffer info on %s: %s\n", ast_channel_name(chan), strerror(errno));
-		return -1;
-	}
-	if (samples > bi.bufsize && (bi.numbufs < ((samples / bi.bufsize) + 1))) {
-		bi.numbufs = (samples / bi.bufsize) + 1;
-		if (ioctl(ast_channel_fd(chan, 0), DAHDI_SET_BUFINFO, &bi)) {
-			ast_log(LOG_ERROR, "Failed to set buffer info on %s: %s\n", ast_channel_name(chan), strerror(errno));
-			return -1;
-		}
-	}
+	ast_channel_zone_set(chan, ast_tone_zone_ref(new_zone));
+	ast_channel_unlock(chan);
+	new_zone = ast_tone_zone_unref(new_zone);
 	return 0;
 }
 

--- a/apps/app_rpt/rpt_bridging.h
+++ b/apps/app_rpt/rpt_bridging.h
@@ -2,12 +2,17 @@
 enum rpt_chan_type {
 	RPT_RXCHAN, /* Receive channel */
 	RPT_TXCHAN, /* Transmit channel */
-	RPT_PCHAN,
-	RPT_DAHDITXCHAN,
+	RPT_PCHAN,	/* CONF to TXCONF */
+	RPT_LOCALTXCHAN,
 	RPT_MONCHAN, /* Monitor channel */
-	RPT_PARROTCHAN,
-	RPT_VOXCHAN,
 	RPT_TXPCHAN,
+	RPT_RXPCHAN, /* RXChannel to CONF */
+};
+
+enum rpt_bridge_chan_type {
+	RPT_LOCAL,
+	RPT_TELEMETRY,
+	RPT_MONITOR,
 };
 
 /* Each of these corresponds to a member of the rpt_conf structure in app_rpt.h */
@@ -16,19 +21,8 @@ enum rpt_conf_type {
 	RPT_TXCONF, /* Local Audio */
 };
 
-/* Uses same flag name style as DAHDI_CONF flags, since that's what these are based on */
-enum rpt_conf_flags {
-	RPT_CONF_NORMAL = (1 << 0),
-	RPT_CONF_MONITOR = (1 << 1),
-	RPT_CONF_MONITORTX = (1 << 2),
-	RPT_CONF_CONF = (1 << 3),
-	RPT_CONF_CONFANN = (1 << 4),
-	RPT_CONF_CONFMON = (1 << 5),
-	RPT_CONF_CONFANNMON = (1 << 6),
-	RPT_CONF_LISTENER = (1 << 7),
-	RPT_CONF_TALKER = (1 << 8),
-};
-
+#define RPT_TXCONF_NAME "TXCONF" /* TX Conference Name */
+#define RPT_CONF_NAME "CONF"	 /* Repeater Conference Name */
 enum rpt_chan_flags {
 	RPT_LINK_CHAN = (1 << 0),
 };
@@ -54,12 +48,16 @@ int __rpt_request(void *data, struct ast_format_cap *cap, enum rpt_chan_type cha
 #define rpt_request(data, cap, chantype) __rpt_request(data, cap, chantype, 0)
 
 /*!
- * \brief Request a pseudo channel
+ * \brief Request a Local channel
  * \param cap
  * \return channel on success
  * \return NULL on failure
  */
-struct ast_channel *rpt_request_pseudo_chan(struct ast_format_cap *cap);
+struct ast_channel *__rpt_request_local_chan(struct ast_format_cap *cap, const char *exten, enum rpt_bridge_chan_type type);
+
+#define rpt_request_local_chan(cap, exten) __rpt_request_local_chan(cap, exten, RPT_LOCAL)
+#define rpt_request_telem_chan(cap, exten) __rpt_request_local_chan(cap, exten, RPT_TELEMETRY)
+#define rpt_request_mon_chan(cap, exten) __rpt_request_local_chan(cap, exten, RPT_MONITOR)
 
 /*!
  * \brief Request a repeater channel not associated with a real device
@@ -69,37 +67,37 @@ struct ast_channel *rpt_request_pseudo_chan(struct ast_format_cap *cap);
  * \note myrpt->lock must be held when calling
  * \retval 0 on success, -1 on failure
  */
-int __rpt_request_pseudo(void *data, struct ast_format_cap *cap, enum rpt_chan_type chantype, enum rpt_chan_flags flags);
+int __rpt_request_local(void *data, struct ast_format_cap *cap, enum rpt_chan_type chantype, enum rpt_chan_flags flags, const char *exten);
 
-#define rpt_request_pseudo(data, cap, chantype) __rpt_request_pseudo(data, cap, chantype, 0)
+#define rpt_request_local(data, cap, chantype, exten) __rpt_request_local(data, cap, chantype, 0, exten)
 
-int __rpt_conf_create(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_type type, enum rpt_conf_flags flags, const char *file, int line);
+int __rpt_conf_create(struct rpt *myrpt, enum rpt_conf_type type, const char *file, int line);
 
-int __rpt_conf_add(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_type type, enum rpt_conf_flags flags, const char *file, int line);
+int __rpt_conf_add(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_type type, const char *file, int line);
 
-int rpt_equate_tx_conf(struct rpt *myrpt);
+#define rpt_conf_create(myrpt, type) __rpt_conf_create(myrpt, type, __FILE__, __LINE__)
+#define rpt_conf_add(chan, myrpt, type) __rpt_conf_add(chan, myrpt, type, __FILE__, __LINE__)
 
-#define rpt_conf_create(chan, myrpt, type, flags) __rpt_conf_create(chan, myrpt, type, flags, __FILE__, __LINE__)
-#define rpt_conf_add(chan, myrpt, type, flags) __rpt_conf_add(chan, myrpt, type, flags, __FILE__, __LINE__)
+/*!
+ * \param chan Channel to play tone on
+ * \param tone tone type (e.g., "dial", "congestion")
+ * \retval 0 on success, -1 on failure
+ */
+int rpt_play_tone(struct ast_channel *chan, const char *tone);
 
-#define rpt_conf_add_speaker(chan, myrpt) rpt_conf_add(chan, myrpt, RPT_CONF, RPT_CONF_CONF | RPT_CONF_LISTENER | RPT_CONF_TALKER)
+/*!
+ * \brief Play congestion on a channel
+ * \param chan
+ * \retval 0 on success, -1 on failure
+ */
+#define rpt_play_congestion(chan) rpt_play_tone(chan, "congestion")
 
-#define rpt_tx_conf_add_speaker(chan, myrpt) rpt_conf_add(chan, myrpt, RPT_TXCONF, RPT_CONF_CONF | RPT_CONF_LISTENER | RPT_CONF_TALKER)
-
-#define rpt_conf_add_announcer(chan, myrpt) rpt_conf_add(chan, myrpt, RPT_CONF, RPT_CONF_CONFANN)
-
-#define rpt_conf_add_announcer_monitor(chan, myrpt) rpt_conf_add(chan, myrpt, RPT_CONF, RPT_CONF_CONFANNMON)
-
-#define rpt_tx_conf_add_announcer(chan, myrpt) rpt_conf_add(chan, myrpt, RPT_TXCONF, RPT_CONF_CONFANN)
-
-/*! \note Used in app_rpt.c */
-int rpt_call_bridge_setup(struct rpt *myrpt, struct ast_channel *mychannel);
-
-/*! \note Used in app_rpt.c */
-int rpt_mon_setup(struct rpt *myrpt);
-
-/*! \note Used in app_rpt.c */
-int rpt_parrot_add(struct rpt *myrpt);
+/*!
+ * \brief Play dialtone on a channel
+ * \param chan
+ * \retval 0 on success, -1 on failure
+ */
+#define rpt_play_dialtone(chan) rpt_play_tone(chan, "dial")
 
 /*!
  * \brief Get if channel is muted in conference
@@ -108,20 +106,6 @@ int rpt_parrot_add(struct rpt *myrpt);
  * \retval 0 if not muted, 1 if muted
  */
 int rpt_conf_get_muted(struct ast_channel *chan, struct rpt *myrpt);
-
-/*!
- * \brief Play dialtone on a channel
- * \param chan
- * \retval 0 on success, -1 on failure
- */
-int rpt_play_dialtone(struct ast_channel *chan);
-
-/*!
- * \brief Play congestion tone on a channel
- * \param chan
- * \retval 0 on success, -1 on failure
- */
-int rpt_play_congestion(struct ast_channel *chan);
 
 /*!
  * \brief Stop playing tones on a channel
@@ -137,31 +121,7 @@ int rpt_stop_tone(struct ast_channel *chan);
  */
 int rpt_set_tone_zone(struct ast_channel *chan, const char *tz);
 
-/*!
- * \brief Wait for the DAHDI driver to physically write all audio to the hardware
- * \note Up to a max of 1 second
- * \note Only use with DAHDI channels!
- * \param chan
- * \retval 0 on success, -1 on failure
- */
-int dahdi_write_wait(struct ast_channel *chan);
-
-/*!
- * \brief Flush events on a DAHDI channel
- * \note Only use with DAHDI channels!
- * \param chan
- * \retval 0 on success, -1 on failure
- */
-int dahdi_flush(struct ast_channel *chan);
-
-/*!
- * \brief Increase buffer space on DAHDI channel, if needed to accommodate samples
- * \note Only use with DAHDI channels!
- * \param chan
- * \param samples
- * \retval 0 on success, -1 on failure
- */
-int dahdi_bump_buffers(struct ast_channel *chan, int samples);
+#define DEFAULT_TALKING_THRESHOLD 160 /* Bridge talking threshold - setting VOX level for when a user is indicated at "talking" */
 
 /*!
  * \brief Get value of rxisoffhook

--- a/apps/app_rpt/rpt_channel.c
+++ b/apps/app_rpt/rpt_channel.c
@@ -54,7 +54,7 @@ int wait_interval(struct rpt *myrpt, enum rpt_delay type, struct ast_channel *ch
 		}
 
 		interval = get_wait_interval(myrpt, type);
-		ast_debug(1, "Delay interval = %d\n", interval);
+		ast_debug(1, "Delay interval = %d on %s\n", interval, ast_channel_name(chan));
 		if (interval && ast_safe_sleep(chan, interval) < 0) {
 			return -1;
 		}

--- a/apps/app_rpt/rpt_cli.c
+++ b/apps/app_rpt/rpt_cli.c
@@ -1079,12 +1079,11 @@ static int rpt_show_channels(int fd, int argc, const char *const *argv)
 	DUMP_CHANNEL(rxchannel);
 	DUMP_CHANNEL(txchannel);
 	DUMP_CHANNEL(monchannel);
-	DUMP_CHANNEL(parrotchannel);
 	DUMP_CHANNEL(pchannel);
+	DUMP_CHANNEL(rxpchannel);
 	DUMP_CHANNEL(txpchannel);
-	DUMP_CHANNEL(dahdirxchannel);
-	DUMP_CHANNEL(dahditxchannel);
-	DUMP_CHANNEL(voxchannel);
+	DUMP_CHANNEL(localrxchannel);
+	DUMP_CHANNEL(localtxchannel);
 	rpt_mutex_unlock(&rpt_vars[this_rpt].lock);
 #undef DUMP_CHANNEL
 

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -835,7 +835,7 @@ enum rpt_function_response function_remote(struct rpt *myrpt, char *param, char 
 			 (!strcmp(myrpt->remoterig, REMOTE_RIG_FT100)) ||
 			 (!strcmp(myrpt->remoterig, REMOTE_RIG_FT950)) || (!strcmp(myrpt->remoterig, REMOTE_RIG_IC706)))) {
 			myrpt->remotetx = 0;
-			if (!IS_PSEUDO(myrpt->txchannel)) {
+			if (!IS_LOCAL(myrpt->txchannel)) {
 				ast_indicate(myrpt->txchannel, AST_CONTROL_RADIO_UNKEY);
 			}
 			myrpt->tunetx = 0;

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -764,9 +764,9 @@ void *rpt_link_connect(void *data)
 		goto cleanup;
 	}
 
-	rpt_make_call(l->chan, tele, 2000, deststr, "(Remote Rx)", "remote", myrpt->name);
+	rpt_make_call(l->chan, tele, 2000, deststr, "Remote Rx", "remote", myrpt->name);
 
-	if (__rpt_request_pseudo(l, cap, RPT_PCHAN, RPT_LINK_CHAN)) {
+	if (__rpt_request_local(l, cap, RPT_PCHAN, RPT_LINK_CHAN, "IAXLink")) {
 		ao2_ref(cap, -1);
 		ast_hangup(l->chan);
 		l->connect_in_progress = 0;
@@ -776,8 +776,7 @@ void *rpt_link_connect(void *data)
 
 	ao2_ref(cap, -1);
 
-	/* make a conference for the tx */
-	if (rpt_conf_add_speaker(l->pchan, myrpt)) {
+	if (rpt_conf_add(l->pchan, myrpt, RPT_CONF)) {
 		ast_hangup(l->chan);
 		ast_hangup(l->pchan);
 		l->connect_in_progress = 0;

--- a/apps/app_rpt/rpt_manager.c
+++ b/apps/app_rpt/rpt_manager.c
@@ -279,15 +279,15 @@ static int rpt_manager_do_xstat(struct mansession *ses, const struct message *m)
 
 			/* Get variables info */
 			j = 0;
-			if (!strcasecmp(rxchanname, "DAHDI/pseudo")) {
-				/* DAHDI/pseudo isn't a real channel name, calling ast_channel_get_by_name
+			if (!strcasecmp(rxchanname, "Local/pseudo")) {
+				/* Local/pseudo isn't a real channel name, calling ast_channel_get_by_name
 				 * will always fail, so avoid an unnecessary traversal of the channels container for nothing. */
 				pseudo = 1;
 			} else {
 				rxchan = ast_channel_get_by_name(rxchanname);
 			}
 			/* rxchan might've disappeared in the meantime. Verify it still exists before we try to lock it,
-			 * at least unless it's a DAHDI pseudo channel.
+			 * at least unless it's a Local channel.
 			 * XXX This was added to address assertions due to bad locking, but app_rpt should probably
 			 * be globally ref'ing the channel and holding it until it unloads. Should be investigated. */
 			if (rxchan || pseudo) {

--- a/apps/app_rpt/rpt_serial.c
+++ b/apps/app_rpt/rpt_serial.c
@@ -416,12 +416,15 @@ static void rbi_out_parallel(struct rpt *myrpt, unsigned char *data)
 
 static void rbi_out(struct rpt *myrpt, unsigned char *data)
 {
-	if (rpt_radio_set_param(myrpt->dahdirxchannel, RPT_RADPAR_REMMODE, RPT_RADPAR_REM_RBI1)) {
+	if (!myrpt->localrxchannel) {
+		return;
+	}
+	if (rpt_radio_set_param(myrpt->localrxchannel, RPT_RADPAR_REMMODE, RPT_RADPAR_REM_RBI1)) {
 		/* if setparam ioctl fails, its probably not a pciradio card */
 		rbi_out_parallel(myrpt, data);
 		return;
 	}
-	rpt_radio_set_remcommand_data(myrpt->dahdirxchannel, data, 5);
+	rpt_radio_set_remcommand_data(myrpt->localrxchannel, data, 5);
 }
 
 int serial_remote_io(struct rpt *myrpt, unsigned char *txbuf, int txbytes, unsigned char *rxbuf, int rxmaxbytes, int asciiflag)
@@ -489,7 +492,7 @@ int serial_remote_io(struct rpt *myrpt, unsigned char *txbuf, int txbytes, unsig
 	}
 
 	/* if not a DAHDI channel, can't use pciradio stuff */
-	if (myrpt->rxchannel != myrpt->dahdirxchannel) {
+	if (myrpt->rxchannel != myrpt->localrxchannel) {
 		return -1;
 	}
 

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -686,8 +686,6 @@ static int send_tone_telemetry(struct ast_channel *chan, const char *tonestring)
 
 	ast_stopstream(chan);
 
-	/* Wait for the DAHDI driver to physically write the tone blocks to the hardware */
-	res = dahdi_write_wait(chan);
 	return res;
 }
 
@@ -871,9 +869,6 @@ static void handle_varcmd_tele(struct rpt *myrpt, struct ast_channel *mychannel,
 		return;
 	}
 	if (!strcasecmp(strs[0], "PROC")) {
-		if (wait_interval(myrpt, DLY_TELEM, mychannel) == -1) {
-			return;
-		}
 		res = telem_lookup(myrpt, mychannel, "patchup", "PROC");
 		if (res < 0) { /* Then default message */
 			sayfile(mychannel, "rpt/callproceeding");
@@ -1292,32 +1287,6 @@ void *rpt_tele_thread(void *this)
 		ident = "";
 		id_malloc = 0;
 	}
-	rpt_mutex_unlock(&myrpt->lock);
-
-	cap = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
-	if (!cap) {
-		ast_log(LOG_ERROR, "Failed to alloc cap\n");
-		rpt_mutex_lock(&myrpt->lock);
-		goto abort2; /* Didn't set active_telem, so goto abort2, not abort. */
-	}
-
-	ast_format_cap_append(cap, ast_format_slin, 0);
-
-	/* allocate a pseudo-channel thru asterisk */
-	mychannel = rpt_request_pseudo_chan(cap);
-	ao2_ref(cap, -1);
-
-	if (!mychannel) {
-		ast_log(LOG_WARNING, "Unable to obtain pseudo channel (mode: %d)\n", mytele->mode);
-		rpt_mutex_lock(&myrpt->lock);
-		goto abort2; /* Didn't set active_telem, so goto abort2, not abort. */
-	}
-	ast_debug(1, "Requested channel %s\n", ast_channel_name(mychannel));
-
-	rpt_mutex_lock(&myrpt->lock);
-	ast_channel_ref(mychannel); /* Create a reference to prevent channel from being freed too soon */
-	mytele->chan = mychannel;
-
 	/* Wait for previous telemetry to finish before we start so we're not speaking on top of each other. */
 	ast_debug(5, "Queued telemetry, active_telem = %p, mytele = %p\n", myrpt->active_telem, mytele);
 	while (myrpt->active_telem && ((myrpt->active_telem->mode == PAGE) || (myrpt->active_telem->mode == MDC1200))) {
@@ -1341,29 +1310,49 @@ void *rpt_tele_thread(void *this)
 
 	ast_debug(5, "Beginning telemetry, active_telem = %p, mytele = %p\n", myrpt->active_telem, mytele);
 
-	/* make a conference for the tx */
-	/* If the telemetry is only intended for a local audience, only connect the ID audio to the local tx conference so linked systems can't hear it */
-	/* first put the channel on the conference in announce mode */
-	switch (mytele->mode) {
-		case ID1:
-		case PLAYBACK:
-		case TEST_TONE:
-		case STATS_GPS_LEGACY:
-			type = RPT_CONF;
-			break;
-		default:
-			type = RPT_TXCONF;
-			break;
+	cap = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
+	if (!cap) {
+		ast_log(LOG_ERROR, "Failed to alloc cap\n");
+		rpt_mutex_lock(&myrpt->lock);
+		goto abort;
 	}
+
+	ast_format_cap_append(cap, ast_format_slin, 0);
+	/* allocate a local channel thru asterisk and call the correct conference */
+	mychannel = rpt_request_telem_chan(cap, "Telemetry");
+	ao2_ref(cap, -1);
+
+	if (!mychannel) {
+		ast_log(LOG_WARNING, "Unable to obtain local channel (mode: %d)\n", mytele->mode);
+		rpt_mutex_lock(&myrpt->lock);
+		goto abort;
+	}
+	ast_debug(1, "Requested channel %s\n", ast_channel_name(mychannel));
+	ast_channel_ref(mychannel); /* Create a reference to prevent channel from being freed too soon */
+	mytele->chan = mychannel;
+
+	switch (mytele->mode) {
+	case ID1:
+	case PLAYBACK:
+	case TEST_TONE:
+	case STATS_GPS_LEGACY:
+		type = RPT_CONF;
+		break;
+	default:
+		type = RPT_TXCONF;
+		break;
+	}
+
 	if (ast_audiohook_volume_set_float(mychannel, AST_AUDIOHOOK_DIRECTION_WRITE, myrpt->p.telemnomgain)) {
 		ast_log(LOG_WARNING, "Setting the volume on channel %s to %2.2f failed", ast_channel_name(mychannel), myrpt->p.telemnomgain);
 	}
 
-	if (rpt_conf_add(mychannel, myrpt, type, RPT_CONF_CONFANN)) {
+	if (rpt_conf_add(mychannel, myrpt, type)) {
+		ast_log(LOG_WARNING, "Unable to join local channel to conference %s\n", type == RPT_CONF ? RPT_CONF_NAME : RPT_TXCONF_NAME);
 		rpt_mutex_lock(&myrpt->lock);
 		goto abort;
 	}
-	ast_stopstream(mychannel);
+
 	res = 0;
 	switch (mytele->mode) {
 	case USEROUT:
@@ -1671,11 +1660,6 @@ treataslocal:
 			res = telem_send_ct(myrpt, mychannel, "unlinkedct", mytele->mode == UNKEY ? "UNKEY" : "LOCUNKEY", 0);
 		}
 		if (hasremote && ((!myrpt->cmdnode[0]) || (!strcmp(myrpt->cmdnode, "aprstt")))) {
-			/* set for all to hear */
-			if (rpt_conf_add_announcer(mychannel, myrpt)) {
-				rpt_mutex_lock(&myrpt->lock);
-				goto abort;
-			}
 			/* Remote Unkey Courtesy Tone */
 			res = telem_send_ct(myrpt, mychannel, "remotect", mytele->mode == UNKEY ? "UNKEY" : "LOCUNKEY", 200);
 		}
@@ -1684,11 +1668,6 @@ treataslocal:
 			char mystr[10];
 
 			ast_safe_sleep(mychannel, 200);
-			/* set for all to hear */
-			if (rpt_tx_conf_add_announcer(mychannel, myrpt)) {
-				rpt_mutex_lock(&myrpt->lock);
-				goto abort;
-			}
 			snprintf(mystr, sizeof(mystr), "%04x", myrpt->lastunit);
 			myrpt->lastunit = 0;
 			ast_say_character_str(mychannel, mystr, NULL, ast_channel_language(mychannel));
@@ -2008,21 +1987,10 @@ treataslocal:
 				res = -1;
 				break;
 			}
-			if (myrpt->iofd < 0) {
-				int rxisoffhook;
-				if (dahdi_flush(myrpt->dahditxchannel) || ((rxisoffhook = dahdi_rx_offhook(myrpt->dahdirxchannel)) < 0)) {
-					myrpt->remsetting = 0;
-					ast_mutex_unlock(&myrpt->remlock);
-					res = -1;
-					break;
-				}
-				myrpt->remoterx = rxisoffhook || myrpt->tele.next != &myrpt->tele;
-			}
 		} else if (!strcmp(myrpt->remoterig, REMOTE_RIG_TMD700)) {
 			res = set_tmd700(myrpt);
 			setxpmr(myrpt, 0);
 		}
-
 		myrpt->remsetting = 0;
 		ast_mutex_unlock(&myrpt->remlock);
 		if (!res) {

--- a/configs/rpt/extensions.conf
+++ b/configs/rpt/extensions.conf
@@ -67,12 +67,14 @@ exten => ${NODE},1,Ringing()
 
 ; Comment-out the following clause if you want Allstar Autopatch service
 [pstn-out]
-exten => _NXXNXXXXXX,1,playback(ss-noservice)
-	same => n,Congestion
+exten => _NXXNXXXXXX,1,Wait(1)
+	same => n,Playback(ss-noservice)
+	same => n,Hangup
 
 ; Un-comment out the following clause if you want Allstar Autopatch service
 ;[pstn-out]
-;exten => _NXXNXXXXXX,1,Dial(IAX2/allstar-autopatch/\${EXTEN})
+;exten => _NXXNXXXXXX,1,Wait(1)
+; same => n, Dial(IAX2/allstar-autopatch/\${EXTEN})
 ; same => n,Busy
 
 [invalidnum]

--- a/configs/rpt/modules.conf
+++ b/configs/rpt/modules.conf
@@ -41,9 +41,14 @@ load    = app_sendtext.so                ; Send and Receive Text Applications
 load    = app_system.so                  ; Generic System() application
 load    = app_transfer.so                ; Transfers a caller to another extension
 
+; Bridging
+
+require = bridge_softmix.so              ; Multi-party software based channel mixing
+
 ; Channel Drivers
 
-load    = chan_dahdi.so                  ; DAHDI Telephony w/PRI & SS7 & MFC/R2
+require = chan_bridge_media.so           ; Bridge Media Channel Driver
+noload  = chan_dahdi.so                  ; DAHDI Telephony w/PRI & SS7 & MFC/R2
 noload  = chan_echolink.so               ; Echolink Channel Driver
 require = chan_iax2.so                   ; Inter Asterisk eXchange (Ver 2)
 noload  = chan_mobile.so                 ; Bluetooth Mobile Device Channel Driver
@@ -121,7 +126,7 @@ load    = pbx_config.so                  ; Text Extension Configuration
 load    = res_crypto.so                  ; Cryptographic Digital Signatures
 require = res_curl.so                    ; cURL Resource Module
 require = res_rpt_http_registrations.so  ; RPT HTTP Periodic Registrations
-load    = res_timing_dahdi.so            ; DAHDI Timing Interface
+noload  = res_timing_dahdi.so            ; DAHDI Timing Interface
 load    = res_timing_timerfd.so          ; Timerfd Timing Interface is preferred for ASL3
 require = res_usbradio.so                ; USB Radio Resource
 
@@ -135,8 +140,6 @@ require = res_usbradio.so                ; USB Radio Resource
 ;load   = bridge_holding.so                           ; Holding bridge module
 ;load   = bridge_native_rtp.so                        ; Native RTP bridging module
 ;load   = bridge_simple.so                            ; Simple two channel bridging module
-;load   = bridge_softmix.so                           ; Multi-party software based channel mixing
-;load   = chan_bridge_media.so                        ; Bridge Media Channel Driver
 ;load   = chan_pjsip.so                               ; PJSIP Channel Driver
 ;load   = func_pjsip_endpoint.so                      ; Get information about a PJSIP endpoint
 ;load   = func_sorcery.so                             ; Get a field from a sorcery object

--- a/configs/rpt/rpt.conf
+++ b/configs/rpt/rpt.conf
@@ -65,13 +65,13 @@ node_lookup_method = dns            ;method used to lookup nodes
 ; Must also be enabled in modules.conf
 ; Enable the selected channel driver in modules.conf !!!
 ; Rx/Tx audio/signaling channel. Choose ONLY 1 per node stanza.
-; rxchannel = dahdi/pseudo          ; No radio (hub)
+; rxchannel = Local/pseudo          ; No radio (hub)
 ; rxchannel = SimpleUSB/1999        ; SimpleUSB
 ; rxchannel = Radio/1999            ; USBRadio (DSP)
 ; rxchannel = Voter/1999            ; RTCM device
 ; rxchannel = USRP/127.0.0.1:34001:32001    ;GNU Radio interface USRP
 
-rxchannel = dahdi/pseudo            ; No radio (hub)
+rxchannel = Local/pseudo            ; No radio (hub)
 
 duplex = 2                          ; 0 = Half duplex with no telemetry tones or hang time.
                                     ;     Special Case: Full duplex if linktolink is set to yes.


### PR DESCRIPTION
- Convert all DAHDI/Pseudo channel references to local channels.
- Remove all DAHDI and Pseudo channel related code and configuration.
- Utilize softmix conference bridge for CONF and TXCONF functionality.
- Replace VOX channel with talker detection callback to control transmitter state on outbound autopatch.
- Replace PARROT channel placing file recording inline with txpchannel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bridge-based conferencing with Local-channel types and talker callback support.

* **Improvements**
  * Migrated from hardware-specific channels to Local/bridge topology across autopatch, link and telemetry.
  * Tone playback unified to indication-based API; improved logging and safer CDR handling for local channels.

* **Bug Fixes**
  * Parrot/monitor resources cleaned up automatically; more robust channel teardown.

* **Configuration Changes**
  * Default channel set to Local/pseudo; bridging components enabled and DAHDI timing/driver disabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->