### PR TITLE
app_rpt: Add {} to ilink cases where variables are defined

### DIFF
--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -101,7 +101,12 @@ enum rpt_function_response function_ilink(struct rpt *myrpt, char *param, char *
 	switch (myatoi(param)) {
 	case 11:					/* Perm Link off */
 	case 1: {					/* Link off */
-		struct ast_frame wf;
+		struct ast_frame wf = {
+			.frametype = AST_FRAME_TEXT,
+			.src = __PRETTY_FUNCTION__,
+			.datalen = sizeof(DISCSTR),
+			.data.ptr = DISCSTR,
+		};
 
 		if (strlen(digitbuf) < 1)
 			break;
@@ -126,9 +131,6 @@ enum rpt_function_response function_ilink(struct rpt *myrpt, char *param, char *
 		l->disced = 1;
 		l->hasconnected = 1;
 		rpt_mutex_unlock(&myrpt->lock);
-		init_text_frame(&wf, "function_ilink:1");
-		wf.datalen = strlen(DISCSTR) + 1;
-		wf.data.ptr = DISCSTR;
 		if (l->chan) {
 			if (l->thisconnected)
 				ast_write(l->chan, &wf);
@@ -238,11 +240,12 @@ enum rpt_function_response function_ilink(struct rpt *myrpt, char *param, char *
 		return DC_COMPLETE;
 
 	case 6: { /* All Links Off, including permalinks */
-		struct ast_frame wf;
-
-		init_text_frame(&wf, "function_ilink:6");
-		wf.datalen = strlen(DISCSTR) + 1;
-		wf.data.ptr = DISCSTR;
+		struct ast_frame wf = {
+			.frametype = AST_FRAME_TEXT,
+			.src = __PRETTY_FUNCTION__,
+			.datalen = sizeof(DISCSTR),
+			.data.ptr = DISCSTR,
+		};
 		rpt_mutex_lock(&myrpt->lock);
 		myrpt->savednodes[0] = 0;
 		/* loop through all links */


### PR DESCRIPTION
Add {} to ilink cases where variables are defined
Refactor `case 6` creating the "static" frame 1 time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization by tightening variable scopes and reducing repeated initialization in looping logic, simplifying control flow and debug output placement. No user-facing behavior changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->