### PR TITLE
app_rpt: Remove duplicate initialization of `l->link_newkey` in `attempt_reconnect()`

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2466,7 +2466,6 @@ static void *attempt_reconnect(struct rpt *myrpt, struct rpt_link *l)
 	l->elaptime = 0;
 	l->connecttime = ast_tv(0, 0); /* not connected */
 	l->thisconnected = 0;
-	l->link_newkey = RADIO_KEY_ALLOWED;
 	l->linkmode = 0;
 	l->lastrx1 = 0;
 	l->lastrealrx = 0;


### PR DESCRIPTION
Also assigned to a different value here:
https://github.com/AllStarLink/app_rpt/blob/765f88b78a01817b7521c409cdec1e9baa6b8e22/apps/app_rpt.c#L2476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed radio reconnection behavior to prevent premature key-up permissions during the reconnection sequence, ensuring proper initialization order takes precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->