### PR TITLE
rpt_link.c: disable check_tlink_list() preparatory to removal

### DIFF
--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -24,7 +24,7 @@
 #include "rpt_link.h"
 #include "rpt_telemetry.h"
 
-#define ENABLE_CHECK_TLINK_LIST	0
+#define ENABLE_CHECK_TLINK_LIST 0
 
 #define OBUFSIZE(size) (size + sizeof("123456,")) /* size of buffer + room for node count + comma */
 #define BUFSIZE(size) (size)


### PR DESCRIPTION
Permissive #define is ENABLE_CHECK_TLINK_LIST

DeveloperNote: For now we simply disable the list check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled linked-list integrity validation checks by default to optimize performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->