### PR TITLE
app_rpt: Remove incorrect warning message from telemetry thread

### DIFF
--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -546,9 +546,6 @@ int priority_telemetry_pending(struct rpt *myrpt)
  */
 #define telem_done(myrpt, telem) \
 	ast_debug(5, "Ending telemetry, active_telem = %p, mytele = %p\n", myrpt->active_telem, telem); \
-	if (myrpt->active_telem && myrpt->active_telem != telem) { \
-		ast_log(LOG_WARNING, "Attempting to clear active_telem %p when telem is %p", myrpt->active_telem, telem); \
-	} \
 	if (myrpt->active_telem == telem) { \
 		myrpt->active_telem = NULL; \
 	}


### PR DESCRIPTION
This is a "normal" situation when unkey type telemetry messages are activated.  The warning is invalid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined internal telemetry state management logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->