### PR TITLE
app_rpt: limit text message size, adjust stat post and link update interval

### DIFF
--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -74,9 +74,8 @@ typedef struct {
 #define	MAXMACRO 2048
 #define	MAXNODES 500			  /* Maximum number of nodes allowed in the link list */
 #define	RPT_AST_STR_INIT_SIZE 500 /* initial guess for ast_str size */
-#define	LINKLISTTIME 10000
-#define	LINKLISTSHORTTIME 200
-#define	LINKPOSTTIME 30000
+
+#define LINKLISTSHORTTIME 200
 #define LINKPOSTSHORTTIME 200
 #define	KEYTIMERTIME 250
 #define	MACROTIME 100
@@ -206,8 +205,6 @@ typedef struct {
 #define	SIMPLEX_PHONE_DELAY 25
 
 #define RX_LINGER_TIME 50
-
-#define	STATPOST_PROGRAM "/usr/bin/wget,-q,--output-document=/dev/null,--no-check-certificate"
 
 #define	ALLOW_LOCAL_CHANNELS
 
@@ -863,8 +860,10 @@ struct rpt {
 		int simplexpatchdelay;
 		int simplexphonedelay;
 		char telemdefault;
-		const char *statpost_program;
+		int linkpost_time;
+		int linkpost_max_message_len;
 		const char *statpost_url;
+		int statpost_time;
 		enum rpt_linkmode linkmode[10];
 		char linkmodedynamic[10];
 		const char *locallist[16];

--- a/apps/app_rpt/rpt_cli.c
+++ b/apps/app_rpt/rpt_cli.c
@@ -525,7 +525,7 @@ static int rpt_do_xnode(int fd, int argc, const char *const *argv)
 			/* ### GET CONNECTED NODE INFO ####################
 			 * Traverse the list of connected nodes
 			 */
-			n = __mklinklist(myrpt, NULL, &lbuf, 0) + 1;
+			n = __mklinklist(myrpt, NULL, &lbuf, USE_FORMAT_RPT_LINK) + 1;
 
 			j = 0;
 			rpt_mutex_unlock(&myrpt->lock); // UNLOCK
@@ -646,7 +646,7 @@ static int rpt_do_nodes(int fd, int argc, const char *const *argv)
 			/* Make a copy of all stat variables while locked */
 			myrpt = &rpt_vars[i];
 			rpt_mutex_lock(&myrpt->lock);	/* LOCK */
-			n = __mklinklist(myrpt, NULL, &lbuf, 0) + 1;
+			n = __mklinklist(myrpt, NULL, &lbuf, USE_FORMAT_RPT_LINK) + 1;
 			rpt_mutex_unlock(&myrpt->lock);	/* UNLOCK */
 			strs = ast_malloc(n * sizeof(char *));
 			if (!strs) {

--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -877,7 +877,17 @@ void load_rpt_vars(int n, int init)
 	RPT_CONFIG_VAR_INT_DEFAULT(voxrecover_ms, "voxrecover", VOX_RECOVER_MS);
 	RPT_CONFIG_VAR_INT_DEFAULT(simplexpatchdelay, "simplexpatchdelay", SIMPLEX_PATCH_DELAY);
 	RPT_CONFIG_VAR_INT_DEFAULT(simplexphonedelay, "simplexphonedelay", SIMPLEX_PHONE_DELAY);
-	RPT_CONFIG_VAR_DEFAULT(statpost_program, "statpost_program", STATPOST_PROGRAM);
+
+	/* configure how "L" messages are sent */
+	RPT_CONFIG_VAR_INT_DEFAULT_MIN_MAX(linkpost_max_message_len, "linkpost_max_message_len", 0, 0, 10000);
+	if (rpt_vars[n].p.linkpost_max_message_len && (rpt_vars[n].p.linkpost_max_message_len < 500)) {
+		/* if message truncation enabled, set minimum */
+		rpt_vars[n].p.linkpost_max_message_len = 500;
+	}
+	RPT_CONFIG_VAR_INT_DEFAULT_MIN_MAX(linkpost_time, "linkpost_time", 60, 10, 600);
+
+	/* configure how we interact with "stats.allstarlink.org" */
+	RPT_CONFIG_VAR_INT_DEFAULT_MIN_MAX(statpost_time, "statpost_time", 60, 30, 600);
 	RPT_CONFIG_VAR(statpost_url, "statpost_url");
 
 	rpt_vars[n].p.tailmessagetime = retrieve_astcfgint(&rpt_vars[n], cat, "tailmessagetime", 0, 200000000, 0);

--- a/apps/app_rpt/rpt_link.h
+++ b/apps/app_rpt/rpt_link.h
@@ -64,16 +64,30 @@ void rpt_link_remove(struct ao2_container *links, struct rpt_link *l);
 void rpt_link_destroy(void *obj);
 
 /*!
+ * \brief __mklinklist() flags
+ */
+enum __mklinklist_flags {
+	/*! \brief Create RPT_LINK format (<mode><node>) string */
+	USE_FORMAT_RPT_LINK = 0,
+	/*! \brief Create RPT_ALINK format (<node><mode><keystate>) string */
+	USE_FORMAT_RPT_ALINK = (1 << 0),
+	/*! \brief Create RPT_LINKPOST format (<mode><node>) string */
+	USE_FORMAT_RPT_LINKPOST = (1 << 1),
+	/*! \brief Limit string length to avoid fragmentation */
+	LIMIT_STRING_LENGTH = (1 << 8),
+};
+
+/*!
  * \brief Create a list of links for this node.
  * Must be called locked.
  * \param myrpt		Pointer to rpt structure.
  * \param mylink	Pointer to rpt_link structure.
  * \param buf		Pointer to ast_str buffer - link string is generated in this buffer.
- * \param alink_format	Flag to indicate if RPT_ALINK format is returned. If not, RPT_LINK
+ * \param flags		Flags specifying format as the returned string.
  * format is returned. \retval		link count.
  */
 
-int __mklinklist(struct rpt *myrpt, struct rpt_link *mylink, struct ast_str **buf, int alink_format);
+int __mklinklist(struct rpt *myrpt, struct rpt_link *mylink, struct ast_str **buf, enum __mklinklist_flags flags);
 
 /*! \brief must be called locked */
 void __kickshort(struct rpt *myrpt);

--- a/apps/app_rpt/rpt_manager.c
+++ b/apps/app_rpt/rpt_manager.c
@@ -208,7 +208,7 @@ static int rpt_manager_do_xstat(struct mansession *ses, const struct message *m)
 
 			/* Get connected node info */
 			/* Traverse the list of connected nodes */
-			n = __mklinklist(myrpt, NULL, &lbuf, 0) + 1;
+			n = __mklinklist(myrpt, NULL, &lbuf, USE_FORMAT_RPT_LINK) + 1;
 			links_copy = ao2_container_clone(myrpt->links, OBJ_NOLOCK);
 			rpt_mutex_unlock(&myrpt->lock);
 			if (!links_copy) {

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -1575,7 +1575,7 @@ treataslocal:
 			goto abort;
 		}
 		/* get all the nodes */
-		n = __mklinklist(myrpt, NULL, &lbuf, 0) + 1;
+		n = __mklinklist(myrpt, NULL, &lbuf, USE_FORMAT_RPT_LINK) + 1;
 		rpt_mutex_unlock(&myrpt->lock);
 		strs = ast_malloc(n * sizeof(char *));
 		if (!strs) {
@@ -2414,7 +2414,7 @@ treataslocal:
 		}
 		rpt_mutex_lock(&myrpt->lock);
 		/* get all the nodes */
-		n = __mklinklist(myrpt, NULL, &lbuf, 0) + 1;
+		n = __mklinklist(myrpt, NULL, &lbuf, USE_FORMAT_RPT_LINK) + 1;
 		rpt_mutex_unlock(&myrpt->lock);
 		strs = ast_malloc(n * sizeof(char *));
 		if (!strs) {
@@ -3153,7 +3153,7 @@ void rpt_telemetry(struct rpt *myrpt, enum rpt_tele_mode mode, void *data)
 			rpt_mutex_lock(&myrpt->lock);
 			snprintf(mystr, sizeof(mystr), "STATUS,%s,%d", myrpt->name, myrpt->callmode);
 			/* get all the nodes */
-			n = __mklinklist(myrpt, NULL, &lbuf, 0) + 1;
+			n = __mklinklist(myrpt, NULL, &lbuf, USE_FORMAT_RPT_LINK) + 1;
 			rpt_mutex_unlock(&myrpt->lock);
 			strs = ast_malloc(n * sizeof(char *));
 			if (!strs) {

--- a/configs/rpt/rpt.conf
+++ b/configs/rpt/rpt.conf
@@ -211,6 +211,11 @@ parrottime = 1000                   ; Set the amount of time in milliseconds
 ; per-node stanza(s).
 ;
 ;statpost_url = http://stats.allstarlink.org/uhandler ; Status updates
+;
+; Uncomment the following "statpost_time" line to control how frequently
+; your nodes reports it's connected links.  This time does not affect the
+; reporting of key up/down changes.
+;statpost_time = 60                 ; (optional) time (in seconds) (min 30, max 600, default 60)
 
 ; *** Audio Archiving ***
 ;


### PR DESCRIPTION
It appears that fragmented IAX2 frames can cause network storms.
Closes #930 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable link and status post intervals and configurable max link-post message length.
  * Posting now respects the configured enable/disable state and skips sending when disabled.

* **Bug Fixes**
  * Improved link-list payload generation with fragmentation-aware truncation and safer formatting to avoid oversized messages.
  * Improved frame handling to prevent oversized messages from causing issues. Messages exceeding size limits are now gracefully truncated with an indicator.

* **Documentation**
  * Added config documentation for the new status-report interval setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->