### PR TITLE
app_rpt: only downgrade nodes on a links list

### DIFF
--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -454,7 +454,6 @@ int __mklinklist(struct rpt *myrpt, struct rpt_link *mylink, struct ast_str **bu
 
 	/* go thru all links */
 	RPT_LIST_TRAVERSE(myrpt->links, l, l_it) {
-		spos = ast_str_strlen(*buf); /* current buf size (before we add our stuff) */
 		if (l->name[0] == '0') {
 			/* if is not a real link, ignore it */
 			continue;
@@ -472,7 +471,7 @@ int __mklinklist(struct rpt *myrpt, struct rpt_link *mylink, struct ast_str **bu
 				continue;
 			}
 		}
-
+		spos = ast_str_strlen(*buf); /* current buf size (before we add our stuff) */
 		/* figure out "mode" to report */
 		mode = 'T'; /* use Transceive by default */
 		if (l->mode == MODE_MONITOR) {


### PR DESCRIPTION
Needed to "remember" that start each time we traverse the list, otherwise we incorrectly downgrade all of the links (including adjacent links)
