### PR TITLE
app_rpt: Remove requirement for `ident` to be defined/configured

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -5853,11 +5853,6 @@ static void *rpt_master(void *ignore)
 		rpt_vars[i].offset = REM_SIMPLEX;
 		rpt_vars[i].powerlevel = REM_LOWPWR;
 		rpt_vars[i].splitkhz = 0;
-
-		if (rpt_vars[i].p.ident && (!*rpt_vars[i].p.ident)) {
-			ast_log(LOG_WARNING, "Did not specify ident for node %s\n", rpt_vars[i].name);
-			pthread_exit(NULL);
-		}
 		rpt_vars[i].ready = 0;
 		rpt_vars[i].lastthreadupdatetime = current_time;
 		ast_pthread_create_detached(&rpt_vars[i].rpt_thread, NULL, rpt, &rpt_vars[i]);


### PR DESCRIPTION
Fixes #381 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when repeater nodes are misconfigured: nodes with missing identifiers no longer cause the main repeater controller to exit. Affected repeaters are now skipped or disabled so other nodes continue operating.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->