### PR TITLE
app_rpt: Refactor `telem_done`

### DIFF
--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -545,11 +545,12 @@ int priority_telemetry_pending(struct rpt *myrpt)
  * and things will get doubled up.
  */
 #define telem_done(myrpt, telem) \
-	if (myrpt->active_telem == telem) { \
-		ast_debug(5, "Ending telemetry, active_telem = %p, mytele = %p\n", myrpt->active_telem, telem); \
-		myrpt->active_telem = NULL; \
-	} else { \
+	ast_debug(5, "Ending telemetry, active_telem = %p, mytele = %p\n", myrpt->active_telem, telem); \
+	if (myrpt->active_telem && myrpt->active_telem != telem) { \
 		ast_log(LOG_WARNING, "Attempting to clear active_telem %p when telem is %p", myrpt->active_telem, telem); \
+	} \
+	if (myrpt->active_telem == telem) { \
+		myrpt->active_telem = NULL; \
 	}
 
 void flush_telem(struct rpt *myrpt)


### PR DESCRIPTION
Turns out it is "normal" to play a telemetry message that is NOT active, but it's not "normal" to clear active_telem if not the matching thread. 
This PR addresses a "normal" case warning message that is not important.
See https://github.com/AllStarLink/app_rpt/pull/865#issuecomment-3651089312
Created here: https://github.com/AllStarLink/app_rpt/pull/852

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal telemetry diagnostics with improved logging for better error tracking and system monitoring.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->