### PR TITLE
build: Fix discarded-qualifiers errors with gcc 15.2.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  container:
+  ubuntu:
     runs-on: ubuntu-latest
     container: 
       image: ghcr.io/allstarlink/asl3-ci:latest
@@ -28,3 +28,25 @@ jobs:
         run: |
           cd /usr/src/testsuite
           phreaknet runtest apps/rpt
+#  archlinux:
+#    runs-on: ubuntu-24.04
+#    name: Arch Linux
+#    container: archlinux:latest
+#    steps:
+#      - name: Build Asterisk
+#        run: |
+#          cd /usr/src
+#          pacman -Syu --noconfirm
+#          pacman -Sy --noconfirm wget libusb libusb-compat alsa-utils
+#          wget https://docs.phreaknet.org/script/phreaknet.sh
+#          chmod +x phreaknet.sh
+#          ./phreaknet.sh make
+#          phreaknet update
+#          phreaknet install --dahdi --disable-vpmadt032 --lightweight --alsa --fast --devmode
+#      - name: Checkout
+#        uses: actions/checkout@v4
+#      - name: Build app_rpt
+#        run: |
+#          cp -r ../app_rpt /usr/src
+#          cd /usr/src/app_rpt
+#          ./rpt_install.sh

--- a/apps/app_gps.c
+++ b/apps/app_gps.c
@@ -596,7 +596,7 @@ static void *aprs_connection_thread(void *data)
  * \retval 0		Success
  * \retval -1		Failure
  */
-static int report_aprs(const char *ctg, const char *lat, const char *lon, const char *elev)
+static int report_aprs(const char *ctg, char *lat, char *lon, const char *elev)
 {
 	struct ast_config *cfg = NULL;
 	char *call, *comment, icon, icon_table;
@@ -758,7 +758,7 @@ static int report_aprs(const char *ctg, const char *lat, const char *lon, const 
  * \retval -1		Failure
  */
 
-static int report_aprstt(const char *ctg, const char *lat, const char *lon, const char *theircall, const char overlay)
+static int report_aprstt(const char *ctg, char *lat, char *lon, const char *theircall, const char overlay)
 {
 	struct ast_config *cfg = NULL;
 	char *call, *comment;

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -6296,7 +6296,7 @@ static inline int exec_txchannel_read(struct rpt *myrpt)
 	return wait_for_hangup_helper(myrpt->txchannel, "txchannel");
 }
 
-static int parse_caller(const char *b1, const char *hisip, char *s)
+static int parse_caller(const char *b1, char *hisip, char *s)
 {
 	char sx[320];
 	char *s1, *s2, *s3;

--- a/apps/app_rpt/rpt_cli.c
+++ b/apps/app_rpt/rpt_cli.c
@@ -1024,7 +1024,7 @@ static int rpt_do_setvar(int fd, int argc, const char *const *argv)
 	}
 
 	for (x = 4; x < argc; x++) {
-		const char *name = argv[x];
+		char *name = ast_strdupa(argv[x]);
 		if ((value = strchr(name, '='))) {
 			*value++ = '\0';
 			pbx_builtin_setvar_helper(rpt_vars[thisRpt].rxchannel, name, value);


### PR DESCRIPTION
Starting with gcc 15.2.1, the type used to save the return value of strchr, strrchr, memchr, or memrchr must be const if the argument was const.

Resolves: #936

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Expanded CI/CD testing to include Archlinux container environment alongside existing Ubuntu testing

* **Refactor**
  * Improved internal buffer handling to prevent unintended modifications of caller arguments
  * Updated function signatures to support proper buffer management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->