### PR TITLE
app_rpt: statpost should only report adjacent nodes

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -3307,7 +3307,7 @@ static inline void periodic_process_link(struct rpt *myrpt, struct rpt_link *l, 
 		l->linklisttimer = myrpt->p.linkpost_time * 1000;
 		ast_str_set(&lstr, 0, "%s", "L ");
 		rpt_mutex_lock(&myrpt->lock);
-		__mklinklist(myrpt, l, &lstr, 0);
+		__mklinklist(myrpt, l, &lstr, USE_FORMAT_RPT_LINK);
 		rpt_mutex_unlock(&myrpt->lock);
 		if (l->chan) {
 			struct ast_frame lf = {

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -519,6 +519,10 @@ int __mklinklist(struct rpt *myrpt, struct rpt_link *mylink, struct ast_str **bu
 			/* add the adjacent node */
 			ast_str_append(buf, 0, "%s%c%s", sep, mode, l->name);
 
+			if (flags & USE_FORMAT_RPT_LINKPOST) {
+				continue;
+			}
+
 			/* and append any nodes linked to the adjacent node */
 			str = ast_str_buffer(l->linklist);
 			len = ast_str_strlen(l->linklist);
@@ -557,10 +561,6 @@ int __mklinklist(struct rpt *myrpt, struct rpt_link *mylink, struct ast_str **bu
 					break;
 				}
 			}
-		}
-
-		if (flags & USE_FORMAT_RPT_LINKPOST) {
-			continue;
 		}
 
 		if (mode == 'T') {


### PR DESCRIPTION
This change corrects a regression that was introduced with #933.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting behavior for link-list generation with updated processing logic.
  * Adjusted control flow to optimize node iteration handling in report formatting operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->