### PR TITLE
Document HAMVOIP time limit in rpt_config.c

### DIFF
--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -884,8 +884,9 @@ void load_rpt_vars(int n, int init)
 		/* if message truncation enabled, set minimum */
 		rpt_vars[n].p.linkpost_max_message_len = 500;
 	}
-	/* Due to a limit imposed by HAMVOIP, 40 seconds is the maximum time allowed
-	 * Without the HAMVOIP limitation, the upper limit could be increased in the future
+	/* Due to a limit imposed by some old clients, 40 seconds is the maximum time allowed
+	 * Without the old client limitation, the upper limit could be increased in the future
+	 * Refer to PR #974 for further details
 	 */
 	RPT_CONFIG_VAR_INT_DEFAULT_MIN_MAX(linkpost_time, "linkpost_time", 30, 10, 40);
 


### PR DESCRIPTION
Added comment regarding HAMVOIP time limit for linkpost_time.
Further information is available at https://github.com/AllStarLink/app_rpt/pull/973.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced internal documentation with clarifications on system configuration parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->