### PR TITLE
Dev: Keep format for AST_DECLARE_APP_ARGS

### DIFF
--- a/.dev/.clang-format
+++ b/.dev/.clang-format
@@ -159,6 +159,7 @@ StatementAttributeLikeMacros:
 StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
+  - AST_APP_ARG
 TabWidth:        4
 UseCRLF:         false
 UseTab:          Always
@@ -169,4 +170,4 @@ WhitespaceSensitiveMacros:
   - NS_SWIFT_NAME
   - CF_SWIFT_NAME
   - AST_DECLARE_APP_ARGS
-  
+


### PR DESCRIPTION
Should address https://github.com/AllStarLink/app_rpt/pull/957#discussion_r2867026207
While it will not enforce the format, it will no longer complain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code formatting configuration standards to ensure consistency in code style handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->