### PR TITLE
correct spelling; corresponding change is coupled in asl3-asterisk/rpt-sounds

### DIFF
--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -1219,7 +1219,7 @@ static int handle_varcmd_tele(struct rpt *myrpt, struct ast_channel *mychannel, 
 		for (i = 3; i < n; i++) {
 			saynode(myrpt, mychannel, strs[i] + 1);
 			if (*strs[i] == 'T') {
-				sayfile(mychannel, "rpt/tranceive");
+				sayfile(mychannel, "rpt/transceive");
 			} else if (*strs[i] == 'R') {
 				sayfile(mychannel, "rpt/monitor");
 			} else if (*strs[i] == 'L') {
@@ -2375,7 +2375,7 @@ treataslocal:
 			}
 			hastx = 1;
 			res = saynode(myrpt, mychannel, l->name);
-			s = "rpt/tranceive";
+			s = "rpt/transceive";
 			if (l->mode == MODE_MONITOR) {
 				s = "rpt/monitor";
 			}
@@ -2452,7 +2452,7 @@ treataslocal:
 
 			hastx = 1;
 			res = saynode(myrpt, mychannel, strs[i]);
-			s = "rpt/tranceive";
+			s = "rpt/transceive";
 			if (mode == 'R') {
 				s = "rpt/monitor";
 			}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a misspelled telemetry sound file identifier to ensure proper audio playback for repeater status reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->