### PR TITLE
app_rpt: Add RPT_NODE dialplan function

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -319,6 +319,7 @@
 #include "app_rpt/rpt_utils.h"
 #include "app_rpt/rpt_daq.h"
 #include "app_rpt/rpt_cli.h"
+#include "app_rpt/rpt_dialplan_functions.h"
 #include "app_rpt/rpt_bridging.h"
 #include "app_rpt/rpt_call.h"
 #include "app_rpt/rpt_capabilities.h"
@@ -7658,6 +7659,7 @@ static int unload_module(void)
 	}
 
 	res = ast_unregister_application(app);
+	res |= rpt_dialplan_funcs_unload();
 	res |= rpt_cleanup_telemetry();
 
 #ifdef _MDC_ENCODE_H_
@@ -7672,7 +7674,7 @@ static int unload_module(void)
 
 static int load_module(void)
 {
-	int res;
+	int res = 0;
 
 	nullfd = open("/dev/null", O_RDWR);
 	if (nullfd == -1) {
@@ -7681,8 +7683,8 @@ static int load_module(void)
 	}
 	ast_pthread_create(&rpt_master_thread, NULL, rpt_master, NULL);
 
-	rpt_cli_load();
-	res = 0;
+	res |= rpt_cli_load();
+	res |= rpt_dialplan_funcs_load();
 	res |= rpt_manager_load();
 	res |= ast_register_application_xml(app, rpt_exec);
 	res |= rpt_init_telemetry();

--- a/apps/app_rpt/rpt_dialplan_functions.c
+++ b/apps/app_rpt/rpt_dialplan_functions.c
@@ -1,0 +1,116 @@
+
+/*! \file
+ *
+ * \brief RPT dialplan functions
+ */
+
+#include "asterisk.h"
+
+#include "asterisk/module.h"
+#include "asterisk/pbx.h"
+#include "asterisk/channel.h"
+#include "asterisk/app.h"
+
+#include "app_rpt.h"
+#include "rpt_dialplan_functions.h"
+
+/*** DOCUMENTATION
+	<function name="RPT_NODE" language="en_US">
+		<synopsis>
+			Retrieves information about a repeater node
+		</synopsis>
+		<syntax>
+			<parameter name="node" required="true">
+				<para>Node number</para>
+			</parameter>
+			<parameter name="field" required="true">
+				<para>Information to retrieve</para>
+				<enumlist>
+					<enum name="exists">
+						<para>Whether a node with this node number exists on this system.</para>
+					</enum>
+					<enum name="keyed">
+						<para>Whether a node is currently keyed.</para>
+					</enum>
+					<enum name="txkeyed">
+						<para>Whether a node's transmitter is currently keyed.</para>
+					</enum>
+				</enumlist>
+			</parameter>
+		</syntax>
+		<description>
+			<para>Retrieves information about a repeater node, by node number.</para>
+		</description>
+	</function>
+ ***/
+
+extern struct rpt rpt_vars[MAXRPTS];
+
+static int rpt_node_read(struct ast_channel *chan, const char *function, char *data, char *buf, size_t len)
+{
+	char *parse;
+	struct rpt *rpt = NULL;
+	int i, nrpts;
+	AST_DECLARE_APP_ARGS(args,
+		AST_APP_ARG(nodenum);
+		AST_APP_ARG(field);
+	);
+
+	*buf = '\0';
+
+	if (ast_strlen_zero(data)) {
+		ast_log(LOG_ERROR, "%s: Arguments required\n", function);
+		return -1;
+	}
+
+	parse = ast_strdupa(data);
+	AST_STANDARD_APP_ARGS(args, parse);
+
+	if (ast_strlen_zero(args.nodenum)) {
+		ast_log(LOG_ERROR, "%s: Node number required\n", function);
+		return -1;
+	} else if (ast_strlen_zero(args.field)) {
+		ast_log(LOG_ERROR, "%s: Field required\n", function);
+		return -1;
+	}
+
+	/* Find the node */
+	nrpts = rpt_num_rpts();
+	for (i = 0; i < nrpts; i++) {
+		if (!strcasecmp(rpt_vars[i].name, args.nodenum)) {
+			rpt = &rpt_vars[i];
+			break;
+		}
+	}
+
+	if (!strcasecmp(args.field, "exists")) {
+		snprintf(buf, len, "%d", rpt ? 1 : 0);
+	} else if (!strcasecmp(args.field, "keyed")) {
+		snprintf(buf, len, "%d", rpt && rpt->keyed ? 1 : 0);
+	} else if (!strcasecmp(args.field, "txkeyed")) {
+		snprintf(buf, len, "%d", rpt && rpt->txkeyed ? 1 : 0);
+	} else {
+		ast_log(LOG_ERROR, "%s: Invalid field '%s'\n", function, args.field);
+		return -1;
+	}
+	return 0;
+}
+
+static struct ast_custom_function rpt_node_function = {
+	.name = "RPT_NODE",
+	.read = rpt_node_read,
+};
+
+int rpt_dialplan_funcs_load(void)
+{
+	int res = 0;
+	res |= ast_custom_function_register(&rpt_node_function);
+	return res;
+}
+
+int rpt_dialplan_funcs_unload(void)
+{
+	int res = 0;
+	res |= ast_custom_function_unregister(&rpt_node_function);
+	return res;
+}

--- a/apps/app_rpt/rpt_dialplan_functions.h
+++ b/apps/app_rpt/rpt_dialplan_functions.h
@@ -1,0 +1,2 @@
+int rpt_dialplan_funcs_load(void);
+int rpt_dialplan_funcs_unload(void);

--- a/configs/rpt/extensions.conf
+++ b/configs/rpt/extensions.conf
@@ -13,11 +13,9 @@ TAILFILEINDEX=0 ; used for telemetry, do not remove/change
 exten => i,1,Hangup
 
 [radio-secure]
-;exten => ${NODE},1,rpt(${EXTEN})
 exten => _XXXX!,1,Set(NODENUM=${CALLERID(num)})
-	same => n,NoOp(Connect from node: ${NODENUM})
-	same => n,NoOp(Connect to: ${EXTEN})
-	same => n,NoOp(Channel type: ${CHANNEL(channeltype)})
+	same => n,NoOp(Connect from node ${NODENUM} to node ${EXTEN} using ${CHANNEL(channeltype)})
+	same => n,ExecIf($[!${RPT_NODE(${EXTEN},exists)}]?Hangup) ; disconnect if requested node is not on this server
 	same => n,GotoIf($["${CHANNEL(channeltype)}" = "IAX2"]?:allowlist)              ; if not IAX2, skip IP check
 
 	; if peer IP is localhost, connect


### PR DESCRIPTION
Add a dialplan function that can be used to retrieve information about nodes. To start with, only some basic information is available, but this can be easily extended over time as other use cases arise.

Resolves: #956

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RPT_NODE dialplan function to query repeater node information and operational status

* **Chores**
  * Updated module initialization to properly manage new dialplan functionality lifecycle

<!-- end of auto-generated comment: release notes by coderabbit.ai -->