### PR TITLE
chan_voter: Remove un-documented duplex option and add dmwdiag

### DIFF
--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -332,7 +332,7 @@ Use "core show help voter <command>"" to display usage.
 #include "../apps/app_rpt/pocsag.c"
 
 /* Setting dmwdiag = 1 in voter.conf will force all clients in an instance
- * to send a 1kHz tone. Can be used for setting transmitter deviation.
+ * to send a 1kHz tone at nearly full system deviation.
  */
 unsigned char ulaw_digital_milliwatt[8] = { 0x1e, 0x0b, 0x0b, 0x1e, 0x9e, 0x8b, 0x8b, 0x9e };
 unsigned char mwp;
@@ -1049,7 +1049,7 @@ static int voter_indicate(struct ast_channel *ast, int cond, const void *data, s
 		p->txkey = 1;
 		ast_verb(3, "Channel %s: TX On\n", ast_channel_name(ast));
 		if (p->dmwdiag) {
-			ast_verb(3, "Sending 1kHz test tone to node Voter/%i transmitter(s)", p->nodenum);
+			ast_verb(3, "Sending 1kHz test tone to node Voter/%i transmitter(s)\n", p->nodenum);
 		}
 		break;
 	case AST_CONTROL_RADIO_UNKEY:
@@ -3156,7 +3156,8 @@ static void *voter_xmit(void *data)
 				memcpy(audiopacket.audio, f1->data.ptr, FRAME_SIZE);
 			}
 			/* If dmwdiag is set in voter.conf, replace all the audio samples with those from
-			 * the digital milliwatt array, to generate a 1kHz tone on the transmitter.
+			 * the digital milliwatt array, to generate a 1kHz tone at nearly full system deviation
+			 * on the transmitter.
 			 */
 			if (p->dmwdiag) {
 				for (i = 0; i < FRAME_SIZE; i++) {

--- a/configs/rpt/voter.conf
+++ b/configs/rpt/voter.conf
@@ -41,7 +41,7 @@ plfilter = y                    ; use DSP IIR 6 pole High pass filter, 300 Hz co
 
 ;gtxgain = 3.0                  ; adjust the audio gain to all transmitters (in db voltage gain)
 ;hostdeemp = 1                  ; force the use of the DSP FIR Integrator providing de-emphasis at 8000 samples/sec. Used with Duplex Mode 3 setting in RTCM/VOTER
-;dmwdiag = y                    ; replace all audio with 1kHz test tone and send to all transmitters
+;dmwdiag = y                    ; replace all audio with 1kHz test tone at nearly full system deviation and send to all transmitters
 
 thresholds = 255,110=5          ;
 ; linger=6                      ; linger default is 6 if no other value specified


### PR DESCRIPTION
The duxplex option in voter.conf has never been documented, does not work properly, and does not seem to have any practical use. Removed this option, and associated code.

A compile-time option existed to send a generated 1kHz tone out the transmitters, replacing all repeated audio. This update extends that option to userspace by allowing users to set the dmwdiag option in voter.conf on a per-instance basis.

Resolves #858 #720

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dmwdiag runtime configuration option for diagnostic testing that replaces all audio with 1kHz test tone output to transmitters.

* **Refactor**
  * Converted diagnostic support from compile-time configuration to dynamic runtime flag, enabling configuration changes without recompilation.
  * Updated configuration system to use new dmwdiag parameter.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->