### PR TITLE
app_rpt: re-install lost ASL2 kerchunk timer

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -5039,7 +5039,7 @@ static void *rpt(void *this)
 	lastexttx = 0;
 	myrpt->keyed = 0;
 	myrpt->txkeyed = 0;
-	myrpt->kerchunked_ok = 0;
+	myrpt->kerchunked = 0;
 	time(&myrpt->lastkeyedtime);
 	myrpt->lastkeyedtime -= RPT_LOCKOUT_SECS;
 	time(&myrpt->lasttxkeyedtime);
@@ -5434,7 +5434,7 @@ static void *rpt(void *this)
 			myrpt->macropatch = 0;
 			channel_revert(myrpt);
 		}
-		if (!myrpt->totimer || (!myrpt->mustid && myrpt->p.beaconing) || !myrpt->kerchunked_ok) {
+		if (!myrpt->totimer || (!myrpt->mustid && myrpt->p.beaconing) || !myrpt->kerchunked) {
 			/* get rid of tail if timed out, beaconing, or kerchunked */
 			myrpt->tailtimer = 0;
 		}
@@ -5537,7 +5537,7 @@ static void *rpt(void *this)
 		/* Detect and log keyed to unkeyed transition point */
 		if (!totx && lasttx) {
 			lasttx = 0;
-			myrpt->kerchunked_ok = 0;
+			myrpt->kerchunked = 0;
 			log_unkeyed(myrpt);
 		}
 		time(&t);

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -5039,6 +5039,7 @@ static void *rpt(void *this)
 	lastexttx = 0;
 	myrpt->keyed = 0;
 	myrpt->txkeyed = 0;
+	myrpt->kerchunked = 0;
 	time(&myrpt->lastkeyedtime);
 	myrpt->lastkeyedtime -= RPT_LOCKOUT_SECS;
 	time(&myrpt->lasttxkeyedtime);
@@ -5218,16 +5219,25 @@ static void *rpt(void *this)
 				}
 			}
 
-			if (myrpt->sleep)
+			if (myrpt->sleep) {
 				myrpt->localtx = 0; /* No RX if asleep */
-			else
+			} else {
 				myrpt->localtx = myrpt->keyed; /* Set localtx to keyed state if awake */
+			}
 		} else {
 			myrpt->localtx = myrpt->keyed; /* If sleep disabled, just copy keyed state to localrx */
 		}
+
+		/* Set the kerchunk timer */
+		if ((myrpt->remrx || myrpt->keyed) && !myrpt->kerchunk_timer) {
+			time(&myrpt->kerchunk_timer);
+		}
+
 		/* Create a "must_id" flag for the cleanup ID */
-		if (myrpt->p.idtime) /* ID time must be non-zero */
+		if (myrpt->p.idtime) { /* ID time must be non-zero */
 			myrpt->mustid |= (myrpt->idtimer) && (myrpt->keyed || myrpt->remrx);
+		}
+
 		if (myrpt->keyed || myrpt->remrx) {
 			/* Set the inactivity was keyed flag and reset its timer */
 			myrpt->rptinactwaskeyedflag = 1;
@@ -5422,8 +5432,8 @@ static void *rpt(void *this)
 			myrpt->macropatch = 0;
 			channel_revert(myrpt);
 		}
-		if (!myrpt->totimer || (!myrpt->mustid && myrpt->p.beaconing)) {
-			/* get rid of tail if timed out or beaconing */
+		if (!myrpt->totimer || (!myrpt->mustid && myrpt->p.beaconing) || !myrpt->kerchunked) {
+			/* get rid of tail if timed out, beaconing, or kerchunked */
 			myrpt->tailtimer = 0;
 		}
 		if (myrpt->totimer) {
@@ -5525,6 +5535,7 @@ static void *rpt(void *this)
 		/* Detect and log keyed to unkeyed transition point */
 		if (!totx && lasttx) {
 			lasttx = 0;
+			myrpt->kerchunked = 0;
 			log_unkeyed(myrpt);
 		}
 		time(&t);

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -5039,7 +5039,7 @@ static void *rpt(void *this)
 	lastexttx = 0;
 	myrpt->keyed = 0;
 	myrpt->txkeyed = 0;
-	myrpt->kerchunked = 0;
+	myrpt->kerchunked_ok = 0;
 	time(&myrpt->lastkeyedtime);
 	myrpt->lastkeyedtime -= RPT_LOCKOUT_SECS;
 	time(&myrpt->lasttxkeyedtime);
@@ -5229,8 +5229,10 @@ static void *rpt(void *this)
 		}
 
 		/* Set the kerchunk timer */
-		if ((myrpt->remrx || myrpt->keyed) && !myrpt->kerchunk_timer) {
-			time(&myrpt->kerchunk_timer);
+		if ((myrpt->remrx || myrpt->keyed)) {
+			if (!myrpt->kerchunk_timer) {
+				time(&myrpt->kerchunk_timer);
+			}
 		}
 
 		/* Create a "must_id" flag for the cleanup ID */
@@ -5432,7 +5434,7 @@ static void *rpt(void *this)
 			myrpt->macropatch = 0;
 			channel_revert(myrpt);
 		}
-		if (!myrpt->totimer || (!myrpt->mustid && myrpt->p.beaconing) || !myrpt->kerchunked) {
+		if (!myrpt->totimer || (!myrpt->mustid && myrpt->p.beaconing) || !myrpt->kerchunked_ok) {
 			/* get rid of tail if timed out, beaconing, or kerchunked */
 			myrpt->tailtimer = 0;
 		}
@@ -5535,7 +5537,7 @@ static void *rpt(void *this)
 		/* Detect and log keyed to unkeyed transition point */
 		if (!totx && lasttx) {
 			lasttx = 0;
-			myrpt->kerchunked = 0;
+			myrpt->kerchunked_ok = 0;
 			log_unkeyed(myrpt);
 		}
 		time(&t);

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -976,9 +976,9 @@ struct rpt {
 	int calldigittimer;
 	int tailtimer, totimer, idtimer, cidx, scantimer, tmsgtimer, skedtimer, linkactivitytimer, elketimer;
 	int remote_time_out_reset_unkey_interval_timer, time_out_reset_unkey_interval_timer;
-	int kerchunked_ok;	   /*!< \brief Kerchunk timer has passed the kerchunk time */
 	time_t kerchunk_timer; /*!< \brief Kerchunk timer */
 	enum patch_call_mode callmode;
+	rpt_bool kerchunked:1; /*!< \brief Kerchunk timer has passed the kerchunk time */
 	rpt_bool mustid:1;
 	rpt_bool tailid:1;
 	int rptinacttimer;

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -976,8 +976,8 @@ struct rpt {
 	int calldigittimer;
 	int tailtimer, totimer, idtimer, cidx, scantimer, tmsgtimer, skedtimer, linkactivitytimer, elketimer;
 	int remote_time_out_reset_unkey_interval_timer, time_out_reset_unkey_interval_timer;
-	int kerchunked;
-	time_t kerchunk_timer;
+	int kerchunked_ok;	   /*!< \brief Kerchunk timer has passed the kerchunk time */
+	time_t kerchunk_timer; /*!< \brief Kerchunk timer */
 	enum patch_call_mode callmode;
 	rpt_bool mustid:1;
 	rpt_bool tailid:1;

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -805,6 +805,7 @@ struct rpt {
 		const char *dtmfkeys;
 		int hangtime;
 		int althangtime;
+		int kerchunktime;
 		int totime;
 		int time_out_reset_unkey_interval;
 		int time_out_reset_kerchunk_interval;
@@ -975,6 +976,8 @@ struct rpt {
 	int calldigittimer;
 	int tailtimer, totimer, idtimer, cidx, scantimer, tmsgtimer, skedtimer, linkactivitytimer, elketimer;
 	int remote_time_out_reset_unkey_interval_timer, time_out_reset_unkey_interval_timer;
+	int kerchunked;
+	time_t kerchunk_timer;
 	enum patch_call_mode callmode;
 	rpt_bool mustid:1;
 	rpt_bool tailid:1;

--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -937,6 +937,7 @@ void load_rpt_vars(int n, int init)
 
 	/* configure how we interact with "stats.allstarlink.org" */
 	RPT_CONFIG_VAR_INT_DEFAULT_MIN_MAX(statpost_time, "statpost_time", 60, 30, 600);
+	RPT_CONFIG_VAR_INT_DEFAULT_MIN_MAX(kerchunktime, "kerchunk_time", 0, 0, 5);
 	RPT_CONFIG_VAR(statpost_url, "statpost_url");
 
 	rpt_vars[n].p.tailmessagetime = retrieve_astcfgint(&rpt_vars[n], cat, "tailmessagetime", 0, 200000000, 0);

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -3547,10 +3547,6 @@ void rpt_telemetry(struct rpt *myrpt, enum rpt_tele_mode mode, void *data)
 			return;
 		}
 
-		if (myrpt->p.nounkeyct) {
-			return;
-		}
-
 		if (myrpt->p.kerchunktime && (time(NULL) - kerchunk_time_stamp) < myrpt->p.kerchunktime) {
 			return;
 		}
@@ -3558,6 +3554,11 @@ void rpt_telemetry(struct rpt *myrpt, enum rpt_tele_mode mode, void *data)
 		if (!myrpt->kerchunked || !myrpt->p.kerchunktime) {
 			myrpt->kerchunked = 1;
 		}
+
+		if (myrpt->p.nounkeyct) {
+			return;
+		}
+
 		/* if any of the following are defined, go ahead and do it,
 		   otherwise, dont bother */
 		v1 = ast_variable_retrieve(myrpt->cfg, myrpt->name, "unlinkedct");
@@ -3582,16 +3583,16 @@ void rpt_telemetry(struct rpt *myrpt, enum rpt_tele_mode mode, void *data)
 			return;
 		}
 
-		if (myrpt->p.nounkeyct) {
-			return;
-		}
-
 		if (myrpt->p.kerchunktime && (time(NULL) - kerchunk_time_stamp) < myrpt->p.kerchunktime) {
 			return;
 		}
 
 		if (!myrpt->kerchunked || !myrpt->p.kerchunktime) {
 			myrpt->kerchunked = 1;
+		}
+
+		if (myrpt->p.nounkeyct) {
+			return;
 		}
 
 		if (myrpt->p.locallinknodesn) {

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -3497,9 +3497,6 @@ void rpt_telemetry(struct rpt *myrpt, enum rpt_tele_mode mode, void *data)
 	struct ao2_iterator l_it;
 	time_t kerchunk_time_stamp;
 
-	kerchunk_time_stamp = myrpt->kerchunk_timer;
-	myrpt->kerchunk_timer = 0;
-
 	ast_debug(6, "Tracepoint rpt_telemetry() entered mode=%s\n", rpt_tele_mode_str(mode));
 
 	if ((mode == ID) && is_paging(myrpt)) {
@@ -3542,6 +3539,9 @@ void rpt_telemetry(struct rpt *myrpt, enum rpt_tele_mode mode, void *data)
 
 	case UNKEY:
 	case LOCUNKEY:
+		kerchunk_time_stamp = myrpt->kerchunk_timer;
+		myrpt->kerchunk_timer = 0;
+
 		/* if voting and the main rx unkeys but a voter link is still active */
 		if (myrpt->p.votertype == 1 && (myrpt->rxchankeyed || myrpt->voteremrx)) {
 			return;
@@ -3551,12 +3551,12 @@ void rpt_telemetry(struct rpt *myrpt, enum rpt_tele_mode mode, void *data)
 			return;
 		}
 
-		if (time(NULL) - kerchunk_time_stamp < myrpt->p.kerchunktime) {
+		if (myrpt->p.kerchunktime && (time(NULL) - kerchunk_time_stamp) < myrpt->p.kerchunktime) {
 			return;
 		}
 
-		if (!myrpt->kerchunked_ok) {
-			myrpt->kerchunked_ok = 1;
+		if (!myrpt->kerchunked || !myrpt->p.kerchunktime) {
+			myrpt->kerchunked = 1;
 		}
 		/* if any of the following are defined, go ahead and do it,
 		   otherwise, dont bother */
@@ -3574,8 +3574,10 @@ void rpt_telemetry(struct rpt *myrpt, enum rpt_tele_mode mode, void *data)
 		break;
 
 	case LINKUNKEY:
-		mylink = (struct rpt_link *) data;
+		kerchunk_time_stamp = myrpt->kerchunk_timer;
+		myrpt->kerchunk_timer = 0;
 
+		mylink = (struct rpt_link *) data;
 		if (!mylink) {
 			return;
 		}
@@ -3584,8 +3586,12 @@ void rpt_telemetry(struct rpt *myrpt, enum rpt_tele_mode mode, void *data)
 			return;
 		}
 
-		if (time(NULL) - kerchunk_time_stamp < myrpt->p.kerchunktime) {
+		if (myrpt->p.kerchunktime && (time(NULL) - kerchunk_time_stamp) < myrpt->p.kerchunktime) {
 			return;
+		}
+
+		if (!myrpt->kerchunked || !myrpt->p.kerchunktime) {
+			myrpt->kerchunked = 1;
 		}
 
 		if (myrpt->p.locallinknodesn) {

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -3555,8 +3555,8 @@ void rpt_telemetry(struct rpt *myrpt, enum rpt_tele_mode mode, void *data)
 			return;
 		}
 
-		if (!myrpt->kerchunked) {
-			myrpt->kerchunked = 1;
+		if (!myrpt->kerchunked_ok) {
+			myrpt->kerchunked_ok = 1;
 		}
 		/* if any of the following are defined, go ahead and do it,
 		   otherwise, dont bother */

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -3495,6 +3495,10 @@ void rpt_telemetry(struct rpt *myrpt, enum rpt_tele_mode mode, void *data)
 	char gps_data[100], lat[25], lon[25], elev[25];
 	struct ast_str *lbuf;
 	struct ao2_iterator l_it;
+	time_t kerchunk_time_stamp;
+
+	kerchunk_time_stamp = myrpt->kerchunk_timer;
+	myrpt->kerchunk_timer = 0;
 
 	ast_debug(6, "Tracepoint rpt_telemetry() entered mode=%s\n", rpt_tele_mode_str(mode));
 
@@ -3546,6 +3550,14 @@ void rpt_telemetry(struct rpt *myrpt, enum rpt_tele_mode mode, void *data)
 		if (myrpt->p.nounkeyct) {
 			return;
 		}
+
+		if (time(NULL) - kerchunk_time_stamp < myrpt->p.kerchunktime) {
+			return;
+		}
+
+		if (!myrpt->kerchunked) {
+			myrpt->kerchunked = 1;
+		}
 		/* if any of the following are defined, go ahead and do it,
 		   otherwise, dont bother */
 		v1 = ast_variable_retrieve(myrpt->cfg, myrpt->name, "unlinkedct");
@@ -3565,6 +3577,14 @@ void rpt_telemetry(struct rpt *myrpt, enum rpt_tele_mode mode, void *data)
 		mylink = (struct rpt_link *) data;
 
 		if (!mylink) {
+			return;
+		}
+
+		if (myrpt->p.nounkeyct) {
+			return;
+		}
+
+		if (time(NULL) - kerchunk_time_stamp < myrpt->p.kerchunktime) {
 			return;
 		}
 

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -3539,13 +3539,13 @@ void rpt_telemetry(struct rpt *myrpt, enum rpt_tele_mode mode, void *data)
 
 	case UNKEY:
 	case LOCUNKEY:
-		kerchunk_time_stamp = myrpt->kerchunk_timer;
-		myrpt->kerchunk_timer = 0;
-
 		/* if voting and the main rx unkeys but a voter link is still active */
 		if (myrpt->p.votertype == 1 && (myrpt->rxchankeyed || myrpt->voteremrx)) {
 			return;
 		}
+
+		kerchunk_time_stamp = myrpt->kerchunk_timer;
+		myrpt->kerchunk_timer = 0;
 
 		if (myrpt->p.kerchunktime && (time(NULL) - kerchunk_time_stamp) < myrpt->p.kerchunktime) {
 			return;
@@ -3575,13 +3575,13 @@ void rpt_telemetry(struct rpt *myrpt, enum rpt_tele_mode mode, void *data)
 		break;
 
 	case LINKUNKEY:
-		kerchunk_time_stamp = myrpt->kerchunk_timer;
-		myrpt->kerchunk_timer = 0;
-
 		mylink = (struct rpt_link *) data;
 		if (!mylink) {
 			return;
 		}
+
+		kerchunk_time_stamp = myrpt->kerchunk_timer;
+		myrpt->kerchunk_timer = 0;
 
 		if (myrpt->p.kerchunktime && (time(NULL) - kerchunk_time_stamp) < myrpt->p.kerchunktime) {
 			return;

--- a/configs/rpt/rpt.conf
+++ b/configs/rpt/rpt.conf
@@ -140,7 +140,7 @@ time_out_reset_unkey_interval = 0   ; The minimum time for no carrier detect aft
 time_out_reset_kerchunk_interval = 250 ; Allows users to reset the time out timer when there is a signal coming in from a link (optional).
 									; A value of 0 disables this feature. Valid only if time_time_out_reset_unkey_interval is non zero. 
 									; Value is in milliseconds. Default is 250ms, minimum is 0ms, maximum is 3000ms
-;kerchunk_time = 500                ; kerchunk time (in milliseconds) (optional, default is 0, max 5000)
+;kerchunk_time = 1                  ; kerchunk time (in seconds) (optional, default is 0, max 5)
 idrecording = |iNOTSET              ; id recording or morse string
 ;idtalkover =                       ; Talkover ID (optional) default is none
 idtime = 540000                     ; id interval time (in ms) (optional) Default 5 minutes (300000 ms)

--- a/configs/rpt/rpt.conf
+++ b/configs/rpt/rpt.conf
@@ -140,7 +140,7 @@ time_out_reset_unkey_interval = 0   ; The minimum time for no carrier detect aft
 time_out_reset_kerchunk_interval = 250 ; Allows users to reset the time out timer when there is a signal coming in from a link (optional).
 									; A value of 0 disables this feature. Valid only if time_time_out_reset_unkey_interval is non zero. 
 									; Value is in milliseconds. Default is 250ms, minimum is 0ms, maximum is 3000ms
-kerchunk_time = 1                   ; kerchunk time (in seconds) (optional, default is 0, max 5)
+;kerchunk_time = 500                ; kerchunk time (in milliseconds) (optional, default is 0, max 5000)
 idrecording = |iNOTSET              ; id recording or morse string
 ;idtalkover =                       ; Talkover ID (optional) default is none
 idtime = 540000                     ; id interval time (in ms) (optional) Default 5 minutes (300000 ms)

--- a/configs/rpt/rpt.conf
+++ b/configs/rpt/rpt.conf
@@ -140,6 +140,7 @@ time_out_reset_unkey_interval = 0   ; The minimum time for no carrier detect aft
 time_out_reset_kerchunk_interval = 250 ; Allows users to reset the time out timer when there is a signal coming in from a link (optional).
 									; A value of 0 disables this feature. Valid only if time_time_out_reset_unkey_interval is non zero. 
 									; Value is in milliseconds. Default is 250ms, minimum is 0ms, maximum is 3000ms
+kerchunk_time = 1                   ; kerchunk time (in seconds) (optional, default is 0, max 5)
 idrecording = |iNOTSET              ; id recording or morse string
 ;idtalkover =                       ; Talkover ID (optional) default is none
 idtime = 540000                     ; id interval time (in ms) (optional) Default 5 minutes (300000 ms)


### PR DESCRIPTION
https://github.com/AllStarLink/ASL-Asterisk/pull/69/changes

Fixes #90 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced repeater systems with kerchunk detection and state tracking capabilities. Added timing-based control mechanism for telemetry filtering.

* **Configuration**
  * New `kerchunk_time` configuration parameter for repeater nodes enables adjustable kerchunk sensitivity. Available range: 0–5 seconds (default: 0).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->