### PR TITLE
app_rpt: `cancel_pfxtone()` should not try to hangup on a null channel

### DIFF
--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -597,7 +597,7 @@ void cancel_pfxtone(struct rpt *myrpt)
 	ast_debug(3, "cancel_pfxfone!!");
 	telem = myrpt->tele.next;
 	while (telem != &myrpt->tele) {
-		if (telem->mode == PFXTONE) {
+		if (telem->mode == PFXTONE && telem->chan) {
 			ast_softhangup(telem->chan, AST_SOFTHANGUP_DEV);
 		}
 		telem = telem->next;


### PR DESCRIPTION
Similar to `birdbath()` and `flush_telem()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability in call handling during tone cancellation operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->