### PR TITLE
chan_usbradio.c: Remove unused configuration variable rxctcssadj

### DIFF
--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -462,7 +462,6 @@ static int usbradio_indicate(struct ast_channel *chan, int cond_in, const void *
 static int usbradio_fixup(struct ast_channel *oldchan, struct ast_channel *newchan);
 static int usbradio_setoption(struct ast_channel *chan, int option, void *data, int datalen);
 static void store_rxvoiceadj(struct chan_usbradio_pvt *o, const char *s);
-static void store_rxctcssadj(struct chan_usbradio_pvt *o, const char *s);
 static int set_txctcss_level(struct chan_usbradio_pvt *o);
 static void pmrdump(struct chan_usbradio_pvt *o, int fd);
 static void mult_set(struct chan_usbradio_pvt *o);
@@ -787,7 +786,6 @@ static int load_tune_config(struct chan_usbradio_pvt *o, const struct ast_config
 		CV_UINT("txmixaset", o->txmixaset);
 		CV_UINT("txmixbset", o->txmixbset);
 		CV_F("rxvoiceadj", store_rxvoiceadj(o, v->value));
-		CV_F("rxctcssadj", store_rxctcssadj(o, v->value));
 		CV_UINT("txctcssadj", o->txctcssadj);
 		CV_UINT("rxsquelchadj", o->rxsquelchadj);
 		CV_UINT("txslimsp", o->txslimsp);

--- a/configs/rpt/usbradio.conf
+++ b/configs/rpt/usbradio.conf
@@ -209,6 +209,5 @@ rxmixerset=500
 txmixaset=500
 txmixbset=500
 rxvoiceadj=0.5
-rxctcssadj=0.5
 txctcssadj=200
 rxsquelchadj=500

--- a/configs/samples/usbradio.conf.sample
+++ b/configs/samples/usbradio.conf.sample
@@ -188,7 +188,6 @@ legacyaudioscaling = no     ; If yes, continue to do raw audio sample scaling an
 ;txmixaset=500
 ;txmixbset=500
 ;rxvoiceadj=0.5
-;rxctcssadj=0.5
 ;txctcssadj=200
 ;rxsquelchadj=500
 


### PR DESCRIPTION
Ongoing code cleanup

Fixes: #751

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed RX CTCSS adjustment feature. CTCSS functionality now relies on standard configuration paths instead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->