### PR TITLE
app_rpt: no need to pass "size - 1" when API includes NUL term

### DIFF
--- a/apps/app_gps.c
+++ b/apps/app_gps.c
@@ -1034,9 +1034,9 @@ static void *gps_reader(void *data)
 
 			ast_mutex_lock(&position_update_lock);
 			current_gps_position.is_valid = 1;
-			snprintf(current_gps_position.latitude, sizeof(current_gps_position.latitude) - 1, "%s%s", strs[2], strs[3]);
-			snprintf(current_gps_position.longitude, sizeof(current_gps_position.longitude) - 1, "%s%s", strs[4], strs[5]);
-			snprintf(current_gps_position.elevation, sizeof(current_gps_position.elevation) - 1, "%s%s", strs[9], strs[10]);
+			snprintf(current_gps_position.latitude, sizeof(current_gps_position.latitude), "%s%s", strs[2], strs[3]);
+			snprintf(current_gps_position.longitude, sizeof(current_gps_position.longitude), "%s%s", strs[4], strs[5]);
+			snprintf(current_gps_position.elevation, sizeof(current_gps_position.elevation), "%s%s", strs[9], strs[10]);
 			current_gps_position.last_updated = time(NULL);
 			current_gps_position.last_updated_mono = now_mono;
 			ast_mutex_unlock(&position_update_lock);
@@ -1299,7 +1299,7 @@ static void *aprstt_sender_thread(void *data)
 	if (!strcmp(sender_entry->section, "general")) {
 		strcpy(fname, TT_COMMON);
 	} else {
-		snprintf(fname, sizeof(fname) - 1, TT_SUB_COMMON, sender_entry->section);
+		snprintf(fname, sizeof(fname), TT_SUB_COMMON, sender_entry->section);
 	}
 	if (stat(fname, &mystat) == -1) {
 		mfp = fopen(fname, "w");
@@ -1404,7 +1404,7 @@ static void *aprstt_sender_thread(void *data)
 				}
 			}
 			if (ttslot < ttlist) {
-				ast_copy_string(ttentries[ttslot].call, theircall, sizeof(ttentries[ttslot].call) - 1);
+				ast_copy_string(ttentries[ttslot].call, theircall, sizeof(ttentries[ttslot].call));
 				ttentries[ttslot].last_updated = now;
 			} else {
 				ast_log(LOG_WARNING, "APRStt attempting to add call %s to full list (%d items)\n", theircall, ttlist);

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -892,12 +892,12 @@ void rpt_event_process(struct rpt *myrpt)
 				myrpt->cmdAction.functionNumber = thisAction;
 				myrpt->cmdAction.param[0] = 0;
 				if (argc > 1) {
-					ast_copy_string(myrpt->cmdAction.param, argv[1], MAX(sizeof(myrpt->cmdAction.param), MAXDTMF));
+					ast_copy_string(myrpt->cmdAction.param, argv[1], sizeof(myrpt->cmdAction.param));
 				}
 				myrpt->cmdAction.digits[0] = 0;
 				if (argc > 2) {
-					ast_copy_string(myrpt->cmdAction.digits, argv[2], MAX(sizeof(myrpt->cmdAction.digits), MAXDTMF));
-					snprintf(myrpt->cmdAction.param, MAX(sizeof(myrpt->cmdAction.param), MAXDTMF), "%s,%s", argv[1], argv[2]);
+					ast_copy_string(myrpt->cmdAction.digits, argv[2], sizeof(myrpt->cmdAction.digits));
+					snprintf(myrpt->cmdAction.param, sizeof(myrpt->cmdAction.param), "%s,%s", argv[1], argv[2]);
 				}
 				myrpt->cmdAction.command_source = SOURCE_RPT;
 				myrpt->cmdAction.state = CMD_STATE_READY;

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -801,7 +801,7 @@ void rpt_event_process(struct rpt *myrpt)
 			if (!myval) {
 				pbx_builtin_setvar_helper(myrpt->rxchannel, v->name, "0");
 			}
-			snprintf(valbuf, sizeof(valbuf) - 1, "$[ %s ]", argv[2]);
+			snprintf(valbuf, sizeof(valbuf), "$[ %s ]", argv[2]);
 			buf[0] = 0;
 			pbx_substitute_variables_helper(myrpt->rxchannel, valbuf, buf, sizeof(buf) - 1);
 			if (pbx_checkcondition(buf)) {
@@ -892,12 +892,12 @@ void rpt_event_process(struct rpt *myrpt)
 				myrpt->cmdAction.functionNumber = thisAction;
 				myrpt->cmdAction.param[0] = 0;
 				if (argc > 1) {
-					ast_copy_string(myrpt->cmdAction.param, argv[1], MAXDTMF - 1);
+					ast_copy_string(myrpt->cmdAction.param, argv[1], MAX(sizeof(myrpt->cmdAction.param), MAXDTMF));
 				}
 				myrpt->cmdAction.digits[0] = 0;
 				if (argc > 2) {
-					ast_copy_string(myrpt->cmdAction.digits, argv[2], MAXDTMF - 1);
-					snprintf(myrpt->cmdAction.param, MAXDTMF - 1, "%s,%s", argv[1], argv[2]);
+					ast_copy_string(myrpt->cmdAction.digits, argv[2], MAX(sizeof(myrpt->cmdAction.digits), MAXDTMF));
+					snprintf(myrpt->cmdAction.param, MAX(sizeof(myrpt->cmdAction.param), MAXDTMF), "%s,%s", argv[1], argv[2]);
 				}
 				myrpt->cmdAction.command_source = SOURCE_RPT;
 				myrpt->cmdAction.state = CMD_STATE_READY;
@@ -1700,8 +1700,7 @@ static inline void collect_function_digits_post(struct rpt *myrpt, enum rpt_func
 	case DC_COMPLETEQUIET:
 		myrpt->totalexecdcommands++;
 		myrpt->dailyexecdcommands++;
-		ast_copy_string(myrpt->lastdtmfcommand, cmd, MAXDTMF);
-		myrpt->lastdtmfcommand[MAXDTMF - 1] = '\0';
+		ast_copy_string(myrpt->lastdtmfcommand, cmd, sizeof(myrpt->lastdtmfcommand));
 		myrpt->rem_dtmfbuf[0] = 0;
 		myrpt->rem_dtmfidx = -1;
 		myrpt->rem_dtmf_time = 0;
@@ -1735,7 +1734,7 @@ static void do_aprstt(struct rpt *myrpt)
 	char cmd[300] = "";
 	char overlay, aprscall[100], func[100];
 
-	snprintf(cmd, sizeof(cmd) - 1, "A%s", myrpt->dtmfbuf);
+	snprintf(cmd, sizeof(cmd), "A%s", myrpt->dtmfbuf);
 	/*! \todo we need to support all 4 types of APRStt
 	 * we only support the 'A' type for call sign
 	 */
@@ -2043,7 +2042,7 @@ static void handle_link_data(struct rpt *myrpt, struct rpt_link *mylink, char *s
 			}
 		}
 		if (i < TOPKEYN) {
-			ast_copy_string(myrpt->topkey[i].node, src, TOPKEYMAXSTR - 1);
+			ast_copy_string(myrpt->topkey[i].node, src, sizeof(myrpt->topkey[i].node));
 			myrpt->topkey[i].timesince = ts;
 			myrpt->topkey[i].keyed = seq;
 		}
@@ -2313,8 +2312,7 @@ static int handle_remote_dtmf_digit(struct rpt *myrpt, char c, char *keyed, enum
 	case DC_COMPLETEQUIET:
 		myrpt->totalexecdcommands++;
 		myrpt->dailyexecdcommands++;
-		ast_copy_string(myrpt->lastdtmfcommand, myrpt->dtmfbuf, MAXDTMF);
-		myrpt->lastdtmfcommand[MAXDTMF - 1] = '\0';
+		ast_copy_string(myrpt->lastdtmfcommand, myrpt->dtmfbuf, sizeof(myrpt->lastdtmfcommand));
 		myrpt->dtmfbuf[0] = 0;
 		myrpt->dtmfidx = -1;
 		myrpt->dtmf_time_rem = 0;
@@ -2466,7 +2464,7 @@ static void *attempt_reconnect(struct rpt *myrpt, struct rpt_link *l)
 	struct ast_format_cap *cap;
 
 	ast_debug(1, "Attempting Reconnect");
-	if (node_lookup(myrpt, l->name, tmp, sizeof(tmp) - 1, 1)) {
+	if (node_lookup(myrpt, l->name, tmp, sizeof(tmp), 1)) {
 		ast_log(LOG_WARNING, "attempt_reconnect: cannot find node %s\n", l->name);
 		rpt_mutex_lock(&myrpt->lock);
 		l->retrytimer = RETRY_TIMER_MS;
@@ -2635,8 +2633,7 @@ static void local_dtmf_helper(struct rpt *myrpt, char c_in)
 				case DC_COMPLETEQUIET:
 					myrpt->totalexecdcommands++;
 					myrpt->dailyexecdcommands++;
-					ast_copy_string(myrpt->lastdtmfcommand, cmd, MAXDTMF);
-					myrpt->lastdtmfcommand[MAXDTMF - 1] = '\0';
+					ast_copy_string(myrpt->lastdtmfcommand, cmd, sizeof(myrpt->lastdtmfcommand));
 					myrpt->dtmfbuf[0] = 0;
 					myrpt->dtmfidx = -1;
 					myrpt->dtmf_time = 0;
@@ -2663,7 +2660,7 @@ static void local_dtmf_helper(struct rpt *myrpt, char c_in)
 			myrpt->patchfarenddisconnect = 0;
 			myrpt->patchdialtime = 0;
 			myrpt->calldigittimer = 0;
-			ast_copy_string(myrpt->patchcontext, myrpt->p.ourcontext, MAXPATCHCONTEXT - 1);
+			ast_copy_string(myrpt->patchcontext, myrpt->p.ourcontext, sizeof(myrpt->patchcontext));
 			myrpt->cidx = 0;
 			myrpt->exten[myrpt->cidx] = 0;
 			rpt_mutex_unlock(&myrpt->lock);
@@ -6697,12 +6694,12 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 
 				strcpy(tmp2, tmp);
 				if (options && callstr)
-					snprintf(tmp2, sizeof(tmp2) - 1, "0%s%s", callstr, tmp);
+					snprintf(tmp2, sizeof(tmp2), "0%s%s", callstr, tmp);
 				mypfx = ast_variable_retrieve(cfg, "proxy", "nodeprefix");
 				if (mypfx)
-					snprintf(dstr, sizeof(dstr) - 1, "radio-proxy@%s%s/%s", mypfx, tmp, tmp2);
+					snprintf(dstr, sizeof(dstr), "radio-proxy@%s%s/%s", mypfx, tmp, tmp2);
 				else
-					snprintf(dstr, sizeof(dstr) - 1, "radio-proxy@%s/%s", tmp, tmp2);
+					snprintf(dstr, sizeof(dstr), "radio-proxy@%s/%s", tmp, tmp2);
 				ast_config_destroy(cfg);
 				rpt_forward(chan, dstr, b1);
 				return -1;
@@ -6960,7 +6957,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 		}
 
 		/* look for his reported node string */
-		if (node_lookup(myrpt, b1, tmp, sizeof(tmp) - 1, 0)) {
+		if (node_lookup(myrpt, b1, tmp, sizeof(tmp), 0)) {
 			ast_log(LOG_WARNING, "Reported node %s cannot be found!!\n", b1);
 			return -1;
 		}

--- a/apps/app_rpt/rpt_channel.c
+++ b/apps/app_rpt/rpt_channel.c
@@ -174,14 +174,14 @@ int saynode(struct rpt *myrpt, struct ast_channel *mychannel, char *name)
 
 void do_dtmf_local(struct rpt *myrpt, char c)
 {
-	int i;
-	char digit;
-
 	if (c) {
-		i = strlen(myrpt->dtmf_local_str);
-		if (i < sizeof(myrpt->dtmf_local_str) - 1) {
-			myrpt->dtmf_local_str[i++] = c;
-			myrpt->dtmf_local_str[i] = '\0';
+		size_t len;
+
+		len = strlen(myrpt->dtmf_local_str);
+		if (len < sizeof(myrpt->dtmf_local_str) - 1) {
+			/* append DTMF digit */
+			myrpt->dtmf_local_str[len] = c;
+			myrpt->dtmf_local_str[len + 1] = '\0';
 		}
 
 		if (!myrpt->dtmf_local_timer) {
@@ -191,6 +191,9 @@ void do_dtmf_local(struct rpt *myrpt, char c)
 
 	/* if at timeout */
 	if (myrpt->dtmf_local_timer == 1) {
+		int i;
+		char digit;
+
 		ast_debug(7, "time out dtmf_local_timer=%i\n", myrpt->dtmf_local_timer);
 
 		/* if anything in the string */

--- a/apps/app_rpt/rpt_channel.c
+++ b/apps/app_rpt/rpt_channel.c
@@ -143,7 +143,7 @@ int saynode(struct rpt *myrpt, struct ast_channel *mychannel, char *name)
 		if (!val) {
 			val = NODENAMES;
 		}
-		snprintf(fname, sizeof(fname) - 1, "%s/%s", val, name);
+		snprintf(fname, sizeof(fname), "%s/%s", val, name);
 		if (ast_fileexists(fname, NULL, ast_channel_language(mychannel)) > 0) {
 			return (sayfile(mychannel, fname));
 		}
@@ -178,11 +178,17 @@ void do_dtmf_local(struct rpt *myrpt, char c)
 	char digit;
 
 	if (c) {
-		snprintf(myrpt->dtmf_local_str + strlen(myrpt->dtmf_local_str), sizeof(myrpt->dtmf_local_str) - 1, "%c", c);
+		i = strlen(myrpt->dtmf_local_str);
+		if (i < sizeof(myrpt->dtmf_local_str) - 1) {
+			myrpt->dtmf_local_str[i++] = c;
+			myrpt->dtmf_local_str[i] = '\0';
+		}
+
 		if (!myrpt->dtmf_local_timer) {
 			myrpt->dtmf_local_timer = DTMF_LOCAL_STARTTIME;
 		}
 	}
+
 	/* if at timeout */
 	if (myrpt->dtmf_local_timer == 1) {
 		ast_debug(7, "time out dtmf_local_timer=%i\n", myrpt->dtmf_local_timer);

--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -197,7 +197,7 @@ int retrieve_memory(struct rpt *myrpt, char *memory)
 	}
 	ast_copy_string(myrpt->freq, tmp, sizeof(myrpt->freq));
 	ast_copy_string(myrpt->rxpl, s, sizeof(myrpt->rxpl));
-	ast_copy_string(myrpt->txpl, s, sizeof(myrpt->rxpl));
+	ast_copy_string(myrpt->txpl, s, sizeof(myrpt->txpl));
 	myrpt->remmode = REM_MODE_FM;
 	myrpt->offset = REM_SIMPLEX;
 	myrpt->powerlevel = REM_MEDPWR;

--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -195,9 +195,9 @@ int retrieve_memory(struct rpt *myrpt, char *memory)
 	} else {
 		*s2++ = 0;
 	}
-	ast_copy_string(myrpt->freq, tmp, sizeof(myrpt->freq) - 1);
-	ast_copy_string(myrpt->rxpl, s, sizeof(myrpt->rxpl) - 1);
-	ast_copy_string(myrpt->txpl, s, sizeof(myrpt->rxpl) - 1);
+	ast_copy_string(myrpt->freq, tmp, sizeof(myrpt->freq));
+	ast_copy_string(myrpt->rxpl, s, sizeof(myrpt->rxpl));
+	ast_copy_string(myrpt->txpl, s, sizeof(myrpt->rxpl));
 	myrpt->remmode = REM_MODE_FM;
 	myrpt->offset = REM_SIMPLEX;
 	myrpt->powerlevel = REM_MEDPWR;

--- a/apps/app_rpt/rpt_daq.c
+++ b/apps/app_rpt/rpt_daq.c
@@ -176,7 +176,7 @@ void daq_init(struct ast_config *cfg)
 			ast_log(LOG_WARNING, "Error in daq_entries stanza on line %d\n", var->lineno);
 			break;
 		}
-		ast_copy_string(s, var->value, sizeof(s) - 1); /* Make copy of device entry */
+		ast_copy_string(s, var->value, sizeof(s));
 		if (!(p = ast_variable_retrieve(cfg, s, "hwtype"))) {
 			ast_log(LOG_WARNING, "hwtype variable required for %s stanza\n", s);
 			break;

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -172,7 +172,7 @@ enum rpt_function_response function_ilink(struct rpt *myrpt, char *param, char *
 			ao2_ref(l, -1);
 			return DC_COMPLETE;
 		}
-		ast_copy_string(myrpt->lastlinknode, digitbuf, MAXNODESTR - 1);
+		ast_copy_string(myrpt->lastlinknode, digitbuf, sizeof(myrpt->lastlinknode));
 		l->retries = l->max_retries + 1;
 		l->disced = RPT_LINK_DISCONNECT;
 		l->hasconnected = 1;
@@ -285,7 +285,7 @@ enum rpt_function_response function_ilink(struct rpt *myrpt, char *param, char *
 		}
 		rpt_mutex_lock(&myrpt->lock);
 		strcpy(myrpt->lastlinknode, digitbuf);
-		ast_copy_string(myrpt->cmdnode, digitbuf, sizeof(myrpt->cmdnode) - 1);
+		ast_copy_string(myrpt->cmdnode, digitbuf, sizeof(myrpt->cmdnode));
 		rpt_mutex_unlock(&myrpt->lock);
 		rpt_telem_select(myrpt, command_source, mylink);
 		rpt_telemetry(myrpt, REMGO, NULL);
@@ -374,7 +374,7 @@ enum rpt_function_response function_ilink(struct rpt *myrpt, char *param, char *
 		if (!s2)
 			break;
 		*s2 = 0;
-		snprintf(tmp, MAX_TEXTMSG_SIZE - 1, "M %s %s %s", myrpt->name, s1 + 1, s2 + 1);
+		snprintf(tmp, MAX(sizeof(tmp), MAX_TEXTMSG_SIZE), "M %s %s %s", myrpt->name, s1 + 1, s2 + 1);
 		rpt_mutex_lock(&myrpt->lock);
 		/* otherwise, send it to all of em */
 		ao2_callback(myrpt->links, OBJ_MULTIPLE | OBJ_NODATA, rpt_sendtext_cb, tmp);
@@ -638,15 +638,15 @@ enum rpt_function_response function_remote(struct rpt *myrpt, char *param, char 
 		}
 		offsave = myrpt->offset;
 		modesave = myrpt->remmode;
-		ast_copy_string(savestr, myrpt->freq, sizeof(savestr) - 1);
-		ast_copy_string(myrpt->freq, freq, sizeof(myrpt->freq) - 1);
+		ast_copy_string(savestr, myrpt->freq, sizeof(savestr));
+		ast_copy_string(myrpt->freq, freq, sizeof(myrpt->freq));
 		myrpt->offset = offset;
 		myrpt->remmode = defmode;
 
 		if (setrem(myrpt) == -1) {
 			myrpt->offset = offsave;
 			myrpt->remmode = modesave;
-			ast_copy_string(myrpt->freq, savestr, sizeof(myrpt->freq) - 1);
+			ast_copy_string(myrpt->freq, savestr, sizeof(myrpt->freq));
 			goto invalid_freq;
 		}
 		if (strcmp(myrpt->remoterig, REMOTE_RIG_TM271) && strcmp(myrpt->remoterig, REMOTE_RIG_KENWOOD)) {
@@ -689,13 +689,13 @@ invalid_freq:
 		if (s) {
 			*s = '.';
 		}
-		ast_copy_string(savestr, myrpt->rxpl, sizeof(savestr) - 1);
-		ast_copy_string(myrpt->rxpl, tmp, sizeof(myrpt->rxpl) - 1);
+		ast_copy_string(savestr, myrpt->rxpl, sizeof(savestr));
+		ast_copy_string(myrpt->rxpl, tmp, sizeof(myrpt->rxpl));
 		if ((!strcmp(myrpt->remoterig, REMOTE_RIG_RBI)) || (!strcmp(myrpt->remoterig, REMOTE_RIG_FT100))) {
-			ast_copy_string(myrpt->txpl, tmp, sizeof(myrpt->txpl) - 1);
+			ast_copy_string(myrpt->txpl, tmp, sizeof(myrpt->txpl));
 		}
 		if (setrem(myrpt) == -1) {
-			ast_copy_string(myrpt->rxpl, savestr, sizeof(myrpt->rxpl) - 1);
+			ast_copy_string(myrpt->rxpl, savestr, sizeof(myrpt->rxpl));
 			return DC_ERROR;
 		}
 		return DC_COMPLETE;
@@ -752,13 +752,13 @@ invalid_freq:
 			*s = '.';
 		}
 		rpt_mutex_lock(&myrpt->lock);
-		ast_copy_string(savestr, myrpt->txpl, sizeof(savestr) - 1);
-		ast_copy_string(myrpt->txpl, tmp, sizeof(myrpt->txpl) - 1);
+		ast_copy_string(savestr, myrpt->txpl, sizeof(savestr));
+		ast_copy_string(myrpt->txpl, tmp, sizeof(myrpt->txpl));
 		rpt_mutex_unlock(&myrpt->lock);
 
 		if (setrem(myrpt) == -1) {
 			rpt_mutex_lock(&myrpt->lock);
-			ast_copy_string(myrpt->txpl, savestr, sizeof(myrpt->txpl) - 1);
+			ast_copy_string(myrpt->txpl, savestr, sizeof(myrpt->txpl));
 			rpt_mutex_unlock(&myrpt->lock);
 			return DC_ERROR;
 		}
@@ -826,7 +826,7 @@ invalid_freq:
 				*cp2 = 0;
 				ast_copy_string(myrpt->loginlevel, cp2 + 1, sizeof(myrpt->loginlevel));
 			}
-			ast_copy_string(myrpt->loginuser, cp1 + 1, sizeof(myrpt->loginuser) - 1);
+			ast_copy_string(myrpt->loginuser, cp1 + 1, sizeof(myrpt->loginuser));
 			rpt_mutex_unlock(&myrpt->lock);
 			donodelog_fmt(myrpt, "LOGIN,%s,%s", myrpt->loginuser, myrpt->loginlevel);
 			ast_debug(1, "loginuser %s level %s\n", myrpt->loginuser, myrpt->loginlevel);
@@ -1911,7 +1911,7 @@ enum rpt_function_response function_cop(struct rpt *myrpt, char *param, char *di
 			ast_log(LOG_WARNING, "app_gps is not loaded.  APRStt failed\n");
 			return DC_COMPLETE;
 		}
-		snprintf(func, sizeof(func) - 1, "APRS_SENDTT(%s,%c)", !myrpt->p.aprstt ? "general" : myrpt->p.aprstt, argc > 2 ? argv[2][0] : ' ');
+		snprintf(func, sizeof(func), "APRS_SENDTT(%s,%c)", !myrpt->p.aprstt ? "general" : myrpt->p.aprstt, argc > 2 ? argv[2][0] : ' ');
 		/* execute the APRS_SENDTT function in app_gps*/
 		if (!ast_func_write(NULL, func, argv[1])) {
 			if (myatoi(argv[0]) == 63) {

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -374,7 +374,7 @@ enum rpt_function_response function_ilink(struct rpt *myrpt, char *param, char *
 		if (!s2)
 			break;
 		*s2 = 0;
-		snprintf(tmp, MAX(sizeof(tmp), MAX_TEXTMSG_SIZE), "M %s %s %s", myrpt->name, s1 + 1, s2 + 1);
+		snprintf(tmp, MIN(sizeof(tmp), MAX_TEXTMSG_SIZE), "M %s %s %s", myrpt->name, s1 + 1, s2 + 1);
 		rpt_mutex_lock(&myrpt->lock);
 		/* otherwise, send it to all of em */
 		ao2_callback(myrpt->links, OBJ_MULTIPLE | OBJ_NODATA, rpt_sendtext_cb, tmp);

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -795,7 +795,7 @@ void *rpt_link_connect(void *data)
 		|| !strncasecmp(s1, "local/", 6)
 #endif
 	) {
-		ast_copy_string(deststr, s1, sizeof(deststr) - 1);
+		ast_copy_string(deststr, s1, sizeof(deststr));
 	} else {
 		snprintf(deststr, sizeof(deststr), "IAX2/%s", s1);
 	}

--- a/apps/app_rpt/rpt_lock.c
+++ b/apps/app_rpt/rpt_lock.c
@@ -82,7 +82,7 @@ static void rpt_mutex_spew(void)
 
 	for (i = 0; i < 32; i++) {
 		j = (i + lock_ring_index_copy) % 32;
-		strftime(a, sizeof(a) - 1, "%m/%d/%Y %H:%M:%S", localtime(&lock_ring_copy[j].tv.tv_sec));
+		strftime(a, sizeof(a), "%m/%d/%Y %H:%M:%S", localtime(&lock_ring_copy[j].tv.tv_sec));
 		diff = 0;
 		if (lasttv.tv_sec) {
 			diff = (lock_ring_copy[j].tv.tv_sec - lasttv.tv_sec) * 1000000;

--- a/apps/app_rpt/rpt_mdc1200.c
+++ b/apps/app_rpt/rpt_mdc1200.c
@@ -97,7 +97,7 @@ void mdc1200_notify(struct rpt *myrpt, char *fromnode, char *data)
 				return;
 			}
 			time(&t);
-			strftime(str, sizeof(str) - 1, "%Y%m%d%H%M%S", localtime(&t));
+			strftime(str, sizeof(str), "%Y%m%d%H%M%S", localtime(&t));
 			fprintf(fp, "%s %s %s\n", str, myrpt->name, data);
 			fl.l_type = F_UNLCK;
 			fcntl(fileno(fp), F_SETLK, &fl);

--- a/apps/app_rpt/rpt_serial.c
+++ b/apps/app_rpt/rpt_serial.c
@@ -585,7 +585,7 @@ int setrbi(struct rpt *myrpt)
 		return -1;
 	}
 
-	ast_copy_string(tmp, myrpt->freq, sizeof(tmp) - 1);
+	ast_copy_string(tmp, myrpt->freq, sizeof(tmp));
 	s = strchr(tmp, '.');
 	/* if no decimal, is invalid */
 
@@ -694,7 +694,7 @@ int setrtx(struct rpt *myrpt)
 	if (!IS_XPMR(myrpt)) {
 		return 0;
 	}
-	ast_copy_string(tmp, myrpt->freq, sizeof(tmp) - 1);
+	ast_copy_string(tmp, myrpt->freq, sizeof(tmp));
 	s = strchr(tmp, '.');
 	/* if no decimal, is invalid */
 
@@ -851,7 +851,7 @@ int setrbi_check(struct rpt *myrpt)
 		return 0;
 	}
 
-	ast_copy_string(tmp, myrpt->freq, sizeof(tmp) - 1);
+	ast_copy_string(tmp, myrpt->freq, sizeof(tmp));
 	s = strchr(tmp, '.');
 	if (s == NULL) {
 		/* if no decimal, is invalid */
@@ -905,7 +905,7 @@ int setrtx_check(struct rpt *myrpt)
 		return 0;
 	}
 
-	ast_copy_string(tmp, myrpt->freq, sizeof(tmp) - 1);
+	ast_copy_string(tmp, myrpt->freq, sizeof(tmp));
 	s = strchr(tmp, '.');
 	if (s == NULL) {
 		/* if no decimal, is invalid */

--- a/apps/app_rpt/rpt_uchameleon.c
+++ b/apps/app_rpt/rpt_uchameleon.c
@@ -176,7 +176,7 @@ int uchameleon_pin_init(struct daq_entry_tag *t)
 
 		/* Parse alarm entry */
 
-		ast_copy_string(s, var->value, sizeof(s) - 1);
+		ast_copy_string(s, var->value, sizeof(s));
 
 		if (explode_string(s, argv, ARRAY_LEN(argv), ',', 0) != 6) {
 			ast_log(LOG_WARNING, "Alarm arguments must be 6 for %s\n", var->name);

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -1363,7 +1363,7 @@ static int el_call(struct ast_channel *ast, const char *dest, int timeout)
 		return -1;
 	}
 
-	snprintf(buf, sizeof(buf) - 1, "o.conip %s", ipaddr);
+	snprintf(buf, sizeof(buf), "o.conip %s", ipaddr);
 
 	ast_debug(1, "Calling %s/%s on %s.\n", dest, ipaddr, ast_channel_name(ast));
 
@@ -3065,7 +3065,6 @@ static int do_el_directory(const char *hostname)
 		ast_log(LOG_ERROR, "Unable to send to directory server %s.\n", hostname);
 		goto cleanup;
 	}
-	str[strlen(str) - 1] = 0;
 	ast_debug(4, "Sending: %s to %s.\n", str, hostname);
 	if (recv(sock, str, 4, 0) != 4) {
 		ast_log(LOG_ERROR, "Error in directory download (header) on %s.\n", hostname);
@@ -3943,7 +3942,7 @@ static int store_config(struct ast_config *cfg, char *ctg)
 
 	val = ast_variable_retrieve(cfg, ctg, "recfile");
 	if (!val) {
-		ast_copy_string(instp->fdr_file, "/tmp/echolink_recorded.gsm", FILENAME_MAX - 1);
+		ast_copy_string(instp->fdr_file, "/tmp/echolink_recorded.gsm", sizeof(instp->fdr_file));
 	} else {
 		ast_copy_string(instp->fdr_file, val, FILENAME_MAX);
 	}

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -4153,7 +4153,7 @@ static int load_config(int reload)
 	pbase = 0;
 	val = ast_variable_retrieve(cfg, "general", "pport");
 	if (val) {
-		ast_copy_string(pport, val, sizeof(pport) - 1);
+		ast_copy_string(pport, val, sizeof(pport));
 	} else {
 		strcpy(pport, PP_PORT);
 	}

--- a/channels/chan_tlb.c
+++ b/channels/chan_tlb.c
@@ -2008,7 +2008,7 @@ static int do_new_call(struct TLB_instance *instp, struct TLB_pvt *p, const char
 
 	mycodec[0] = 0;
 	if (codec) {
-		ast_copy_string(mycodec, codec, sizeof(mycodec) - 1);
+		ast_copy_string(mycodec, codec, sizeof(mycodec));
 	}
 	TLB_node_key = ast_malloc(sizeof(struct TLB_node));
 	if (!TLB_node_key) {
@@ -2048,7 +2048,7 @@ static int do_new_call(struct TLB_instance *instp, struct TLB_pvt *p, const char
 		}
 		TLB_node_key->nodenum = atoi(v->name);
 		if (n > 3) {
-			ast_copy_string(mycodec, strs[3], sizeof(mycodec) - 1);
+			ast_copy_string(mycodec, strs[3], sizeof(mycodec));
 		}
 	} else {
 		TLB_node_key->nodenum = 0;

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -5577,7 +5577,7 @@ static int load_config(int reload)
 	pbase = 0;
 	val = ast_variable_retrieve(cfg, "general", "pport");
 	if (val) {
-		ast_copy_string(pport, val, sizeof(pport) - 1);
+		ast_copy_string(pport, val, sizeof(pport));
 	} else {
 		strcpy(pport, PP_PORT);
 	}

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -4572,7 +4572,7 @@ static void *voter_reader(void *data)
 			if (DEBUG_ATLEAST(4) && client && ((unsigned char) *(buf + sizeof(VOTER_PACKET_HEADER)) > 0) &&
 				ntohs(vph->payload_type) == VOTER_PAYLOAD_ULAW) {
 				timestuff = (time_t) ntohl(vph->curtime.vtime_sec);
-				strftime(timestr, sizeof(timestr), "%Y %T", localtime((time_t *) &timestuff));
+				strftime(timestr, sizeof(timestr), "%Y %T", localtime(&timestuff));
 				ast_debug(4, "Client %s sending time: %s.%03d, RSSI: %d\n", client->name, timestr,
 					ntohl(vph->curtime.vtime_nsec) / 1000000, (unsigned char) *(buf + sizeof(VOTER_PACKET_HEADER)));
 			}
@@ -4890,12 +4890,12 @@ static void *voter_reader(void *data)
 						if (DEBUG_ATLEAST(5) && ((unsigned char) *(buf + sizeof(VOTER_PACKET_HEADER)) > 0)) {
 							/* Get the time of the master client so we can display it */
 							timestuff = (time_t) master_time.vtime_sec;
-							strftime(timestr, sizeof(timestr), "%Y %T", localtime((time_t *) &timestuff));
+							strftime(timestr, sizeof(timestr), "%Y %T", localtime(&timestuff));
 							ast_debug(5, "MasterTime: %s.%03d\n", timestr, master_time.vtime_nsec / 1000000);
 							/* Get the system time so we can display it */
 							gettimeofday(&timetv, NULL);
 							timestuff = (time_t) timetv.tv_sec;
-							strftime(timestr, sizeof(timestr), "%Y %T", localtime((time_t *) &timestuff));
+							strftime(timestr, sizeof(timestr), "%Y %T", localtime(&timestuff));
 							ast_debug(5, "SysTime:    %s.%03d\n", timestr, (int) timetv.tv_usec / 1000);
 							ast_debug(5, "Time diff between master and client: %lld ns\n", btime - ptime);
 							ast_debug(5, "VOTER drain index: %i\n)", index);
@@ -5361,7 +5361,7 @@ static void *voter_reader(void *data)
 				ast_verb(1, "PING (%s) Response:   seqno: %u  diff: %d ms\n", client->name, pingpacket.seqno, timediff);
 
 				timestuff = (time_t) ntohl(vph->curtime.vtime_sec);
-				strftime(timestr, sizeof(timestr), "%Y %T", localtime((time_t *) &timestuff));
+				strftime(timestr, sizeof(timestr), "%Y %T", localtime(&timestuff));
 				/* ast_debug(3, "PING (%s):   seqno: %u %s.%09d\n",client->name,seqno,timestr,ntohl(vph->curtime.vtime_nsec)); */
 
 				check_ping_done(client);
@@ -5420,7 +5420,7 @@ process_gps:
 				if (DEBUG_ATLEAST(4)) {
 					/* Get and display GPS Time that the client is sending us */
 					timestuff = (time_t) ntohl(vph->curtime.vtime_sec);
-					strftime(timestr, sizeof(timestr), "%Y %T", localtime((time_t *) &timestuff));
+					strftime(timestr, sizeof(timestr), "%Y %T", localtime(&timestuff));
 					ast_debug(4, "GPSTime:    %s.%09d from %s\n", timestr, ntohl(vph->curtime.vtime_nsec), client->name);
 					/* Get and display the System time */
 					gettimeofday(&timetv, NULL);
@@ -5430,11 +5430,11 @@ process_gps:
 						timetv.tv_usec -= 1000000;
 					}
 					timestuff = (time_t) timetv.tv_sec;
-					strftime(timestr, sizeof(timestr), "%Y %T", localtime((time_t *) &timestuff));
+					strftime(timestr, sizeof(timestr), "%Y %T", localtime(&timestuff));
 					ast_debug(4, "SysTime:    %s.%06d\n", timestr, (int) timetv.tv_usec);
 					/* Display the time from the master client */
 					timestuff = (time_t) master_time.vtime_sec;
-					strftime(timestr, sizeof(timestr), "%Y %T", localtime((time_t *) &timestuff));
+					strftime(timestr, sizeof(timestr), "%Y %T", localtime(&timestuff));
 					ast_debug(4, "MasterTime: %s.%09d\n", timestr, master_time.vtime_nsec);
 				}
 				if (recvlen == sizeof(VOTER_PACKET_HEADER)) {

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -2553,7 +2553,7 @@ static int voter_do_txlockout(int fd, int argc, const char *const *argv)
 				client->txlockout = 0;
 			}
 		} else { /* Must be a comma-delimited list */
-			ast_copy_string(str, argv[3], sizeof(str) - 1);
+			ast_copy_string(str, argv[3], sizeof(str));
 			n = finddelim((char *) argv[3], strs, ARRAY_LEN(strs));
 			for (i = 0; i < n; i++) {
 				if (!*strs[i]) {
@@ -3729,7 +3729,7 @@ static struct ast_channel *voter_request(const char *type, struct ast_format_cap
 				p->primary.sin_family = AF_INET;
 				p->primary.sin_addr.s_addr = inet_addr(strs[0]);
 				p->primary.sin_port = htons(j);
-				ast_copy_string(p->primary_pswd, strs[1], sizeof(p->primary_pswd) - 1);
+				ast_copy_string(p->primary_pswd, strs[1], sizeof(p->primary_pswd));
 			}
 			ast_free(cp);
 		}
@@ -3875,14 +3875,14 @@ static int reload(void)
 
 	val = ast_variable_retrieve(cfg, "general", "password");
 	if (val) {
-		ast_copy_string(password, val, sizeof(password) - 1);
+		ast_copy_string(password, val, sizeof(password));
 	} else {
 		password[0] = 0;
 	}
 
 	val = ast_variable_retrieve(cfg, "general", "context");
 	if (val) {
-		ast_copy_string(context, val, sizeof(context) - 1);
+		ast_copy_string(context, val, sizeof(context));
 	} else {
 		context[0] = 0;
 	}
@@ -4166,7 +4166,7 @@ static int reload(void)
 					return -1;
 				}
 				client->prio_override = -2;
-				ast_copy_string(client->name, v->name, VOTER_NAME_LEN - 1);
+				ast_copy_string(client->name, v->name, sizeof(client->name));
 				newclient = 1;
 			}
 			client->reload = 1;
@@ -4214,7 +4214,7 @@ static int reload(void)
 			/* This effectively turns buflen into 40ms resolution "steps". */
 			client->buflen -= client->buflen % (FRAME_SIZE * 2);
 			client->digest = crc32_bufs(challenge, strs[0]);
-			ast_copy_string(client->pswd, strs[0], sizeof(client->pswd) - 1);
+			ast_copy_string(client->pswd, strs[0], sizeof(client->pswd));
 			ast_free(cp);
 			if (client->old_buflen && (client->buflen != client->old_buflen)) {
 				client->drainindex = 0;
@@ -4570,7 +4570,7 @@ static void *voter_reader(void *data)
 			if (DEBUG_ATLEAST(4) && client && ((unsigned char) *(buf + sizeof(VOTER_PACKET_HEADER)) > 0) &&
 				ntohs(vph->payload_type) == VOTER_PAYLOAD_ULAW) {
 				timestuff = (time_t) ntohl(vph->curtime.vtime_sec);
-				strftime(timestr, sizeof(timestr) - 1, "%Y %T", localtime((time_t *) &timestuff));
+				strftime(timestr, sizeof(timestr), "%Y %T", localtime((time_t *) &timestuff));
 				ast_debug(4, "Client %s sending time: %s.%03d, RSSI: %d\n", client->name, timestr,
 					ntohl(vph->curtime.vtime_nsec) / 1000000, (unsigned char) *(buf + sizeof(VOTER_PACKET_HEADER)));
 			}
@@ -4751,7 +4751,7 @@ static void *voter_reader(void *data)
 								sendto(udp_socket, buf, recvlen - sizeof(proxy), 0, (struct sockaddr *) &psin, sizeof(psin));
 								continue;
 							}
-							ast_copy_string(client->saved_challenge, proxy.challenge, sizeof(client->saved_challenge) - 1);
+							ast_copy_string(client->saved_challenge, proxy.challenge, sizeof(client->saved_challenge));
 							client->proxy_sin = psin;
 							/* Is the mix mode flag being sent by the proxy client? */
 							if (proxy.flags & 32) {
@@ -4796,7 +4796,7 @@ static void *voter_reader(void *data)
 							proxy.ipaddr = sin.sin_addr.s_addr;
 							proxy.port = sin.sin_port;
 							proxy.payload_type = vph->payload_type;
-							ast_copy_string(proxy.challenge, challenge, sizeof(proxy.challenge) - 1);
+							ast_copy_string(proxy.challenge, challenge, sizeof(proxy.challenge));
 							vph->payload_type = htons(VOTER_PAYLOAD_PROXY);
 							proxy.flags = 0;
 							if (client->ismaster) {
@@ -4888,12 +4888,12 @@ static void *voter_reader(void *data)
 						if (DEBUG_ATLEAST(5) && ((unsigned char) *(buf + sizeof(VOTER_PACKET_HEADER)) > 0)) {
 							/* Get the time of the master client so we can display it */
 							timestuff = (time_t) master_time.vtime_sec;
-							strftime(timestr, sizeof(timestr) - 1, "%Y %T", localtime((time_t *) &timestuff));
+							strftime(timestr, sizeof(timestr), "%Y %T", localtime((time_t *) &timestuff));
 							ast_debug(5, "MasterTime: %s.%03d\n", timestr, master_time.vtime_nsec / 1000000);
 							/* Get the system time so we can display it */
 							gettimeofday(&timetv, NULL);
 							timestuff = (time_t) timetv.tv_sec;
-							strftime(timestr, sizeof(timestr) - 1, "%Y %T", localtime((time_t *) &timestuff));
+							strftime(timestr, sizeof(timestr), "%Y %T", localtime((time_t *) &timestuff));
 							ast_debug(5, "SysTime:    %s.%03d\n", timestr, (int) timetv.tv_usec / 1000);
 							ast_debug(5, "Time diff between master and client: %lld ns\n", btime - ptime);
 							ast_debug(5, "VOTER drain index: %i\n)", index);
@@ -5242,7 +5242,7 @@ static void *voter_reader(void *data)
 											memcpy(rec.audio, &master_time, sizeof(master_time));
 											fwrite(&rec, 1, sizeof(rec), p->recfp);
 										}
-										ast_copy_string(rec.name, client->name, sizeof(rec.name) - 1);
+										ast_copy_string(rec.name, client->name, sizeof(rec.name));
 										rec.rssi = client->lastrssi;
 										if (i >= 0) {
 											memcpy(rec.audio, client->audio + client->drainindex, FRAME_SIZE);
@@ -5359,7 +5359,7 @@ static void *voter_reader(void *data)
 				ast_verb(1, "PING (%s) Response:   seqno: %u  diff: %d ms\n", client->name, pingpacket.seqno, timediff);
 
 				timestuff = (time_t) ntohl(vph->curtime.vtime_sec);
-				strftime(timestr, sizeof(timestr) - 1, "%Y %T", localtime((time_t *) &timestuff));
+				strftime(timestr, sizeof(timestr), "%Y %T", localtime((time_t *) &timestuff));
 				/* ast_debug(3, "PING (%s):   seqno: %u %s.%09d\n",client->name,seqno,timestr,ntohl(vph->curtime.vtime_nsec)); */
 
 				check_ping_done(client);
@@ -5418,7 +5418,7 @@ process_gps:
 				if (DEBUG_ATLEAST(4)) {
 					/* Get and display GPS Time that the client is sending us */
 					timestuff = (time_t) ntohl(vph->curtime.vtime_sec);
-					strftime(timestr, sizeof(timestr) - 1, "%Y %T", localtime((time_t *) &timestuff));
+					strftime(timestr, sizeof(timestr), "%Y %T", localtime((time_t *) &timestuff));
 					ast_debug(4, "GPSTime:    %s.%09d from %s\n", timestr, ntohl(vph->curtime.vtime_nsec), client->name);
 					/* Get and display the System time */
 					gettimeofday(&timetv, NULL);
@@ -5428,11 +5428,11 @@ process_gps:
 						timetv.tv_usec -= 1000000;
 					}
 					timestuff = (time_t) timetv.tv_sec;
-					strftime(timestr, sizeof(timestr) - 1, "%Y %T", localtime((time_t *) &timestuff));
+					strftime(timestr, sizeof(timestr), "%Y %T", localtime((time_t *) &timestuff));
 					ast_debug(4, "SysTime:    %s.%06d\n", timestr, (int) timetv.tv_usec);
 					/* Display the time from the master client */
 					timestuff = (time_t) master_time.vtime_sec;
-					strftime(timestr, sizeof(timestr) - 1, "%Y %T", localtime((time_t *) &timestuff));
+					strftime(timestr, sizeof(timestr), "%Y %T", localtime((time_t *) &timestuff));
 					ast_debug(4, "MasterTime: %s.%09d\n", timestr, master_time.vtime_nsec);
 				}
 				if (recvlen == sizeof(VOTER_PACKET_HEADER)) {
@@ -5440,8 +5440,8 @@ process_gps:
 				} else {
 					vgp = (VOTER_GPS *) (buf + sizeof(VOTER_PACKET_HEADER));
 					if (client->gpsid) {
-						snprintf(gps1, sizeof(gps1) - 1, GPS_WORK_FILE, client->gpsid);
-						snprintf(gps2, sizeof(gps2) - 1, GPS_DATA_FILE, client->gpsid);
+						snprintf(gps1, sizeof(gps1), GPS_WORK_FILE, client->gpsid);
+						snprintf(gps2, sizeof(gps2), GPS_DATA_FILE, client->gpsid);
 						gpsfp = fopen(gps1, "w");
 						if (!gpsfp) {
 							ast_log(LOG_ERROR, "Unable to open GPS work file %s!!\n", gps1);

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -2537,7 +2537,8 @@ static int voter_do_txlockout(int fd, int argc, const char *const *argv)
 		ast_cli(fd, "VOTER instance %s not found\n", argv[2]);
 		return RESULT_SUCCESS;
 	}
-	if (argc > 3) { /* Specify list of lockouts */
+	if (argc > 3) {
+		/* Specify list of lockouts */
 		if (!strcasecmp(argv[3], "all")) {
 			for (client = clients; client; client = client->next) {
 				if (client->nodenum != p->nodenum) {
@@ -2552,9 +2553,10 @@ static int voter_do_txlockout(int fd, int argc, const char *const *argv)
 				}
 				client->txlockout = 0;
 			}
-		} else { /* Must be a comma-delimited list */
+		} else {
+			/* Must be a comma-delimited list */
 			ast_copy_string(str, argv[3], sizeof(str));
-			n = finddelim((char *) argv[3], strs, ARRAY_LEN(strs));
+			n = finddelim(str, strs, ARRAY_LEN(strs));
 			for (i = 0; i < n; i++) {
 				if (!*strs[i]) {
 					continue;

--- a/utils/radio-tune-menu.c
+++ b/utils/radio-tune-menu.c
@@ -471,7 +471,7 @@ static void menu_selectusb(void)
 		printf("USB device not changed\n");
 		return;
 	}
-	snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "active %s", strs[i - 1]);
+	snprintf(str, sizeof(str), COMMAND_PREFIX "active %s", strs[i - 1]);
 	astgetresp(str);
 }
 
@@ -527,7 +527,7 @@ static void menu_swapusb(void)
 		printf("USB device not swapped\n");
 		return;
 	}
-	snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "tune swap %s", strs[i - 1]);
+	snprintf(str, sizeof(str), COMMAND_PREFIX "tune swap %s", strs[i - 1]);
 	astgetresp(str);
 }
 
@@ -568,7 +568,7 @@ static void menu_rxvoice(void)
 			printf("Entry Error, Rx voice setting not changed\n");
 			continue;
 		}
-		snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "tune menu-support c%d", i);
+		snprintf(str, sizeof(str), COMMAND_PREFIX "tune menu-support c%d", i);
 		if (astgetresp(str)) {
 			break;
 		}
@@ -608,7 +608,7 @@ static void menu_rxsquelch(void)
 		printf("Entry Error, Rx Squelch Level setting not changed\n");
 		return;
 	}
-	snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "tune menu-support e%d", i);
+	snprintf(str, sizeof(str), COMMAND_PREFIX "tune menu-support e%d", i);
 	astgetresp(str);
 }
 
@@ -653,9 +653,9 @@ static void menu_txvoice(int keying)
 		return;
 	}
 	if (keying) {
-		snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "tune menu-support fK%d", i);
+		snprintf(str, sizeof(str), COMMAND_PREFIX "tune menu-support fK%d", i);
 	} else {
-		snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "tune menu-support f%d", i);
+		snprintf(str, sizeof(str), COMMAND_PREFIX "tune menu-support f%d", i);
 	}
 	astgetresp(str);
 }
@@ -693,7 +693,7 @@ static void menu_auxvoice(void)
 		printf("Entry Error, Aux Voice Level setting not changed\n");
 		return;
 	}
-	snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "tune menu-support g%d", i);
+	snprintf(str, sizeof(str), COMMAND_PREFIX "tune menu-support g%d", i);
 	astgetresp(str);
 }
 
@@ -739,9 +739,9 @@ static void menu_txtone(int keying)
 		return;
 	}
 	if (keying) {
-		snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "tune menu-support hK%d", i);
+		snprintf(str, sizeof(str), COMMAND_PREFIX "tune menu-support hK%d", i);
 	} else {
-		snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "tune menu-support h%d", i);
+		snprintf(str, sizeof(str), COMMAND_PREFIX "tune menu-support h%d", i);
 	}
 	astgetresp(str);
 }
@@ -798,7 +798,7 @@ static int menu_get_delay(const char *delay_type, const char *menu_option, int d
 	char str[100];
 	int value, x;
 
-	snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "tune menu-support %s", menu_option);
+	snprintf(str, sizeof(str), COMMAND_PREFIX "tune menu-support %s", menu_option);
 	if (astgetresp(str)) {
 		return delay;
 	}
@@ -903,18 +903,18 @@ static void options_menu(void)
 		case '3': /* select rx demodulation */
 			result = menu_select_value("RX Demodulation", demodulation_type, 3, rxdemod);
 			if (result > 0) {
-				snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "tune menu-support u%d", result - 1);
+				snprintf(str, sizeof(str), COMMAND_PREFIX "tune menu-support u%d", result - 1);
 				astgetresp(str);
 			}
 			break;
 		case '4': /* set rx on delay */
 			result = menu_get_delay("RX On Delay", "q", rxondelay);
-			snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "tune menu-support q%d", result);
+			snprintf(str, sizeof(str), COMMAND_PREFIX "tune menu-support q%d", result);
 			astgetresp(str);
 			break;
 		case '5': /* set tx off delay */
 			result = menu_get_delay("TX Off Delay", "r", txoffdelay);
-			snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "tune menu-support r%d", result);
+			snprintf(str, sizeof(str), COMMAND_PREFIX "tune menu-support r%d", result);
 			astgetresp(str);
 			break;
 		case '6': /* toggle txprelim */
@@ -942,14 +942,14 @@ static void options_menu(void)
 		case '8': /* select tx mixer a */
 			result = menu_select_value("TX Mixer A", mixer_type, 5, txmixa);
 			if (result > 0) {
-				snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "tune menu-support w%d", result - 1);
+				snprintf(str, sizeof(str), COMMAND_PREFIX "tune menu-support w%d", result - 1);
 				astgetresp(str);
 			}
 			break;
 		case '9': /* select tx mixer b */
 			result = menu_select_value("TX Mixer B", mixer_type, 5, txmixb);
 			if (result > 0) {
-				snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "tune menu-support x%d", result - 1);
+				snprintf(str, sizeof(str), COMMAND_PREFIX "tune menu-support x%d", result - 1);
 				astgetresp(str);
 			}
 			break;
@@ -992,7 +992,7 @@ int main(int argc, char *argv[])
 	}
 
 	if ((device != NULL) && (strlen(device) > 0)) {
-		snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "active %s", device);
+		snprintf(str, sizeof(str), COMMAND_PREFIX "active %s", device);
 		if (astgetline(str, str, sizeof(str) - 1)) {
 			printf("The chan_usbradio active device could not be set!\n\n");
 			printf("Verify that Asterisk is running and chan_usbradio is loaded.\n\n");
@@ -1179,7 +1179,7 @@ int main(int argc, char *argv[])
 		case 'G':
 			result = menu_select_value("Carrier From", cd_signal_type, 7, carrierfrom);
 			if (result > 0) {
-				snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "tune menu-support o%d", result - 1);
+				snprintf(str, sizeof(str), COMMAND_PREFIX "tune menu-support o%d", result - 1);
 				astgetresp(str);
 			}
 			break;
@@ -1187,7 +1187,7 @@ int main(int argc, char *argv[])
 		case 'H':
 			result = menu_select_value("CTCSS From", sd_signal_type, 6, ctcssfrom);
 			if (result > 0) {
-				snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "tune menu-support p%d", result - 1);
+				snprintf(str, sizeof(str), COMMAND_PREFIX "tune menu-support p%d", result - 1);
 				astgetresp(str);
 			}
 			break;

--- a/utils/simpleusb-tune-menu.c
+++ b/utils/simpleusb-tune-menu.c
@@ -453,7 +453,7 @@ static void menu_selectusb(void)
 		printf("USB device not changed\n");
 		return;
 	}
-	snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "active %s", strs[i - 1]);
+	snprintf(str, sizeof(str), COMMAND_PREFIX "active %s", strs[i - 1]);
 	astgetresp(str);
 }
 
@@ -509,7 +509,7 @@ static void menu_swapusb(void)
 		printf("USB device not swapped\n");
 		return;
 	}
-	snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "tune swap %s", strs[i - 1]);
+	snprintf(str, sizeof(str), COMMAND_PREFIX "tune swap %s", strs[i - 1]);
 	astgetresp(str);
 }
 
@@ -550,7 +550,7 @@ static void menu_rxvoice(void)
 			printf("Entry Error, Rx voice setting not changed\n");
 			continue;
 		}
-		snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "tune menu-support c%d", i);
+		snprintf(str, sizeof(str), COMMAND_PREFIX "tune menu-support c%d", i);
 		if (astgetresp(str)) {
 			break;
 		}
@@ -598,9 +598,9 @@ static void menu_txa(int keying)
 		return;
 	}
 	if (keying) {
-		snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "tune menu-support fK%d", i);
+		snprintf(str, sizeof(str), COMMAND_PREFIX "tune menu-support fK%d", i);
 	} else {
-		snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "tune menu-support f%d", i);
+		snprintf(str, sizeof(str), COMMAND_PREFIX "tune menu-support f%d", i);
 	}
 	astgetresp(str);
 }
@@ -646,9 +646,9 @@ static void menu_txb(int keying)
 		return;
 	}
 	if (keying) {
-		snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "tune menu-support gK%d", i);
+		snprintf(str, sizeof(str), COMMAND_PREFIX "tune menu-support gK%d", i);
 	} else {
-		snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "tune menu-support g%d", i);
+		snprintf(str, sizeof(str), COMMAND_PREFIX "tune menu-support g%d", i);
 	}
 	astgetresp(str);
 }
@@ -731,7 +731,7 @@ static int menu_get_delay(const char *delay_type, const char *menu_option, int d
 	char str[100];
 	int value, x;
 
-	snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "tune menu-support %s", menu_option);
+	snprintf(str, sizeof(str), COMMAND_PREFIX "tune menu-support %s", menu_option);
 	if (astgetresp(str)) {
 		return delay;
 	}
@@ -798,7 +798,7 @@ int main(int argc, char *argv[])
 	}
 
 	if ((device != NULL) && (strlen(device) > 0)) {
-		snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "active %s", device);
+		snprintf(str, sizeof(str), COMMAND_PREFIX "active %s", device);
 		if (astgetline(str, str, sizeof(str) - 1)) {
 			printf("The chan_simpleusb active device could not be set!\n\n");
 			printf("Verify that Asterisk is running and chan_simpleusb is loaded.\n\n");
@@ -971,7 +971,7 @@ int main(int argc, char *argv[])
 		case 'I':
 			result = menu_signal_type("Carrier From", carrierfrom);
 			if (result > 0) {
-				snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "tune menu-support r%d", result - 1);
+				snprintf(str, sizeof(str), COMMAND_PREFIX "tune menu-support r%d", result - 1);
 				astgetresp(str);
 			}
 			break;
@@ -979,20 +979,20 @@ int main(int argc, char *argv[])
 		case 'J':
 			result = menu_signal_type("CTCSS From", ctcssfrom);
 			if (result > 0) {
-				snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "tune menu-support s%d", result - 1);
+				snprintf(str, sizeof(str), COMMAND_PREFIX "tune menu-support s%d", result - 1);
 				astgetresp(str);
 			}
 			break;
 		case 'k': /* set rx on delay */
 		case 'K':
 			result = menu_get_delay("RX On Delay", "t", rxondelay);
-			snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "tune menu-support t%d", result);
+			snprintf(str, sizeof(str), COMMAND_PREFIX "tune menu-support t%d", result);
 			astgetresp(str);
 			break;
 		case 'l': /* set tx off delay */
 		case 'L':
 			result = menu_get_delay("TX Off Delay", "u", txoffdelay);
-			snprintf(str, sizeof(str) - 1, COMMAND_PREFIX "tune menu-support u%d", result);
+			snprintf(str, sizeof(str), COMMAND_PREFIX "tune menu-support u%d", result);
 			astgetresp(str);
 			break;
 		case 'p': /* print current values */


### PR DESCRIPTION
The ast_copy_string(), snprintf(), and strftime() APIs all ensure that the returned buffer will include the NUL termination character.  As such, there is no need to pass a buffer size of "xxx - 1".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated buffer handling across multiple application modules for improved consistency and code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->