### PR TITLE
app_rpt: Handle dialplan execution in `handle_varcmd_telem()`

### DIFF
--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -819,7 +819,7 @@ static int telem_send_ct(struct rpt *myrpt, struct ast_channel *chan, const char
 /*! \brief Processes various telemetry commands that are in the myrpt structure
  * Used extensively when links are built or torn down and other events are processed
  * by the rpt_master threads.
- * returns 1 if PBX, 0 if not
+ * \retval 1 if PBX process handled telemetry command, 0 if not.
  */
 static int handle_varcmd_tele(struct rpt *myrpt, struct ast_channel *mychannel, char *varcmd)
 {


### PR DESCRIPTION
Closes Assert in rpt_telemetry.c executing global time announcement Fixes #931

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal error handling and control flow logic for better code reliability.

---

**Note:** This release contains internal code improvements with no direct changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->