### PR TITLE
app_rpt: Address initialization of calldigittimer missed in PR #864

### DIFF
--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -966,6 +966,7 @@ enum rpt_function_response function_autopatchup(struct rpt *myrpt, char *param, 
 	myrpt->callmode = CALLMODE_DIALING;
 	myrpt->cidx = 0;
 	myrpt->exten[myrpt->cidx] = 0;
+	myrpt->calldigittimer = 0;
 	rpt_mutex_unlock(&myrpt->lock);
 	ast_pthread_create_detached(&myrpt->rpt_call_thread, NULL, rpt_call, (void *) myrpt);
 	return DC_COMPLETE;


### PR DESCRIPTION
Refactoring the variable initialization requires clearing the var before starting the thread.  Missed initialization on one of the thread start calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced state handling during call dialing transitions to improve timing reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->