### PR TITLE
app_rpt: Restore command complete functionality unintentionally removed in PR #879

### DIFF
--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -921,6 +921,9 @@ void *rpt_link_connect(void *data)
 	rpt_link_add(myrpt->links, l);
 	__kickshort(myrpt);
 	rpt_mutex_unlock(&myrpt->lock);
+	myrpt->linkactivityflag = 1;
+	rpt_telem_select(myrpt, connect_data->command_source, connect_data->mylink);
+	rpt_telemetry(myrpt, COMPLETE, NULL);
 
 	/* Service the link channel */
 	process_link_channel(myrpt, l);


### PR DESCRIPTION
`return 0` functionality was in inadvertently removed in PR#879 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed missing telemetry updates when establishing repeater links, ensuring proper audio feedback and activity logging during connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->