### PR TITLE
app_rpt: Fix unused-but-set-variable errors with gcc 16

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -6751,6 +6751,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 			ast_log(LOG_WARNING, "Return Context Invalid, call will return to default|s\n");
 		}
 
+		(void) timeout; /* Avoid unused variable warning for now */
 		/* we are using masq_park here to protect * from touching the channel once we park it.  If the channel comes out of
 		   timeout before we are done announcing and the channel is messed with, Kablooeee.  So we use Masq to prevent this.  */
 


### PR DESCRIPTION
Disable the variables and code related to parking for now, since that isn't currently implemented.

Resolves: #940

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Suppressed an unused-variable compiler warning in the Return/parking flow; no behavioral changes.
  * Maintains existing timeout logic and comments while cleaning up build-time noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->