### PR TITLE
chan_simpleusb/chan_usbradio: manage "devstr=", add "serial="

### DIFF
--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -187,6 +187,7 @@ struct chan_simpleusb_pvt {
 
 	char devicenum;
 	char devstr[128];
+	char serial[128];
 	int spkrmax;
 	int micmax;
 	int micplaymax;
@@ -791,14 +792,17 @@ static int load_tune_config(struct chan_simpleusb_pvt *o, const struct ast_confi
 	int opened = 0;
 	int configured = 0;
 	char devstr[sizeof(o->devstr)];
+	char serial[sizeof(o->serial)];
 
 	o->rxmixerset = 500;
 	o->txmixaset = 500;
 	o->txmixbset = 500;
 
 	devstr[0] = '\0';
+	serial[0] = '\0';
 	if (!reload) {
-		o->devstr[0] = 0;
+		o->devstr[0] = '\0';
+		o->serial[0] = '\0';
 	}
 
 	if (!cfg) {
@@ -819,11 +823,13 @@ static int load_tune_config(struct chan_simpleusb_pvt *o, const struct ast_confi
 		CV_UINT("txmixaset", o->txmixaset);
 		CV_UINT("txmixbset", o->txmixbset);
 		CV_STR("devstr", devstr);
+		CV_STR("serial", serial);
 		CV_END;
 	}
 	if (!reload) {
 		/* Using the ternary operator in CV_STR won't work, due to butchering the sizeof, so copy after if needed */
 		strcpy(o->devstr, devstr); /* Safe */
+		strcpy(o->serial, serial); /* Safe */
 	}
 	if (opened) {
 		ast_config_destroy(cfg2);
@@ -893,6 +899,8 @@ static void *hidthread(void *arg)
 	 * with the usb hid device
 	 */
 	while (!o->stophid) {
+		char serial[sizeof(o->serial)] = { '\0' };
+
 		ast_radio_time(&o->lasthidtime);
 		ast_mutex_lock(&usb_dev_lock);
 		o->hasusb = 0;
@@ -913,7 +921,37 @@ static void *hidthread(void *arg)
 		 * found device.
 		 */
 		ast_radio_time(&o->lasthidtime);
-		
+
+		/* If configuration has a serial number defined, find the device */
+		if (!ast_strlen_zero(o->serial)) {
+			int index;
+			char *index_devstr = NULL;
+
+			for (index = 0;; index++) {
+				index_devstr = ast_radio_usb_get_devstr(index);
+				if (ast_strlen_zero(index_devstr)) {
+					/* if no more devices */
+					break;
+				}
+
+				/* get the device serial number */
+				if (ast_radio_usb_get_serial(index_devstr, serial, sizeof(serial)) == 0) {
+					/* if no serial number */
+					continue;
+				}
+
+				if (strcmp(o->serial, serial) == 0) {
+					/*
+					 * We found a device with the matching serial number, set
+					 * the devstr to the matching device.
+					 */
+					ast_log(LOG_NOTICE, "Matched device serial %s to %s\n", o->serial, o->name);
+					ast_copy_string(o->devstr, index_devstr, sizeof(o->devstr));
+					break;
+				}
+			}
+		}
+
 		/* Automatically assign a devstr if one was not specified in the configuration. */
 		if (ast_strlen_zero(o->devstr)) {
 			int index = 0;
@@ -943,6 +981,9 @@ static void *hidthread(void *arg)
 				/* We found an unused device assign it to our node */
 				ast_copy_string(o->devstr, index_devstr, sizeof(o->devstr));
 				ast_log(LOG_NOTICE, "Channel %s: Automatically assigned USB device %s to SimpleUSB channel\n", o->name, o->devstr);
+				if (ast_radio_usb_get_serial(index_devstr, serial, sizeof(serial)) > 0) {
+					ast_copy_string(o->serial, serial, sizeof(o->serial));
+				}
 				break;
 			}
 			if (ast_strlen_zero(o->devstr)) {
@@ -3118,6 +3159,9 @@ static void _menu_print(int fd, struct chan_simpleusb_pvt *o)
 	ast_cli(fd, "Active radio interface is [%s]\n", simpleusb_active);
 	ast_mutex_lock(&usb_dev_lock);
 	ast_cli(fd, "Device String is %s\n", o->devstr);
+	if (!ast_strlen_zero(o->serial)) {
+		ast_cli(fd, "Device Serial is %s\n", o->serial);
+	}
 	ast_mutex_unlock(&usb_dev_lock);
 	ast_cli(fd, "Card is %i\n", ast_radio_usb_get_usbdev(o->devstr));
 	ast_cli(fd, "Rx Level currently set to %d\n", o->rxmixerset);
@@ -3320,7 +3364,36 @@ static void tune_write(struct chan_simpleusb_pvt *o)
 	if (!category) {
 		ast_log(LOG_ERROR, "No category '%s' exists?\n", o->name);
 	} else {
-		CONFIG_UPDATE_STR(devstr);
+		/*
+		 * To simplify channel driver setup we allow the "devstr=" value
+		 * to be empty/blank indicating that we should match the first
+		 * available interface.
+		 *
+		 * This works (and will continue to work) well as long as the
+		 * "devstr=" value in the configuration file remains empty/blank.
+		 * But, if the value is ever provided then we only match interfaces
+		 * with the specified string.  Moving the interface (accidentally
+		 * or intentionally) to a different "port" will result in not
+		 * finding/matching the interface.
+		 *
+		 * To minimize conflicts, we want to avoid writing out the specific
+		 * "devstr=" value to the configuration file unless needed.  Here,
+		 * we check if the current "devstr=" value is empty/blank and
+		 * that there is only a single audio interface connected to the
+		 * system.  If so, we leave the value empty/blank.
+		 */
+		const char *val;
+		char *dev;
+
+		val = ast_variable_retrieve(cfg, o->name, "devstr");
+		dev = ast_radio_usb_get_devstr(1);
+		if (!ast_strlen_zero(val) || !ast_strlen_zero(dev)) {
+			/* if the "devstr=" value exists or there is more than 1 sound device */
+			CONFIG_UPDATE_STR(devstr);
+			if (!ast_strlen_zero(o->serial)) {
+				CONFIG_UPDATE_STR(serial);
+			}
+		}
 		CONFIG_UPDATE_INT(rxmixerset);
 		CONFIG_UPDATE_INT(txmixaset);
 		CONFIG_UPDATE_INT(txmixbset);

--- a/configs/rpt/simpleusb.conf
+++ b/configs/rpt/simpleusb.conf
@@ -133,7 +133,7 @@ legacyaudioscaling = no             ; If yes, continue to do raw audio sample sc
 ;       place settings that are different than the template.
 ;
 ; Note: the device string is automatically found when the
-;       USB setting "devstr=" is empty.
+;       USB setting "devstr=" and "serial=" are both empty.
 ;
 ; Note: the interface "tune" settings will be added to the
 ;       per-node settings (below).
@@ -142,6 +142,7 @@ legacyaudioscaling = no             ; If yes, continue to do raw audio sample sc
 
 ;;;;; ASL3 Tune settings ;;;;;
 devstr=
+serial=
 rxmixerset=500
 txmixaset=500
 txmixbset=500

--- a/configs/rpt/usbradio.conf
+++ b/configs/rpt/usbradio.conf
@@ -196,7 +196,7 @@ legacyaudioscaling = no     ; If yes, continue to do raw audio sample scaling an
 ;       place settings that are different than the template.
 ;
 ; Note: the device string is automatically found when the
-;       USB setting "devstr=" is empty.
+;       USB setting "devstr=" and "serial=" are both empty.
 ;
 ; Note: the interface "tune" settings will be added to the
 ;       per-node settings (below).
@@ -205,6 +205,7 @@ legacyaudioscaling = no     ; If yes, continue to do raw audio sample scaling an
 
 ;;;;; ASL3 Tune settings ;;;;;
 devstr=
+serial=
 rxmixerset=500
 txmixaset=500
 txmixbset=500

--- a/configs/samples/simpleusb.conf.sample
+++ b/configs/samples/simpleusb.conf.sample
@@ -116,6 +116,7 @@ legacyaudioscaling = no     ; If yes, continue to do raw audio sample scaling an
 
 ;;;;; Tune settings ;;;;;
 ;devstr=
+;serial=
 ;rxmixerset=500
 ;txmixaset=500
 ;txmixbset=500

--- a/configs/samples/usbradio.conf.sample
+++ b/configs/samples/usbradio.conf.sample
@@ -184,6 +184,7 @@ legacyaudioscaling = no     ; If yes, continue to do raw audio sample scaling an
 
 ;;;;; Tune settings ;;;;;
 ;devstr=
+;serial=
 ;rxmixerset=500
 ;txmixaset=500
 ;txmixbset=500

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -347,6 +347,17 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device);
 int ast_radio_usb_get_usbdev(const char *devstr);
 
 /*!
+ * \brief Get serial number from device if available
+ *	This function will attempt to get the serial number from a media device
+ *
+ * \param devstr		The USB device string
+ * \param buf			Pointer to buffer for serial number
+ * \param buflen		Length of the serial number buffer
+ * \retval				Length of returned serial number; 0 if no serial
+ */
+int ast_radio_usb_get_serial(const char *devstr, char *buf, size_t buflen);
+
+/*!
  * \brief See if the internal usb_device_list contains the
  * specified device string.
  * \param devstr	Device string to check.

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -598,6 +598,38 @@ int ast_radio_usb_get_usbdev(const char *devstr)
 	return i;
 }
 
+/*!
+ * \brief Get serial number from device if available
+ *	This function will attempt to get the serial number from a media device
+ *
+ * \param devstr		The USB device string
+ * \param buf			Pointer to buffer for serial number
+ * \param buflen		Length of the serial number buffer
+ * \retval				Length of returned serial number; 0 if no serial
+ */
+int ast_radio_usb_get_serial(const char *devstr, char *buf, size_t buflen)
+{
+	struct usb_device *usb_dev;
+	struct usb_dev_handle *usb_handle;
+	int length = 0;
+
+	usb_dev = ast_radio_hid_device_init(devstr);
+	if (!usb_dev) {
+		return 0;
+	}
+
+	if (usb_dev->descriptor.iSerialNumber) {
+		usb_handle = usb_open(usb_dev);
+		if (!usb_handle) {
+			return 0;
+		}
+		length = usb_get_string_simple(usb_handle, usb_dev->descriptor.iSerialNumber, buf, buflen);
+		usb_close(usb_handle);
+	}
+
+	return length;
+}
+
 int ast_radio_usb_list_check(char *devstr)
 {
 	/* See usb_device_list definition for the format */


### PR DESCRIPTION
To simplify channel driver setup we allow the "devstr=" value to be empty/blank indicating that we can/should match the first available interface.

This works (and will continue to work) well as long as the "devstr=" value in the configuration file remains empty/blank.  But, if the value is ever provided then we only match interfaces with the specified string.  Moving the interface (accidentally or intentionally) to a different "port" will result in not finding/matching the interface.

To minimize conflicts, we want to avoid having the tune menu write out the specific "devstr=" value to the configuration file unless needed.  Now, we check if the current "devstr=" value is empty/blank and that there is only a single audio interface connected to the system.  If so, we leave the value empty/blank.

In addition, included (and reworked) the changes from unmerged PR #394 to add support for matching interface on the device "serial" number.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-device USB serial number support: devices can be identified, selected, and persisted by serial alongside existing device selection.
  * CLI/menu and status displays now show device serial when available.
  * New API to obtain USB device serials for integrations.

* **Documentation**
  * Configuration files and sample configs updated to accept and document a serial= tuning option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->