### PR TITLE
app_rpt: `ast_copy_string()` assures null termination

### DIFF
--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -3214,7 +3214,6 @@ void rpt_telemetry(struct rpt *myrpt, enum rpt_tele_mode mode, void *data)
 	} else if ((mode == ARB_ALPHA) || (mode == REV_PATCH) ||
 			   (mode == PLAYBACK) || (mode == LOCALPLAY) || (mode == VARCMD) || (mode == METER) || (mode == USEROUT)) {
 		ast_copy_string(tele->param, (char *) data, TELEPARAMSIZE);
-		tele->param[TELEPARAMSIZE - 1] = 0;
 	}
 	if ((mode == REMXXX) || (mode == PAGE) || (mode == MDC1200)) {
 		tele->submode.p = data;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor internal code improvement to telemetry data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->