### PR TITLE
Update chan_simpleusb.c

### DIFF
--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1767,15 +1767,15 @@ static int simpleusb_text(struct ast_channel *c, const char *text)
 			break;
 		case '?':				/* Query Page Status */
 			{
-			struct ast_frame wf = {
-				.frametype = AST_FRAME_TEXT,
-				.src = __PRETTY_FUNCTION__,
-			};
-
-			i = 0;
-			ast_mutex_lock(&o->txqlock);
-			AST_LIST_TRAVERSE(&o->txq, f1, frame_list) if (f1->src && (!strcmp(f1->src, PAGER_SRC))) {
-				i++;
+				struct ast_frame wf = {
+					.frametype = AST_FRAME_TEXT,
+					.src = __PRETTY_FUNCTION__,
+				};
+	
+				i = 0;
+				ast_mutex_lock(&o->txqlock);
+				AST_LIST_TRAVERSE(&o->txq, f1, frame_list) if (f1->src && (!strcmp(f1->src, PAGER_SRC))) {
+					i++;
 			}
 			ast_mutex_unlock(&o->txqlock);
 			cmd = (i) ? "PAGES" : "NOPAGES";


### PR DESCRIPTION
fix error for following error:

chan_simpleusb.c: In function ‘simpleusb_text’: chan_simpleusb.c:1769:4: error: a label can only be part of a statement and a declaration is not a statement 1769 | struct ast_frame wf = { | ^~~~~~ make[1]: *** [/usr/src/asterisk-20.17.0/Makefile.rules:165: chan_simpleusb.o] Error 1 make: *** [Makefile:396: channels] Error 2

In C, you cannot declare variables directly after a case label without enclosing the code in braces {}. This violates C syntax rules because labels (like case) can only be followed by statements, not declarations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Minor internal code restructuring for improved code organization and variable scoping. No changes to functionality or user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->