### PR TITLE
app_rpt: Address memory leak in `http_registration`

### DIFF
--- a/res/res_rpt_http_registrations.c
+++ b/res/res_rpt_http_registrations.c
@@ -64,6 +64,7 @@
  ***/
 
 #define CONFIG_FILE "rpt_http_registrations.conf"
+#define RPT_INITIAL_BUFFER_SIZE 512
 
 /*! \brief Default register interval is once per minute */
 #define DEFAULT_REGISTER_INTERVAL 60


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a resource leak in HTTP registration cleanup where associated resources were not being properly released and deallocated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->