### PR TITLE
app_rpt: Address reference leak when calling rpt_link_add()

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -6919,6 +6919,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 		/* insert at end of queue */
 		rpt_mutex_lock(&myrpt->lock);
 		rpt_link_add(myrpt->links, l); /* After putting the link in the link list, other threads can start using it */
+		ao2_ref(l, -1);				   /* and drop the extra ref we're holding */
 		__kickshort(myrpt);
 		myrpt->lastlinktime = rpt_tvnow();
 		rpt_mutex_unlock(&myrpt->lock);


### PR DESCRIPTION
Inbound call is not freeing a link after adding it to the link list.  This results in a "memory leak" for all inbound calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a resource management issue in the repeater component that could lead to resource accumulation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->