### PR TITLE
app_rpt: Change default linkpost_time to 30 seconds

### DIFF
--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -884,7 +884,7 @@ void load_rpt_vars(int n, int init)
 		/* if message truncation enabled, set minimum */
 		rpt_vars[n].p.linkpost_max_message_len = 500;
 	}
-	RPT_CONFIG_VAR_INT_DEFAULT_MIN_MAX(linkpost_time, "linkpost_time", 60, 10, 600);
+	RPT_CONFIG_VAR_INT_DEFAULT_MIN_MAX(linkpost_time, "linkpost_time", 30, 10, 40);
 
 	/* configure how we interact with "stats.allstarlink.org" */
 	RPT_CONFIG_VAR_INT_DEFAULT_MIN_MAX(statpost_time, "statpost_time", 60, 30, 600);


### PR DESCRIPTION
Testing has uncovered a previously unknown interoperability issue with HamVoIP-1.7.1. This requires linkpost_time to be in the range 10-40 seconds, instead of 60.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Changed default linkpost_time from 60 to 30 seconds
  * Reduced maximum allowed linkpost_time from 600 to 40 seconds (minimum remains 10 seconds)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->