### PR TITLE
chan_voter: Use `ast_null_frame`

### DIFF
--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -1307,11 +1307,7 @@ static int voter_text(struct ast_channel *ast, const char *text)
  */
 static struct ast_frame *voter_read(struct ast_channel *ast)
 {
-	struct voter_pvt *p = ast_channel_tech_pvt(ast);
-
-	memset(&p->fr, 0, sizeof(struct ast_frame));
-	p->fr.frametype = AST_FRAME_NULL;
-	return &p->fr;
+	return &ast_null_frame;
 }
 
 /*!


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized frame data handling in the voter channel implementation by utilizing shared null frames instead of maintaining individual per-channel frame instances.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->