### PR TITLE
app_rpt: Allow status ilink,5 to bypass telemmode

### DIFF
--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -2930,7 +2930,7 @@ void rpt_telemetry(struct rpt *myrpt, enum rpt_tele_mode mode, void *data)
 		}
 		break;
 	case VARCMD:
-		if (myrpt->telemmode < 2 && strncasecmp((char *) data, "STATUS", 6)) {
+		if (myrpt->telemmode < 2 && strncasecmp((char *) data, "STATUS,", 7)) {
 			return;
 		}
 		break;


### PR DESCRIPTION
Fixes #839

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * STATUS telemetry command now gets processed correctly even when telemetry mode is set below the usual threshold, preventing it from being ignored in those conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->