### PR TITLE
app_rpt: Write channel text messages to `rpt_qwrite()`

### DIFF
--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -66,16 +66,17 @@ int rpt_sendtext_cb(void *obj, void *arg, int flags)
 {
 	struct rpt_link *link = obj;
 	char *str = arg;
-	struct ast_frame wf;
-
-	init_text_frame(&wf, __PRETTY_FUNCTION__);
 
 	if (link->name[0] == '0') {
 		return 0;
 	}
 	if (link->chan) {
-		wf.data.ptr = str;
-		wf.datalen = strlen(str) + 1;
+		struct ast_frame wf = {
+			.frametype = AST_FRAME_TEXT,
+			.data.ptr = str,
+			.datalen = strlen(str) + 1,
+			.src = __PRETTY_FUNCTION__,
+		};
 		rpt_qwrite(link, &wf);
 	}
 	return 0;


### PR DESCRIPTION
`ast_sendtext()` can not be called while other threads are waiting on the channel.
Fixes #958 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text message delivery by switching from immediate send to queue-based delivery when a channel is active. This reduces race conditions and improves reliability and ordering of outbound messages while preserving prior behavior when no active channel is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->