### PR TITLE
chan_voter: Properly handle minimum buflen when mix mode clients are configured

### DIFF
--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -4816,11 +4816,11 @@ static void *voter_reader(void *data)
 									}
 									continue;
 								} else {
-								client->mix = 1;
-								ast_log(LOG_NOTICE,
-									"Client: %s (proxy) is sending mix mode flag, setting client to mix mode\n", client->name);
-								logged_buflen_too_small = 0;
-								} 
+									client->mix = 1;
+									ast_log(LOG_NOTICE,
+										"Client: %s (proxy) is sending mix mode flag, setting client to mix mode\n", client->name);
+									logged_buflen_too_small = 0;
+								}
 							} else {
 								client->mix = 0;
 							}


### PR DESCRIPTION
This update detects when mix mode (general purpose) clients connect, and checks the value of buflen that was read in from voter.conf. If the value is too small (<160), throw and error and stop chan_voter until the problem is corrected.

This update also adds significant comments to the source on internal operation.

This update formats comments for grammar and accuracy.

This update adds some additonal logging to make the channel driver more verbose during operation. Some debug levels have been adjusted (again), additional debug messages added, and numerous debug messages updated with more useful explanations of their actual use.

Resolves #847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded and clarified module documentation and function comments for better insight into module behavior and system interactions.

* **Style**
  * Improved consistency in log messages and command-line interface output formatting for enhanced readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->