### PR TITLE
app_rpt: Remove double debug message on `ast_format_cap_alloc()` failure

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -1338,7 +1338,6 @@ void *rpt_call(void *this)
 
 	cap = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
 	if (!cap) {
-		ast_log(LOG_ERROR, "Failed to alloc cap\n");
 		myrpt->callmode = CALLMODE_DOWN;
 		return NULL;
 	}
@@ -2445,7 +2444,6 @@ static void *attempt_reconnect(struct rpt *myrpt, struct rpt_link *l)
 
 	cap = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
 	if (!cap) {
-		ast_log(LOG_ERROR, "Failed to alloc cap\n");
 		rpt_mutex_lock(&myrpt->lock);
 		l->retrytimer = RETRY_TIMER_MS;
 		rpt_mutex_unlock(&myrpt->lock);
@@ -4867,7 +4865,6 @@ static void *rpt(void *this)
 
 	cap = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
 	if (!cap) {
-		ast_log(LOG_ERROR, "Failed to alloc cap\n");
 		rpt_mutex_unlock(&myrpt->lock);
 		return NULL;
 	}
@@ -6892,7 +6889,6 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 		myrpt->lastlinktime = rpt_tvnow();
 		cap = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
 		if (!cap) {
-			ast_log(LOG_ERROR, "Failed to alloc cap\n");
 			ao2_ref(l, -1);
 			return -1;
 		}
@@ -7069,7 +7065,6 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 	cap = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
 	if (!cap) {
 		rpt_mutex_unlock(&myrpt->lock);
-		ast_log(LOG_ERROR, "Failed to alloc cap\n");
 		return -1;
 	}
 

--- a/apps/app_rpt/rpt_call.c
+++ b/apps/app_rpt/rpt_call.c
@@ -113,7 +113,6 @@ void rpt_forward(struct ast_channel *chan, char *dialstr, char *nodefrom)
 
 	cap = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
 	if (!cap) {
-		ast_log(LOG_ERROR, "Failed to alloc cap\n");
 		return;
 	}
 

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -726,7 +726,6 @@ void *rpt_link_connect(void *data)
 
 	cap = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
 	if (!cap) {
-		ast_log(LOG_ERROR, "Failed to alloc cap\n");
 		ao2_ref(l, -1);
 		goto cleanup;
 	}

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -1313,7 +1313,6 @@ void *rpt_tele_thread(void *this)
 
 	cap = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
 	if (!cap) {
-		ast_log(LOG_ERROR, "Failed to alloc cap\n");
 		rpt_mutex_lock(&myrpt->lock);
 		goto abort;
 	}


### PR DESCRIPTION
Closes #942

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code cleanup: Streamlined error handling in the telephony routing module by removing redundant logging during allocation failures. All error recovery mechanisms remain intact with no impact on application behavior or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->