### PR TITLE
chan_voter: Remove un-documented duplex option, add "voter tune" CLI

### DIFF
--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -1999,7 +1999,7 @@ static char *handle_cli_tune(struct ast_cli_entry *e, int cmd, struct ast_cli_ar
 	case CLI_INIT:
 		e->command = "voter tune";
 		e->usage = "Usage: voter tune instance_id [y/n]\n"
-				   "       Specifies/Queries tune mode (1kHz test tone) for VOTER instance\n";
+				   "       Specifies/Queries tune mode (send 1kHz test tone to TX) for VOTER instance\n";
 		return NULL;
 	case CLI_GENERATE:
 		return voter_complete_node_list(a->line, a->word, a->pos, 2);
@@ -2670,7 +2670,7 @@ static char *handle_cli_txlockout(struct ast_cli_entry *e, int cmd, struct ast_c
  */
 static struct ast_cli_entry voter_cli[] = {
 	AST_CLI_DEFINE(handle_cli_test, "Specify/Query VOTER instance test mode"),
-	AST_CLI_DEFINE(handle_cli_tune, "Specify/Query VOTER tune (1kHz tone) test mode"),
+	AST_CLI_DEFINE(handle_cli_tune, "Specify/Query VOTER tune (send 1kHz tone to TX) test mode"),
 	AST_CLI_DEFINE(handle_cli_prio, "Specify/Query VOTER client priority value"),
 	AST_CLI_DEFINE(handle_cli_record, "Enable/Specify (or disable) VOTER recording file"),
 	AST_CLI_DEFINE(handle_cli_tone, "Sets/Queries TX CTCSS level for specified VOTER instance"),


### PR DESCRIPTION
The duxplex option in voter.conf has never been documented, does
not work properly, and does not seem to have any practical use.
Removed this option, and associated code.

A compile-time option existed to send a generated 1kHz tone out
the transmitters, replacing all repeated audio. This update
extends that option to userspace with the introduction of the
"voter dmwdiag" Asterisk CLI command.

Resolves: https://github.com/AllStarLink/app_rpt/issues/858 https://github.com/AllStarLink/app_rpt/issues/720

UserNote: New CLI command, "voter dmwdiag <instance-id> [y/n]"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CLI command to query and enable/disable a test tone feature for voter instances at runtime, with per-instance control (previously required recompilation to adjust)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->