### PR TITLE
app_rpt: Allow nodelog to dump logged messages to the file system on app unload

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -5945,7 +5945,6 @@ static void rpt_nodelog(void)
 }
 
 /*! \brief Master thread for managing repeater threads */
-
 static void *rpt_master(void *ignore)
 {
 	int i;


### PR DESCRIPTION
Addresses a memory leak for node log messages left in the linked list at unload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Node log processing was reworked to archive per-node logs into date-stamped files, improving organization and maintainability.

* **Bug Fixes**
  * Shutdown now reliably flushes any remaining queued log entries to storage and frees associated resources, preventing data loss and leaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->