### PR TITLE
chan_voter: Update Keepalive Debug Messages

### DIFF
--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -3519,9 +3519,9 @@ static void *voter_xmit(void *data)
 				continue;
 			}
 			/* The host doesn't have GPS data to send a client (and there is no point). We use the GPS payload
-		 	 * (Payload 2) to send a keepalive packet to keep our UDP session alive. The client does nothing
-		 	 * with this packet.
-		 	 */
+			 * (Payload 2) to send a keepalive packet to keep our UDP session alive. The client does nothing
+			 * with this packet.
+			 */
 			if (ast_tvzero(client->lastsenttime) || (voter_tvdiff_ms(tv, client->lastsenttime) >= TX_KEEPALIVE_MS)) {
 				memset(&audiopacket, 0, sizeof(audiopacket));
 				strcpy((char *) audiopacket.vp.challenge, challenge);
@@ -3545,8 +3545,7 @@ static void *voter_xmit(void *data)
 					sendto(udp_socket, &proxy_audiopacket, sizeof(VOTER_PACKET_HEADER) + sizeof(VOTER_PROXY_HEADER), 0,
 						(struct sockaddr *) &client->sin, sizeof(client->sin));
 				} else {
-					ast_debug(5, "VOTER %i: Sending keepalive packet to client %s digest %08x\n", p->nodenum, client->name,
-						client->respdigest);
+					ast_debug(5, "VOTER %i: Sending keepalive packet to client %s digest %08x\n", p->nodenum, client->name, client->respdigest);
 					sendto(udp_socket, &audiopacket, sizeof(VOTER_PACKET_HEADER), 0, (struct sockaddr *) &client->sin,
 						sizeof(client->sin));
 				}
@@ -4562,8 +4561,8 @@ static void *voter_reader(void *data)
 			continue;
 		}
 		vph = (VOTER_PACKET_HEADER *) buf;
-		ast_debug(7, "Received network packet, len %d payload %d challenge %s digest %08x\n", (int) recvlen, ntohs(vph->payload_type),
-			vph->challenge, ntohl(vph->digest));
+		ast_debug(7, "Received network packet, len %d payload %d challenge %s digest %08x\n", (int) recvlen,
+			ntohs(vph->payload_type), vph->challenge, ntohl(vph->digest));
 		client = NULL;
 		if (!check_client_sanity && master_port) {
 			sin.sin_port = htons(master_port);


### PR DESCRIPTION
Host doesn't have or send GPS data to the client in the keepalive
packets. While they do use Payload 2 (GPS), they are just plain
keepalive packets to keep the UDP network connection alive.

This changes modifies the debug messages to reflect that they are
strictly keepalive (no GPS).

Minor other cosmetic updates to some other messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified log messages and comments to describe keepalive messaging more accurately, noting that GPS data serves as the keepalive payload when utilized in certain scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->