### PR TITLE
app_rpt: Use passed variable `chan` in `rpt_radio_set_recommend_data()` and `rpt_radio_set_param()`

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -6303,11 +6303,11 @@ static int get_his_ip(struct ast_channel *chan, char *buf, size_t len)
 
 static inline int kenwood_uio_helper(struct rpt *myrpt)
 {
-	if (rpt_radio_set_param(myrpt->dahditxchannel, myrpt, RPT_RADPAR_UIOMODE, 3)) {
+	if (rpt_radio_set_param(myrpt->dahditxchannel, RPT_RADPAR_UIOMODE, 3)) {
 		ast_log(LOG_ERROR, "Cannot set UIOMODE on %s: %s\n", ast_channel_name(myrpt->dahditxchannel), strerror(errno));
 		return -1;
 	}
-	if (rpt_radio_set_param(myrpt->dahditxchannel, myrpt, RPT_RADPAR_UIODATA, 3)) {
+	if (rpt_radio_set_param(myrpt->dahditxchannel, RPT_RADPAR_UIODATA, 3)) {
 		ast_log(LOG_ERROR, "Cannot set UIODATA on %s: %s\n", ast_channel_name(myrpt->dahditxchannel), strerror(errno));
 		return -1;
 	}
@@ -7112,7 +7112,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 
 	iskenwood_pci4 = 0;
 	if ((myrpt->iofd < 1) && (myrpt->txchannel == myrpt->dahditxchannel)) {
-		res = rpt_radio_set_param(myrpt->dahditxchannel, myrpt, RPT_RADPAR_REMMODE, RPT_RADPAR_REM_NONE);
+		res = rpt_radio_set_param(myrpt->dahditxchannel, RPT_RADPAR_REMMODE, RPT_RADPAR_REM_NONE);
 		/* if PCIRADIO and kenwood selected */
 		if ((!res) && (!strcmp(myrpt->remoterig, REMOTE_RIG_KENWOOD))) {
 			if (kenwood_uio_helper(myrpt)) {
@@ -7129,12 +7129,12 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 			((!strcmp(myrpt->remoterig, REMOTE_RIG_FT897)) || (!strcmp(myrpt->remoterig, REMOTE_RIG_FT950)) ||
 				(!strcmp(myrpt->remoterig, REMOTE_RIG_FT100)) || (!strcmp(myrpt->remoterig, REMOTE_RIG_XCAT)) ||
 				(!strcmp(myrpt->remoterig, REMOTE_RIG_IC706)) || (!strcmp(myrpt->remoterig, REMOTE_RIG_TM271)))) {
-			if (rpt_radio_set_param(myrpt->dahditxchannel, myrpt, RPT_RADPAR_UIOMODE, 1)) {
+			if (rpt_radio_set_param(myrpt->dahditxchannel, RPT_RADPAR_UIOMODE, 1)) {
 				ast_log(LOG_ERROR, "Cannot set UIOMODE on %s: %s\n", ast_channel_name(myrpt->dahditxchannel), strerror(errno));
 				rpt_mutex_unlock(&myrpt->lock);
 				return -1;
 			}
-			if (rpt_radio_set_param(myrpt->dahditxchannel, myrpt, RPT_RADPAR_UIODATA, 3)) {
+			if (rpt_radio_set_param(myrpt->dahditxchannel, RPT_RADPAR_UIODATA, 3)) {
 				ast_log(LOG_ERROR, "Cannot set UIODATA on %s: %s\n", ast_channel_name(myrpt->dahditxchannel), strerror(errno));
 				rpt_mutex_unlock(&myrpt->lock);
 				return -1;
@@ -7463,7 +7463,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 						telem = telem->next;
 					}
 					if (iskenwood_pci4 && myrpt->txchannel == myrpt->dahditxchannel) {
-						if (rpt_radio_set_param(myrpt->dahditxchannel, myrpt, RPT_RADPAR_UIODATA, 1)) {
+						if (rpt_radio_set_param(myrpt->dahditxchannel, RPT_RADPAR_UIODATA, 1)) {
 							ast_log(LOG_ERROR, "Cannot set UIODATA on %s: %s\n", ast_channel_name(myrpt->dahditxchannel), strerror(errno));
 							return -1;
 						}
@@ -7481,7 +7481,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 				rpt_telemetry(myrpt, UNAUTHTX, NULL);
 			}
 			if (iskenwood_pci4 && myrpt->txchannel == myrpt->dahditxchannel) {
-				if (rpt_radio_set_param(myrpt->dahditxchannel, myrpt, RPT_RADPAR_UIODATA, 3)) {
+				if (rpt_radio_set_param(myrpt->dahditxchannel, RPT_RADPAR_UIODATA, 3)) {
 					ast_log(LOG_ERROR, "Cannot set UIODATA on %s: %s\n", ast_channel_name(myrpt->dahditxchannel), strerror(errno));
 					return -1;
 				}

--- a/apps/app_rpt/rpt_radio.c
+++ b/apps/app_rpt/rpt_radio.c
@@ -48,7 +48,7 @@ int dahdi_radio_set_ctcss_encode(struct ast_channel *chan, int block)
 	return dahdi_set_radpar(chan, DAHDI_RADPAR_NOENCODE, block);
 }
 
-int rpt_radio_set_param(struct ast_channel *chan, struct rpt *myrpt, enum rpt_radpar par, enum rpt_radpar_data data)
+int rpt_radio_set_param(struct ast_channel *chan, enum rpt_radpar par, enum rpt_radpar_data data)
 {
 	/* rpt_radpar and rpt_radpar_data maps to RPT_RADPAR values exactly,
 	 * so for now we can just pass them on. */
@@ -85,11 +85,11 @@ int rpt_pciradio_serial_remote_io(struct rpt *myrpt, unsigned char *txbuf, int t
 	olddata = prm.data;
 	prm.radpar = DAHDI_RADPAR_REMMODE;
 	if ((asciiflag & 1) && strcmp(myrpt->remoterig, REMOTE_RIG_TM271) && strcmp(myrpt->remoterig, REMOTE_RIG_KENWOOD)) {
-		if (rpt_radio_set_param(myrpt->dahdirxchannel, myrpt, RPT_RADPAR_REMMODE, RPT_RADPAR_REM_SERIAL_ASCII)) {
+		if (rpt_radio_set_param(myrpt->dahdirxchannel, RPT_RADPAR_REMMODE, RPT_RADPAR_REM_SERIAL_ASCII)) {
 			return -1;
 		}
 	} else {
-		if (rpt_radio_set_param(myrpt->dahdirxchannel, myrpt, RPT_RADPAR_REMMODE, RPT_RADPAR_REM_SERIAL)) {
+		if (rpt_radio_set_param(myrpt->dahdirxchannel, RPT_RADPAR_REMMODE, RPT_RADPAR_REM_SERIAL)) {
 			return -1;
 		}
 	}
@@ -135,7 +135,7 @@ int rpt_pciradio_serial_remote_io(struct rpt *myrpt, unsigned char *txbuf, int t
 		memcpy(rxbuf, prm.buf, prm.index);
 	}
 	index = prm.index;
-	if (rpt_radio_set_param(myrpt->dahdirxchannel, myrpt, RPT_RADPAR_REMMODE, RPT_RADPAR_REM_NONE)) {
+	if (rpt_radio_set_param(myrpt->dahdirxchannel, RPT_RADPAR_REMMODE, RPT_RADPAR_REM_NONE)) {
 		return -1;
 	}
 	if (asciiflag & 2) {
@@ -143,10 +143,10 @@ int rpt_pciradio_serial_remote_io(struct rpt *myrpt, unsigned char *txbuf, int t
 			return -1;
 		}
 	}
-	if (rpt_radio_set_param(myrpt->dahdirxchannel, myrpt, RPT_RADPAR_UIOMODE, oldmode)) {
+	if (rpt_radio_set_param(myrpt->dahdirxchannel, RPT_RADPAR_UIOMODE, oldmode)) {
 		return -1;
 	}
-	if (rpt_radio_set_param(myrpt->dahdirxchannel, myrpt, RPT_RADPAR_UIODATA, olddata)) {
+	if (rpt_radio_set_param(myrpt->dahdirxchannel, RPT_RADPAR_UIODATA, olddata)) {
 		return -1;
 	}
 	return index;

--- a/apps/app_rpt/rpt_radio.h
+++ b/apps/app_rpt/rpt_radio.h
@@ -32,7 +32,7 @@ enum rpt_radpar_data {
 	RPT_RADPAR_REM_SERIAL_ASCII = 3,
 };
 
-int rpt_radio_set_param(struct ast_channel *chan, struct rpt *myrpt, enum rpt_radpar par, enum rpt_radpar_data data);
+int rpt_radio_set_param(struct ast_channel *chan, enum rpt_radpar par, enum rpt_radpar_data data);
 
 int rpt_radio_set_remcommand_data(struct ast_channel *chan, unsigned char *data, int len);
 

--- a/apps/app_rpt/rpt_serial.c
+++ b/apps/app_rpt/rpt_serial.c
@@ -416,7 +416,7 @@ static void rbi_out_parallel(struct rpt *myrpt, unsigned char *data)
 
 static void rbi_out(struct rpt *myrpt, unsigned char *data)
 {
-	if (rpt_radio_set_param(myrpt->dahdirxchannel, myrpt, RPT_RADPAR_REMMODE, RPT_RADPAR_REM_RBI1)) {
+	if (rpt_radio_set_param(myrpt->dahdirxchannel, RPT_RADPAR_REMMODE, RPT_RADPAR_REM_RBI1)) {
 		/* if setparam ioctl fails, its probably not a pciradio card */
 		rbi_out_parallel(myrpt, data);
 		return;


### PR DESCRIPTION
CodeRabbit pointed this one out...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed radio command routing to ensure commands are properly sent to the correct channel.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->