### PR TITLE
chan_simpleusb.c : Fix variable declaration in switch case statement

### DIFF
--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1766,22 +1766,24 @@ static int simpleusb_text(struct ast_channel *c, const char *text)
 			batch = make_pocsag_batch(i, (char *) text + j + 1, strlen(text + j + 1), ALPHA, 0);
 			break;
 		case '?':				/* Query Page Status */
-			struct ast_frame wf = {
-				.frametype = AST_FRAME_TEXT,
-				.src = __PRETTY_FUNCTION__,
-			};
-
-			i = 0;
-			ast_mutex_lock(&o->txqlock);
-			AST_LIST_TRAVERSE(&o->txq, f1, frame_list) if (f1->src && (!strcmp(f1->src, PAGER_SRC))) {
-				i++;
+			{
+				struct ast_frame wf = {
+					.frametype = AST_FRAME_TEXT,
+					.src = __PRETTY_FUNCTION__,
+				};
+	
+				i = 0;
+				ast_mutex_lock(&o->txqlock);
+				AST_LIST_TRAVERSE(&o->txq, f1, frame_list) if (f1->src && (!strcmp(f1->src, PAGER_SRC))) {
+					i++;
+				}
+				ast_mutex_unlock(&o->txqlock);
+				cmd = (i) ? "PAGES" : "NOPAGES";
+				wf.data.ptr = cmd;
+				wf.datalen = strlen(cmd);
+				ast_queue_frame(o->owner, &wf);
+				return 0;
 			}
-			ast_mutex_unlock(&o->txqlock);
-			cmd = (i) ? "PAGES" : "NOPAGES";
-			wf.data.ptr = cmd;
-			wf.datalen = strlen(cmd);
-			ast_queue_frame(o->owner, &wf);
-			return 0;
 		default:
 			return 0;
 		}


### PR DESCRIPTION
The query page status case ('?') in the paging application had a  variable declaration (struct ast_frame wf) directly after the case  label without enclosing braces. This violates C syntax rules as case  labels can only be followed by statements, not declarations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved mutex management and code scoping in the query page status handler for better resource management and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->