### PR TITLE
chan_tlb: Address truncated node number

### DIFF
--- a/channels/chan_tlb.c
+++ b/channels/chan_tlb.c
@@ -1748,7 +1748,7 @@ static struct ast_channel *TLB_request(const char *type, struct ast_format_cap *
 		*cp++ = 0;
 	}
 	nodenum = 0;
-	if (*cp && *++cp) {
+	if (*cp && *(cp + 1)) {
 		cp1 = strchr(cp, '/');
 		if (cp1) {
 			*cp1++ = 0;


### PR DESCRIPTION
same problem as echolink PR#980
Fixes #1027 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing logic for handling node identifiers in channel requests, allowing for more flexible input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->