### PR TITLE
chan_simpleusb: Use PortAudio for audio output

### DIFF
--- a/channels/Makefile.diff
+++ b/channels/Makefile.diff
@@ -6,7 +6,7 @@ index 0f8d1328c5..c9523f6d69 100644
  $(call MOD_ADD_C,chan_iax2,$(wildcard iax2/*.c))
  iax2/parser.o: _ASTCFLAGS+=$(call get_menuselect_cflags,MALLOC_DEBUG)
  
-+chan_simpleusb.so: LIBS+=-lusb -lasound
++chan_simpleusb.so: LIBS+=-lusb -lasound -lportaudio
 +chan_usbradio.so: LIBS+=-lusb -lasound
 +
  $(call MOD_ADD_C,chan_pjsip,$(wildcard pjsip/*.c))

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -428,13 +428,96 @@ static struct ast_channel_tech simpleusb_tech = {
 	.setoption = simpleusb_setoption,
 };
 
-static int open_stream(struct chan_simpleusb_pvt *pvt)
+/*!
+ * \brief Parse "hw:<card>" or "hw:<card>,<dev>" from anywhere in s.
+ * Returns 1 if found; sets *card; sets *dev to parsed value or -1 if absent.
+ */
+static int parse_hw_anywhere(const char *s, int *card, int *dev)
+{
+	const char *p = s;
+
+	if (!s || !card || !dev) {
+		return 0;
+	}
+
+	while ((p = strstr(p, "hw:")) != NULL) {
+		const char *q = p + 3; /* after "hw:" */
+		int c = 0;
+		int d = -1; /* dev absent by default */
+
+		/* card must start with digit */
+		if (!isdigit((unsigned char) *q)) {
+			p = q;
+			continue;
+		}
+
+		while (isdigit((unsigned char) *q)) {
+			c = c * 10 + (*q - '0');
+			q++;
+		}
+
+		if (*q == ',') {
+			q++;
+			if (!isdigit((unsigned char) *q)) {
+				/* "hw:<card>," is malformed; skip this occurrence */
+				p = q;
+				continue;
+			}
+			d = 0;
+			while (isdigit((unsigned char) *q)) {
+				d = d * 10 + (*q - '0');
+				q++;
+			}
+		}
+
+		*card = c;
+		*dev = d;
+		return 1; /* first valid hw: occurrence */
+	}
+
+	return 0;
+}
+
+/*!
+ * \brief Match rule:
+ * - needle "hw:C" matches any "hw:C" or "hw:C,D" in haystack
+ * - needle "hw:C,D" matches only "hw:C,D" in haystack
+ */
+static int hw_match(const char *haystack, const char *needle)
+{
+	int haystack_c, haystack_d, needle_c, needle_d;
+	const char *p = haystack ? haystack : "";
+
+	if (!parse_hw_anywhere(needle, &needle_c, &needle_d)) {
+		return 0;
+	}
+
+	/* haystack may contain multiple hw: occurrences; scan all */
+	while ((p = strstr(p, "hw:")) != NULL) {
+		if (parse_hw_anywhere(p, &haystack_c, &haystack_d)) {
+			if (haystack_c == needle_c) {
+				if (needle_d < 0) {
+					/* needle is "hw:C" -> accept any dev (including absent) */
+					return 1;
+				} else if (haystack_d == needle_d) {
+					/* needle is "hw:C,D" -> require exact dev match */
+					return 1;
+				}
+			}
+		}
+		p += 3; /* move forward to find next occurrence */
+	}
+
+	return 0;
+}
+
+static int open_stream(struct chan_simpleusb_pvt *o)
 {
 	PaError res = paInternalError;
 
-	if (!strcasecmp(pvt->hw_device, "default")) {
+	if (!strcasecmp(o->hw_device, "default")) {
 		ast_debug(1, "Opening stream with default device\n");
-		res = Pa_OpenDefaultStream(&pvt->stream, INPUT_CHANNELS, OUTPUT_CHANNELS, paInt16, SAMPLE_RATE, NUM_SAMPLES, NULL, NULL);
+		res = Pa_OpenDefaultStream(&o->stream, INPUT_CHANNELS, OUTPUT_CHANNELS, paInt16, SAMPLE_RATE, NUM_SAMPLES, NULL, NULL);
 	} else {
 		PaStreamParameters input_params = {
 			.channelCount = INPUT_CHANNELS,
@@ -449,7 +532,7 @@ static int open_stream(struct chan_simpleusb_pvt *pvt)
 			.device = paNoDevice,
 		};
 		PaDeviceIndex idx, num_devices;
-		ast_debug(1, "Looking for device %s", pvt->hw_device);
+		ast_debug(1, "Looking for device %s", o->hw_device);
 		ast_debug(6, "PortAudio host api count %d\n", Pa_GetHostApiCount());
 		num_devices = Pa_GetDeviceCount();
 		if (num_devices < 0) {
@@ -463,14 +546,14 @@ static int open_stream(struct chan_simpleusb_pvt *pvt)
 			const PaDeviceInfo *dev = Pa_GetDeviceInfo(idx);
 			ast_debug(1, "Found device %s\n", dev->name);
 			if (dev->maxInputChannels) {
-				if (strlen(pvt->hw_device) && strstr(dev->name, pvt->hw_device)) {
+				if (hw_match(dev->name, o->hw_device)) {
 					ast_debug(5, "Found input device %s\n", dev->name);
 					input_params.device = idx;
 				}
 			}
 
 			if (dev->maxOutputChannels) {
-				if (strlen(pvt->hw_device) && strstr(dev->name, pvt->hw_device)) {
+				if (hw_match(dev->name, o->hw_device)) {
 					ast_debug(5, "Found output device %s\n", dev->name);
 					output_params.device = idx;
 				}
@@ -478,14 +561,16 @@ static int open_stream(struct chan_simpleusb_pvt *pvt)
 		}
 
 		if (input_params.device == paNoDevice) {
-			ast_log(LOG_ERROR, "No input device found for simpleusb device '%s'\n", pvt->name);
+			ast_log(LOG_ERROR, "No input device found for simpleusb device '%s'\n", o->name);
+			return res;
 		}
 
 		if (output_params.device == paNoDevice) {
-			ast_log(LOG_ERROR, "No output device found for simpleusb device '%s'\n", pvt->name);
+			ast_log(LOG_ERROR, "No output device found for simpleusb device '%s'\n", o->name);
+			return res;
 		}
-		ast_debug(5, "Opening stream on device %s", pvt->hw_device);
-		res = Pa_OpenStream(&pvt->stream, &input_params, &output_params, SAMPLE_RATE, NUM_SAMPLES, paNoFlag, NULL, NULL);
+		ast_debug(5, "Opening stream on device %s", o->hw_device);
+		res = Pa_OpenStream(&o->stream, &input_params, &output_params, SAMPLE_RATE, NUM_SAMPLES, paNoFlag, NULL, NULL);
 		ast_debug(5, "Stream feedback %s\n", Pa_GetErrorText(res));
 	}
 
@@ -1159,6 +1244,7 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 		o->usb_dev = ast_radio_hid_device_init(o->devstr);
 		if (!o->usb_dev) {
 			ast_log(LOG_ERROR, "Unable to find usb device associated with %s", o->devstr);
+			ast_mutex_unlock(&usb_dev_lock);
 			return -1;
 		}
 	}
@@ -1961,6 +2047,7 @@ static int simpleusb_call(struct ast_channel *c, const char *dest, int timeout)
 		o->stophid = 1;
 		if (o->hidthread != AST_PTHREADT_NULL) {
 			pthread_join(o->hidthread, NULL);
+			o->hidthread = AST_PTHREADT_NULL;
 		}
 		return -1;
 	}
@@ -1996,11 +2083,14 @@ static int simpleusb_hangup(struct ast_channel *c)
 
 	if (o->hidthread != AST_PTHREADT_NULL) {
 		pthread_join(o->hidthread, NULL);
+		o->hidthread = AST_PTHREADT_NULL;
 	}
 
-	pthread_join(o->audiothread, NULL);
-	o->hidthread = AST_PTHREADT_NULL;
-	o->audiothread = AST_PTHREADT_NULL;
+	if (o->audiothread != AST_PTHREADT_NULL) {
+		pthread_join(o->audiothread, NULL);
+		o->audiothread = AST_PTHREADT_NULL;
+	}
+
 	return 0;
 }
 
@@ -2287,6 +2377,7 @@ static void *simpleusb_audio_thread(void *arg)
 							}
 
 							ast_queue_frame(o->owner, &wf);
+							o->waspager = ispager;
 							continue;
 						}
 						o->waspager = ispager;
@@ -4343,6 +4434,7 @@ static int unload_module(void)
 		/* XXX what about the memory allocated ? */
 	}
 
+	Pa_Terminate();
 	ao2_cleanup(simpleusb_tech.capabilities);
 	simpleusb_tech.capabilities = NULL;
 

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -195,10 +195,10 @@ static const char *const sd_signal_type[] = { "no", "usb", "usbinvert", "N/A", "
 struct chan_simpleusb_pvt {
 	struct chan_simpleusb_pvt *next;
 
-	char *name;				 /* the internal name of our channel */
-	char hw_device[50];		 /* hardware device name */
-	int devtype;			 /* actual type of device */
-	int pttkick[2];			 /* ptt kick pipe */
+	char *name;			/* the internal name of our channel */
+	char hw_device[50]; /* hardware device name */
+	int devtype;		/* actual type of device */
+	int pttkick[2];		/* ptt kick pipe */
 	enum {
 		M_UNSET,
 		M_FULL,
@@ -206,7 +206,7 @@ struct chan_simpleusb_pvt {
 		M_WRITE
 	} duplex;
 
-	int warned;				/* various flags used for warnings */
+	int warned; /* various flags used for warnings */
 	int devicenum;
 	char devstr[128];
 	char serial[128];
@@ -436,7 +436,6 @@ static int open_stream(struct chan_simpleusb_pvt *pvt)
 		ast_debug(1, "Opening stream with default device\n");
 		res = Pa_OpenDefaultStream(&pvt->stream, INPUT_CHANNELS, OUTPUT_CHANNELS, paInt16, SAMPLE_RATE, NUM_SAMPLES, NULL, NULL);
 	} else {
-		ast_debug(1, "Looking for device %s", pvt->hw_device);
 		PaStreamParameters input_params = {
 			.channelCount = INPUT_CHANNELS,
 			.sampleFormat = paInt16,
@@ -450,6 +449,7 @@ static int open_stream(struct chan_simpleusb_pvt *pvt)
 			.device = paNoDevice,
 		};
 		PaDeviceIndex idx, num_devices;
+		ast_debug(1, "Looking for device %s", pvt->hw_device);
 		ast_debug(6, "PortAudio host api count %d\n", Pa_GetHostApiCount());
 		num_devices = Pa_GetDeviceCount();
 		if (num_devices < 0) {

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -35,6 +35,8 @@
 
 #include "asterisk.h"
 
+#include <portaudio.h>
+
 #include <stdio.h>
 #include <math.h>
 #include <string.h>
@@ -103,6 +105,28 @@
 #include "asterisk/format_cache.h"
 #include "asterisk/format_compatibility.h"
 
+/*!
+ * \brief The sample rate to request from PortAudio
+ *
+ * \todo Make this optional.  If this is only going to talk to 8 kHz endpoints,
+ *       then it makes sense to use 8 kHz natively.
+ */
+#define SAMPLE_RATE 48000 /* PortAudio Sample rate: Hardware likes 48k and is divisible by 6 for a "nice" down conversion. */
+
+/*!
+ * \brief The number of samples to configure the portaudio stream for
+ *
+ * At 48kHz, 960 samples gives a 20ms frames, which aligns with Asterisk's
+ * common frame size after resampling to 8kHz (160 samples @ 2 bytes per sample).
+ */
+#define NUM_SAMPLES 960 /* The number of 2 byte (paInt16) samples per PortAudio "frame" */
+
+/*! \brief Mono Input */
+#define INPUT_CHANNELS 1 /* PortAudio: Mono input for Microphone / RX */
+
+/*! \brief Stereo Output */
+#define OUTPUT_CHANNELS 2 /* PortAudio: Stereo output for Speaker / TX */
+
 /*! \brief Global jitterbuffer configuration - by default, jb is disabled */
 static struct ast_jb_conf default_jbconf = {
 	.flags = 0,
@@ -120,8 +144,8 @@ static struct ast_jb_conf global_jbconf;
 #define PAGER_SRC "PAGER"
 #define ENDPAGE_STR "ENDPAGE"
 #define AMPVAL 12000
-#define SAMPRATE 8000 /* (Sample Rate) */
-#define DIVLCM 192000 /* (Least Common Mult of 512,1200,2400,8000) */
+#define SAMPRATE 8000 /* Asterisk sample rate (after down conversion) */
+#define DIVLCM 192000 /* Least Common Mult of 512,1200,2400,8000) */
 #define PREAMBLE_BITS 576
 #define MESSAGE_BITS 544 /* (17 * 32), 1 longword SYNC plus 16 longwords data */
 #define ONEVAL -AMPVAL
@@ -171,37 +195,33 @@ static const char *const sd_signal_type[] = { "no", "usb", "usbinvert", "N/A", "
 struct chan_simpleusb_pvt {
 	struct chan_simpleusb_pvt *next;
 
-	char *name;		  /* the internal name of our channel */
-	int devtype;	  /* actual type of device */
-	int pttkick[2];	  /* ptt kick pipe */
-	int total_blocks; /* total blocks in the output device */
-	int sounddev;
+	char *name;				 /* the internal name of our channel */
+	char hw_device[50];		 /* hardware device name */
+	int devtype;			 /* actual type of device */
+	int pttkick[2];			 /* ptt kick pipe */
 	enum {
 		M_UNSET,
 		M_FULL,
 		M_READ,
 		M_WRITE
 	} duplex;
-	int hookstate;
-	unsigned int queuesize; /* max fragments in queue */
-	unsigned int frags;		/* parameter for SETFRAGMENT */
 
-	int warned; /* various flags used for warnings */
-#define WARN_used_blocks 1
-#define WARN_speed 2
-#define WARN_frag 4
-
-	char devicenum;
+	int warned;				/* various flags used for warnings */
+	int devicenum;
 	char devstr[128];
 	char serial[128];
 	int spkrmax;
 	int micmax;
 	int micplaymax;
 
+	pthread_t audiothread;
 	pthread_t hidthread;
 	int stophid;
 
+	struct usb_device *usb_dev;
 	struct ast_channel *owner;
+
+	PaStream *stream; /*! Current PortAudio stream for this device */
 
 	/* buffers used in simpleusb_write, 2 per int */
 	char simpleusb_write_buf[FRAME_SIZE * 2];
@@ -210,8 +230,8 @@ struct chan_simpleusb_pvt {
 	/* buffers used in simpleusb_read - AST_FRIENDLY_OFFSET space for headers
 	 * plus enough room for a full frame
 	 */
-	char simpleusb_read_buf[FRAME_SIZE * 4 * 6]; /* 2 bytes * 2 channels * 6 for 48K */
-	char simpleusb_read_frame_buf[FRAME_SIZE * 2 + AST_FRIENDLY_OFFSET];
+	char simpleusb_read_buf[NUM_SAMPLES * 2];							 /* 2 byte samples for PortAudio - paInt16 */
+	char simpleusb_read_frame_buf[FRAME_SIZE * 2 + AST_FRIENDLY_OFFSET]; /* 2 byte frames at 8k */
 	int readpos;			 /* read position above */
 	struct ast_frame read_f; /* returned by simpleusb_read */
 
@@ -292,12 +312,14 @@ struct chan_simpleusb_pvt {
 	char had_pp_in;
 
 	/* bit fields */
+	unsigned int streamstate:1;		/* indicator if stream is started */
 	unsigned int rxcapraw:1;		/* indicator if receive capture is enabled */
 	unsigned int txcapraw:1;		/* indicator if transmit capture is enabled */
 	unsigned int measure_enabled:1; /* indicator if measure mode is enabled */
 	unsigned int device_error:1;	/* indicator set when we cannot find the USB device */
 	unsigned int newname:1;			/* indicator that we should use MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW */
 	unsigned int hasusb:1;			/* indicator for has a USB device */
+	unsigned int internal_audio:1;	/* indicator for non usb audio device */
 	unsigned int usbass:1;			/* indicator for USB device assigned */
 	unsigned int wanteeprom:1;		/* indicator if we should use EEPROM */
 	unsigned int usedtmf:1;			/* indicator is we should decode DTMF */
@@ -315,7 +337,6 @@ struct chan_simpleusb_pvt {
 	ast_mutex_t eepromlock;
 
 	struct usb_dev_handle *usb_handle;
-	int readerrs;
 	struct timeval tonetime;
 	int toneflag;
 	int duplex3;
@@ -344,10 +365,7 @@ struct chan_simpleusb_pvt {
  * \brief Default channel descriptor
  */
 static struct chan_simpleusb_pvt simpleusb_default = {
-	.sounddev = -1,
 	.duplex = M_FULL,
-	.queuesize = QUEUE_SIZE,
-	.frags = FRAGS,
 	.readpos = 0, /* start here on reads */
 	.wanteeprom = 1,
 	.usedtmf = 1,
@@ -366,7 +384,6 @@ static struct chan_simpleusb_pvt simpleusb_default = {
 
 static int hidhdwconfig(struct chan_simpleusb_pvt *o);
 static void mixer_write(struct chan_simpleusb_pvt *o);
-static int setformat(struct chan_simpleusb_pvt *o, int mode);
 static struct ast_channel *simpleusb_request(const char *type, struct ast_format_cap *cap,
 	const struct ast_assigned_ids *assignedids, const struct ast_channel *requestor, const char *data, int *cause);
 static int simpleusb_digit_begin(struct ast_channel *c, char digit);
@@ -383,12 +400,11 @@ static int simpleusb_setoption(struct ast_channel *chan, int option, void *data,
 static void tune_menusupport(int fd, struct chan_simpleusb_pvt *o, const char *cmd);
 static void tune_write(struct chan_simpleusb_pvt *o);
 static int _send_tx_test_tone(int fd, struct chan_simpleusb_pvt *o, int ms, int intflag);
+static void *simpleusb_audio_thread(void *arg);
 
 static char *simpleusb_active; /* the active device */
 
 static const int ppinshift[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 7, 5, 4, 0, 3 };
-
-static const char tdesc[] = "Simple USB (CM108) Radio Channel Driver";
 
 /*!
  * \brief Asterisk channel technology struct.
@@ -397,7 +413,7 @@ static const char tdesc[] = "Simple USB (CM108) Radio Channel Driver";
  */
 static struct ast_channel_tech simpleusb_tech = {
 	.type = "SimpleUSB",
-	.description = tdesc,
+	.description = "Simple USB (CM108) Radio Channel Driver",
 	.requester = simpleusb_request,
 	.send_digit_begin = simpleusb_digit_begin,
 	.send_digit_end = simpleusb_digit_end,
@@ -411,6 +427,125 @@ static struct ast_channel_tech simpleusb_tech = {
 	.fixup = simpleusb_fixup,
 	.setoption = simpleusb_setoption,
 };
+
+static int open_stream(struct chan_simpleusb_pvt *pvt)
+{
+	PaError res = paInternalError;
+
+	if (!strcasecmp(pvt->hw_device, "default")) {
+		ast_debug(1, "Opening stream with default device\n");
+		res = Pa_OpenDefaultStream(&pvt->stream, INPUT_CHANNELS, OUTPUT_CHANNELS, paInt16, SAMPLE_RATE, NUM_SAMPLES, NULL, NULL);
+	} else {
+		ast_debug(1, "Looking for device %s", pvt->hw_device);
+		PaStreamParameters input_params = {
+			.channelCount = INPUT_CHANNELS,
+			.sampleFormat = paInt16,
+			.suggestedLatency = (1.0 / 50.0), /* 20 ms */
+			.device = paNoDevice,
+		};
+		PaStreamParameters output_params = {
+			.channelCount = OUTPUT_CHANNELS,
+			.sampleFormat = paInt16,
+			.suggestedLatency = (1.0 / 50.0), /* 20 ms */
+			.device = paNoDevice,
+		};
+		PaDeviceIndex idx, num_devices;
+		ast_debug(6, "PortAudio host api count %d\n", Pa_GetHostApiCount());
+		num_devices = Pa_GetDeviceCount();
+		if (num_devices < 0) {
+			ast_debug(1, "No devices found\n");
+			return res;
+		} else {
+			ast_debug(6, "%d Devices found\n", num_devices);
+		}
+
+		for (idx = 0; idx < num_devices && (input_params.device == paNoDevice || output_params.device == paNoDevice); idx++) {
+			const PaDeviceInfo *dev = Pa_GetDeviceInfo(idx);
+			ast_debug(1, "Found device %s\n", dev->name);
+			if (dev->maxInputChannels) {
+				if (strlen(pvt->hw_device) && strstr(dev->name, pvt->hw_device)) {
+					ast_debug(5, "Found input device %s\n", dev->name);
+					input_params.device = idx;
+				}
+			}
+
+			if (dev->maxOutputChannels) {
+				if (strlen(pvt->hw_device) && strstr(dev->name, pvt->hw_device)) {
+					ast_debug(5, "Found output device %s\n", dev->name);
+					output_params.device = idx;
+				}
+			}
+		}
+
+		if (input_params.device == paNoDevice) {
+			ast_log(LOG_ERROR, "No input device found for simpleusb device '%s'\n", pvt->name);
+		}
+
+		if (output_params.device == paNoDevice) {
+			ast_log(LOG_ERROR, "No output device found for simpleusb device '%s'\n", pvt->name);
+		}
+		ast_debug(5, "Opening stream on device %s", pvt->hw_device);
+		res = Pa_OpenStream(&pvt->stream, &input_params, &output_params, SAMPLE_RATE, NUM_SAMPLES, paNoFlag, NULL, NULL);
+		ast_debug(5, "Stream feedback %s\n", Pa_GetErrorText(res));
+	}
+
+	return res;
+}
+
+static int start_stream(struct chan_simpleusb_pvt *pvt)
+{
+	PaError res;
+	int ret_val = 0;
+
+	ast_debug(5, "Starting PA Stream");
+	/* It is possible for simpleusb_hangup to be called before the
+	 * stream is started, if this is the case pvt->owner will be NULL
+	 * and start_stream should be aborted. */
+	if (pvt->streamstate || !pvt->owner)
+		goto return_val;
+
+	res = open_stream(pvt);
+	if (res != paNoError) {
+		ast_log(LOG_WARNING, "Failed to open stream - (%d) %s\n", res, Pa_GetErrorText(res));
+		ret_val = -1;
+		goto return_val;
+	}
+
+	res = Pa_StartStream(pvt->stream);
+	if (res != paNoError) {
+		ast_log(LOG_WARNING, "Failed to start stream - (%d) %s\n", res, Pa_GetErrorText(res));
+		Pa_CloseStream(pvt->stream);
+		pvt->stream = NULL;
+		pvt->streamstate = 0;
+		ret_val = -1;
+		goto return_val;
+	}
+	pvt->streamstate = 1;
+
+return_val:
+	return ret_val;
+}
+
+static int stop_stream(struct chan_simpleusb_pvt *pvt)
+{
+	PaError err;
+
+	if (!pvt->streamstate)
+		return 0;
+
+	/* Wait for pvt->thread to exit cleanly, to avoid killing it while it's holding a lock. */
+	err = Pa_AbortStream(pvt->stream);
+	if (err != paNoError) {
+		ast_log(LOG_WARNING, "Pa_AbortStream failed: %s\n", Pa_GetErrorText(err));
+	}
+	err = Pa_CloseStream(pvt->stream);
+	if (err != paNoError) {
+		ast_log(LOG_WARNING, "Pa_CloseStream failed: %s\n", Pa_GetErrorText(err));
+	}
+	pvt->stream = NULL;
+	pvt->streamstate = 0;
+	return 0;
+}
 
 /*!
  * \brief FIR Low pass filter.
@@ -780,7 +915,7 @@ static void *pulserthread(void *arg)
 		}
 		ast_mutex_unlock(&pp_lock);
 	}
-	pthread_exit(0);
+	return NULL;
 }
 
 /*!
@@ -801,6 +936,7 @@ static int load_tune_config(struct chan_simpleusb_pvt *o, const struct ast_confi
 	o->rxmixerset = 500;
 	o->txmixaset = 500;
 	o->txmixbset = 500;
+	o->hw_device[0] = '\0';
 
 	devstr[0] = '\0';
 	serial[0] = '\0';
@@ -828,6 +964,7 @@ static int load_tune_config(struct chan_simpleusb_pvt *o, const struct ast_confi
 		CV_UINT("txmixbset", o->txmixbset);
 		CV_STR("devstr", devstr);
 		CV_STR("serial", serial);
+		CV_STR("audiodev", o->hw_device); /* use audiodevice as opposed to the usb device path (devstr) */
 		CV_END;
 	}
 	if (!reload) {
@@ -845,76 +982,41 @@ static int load_tune_config(struct chan_simpleusb_pvt *o, const struct ast_confi
 	return 0;
 }
 
-/*!
- * \brief USB sound device GPIO processing thread
- * This thread is responsible for finding and associating the node with the
- * associated usb sound card device.  It performs setup and initialization of
- * the USB device.
- *
- * The CM-XXX USB devices can support up to 8 GPIO pins that can be input or output.
- * It continuously polls the input GPIO pins on the device to see if they have changed.
- * The default GPIOs for COS, and CTCSS provide the basic functionality. An asterisk
- * text frame is raised in the format 'GPIO%d %d' when GPIOs change. Polling generally
- * occurs every HID_POLL_RATE milliseconds.
- *
- * The output PTT (push to talk) GPIO, along with other GPIO outputs are updated as
- * required.
- *
- * If the user has enabled the parallel port for GPIOs, they are polled and updated
- * as appropriate.  An asterisk text frame is raised in the format 'PP%d %d' when
- * GPIOs change. (Parallel port support is not available for all platforms.)
- *
- * This routine also reads and writes to the EPROM attached to the USB device.  The
- * EPROM holds the configuration information (sound level settings) for this device.
- *
- * This routine updates the lasthidtimer during setup and processing.  In the event
- * that this timer update does not occur over a period of 3 seconds, app_rpt will
- * kill the node and restart everything.  This helps to detect problems with a
- * hung USB device.
- *
- * \param argv		chan_simpleusb_pvt structure associated with this thread.
+/*! \brief Find and initialize the audio device.
+ * \param o pointer to private struct
  */
-static void *hidthread(void *arg)
+static int init_audio_device(struct chan_simpleusb_pvt *o)
 {
-	unsigned char buf[4], bufsave[4], keyed, ctcssed, txreq;
-	char *s, lasttxtmp;
-	register int i, j, k;
-	int res;
-	struct usb_device *usb_dev;
-	struct usb_dev_handle *usb_handle;
-	struct chan_simpleusb_pvt *o = arg, *ao;
-	struct timeval then;
-	struct pollfd rfds[1];
+	char serial[sizeof(o->serial)] = { '\0' };
+	char *s;
+	struct chan_simpleusb_pvt *ao;
+	register int i;
 
-	usb_dev = NULL;
-	usb_handle = NULL;
-	/* enable gpio_set so that we will write GPIO information upon start up */
-	o->gpio_set = 1;
+	ast_radio_time(&o->lasthidtime);
+	ast_mutex_lock(&usb_dev_lock);
+	o->hasusb = 0;
+	o->usbass = 0;
+	o->devicenum = 0;
+	o->usb_dev = NULL;
+	o->internal_audio = 0;
 
-#ifdef HAVE_SYS_IO
-	if (haspp == 2) {
-		ioperm(pbase, 2, 1);
-	}
-#endif
-	/* This is the main loop for this thread.
-	 * It performs setup and initialization of the usb device.
-	 * After setup is complete and the device can be accessed,
-	 * it enters a processing loop responsible for interacting
-	 * with the usb hid device
-	 */
-	while (!o->stophid) {
-		char serial[sizeof(o->serial)] = { '\0' };
+	if (o->hw_device[0]) {
+		/* already configured device, extract the device number and usb_dev */
+		if (sscanf(o->hw_device, "hw:%d", &o->devicenum) == 1) {
+			ast_debug(5, "audiodev is defined: %s, Device %d", o->hw_device, o->devicenum);
+			o->usb_dev = ast_radio_usb_device_from_alsa_card(o->devicenum);
+			if (!o->usb_dev) {
+				ast_debug(5, "Unable to find usb device associated with %s", o->hw_device);
+				o->internal_audio = 1;
+			}
 
-		ast_radio_time(&o->lasthidtime);
-		ast_mutex_lock(&usb_dev_lock);
-		o->hasusb = 0;
-		o->usbass = 0;
-		o->devicenum = 0;
-		if (usb_handle) {
-			usb_close(usb_handle);
+		} else {
+			ast_log(LOG_ERROR, "Incorrect audio parameter audiodev (should be hw:0 format), found %s", o->hw_device);
+			ast_mutex_unlock(&usb_dev_lock);
+			return -1;
 		}
-		usb_handle = NULL;
-		usb_dev = NULL;
+	} else {
+		/* use the */
 		ast_radio_hid_device_mklist();
 
 		/* Check to see if our specified device string
@@ -991,7 +1093,7 @@ static void *hidthread(void *arg)
 				break;
 			}
 			if (ast_strlen_zero(o->devstr)) {
-				continue;
+				return -1;
 			}
 		}
 
@@ -1002,20 +1104,20 @@ static void *hidthread(void *arg)
 			 * configured channels.
 			 */
 			s = find_installed_usb_match();
+
 			if (ast_strlen_zero(s)) {
 				if (!o->device_error) {
 					ast_log(LOG_ERROR, "Channel %s: Device string %s was not found.\n", o->name, o->devstr);
 					o->device_error = 1;
 				}
 				ast_mutex_unlock(&usb_dev_lock);
-				usleep(500000);
-				continue;
+				return -1;
 			}
+
 			i = ast_radio_usb_get_usbdev(s);
 			if (i < 0) {
 				ast_mutex_unlock(&usb_dev_lock);
-				usleep(500000);
-				continue;
+				return -1;
 			}
 			/* See if this device is already assigned to another usb channel */
 			for (ao = simpleusb_default.next; ao && ao->name; ao = ao->next) {
@@ -1023,12 +1125,13 @@ static void *hidthread(void *arg)
 					break;
 				}
 			}
+
 			if (ao) {
 				ast_log(LOG_ERROR, "Channel %s: Device string %s is already assigned to channel %s", o->name, s, ao->name);
 				ast_mutex_unlock(&usb_dev_lock);
-				usleep(500000);
-				continue;
+				return -1;
 			}
+
 			ast_log(LOG_NOTICE, "Channel %s: Assigned USB device %s to simpleusb channel\n", o->name, s);
 			ast_copy_string(o->devstr, s, sizeof(o->devstr));
 		}
@@ -1038,41 +1141,108 @@ static void *hidthread(void *arg)
 				break;
 			}
 		}
+
 		if (ao) {
 			ast_log(LOG_ERROR, "Channel %s: Device string %s is already assigned to channel %s", o->name, o->devstr, ao->name);
 			ast_mutex_unlock(&usb_dev_lock);
-			usleep(500000);
-			continue;
+			return -1;
 		}
+
 		/* get the index to the device and assign it to our channel */
 		i = ast_radio_usb_get_usbdev(o->devstr);
 		if (i < 0) {
 			ast_mutex_unlock(&usb_dev_lock);
-			usleep(500000);
-			continue;
+			return -1;
 		}
+		snprintf(o->hw_device, sizeof(o->hw_device), "hw:%d", i);
 		o->devicenum = i;
-		o->device_error = 0;
-		ast_radio_time(&o->lasthidtime);
-		o->usbass = 1;
-		ast_mutex_unlock(&usb_dev_lock);
-		/* set the audio mixer values */
-		o->micmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL);
-		o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL);
-		o->micplaymax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_VOL);
-		if (o->spkrmax == -1) {
-			o->newname = 1;
-			o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW);
+		o->usb_dev = ast_radio_hid_device_init(o->devstr);
+		if (!o->usb_dev) {
+			ast_log(LOG_ERROR, "Unable to find usb device associated with %s", o->devstr);
+			return -1;
 		}
+	}
+
+	o->device_error = 0;
+	ast_radio_time(&o->lasthidtime);
+	o->usbass = 1;
+	ast_mutex_unlock(&usb_dev_lock);
+	/* set the audio mixer values */
+	o->micmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL);
+	o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL);
+	o->micplaymax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_VOL);
+
+	if (o->spkrmax == -1) {
+		o->newname = 1;
+		o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW);
+	}
+
+	return 0;
+}
+
+/*!
+ * \brief USB sound device GPIO processing thread
+ * This thread is responsible for finding and associating the node with the
+ * associated usb sound card device.  It performs setup and initialization of
+ * the USB device.
+ *
+ * The CM-XXX USB devices can support up to 8 GPIO pins that can be input or output.
+ * It continuously polls the input GPIO pins on the device to see if they have changed.
+ * The default GPIOs for COS, and CTCSS provide the basic functionality. An asterisk
+ * text frame is raised in the format 'GPIO%d %d' when GPIOs change. Polling generally
+ * occurs every HID_POLL_RATE milliseconds.
+ *
+ * The output PTT (push to talk) GPIO, along with other GPIO outputs are updated as
+ * required.
+ *
+ * If the user has enabled the parallel port for GPIOs, they are polled and updated
+ * as appropriate.  An asterisk text frame is raised in the format 'PP%d %d' when
+ * GPIOs change. (Parallel port support is not available for all platforms.)
+ *
+ * This routine also reads and writes to the EPROM attached to the USB device.  The
+ * EPROM holds the configuration information (sound level settings) for this device.
+ *
+ * This routine updates the lasthidtimer during setup and processing.  In the event
+ * that this timer update does not occur over a period of 3 seconds, app_rpt will
+ * kill the node and restart everything.  This helps to detect problems with a
+ * hung USB device.
+ *
+ * \param argv		chan_simpleusb_pvt structure associated with this thread.
+ */
+static void *hidthread(void *arg)
+{
+	unsigned char buf[4], bufsave[4], keyed, ctcssed, txreq;
+	char lasttxtmp;
+	register int i, j, k;
+	int res;
+	struct usb_dev_handle *usb_handle = NULL;
+	struct chan_simpleusb_pvt *o = arg;
+	struct timeval then;
+	struct pollfd rfds[1];
+
+	/* enable gpio_set so that we will write GPIO information upon start up */
+	o->gpio_set = 1;
+
+#ifdef HAVE_SYS_IO
+	if (haspp == 2) {
+		ioperm(pbase, 2, 1);
+	}
+#endif
+	/* This is the main loop for this thread.
+	 * It performs setup and initialization of the usb device.
+	 * After setup is complete and the device can be accessed,
+	 * it enters a processing loop responsible for interacting
+	 * with the usb hid device
+	 */
+	while (!o->stophid) {
 		/* initialize the usb device */
-		usb_dev = ast_radio_hid_device_init(o->devstr);
-		if (usb_dev == NULL) {
+		if (o->usb_dev == NULL) {
 			ast_log(LOG_ERROR, "Channel %s: Cannot initialize device %s\n", o->name, o->devstr);
 			usleep(500000);
 			continue;
 		}
 		/* open the usb device device */
-		usb_handle = usb_open(usb_dev);
+		usb_handle = usb_open(o->usb_dev);
 		if (usb_handle == NULL) {
 			ast_log(LOG_ERROR, "Channel %s: Cannot open device %s\n", o->name, o->devstr);
 			usleep(500000);
@@ -1111,12 +1281,12 @@ static void *hidthread(void *arg)
 		}
 		if (pipe(o->pttkick) == -1) {
 			ast_log(LOG_ERROR, "Channel %s: Is not able to create a pipe\n", o->name);
-			pthread_exit(NULL);
+			return NULL;
 		}
-		if ((usb_dev->descriptor.idProduct & 0xfffc) == C108_PRODUCT_ID) {
+		if ((o->usb_dev->descriptor.idProduct & 0xfffc) == C108_PRODUCT_ID) {
 			o->devtype = C108_PRODUCT_ID;
 		} else {
-			o->devtype = usb_dev->descriptor.idProduct;
+			o->devtype = o->usb_dev->descriptor.idProduct;
 		}
 		ast_debug(5, "Channel %s: Starting normally.\n", o->name);
 		ast_debug(5, "Channel %s: Attached to usb device %s.\n", o->name, o->devstr);
@@ -1131,7 +1301,6 @@ static void *hidthread(void *arg)
 		}
 		ast_mutex_unlock(&o->eepromlock);
 
-		setformat(o, O_RDWR);
 		o->hasusb = 1;
 		o->had_gpios_in = 0;
 
@@ -1274,6 +1443,11 @@ static void *hidthread(void *arg)
 						sprintf(buf1, "GPIO%d %d\n", i + 1, (j & (1 << i)) ? 1 : 0);
 						fr.data.ptr = buf1;
 						fr.datalen = strlen(buf1);
+
+						if (!o->owner) {
+							break;
+						}
+
 						ast_queue_frame(o->owner, &fr);
 					}
 				}
@@ -1317,6 +1491,11 @@ static void *hidthread(void *arg)
 							sprintf(buf1, "PP%d %d\n", i, (j & (1 << ppinshift[i])) ? 1 : 0);
 							fr.data.ptr = buf1;
 							fr.datalen = strlen(buf1);
+
+							if (!o->owner) {
+								break;
+							}
+
 							ast_queue_frame(o->owner, &fr);
 						}
 					}
@@ -1436,42 +1615,7 @@ static void *hidthread(void *arg)
 		ast_radio_hid_set_outputs(usb_handle, buf);
 		ast_mutex_unlock(&o->usblock);
 	}
-	pthread_exit(0);
-}
-
-/*!
- * \brief Get the number of blocks used in the audio output channel.
- * \param o		Channel private data.
- * \returns		Number of blocks that have been used.
- */
-static int used_blocks(struct chan_simpleusb_pvt *o)
-{
-	struct audio_buf_info info;
-
-	if (ioctl(o->sounddev, SNDCTL_DSP_GETOSPACE, &info)) {
-		if (!(o->warned & WARN_used_blocks)) {
-			ast_log(LOG_WARNING, "Channel %s: Error reading output space.\n", o->name);
-			o->warned |= WARN_used_blocks;
-		}
-		return 1;
-	}
-
-	/* Set the total blocks */
-	if (o->total_blocks == 0) {
-		ast_debug(1, "Channel %s: fragment total %d, size %d, available %d, bytes %d\n", o->name, info.fragstotal, info.fragsize,
-			info.fragments, info.bytes);
-		o->total_blocks = info.fragments;
-		/* Check the queue size, it cannot exceed the total fragments */
-		if (o->queuesize >= info.fragstotal) {
-			o->queuesize = info.fragstotal - 1;
-			if (o->queuesize < 2) {
-				o->queuesize = QUEUE_SIZE;
-			}
-			ast_debug(1, "Channel %s: Queue size reset to %d\n", o->name, o->queuesize);
-		}
-	}
-
-	return o->total_blocks - info.fragments;
+	return NULL;
 }
 
 /*!
@@ -1484,32 +1628,22 @@ static int used_blocks(struct chan_simpleusb_pvt *o)
  */
 static int soundcard_writeframe(struct chan_simpleusb_pvt *o, short *data)
 {
-	int res;
+	PaError res;
 
-	/* If the sound device is not open, setformat will open the device */
-	if (o->sounddev < 0) {
-		setformat(o, O_RDWR);
-	}
-	if (o->sounddev < 0) {
-		return 0; /* not fatal */
-	}
 	/*
 	 * Nothing complex to manage the audio device queue.
 	 * If the buffer is full just drop the extra, otherwise write.
 	 * In some cases it might be useful to write anyways after
 	 * a number of failures, to restart the output chain.
 	 */
-	res = used_blocks(o);
-	if (res > o->queuesize) { /* no room to write a block */
-		ast_log(LOG_WARNING, "Channel %s: Sound device write buffer overflow - used %d blocks\n", o->name, res);
-		return 0;
-	}
 
-	res = write(o->sounddev, ((void *) data), FRAME_SIZE * 2 * 2 * 6);
-	if (res < 0) {
-		ast_log(LOG_ERROR, "Channel %s: Sound card write error %s\n", o->name, strerror(errno));
-	} else if (res != FRAME_SIZE * 2 * 2 * 6) {
-		ast_log(LOG_ERROR, "Channel %s: Sound card wrote %d bytes of %d\n", o->name, res, (FRAME_SIZE * 2 * 2 * 6));
+	res = Pa_WriteStream(o->stream, data, NUM_SAMPLES);
+	if (res == paOutputUnderflowed) {
+		short null_buf[NUM_SAMPLES * 2] = { 0 };
+		ast_debug(6, "PortAudio write stream underflow, writing a 0 frame");
+		Pa_WriteStream(o->stream, null_buf, NUM_SAMPLES);
+	} else if (res < 0) {
+		ast_debug(1, "PortAudio Error %s", Pa_GetErrorText(res));
 	}
 
 	/* Check Tx audio statistics. FRAME_SIZE define refers to 8Ksps mono which is 160 samples
@@ -1522,114 +1656,6 @@ static int soundcard_writeframe(struct chan_simpleusb_pvt *o, short *data)
 	ast_radio_check_audio(data, &o->txaudiostats, 12 * FRAME_SIZE);
 
 	return res;
-}
-
-/*!
- * \brief Open the sound card device.
- * If the device is already open, this will close the device
- * and open it again.
- * It initializes the device based on our requirements and triggers
- * reads and writes.
- * \param o		chan_usbradio_pvt.
- * \param mode	The mode to open the file.  This is the flags argument to open.
- * \retval 0	Success.
- * \retval -1	Failed.
- */
-static int setformat(struct chan_simpleusb_pvt *o, int mode)
-{
-	int fmt, desired, res, fd;
-	char device[100];
-
-	/* If the device is open, close it */
-	if (o->sounddev >= 0) {
-		ioctl(o->sounddev, SNDCTL_DSP_RESET, 0);
-		close(o->sounddev);
-		o->duplex = M_UNSET;
-		o->sounddev = -1;
-	}
-	if (mode == O_CLOSE) { /* we are done */
-		return 0;
-	}
-
-	strcpy(device, "/dev/dsp");
-	if (o->devicenum) {
-		sprintf(device, "/dev/dsp%d", o->devicenum);
-	}
-	/* open the device */
-	fd = o->sounddev = open(device, mode | O_NONBLOCK);
-	if (fd < 0) {
-		ast_log(LOG_ERROR, "Channel %s: Unable to open DSP device %d: %s.\n", o->name, o->devicenum, strerror(errno));
-		return -1;
-	}
-	if (o->owner) {
-		ast_channel_internal_fd_set(o->owner, 0, fd);
-	}
-
-#if __BYTE_ORDER == __LITTLE_ENDIAN
-	fmt = AFMT_S16_LE;
-#else
-	fmt = AFMT_S16_BE;
-#endif
-	res = ioctl(fd, SNDCTL_DSP_SETFMT, &fmt);
-	if (res < 0) {
-		ast_log(LOG_WARNING, "Channel %s: Unable to set format to 16-bit signed\n", o->name);
-		return -1;
-	}
-	/* set our duplex mode based on the way we opened the device. */
-	switch (mode) {
-	case O_RDWR:
-		res = ioctl(fd, SNDCTL_DSP_SETDUPLEX, 0);
-		/* Check to see if duplex set (FreeBSD Bug) */
-		res = ioctl(fd, SNDCTL_DSP_GETCAPS, &fmt);
-		if (res == 0 && (fmt & DSP_CAP_DUPLEX)) {
-			o->duplex = M_FULL;
-		};
-		break;
-	case O_WRONLY:
-		o->duplex = M_WRITE;
-		break;
-	case O_RDONLY:
-		o->duplex = M_READ;
-		break;
-	}
-
-	fmt = 1;
-	res = ioctl(fd, SNDCTL_DSP_STEREO, &fmt);
-	if (res < 0) {
-		ast_log(LOG_WARNING, "Channel %s: Failed to set audio device to stereo\n", o->name);
-		return -1;
-	}
-	fmt = desired = 48000; /* 48000 Hz desired */
-	res = ioctl(fd, SNDCTL_DSP_SPEED, &fmt);
-	if (res < 0) {
-		ast_log(LOG_WARNING, "Channel %s: Failed to set audio device sample rate.\n", o->name);
-		return -1;
-	}
-	if (fmt != desired) {
-		if (!(o->warned & WARN_speed)) {
-			ast_log(LOG_WARNING, "Channel %s: Requested %d Hz, got %d Hz -- sound may be choppy.\n", o->name, desired, fmt);
-			o->warned |= WARN_speed;
-		}
-	}
-	/*
-	 * on Freebsd, SETFRAGMENT does not work very well on some cards.
-	 * Default to use 256 bytes, let the user override
-	 */
-	if (o->frags) {
-		fmt = o->frags;
-		res = ioctl(fd, SNDCTL_DSP_SETFRAGMENT, &fmt);
-		if (res < 0) {
-			if (!(o->warned & WARN_frag)) {
-				ast_log(LOG_WARNING, "Channel %s: Unable to set fragment size -- sound may be choppy.\n", o->name);
-				o->warned |= WARN_frag;
-			}
-		}
-	}
-	/* on some cards, we need SNDCTL_DSP_SETTRIGGER to start outputting */
-	res = PCM_ENABLE_INPUT | PCM_ENABLE_OUTPUT;
-	res = ioctl(fd, SNDCTL_DSP_SETTRIGGER, &res);
-	/* it may fail if we are in half duplex, never mind */
-	return 0;
 }
 
 /*!
@@ -1912,10 +1938,33 @@ static int simpleusb_text(struct ast_channel *c, const char *text)
 static int simpleusb_call(struct ast_channel *c, const char *dest, int timeout)
 {
 	struct chan_simpleusb_pvt *o = ast_channel_tech_pvt(c);
+	int res;
 
 	o->stophid = 0;
 	ast_radio_time(&o->lasthidtime);
-	ast_pthread_create(&o->hidthread, NULL, hidthread, o);
+	res = init_audio_device(o);
+	if (res < 0) {
+		ast_log(LOG_ERROR, "Channel %s: Failed initialize the audio device\n", o->name);
+		return -1;
+	}
+	if (!o->internal_audio) {
+		res = ast_pthread_create(&o->hidthread, NULL, hidthread, o);
+		if (res) {
+			ast_log(LOG_ERROR, "Channel %s: Failed to create HID thread: %s\n", o->name, strerror(res));
+			return -1;
+		}
+	}
+
+	res = ast_pthread_create(&o->audiothread, NULL, simpleusb_audio_thread, o);
+	if (res) {
+		ast_log(LOG_ERROR, "Channel %s: Failed to create audio thread: %s\n", o->name, strerror(res));
+		o->stophid = 1;
+		if (o->hidthread != AST_PTHREADT_NULL) {
+			pthread_join(o->hidthread, NULL);
+		}
+		return -1;
+	}
+
 	ast_setstate(c, AST_STATE_UP);
 	return 0;
 }
@@ -1943,12 +1992,15 @@ static int simpleusb_hangup(struct ast_channel *c)
 	ast_channel_tech_pvt_set(c, NULL);
 	o->owner = NULL;
 	ast_module_unref(ast_module_info->self);
-	if (o->hookstate) {
-		o->hookstate = 0;
-		setformat(o, O_CLOSE);
-	}
 	o->stophid = 1;
-	pthread_join(o->hidthread, NULL);
+
+	if (o->hidthread != AST_PTHREADT_NULL) {
+		pthread_join(o->hidthread, NULL);
+	}
+
+	pthread_join(o->audiothread, NULL);
+	o->hidthread = AST_PTHREADT_NULL;
+	o->audiothread = AST_PTHREADT_NULL;
 	return 0;
 }
 
@@ -1964,15 +2016,10 @@ static int simpleusb_write(struct ast_channel *c, struct ast_frame *f)
 	struct chan_simpleusb_pvt *o = ast_channel_tech_pvt(c);
 	struct ast_frame *f1;
 
-	if (!o->hasusb) {
+	if (!o->hasusb && !o->internal_audio) {
 		return 0;
 	}
-	if (o->sounddev < 0) {
-		setformat(o, O_RDWR);
-	}
-	if (o->sounddev < 0) {
-		return 0; /* not fatal */
-	}
+
 	/*
 	 * we could receive a block which is not a multiple of our
 	 * FRAME_SIZE, so buffer it locally and write to the device
@@ -2020,32 +2067,357 @@ static int simpleusb_write(struct ast_channel *c, struct ast_frame *f)
  * \param ast			Asterisk channel.
  * \retval 				Asterisk frame.
  */
+
 static struct ast_frame *simpleusb_read(struct ast_channel *c)
 {
-	int res, cd, sd, src, num_frames, ispager, doleft, doright;
+	/* This should never be called... */
+	ast_log(LOG_ERROR, "Read function should not be called!");
+	return &ast_null_frame;
+}
+
+/*!
+ * \brief 				PortAudio processing thread.
+ * \param ast			Asterisk channel.
+ * \retval 				Asterisk frame.
+ */
+static void *simpleusb_audio_thread(void *arg)
+{
+	int cd, sd, src, num_frames, ispager, doleft, doright;
+	PaError res;
 	register int i;
-	struct chan_simpleusb_pvt *o = ast_channel_tech_pvt(c);
+	struct chan_simpleusb_pvt *o = arg;
 	struct ast_frame *f = &o->read_f, *f1;
 	time_t now;
 	register short *sp, *sp1;
-	short outbuf[FRAME_SIZE * 2 * 6];
+	short outbuf[NUM_SAMPLES * 2]; /* 2 bytes per sample on PortAudio config - paInt16 */
 
-	/* check if the hid thread is still processing */
-	if (o->lasthidtime) {
-		ast_radio_time(&now);
-		if ((now - o->lasthidtime) > 3) {
-			ast_log(LOG_ERROR, "Channel %s: HID process has died or is not responding.\n", o->name);
-			return NULL;
-		}
+	ast_debug(5, "Audio thread is starting");
+	if (start_stream(o) < 0) {
+		ast_log(LOG_ERROR, "Channel %s: Failed to start audio stream\n", o->name);
+		return NULL;
 	}
-	/* Set frame defaults */
-	memset(f, 0, sizeof(struct ast_frame));
-	f->frametype = AST_FRAME_NULL;
-	f->src = __PRETTY_FUNCTION__;
+	while (!o->stophid) {
+		/* check if the hid thread is still processing */
+		if (o->lasthidtime && !o->internal_audio) {
+			ast_radio_time(&now);
+			if ((now - o->lasthidtime) > 3) {
+				ast_log(LOG_ERROR, "Channel %s: HID process has died or is not responding.\n", o->name);
+				break;
+			}
+		}
+		/* Set frame defaults */
+		memset(f, 0, sizeof(struct ast_frame));
+		f->frametype = AST_FRAME_NULL;
+		f->src = __PRETTY_FUNCTION__;
+		/* if USB device not ready, just return NULL frame */
+		if (!o->hasusb && !o->internal_audio) {
+			if (o->rxkeyed) {
+				struct ast_frame wf = {
+					.frametype = AST_FRAME_CONTROL,
+					.subclass.integer = AST_CONTROL_RADIO_UNKEY,
+					.src = __PRETTY_FUNCTION__,
+				};
 
-	/* if USB device not ready, just return NULL frame */
-	if (!o->hasusb) {
-		if (o->rxkeyed) {
+				o->lastrx = 0;
+				o->rxkeyed = 0;
+
+				if (!o->owner) {
+					break;
+				}
+
+				ast_queue_frame(o->owner, &wf);
+			}
+			continue;
+		}
+
+		/* If we have stopped echoing, clear the echo queue */
+		if (!o->echomode) {
+			struct qelem *q;
+
+			ast_mutex_lock(&o->echolock);
+			o->echoing = 0;
+			while (o->echoq.q_forw != &o->echoq) {
+				q = o->echoq.q_forw;
+				remque(q);
+				ast_free(q);
+			}
+			ast_mutex_unlock(&o->echolock);
+		}
+
+		/* If we are in echomode and we have stopped receiving audio
+		 * queue up the packets we have stored in the echo queue
+		 * for playback.
+		 */
+		if (o->echomode && (!o->rxkeyed)) {
+			struct usbecho *u;
+
+			ast_mutex_lock(&o->echolock);
+			/* if there is something in the queue */
+			if (o->echoq.q_forw != &o->echoq) {
+				u = (struct usbecho *) o->echoq.q_forw;
+				remque((struct qelem *) u);
+				f->frametype = AST_FRAME_VOICE;
+				f->subclass.format = ast_format_slin;
+				f->samples = FRAME_SIZE;
+				f->datalen = FRAME_SIZE * 2;
+				f->offset = AST_FRIENDLY_OFFSET;
+				f->data.ptr = o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET;
+				memcpy(f->data.ptr, u->data, FRAME_SIZE * 2);
+				ast_free(u);
+				f1 = ast_frdup(f);
+				if (!f1) {
+					ast_mutex_unlock(&o->echolock);
+					continue;
+				}
+				memset(&f1->frame_list, 0, sizeof(f1->frame_list));
+				ast_mutex_lock(&o->txqlock);
+				AST_LIST_INSERT_TAIL(&o->txq, f1, frame_list);
+				ast_mutex_unlock(&o->txqlock);
+				o->echoing = 1;
+			} else {
+				o->echoing = 0;
+			}
+			ast_mutex_unlock(&o->echolock);
+		}
+
+		/* Process the transmit queue */
+		for (;;) {
+			num_frames = 0;
+			ast_mutex_lock(&o->txqlock);
+			AST_LIST_TRAVERSE(&o->txq, f1, frame_list) {
+				num_frames++;
+			}
+			ast_mutex_unlock(&o->txqlock);
+			if (o->txkeyed) {
+				ast_debug(7, "blocks used %d, Dest Buffer %d", num_frames, o->simpleusb_write_dst);
+			}
+			if (num_frames && (num_frames > 3 || (!o->txkeyed && !o->txtestkey))) {
+				ast_mutex_lock(&o->txqlock);
+				f1 = AST_LIST_REMOVE_HEAD(&o->txq, frame_list);
+				ast_mutex_unlock(&o->txqlock);
+
+				src = 0; /* read position into f1->data */
+				while (src < f1->datalen) {
+					/* Compute spare room in the buffer */
+					int l = sizeof(o->simpleusb_write_buf) - o->simpleusb_write_dst;
+
+					if (f1->datalen - src >= l) {
+						/* enough to fill a frame */
+						memcpy(o->simpleusb_write_buf + o->simpleusb_write_dst, (char *) f1->data.ptr + src, l);
+						/* Below is an attempt to match levels to the original CM108 IC which has
+						 * been out of production for over 10 years. Scaling audio to 109.375% will
+						 * result in clipping! Any adjustments for CM1xxx gain differences should be
+						 * made in the mixer settings, not in the audio stream.
+						 * TODO: After the vast majority of existing installs have had a chance to review their
+						 * audio settings and these old scaling/clipping hacks are no longer in significant use
+						 * the legacyaudioscaling cfg and related code should be deleted.
+						 */
+						/* Adjust the audio level for CM119 A/B devices */
+						if (o->legacyaudioscaling && o->devtype != C108_PRODUCT_ID) {
+							register int v;
+
+							sp = (short *) o->simpleusb_write_buf;
+							for (i = 0; i < FRAME_SIZE; i++) {
+								v = *sp;
+								v += v >> 3;   /* add *.125 giving * 1.125 */
+								v -= *sp >> 5; /* subtract *.03125 giving * 1.09375 */
+								if (v > 32765.0) {
+									v = 32765.0;
+								} else if (v < -32765.0) {
+									v = -32765.0;
+								}
+								*sp++ = v;
+							}
+						}
+
+						sp = (short *) o->simpleusb_write_buf;
+						sp1 = outbuf;
+						doright = 1;
+						doleft = 1;
+						ispager = 0;
+						if (f1->src && (!strcmp(f1->src, PAGER_SRC))) {
+							ispager = 1;
+						}
+						/* If pager audio, determine which channel to store audio */
+						if (o->pager != PAGER_NONE) {
+							doleft = (o->pager == PAGER_A) ? ispager : !ispager;
+							doright = (o->pager == PAGER_B) ? ispager : !ispager;
+						}
+						/* Upsample from 8000 mono to 48000 stereo */
+						for (i = 0; i < FRAME_SIZE; i++) {
+							register short s, v;
+
+							if (o->preemphasis) {
+								s = preemph(sp[i], &o->prestate);
+							} else {
+								s = sp[i];
+							}
+							v = lpass(s, o->flpt);
+							*sp1++ = (doleft) ? v : 0;
+							*sp1++ = (doright) ? v : 0;
+							v = lpass(s, o->flpt);
+							*sp1++ = (doleft) ? v : 0;
+							*sp1++ = (doright) ? v : 0;
+							v = lpass(s, o->flpt);
+							*sp1++ = (doleft) ? v : 0;
+							*sp1++ = (doright) ? v : 0;
+							v = lpass(s, o->flpt);
+							*sp1++ = (doleft) ? v : 0;
+							*sp1++ = (doright) ? v : 0;
+							v = lpass(s, o->flpt);
+							*sp1++ = (doleft) ? v : 0;
+							*sp1++ = (doright) ? v : 0;
+							v = lpass(s, o->flpt);
+							*sp1++ = (doleft) ? v : 0;
+							*sp1++ = (doright) ? v : 0;
+						}
+						soundcard_writeframe(o, outbuf);
+						src += l;
+						o->simpleusb_write_dst = 0;
+						if (o->waspager && (!ispager)) {
+							struct ast_frame wf = {
+								.frametype = AST_FRAME_TEXT,
+								.data.ptr = ENDPAGE_STR,
+								.datalen = strlen(ENDPAGE_STR) + 1,
+								.src = __PRETTY_FUNCTION__,
+							};
+
+							if (!o->owner) {
+								break;
+							}
+
+							ast_queue_frame(o->owner, &wf);
+							continue;
+						}
+						o->waspager = ispager;
+					} else {
+						/* copy residue */
+						l = f1->datalen - src;
+						memcpy(o->simpleusb_write_buf + o->simpleusb_write_dst, (char *) f1->data.ptr + src, l);
+						src += l; /* but really, we are done */
+						o->simpleusb_write_dst += l;
+					}
+				}
+				ast_frfree(f1);
+				continue;
+			}
+			break;
+		}
+
+		/* Read audio data from the USB sound device.
+		 * Sound data will arrive at 48000 samples per second
+		 * in mono format.
+		 */
+		res = Pa_ReadStream(o->stream, o->simpleusb_read_buf + o->readpos, NUM_SAMPLES);
+		if (res != paNoError) {
+			/* audio data not ready */
+			if (res == paInputOverflowed) {
+				ast_debug(6, "PortAudio read overflow on channel %s\n", o->name);
+				continue;
+			}
+			ast_debug(4, "PortAudio read error on channel %s: %s\n", o->name, Pa_GetErrorText(res));
+			continue;
+		}
+
+#if DEBUG_CAPTURES == 1
+		if (o->rxcapraw && frxcapraw) {
+			fwrite(o->simpleusb_read_buf + o->readpos, sizeof(short), FRAME_SIZE * 6, frxcapraw);
+		}
+#endif
+
+		o->readpos += FRAME_SIZE * 6 * 2;
+		if (o->readpos < sizeof(o->simpleusb_read_buf)) { /* not enough samples */
+			continue;
+		}
+
+		/* If we have been sending pager audio, see if
+		 * we are finished.
+		 */
+		if (o->waspager) {
+			num_frames = 0;
+			ast_mutex_lock(&o->txqlock);
+			AST_LIST_TRAVERSE(&o->txq, f1, frame_list) {
+				num_frames++;
+			}
+			ast_mutex_unlock(&o->txqlock);
+			if (num_frames < 1) {
+				struct ast_frame wf = {
+					.frametype = AST_FRAME_TEXT,
+					.data.ptr = ENDPAGE_STR,
+					.datalen = sizeof(ENDPAGE_STR),
+					.src = __PRETTY_FUNCTION__,
+				};
+
+				if (!o->owner) {
+					break;
+				}
+
+				ast_queue_frame(o->owner, &wf);
+				o->waspager = 0;
+			}
+		}
+
+		/* Check for carrier detect - COR active */
+		cd = 1;
+		if ((o->rxcdtype == CD_HID) && (!o->rxhidsq)) {
+			cd = 0;
+		} else if ((o->rxcdtype == CD_HID_INVERT) && o->rxhidsq) {
+			cd = 0;
+		} else if ((o->rxcdtype == CD_PP) && (!o->rxppsq)) {
+			cd = 0;
+		} else if ((o->rxcdtype == CD_PP_INVERT) && o->rxppsq) {
+			cd = 0;
+		}
+
+		/* Apply cd turn-on delay, if one specified */
+		if (o->rxondelay && cd && (o->rxoncnt++ < o->rxondelay)) {
+			cd = 0;
+		} else if (!cd) {
+			o->rxoncnt = 0;
+		}
+		o->rx_cos_active = cd;
+
+		/* Check for SD - CTCSS active */
+		sd = 1;
+		if ((o->rxsdtype == SD_HID) && (!o->rxhidctcss)) {
+			sd = 0;
+		} else if ((o->rxsdtype == SD_HID_INVERT) && o->rxhidctcss) {
+			sd = 0;
+		} else if ((o->rxsdtype == SD_PP) && (!o->rxppctcss)) {
+			sd = 0;
+		} else if ((o->rxsdtype == SD_PP_INVERT) && o->rxppctcss) {
+			sd = 0;
+		}
+
+		/* See if we are overriding CTCSS to active */
+		if (o->rxctcssoverride) {
+			sd = 1;
+		}
+		o->rx_ctcss_active = sd;
+
+		/* Special case where cd and sd have been configured for no */
+		if (o->rxcdtype == CD_IGNORE && o->rxsdtype == SD_IGNORE) {
+			cd = 0;
+			sd = 0;
+		}
+
+		/* Timer for how long TX has been unkeyed - used with txoffdelay */
+		if (o->txoffdelay) {
+			if (o->txkeyed == 1) {
+				o->txoffcnt = 0; /* If keyed, set this to zero. */
+			} else {
+				o->txoffcnt++;
+				if (o->txoffcnt > MS_TO_FRAMES(TX_OFF_DELAY_MAX)) {
+					o->txoffcnt = MS_TO_FRAMES(TX_OFF_DELAY_MAX); /* limit count */
+				}
+			}
+		}
+
+		/* Check conditions and set receiver active */
+		o->rxkeyed = sd && cd && ((!o->lasttx) || o->duplex) && (o->txoffcnt >= o->txoffdelay);
+
+		/* Send a message to indicate rx signal detect conditions */
+		if (o->lastrx && (!o->rxkeyed)) {
 			struct ast_frame wf = {
 				.frametype = AST_FRAME_CONTROL,
 				.subclass.integer = AST_CONTROL_RADIO_UNKEY,
@@ -2053,505 +2425,214 @@ static struct ast_frame *simpleusb_read(struct ast_channel *c)
 			};
 
 			o->lastrx = 0;
-			o->rxkeyed = 0;
+
+			if (!o->owner) {
+				break;
+			}
+
 			ast_queue_frame(o->owner, &wf);
-		}
-		return &ast_null_frame;
-	}
-
-	/* If we have stopped echoing, clear the echo queue */
-	if (!o->echomode) {
-		struct qelem *q;
-
-		ast_mutex_lock(&o->echolock);
-		o->echoing = 0;
-		while (o->echoq.q_forw != &o->echoq) {
-			q = o->echoq.q_forw;
-			remque(q);
-			ast_free(q);
-		}
-		ast_mutex_unlock(&o->echolock);
-	}
-
-	/* If we are in echomode and we have stopped receiving audio
-	 * queue up the packets we have stored in the echo queue
-	 * for playback.
-	 */
-	if (o->echomode && (!o->rxkeyed)) {
-		struct usbecho *u;
-
-		ast_mutex_lock(&o->echolock);
-		/* if there is something in the queue */
-		if (o->echoq.q_forw != &o->echoq) {
-			u = (struct usbecho *) o->echoq.q_forw;
-			remque((struct qelem *) u);
-			f->frametype = AST_FRAME_VOICE;
-			f->subclass.format = ast_format_slin;
-			f->samples = FRAME_SIZE;
-			f->datalen = FRAME_SIZE * 2;
-			f->offset = AST_FRIENDLY_OFFSET;
-			f->data.ptr = o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET;
-			memcpy(f->data.ptr, u->data, FRAME_SIZE * 2);
-			ast_free(u);
-			f1 = ast_frdup(f);
-			if (!f1) {
-				ast_mutex_unlock(&o->echolock);
-				return &ast_null_frame;
+			if (o->duplex3) {
+				ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_SW, 0, 0);
 			}
-			memset(&f1->frame_list, 0, sizeof(f1->frame_list));
-			ast_mutex_lock(&o->txqlock);
-			AST_LIST_INSERT_TAIL(&o->txq, f1, frame_list);
-			ast_mutex_unlock(&o->txqlock);
-			o->echoing = 1;
-		} else {
-			o->echoing = 0;
-		}
-		ast_mutex_unlock(&o->echolock);
-	}
-
-	/* Process the transmit queue */
-	for (;;) {
-		num_frames = 0;
-		ast_mutex_lock(&o->txqlock);
-		AST_LIST_TRAVERSE(&o->txq, f1, frame_list) {
-			num_frames++;
-		}
-		ast_mutex_unlock(&o->txqlock);
-		i = used_blocks(o);
-		if (o->txkeyed) {
-			ast_debug(7, "blocks used %d, Dest Buffer %d", i, o->simpleusb_write_dst);
-		}
-		if (num_frames && (num_frames > 3 || (!o->txkeyed && !o->txtestkey)) && i <= o->queuesize) {
-			if (i == 0) { /* We are not keeping the buffer full, add 1 frame */
-				memset(outbuf, 0, sizeof(outbuf));
-				soundcard_writeframe(o, outbuf);
-				ast_debug(7, "A null frame has been added");
-			}
-			ast_mutex_lock(&o->txqlock);
-			f1 = AST_LIST_REMOVE_HEAD(&o->txq, frame_list);
-			ast_mutex_unlock(&o->txqlock);
-
-			src = 0; /* read position into f1->data */
-			while (src < f1->datalen) {
-				/* Compute spare room in the buffer */
-				int l = sizeof(o->simpleusb_write_buf) - o->simpleusb_write_dst;
-
-				if (f1->datalen - src >= l) {
-					/* enough to fill a frame */
-					memcpy(o->simpleusb_write_buf + o->simpleusb_write_dst, (char *) f1->data.ptr + src, l);
-					/* Below is an attempt to match levels to the original CM108 IC which has
-					 * been out of production for over 10 years. Scaling audio to 109.375% will
-					 * result in clipping! Any adjustments for CM1xxx gain differences should be
-					 * made in the mixer settings, not in the audio stream.
-					 * TODO: After the vast majority of existing installs have had a chance to review their
-					 * audio settings and these old scaling/clipping hacks are no longer in significant use
-					 * the legacyaudioscaling cfg and related code should be deleted.
-					 */
-					/* Adjust the audio level for CM119 A/B devices */
-					if (o->legacyaudioscaling && o->devtype != C108_PRODUCT_ID) {
-						register int v;
-
-						sp = (short *) o->simpleusb_write_buf;
-						for (i = 0; i < FRAME_SIZE; i++) {
-							v = *sp;
-							v += v >> 3;   /* add *.125 giving * 1.125 */
-							v -= *sp >> 5; /* subtract *.03125 giving * 1.09375 */
-							if (v > 32765.0) {
-								v = 32765.0;
-							} else if (v < -32765.0) {
-								v = -32765.0;
-							}
-							*sp++ = v;
-						}
-					}
-
-					sp = (short *) o->simpleusb_write_buf;
-					sp1 = outbuf;
-					doright = 1;
-					doleft = 1;
-					ispager = 0;
-					if (f1->src && (!strcmp(f1->src, PAGER_SRC))) {
-						ispager = 1;
-					}
-					/* If pager audio, determine which channel to store audio */
-					if (o->pager != PAGER_NONE) {
-						doleft = (o->pager == PAGER_A) ? ispager : !ispager;
-						doright = (o->pager == PAGER_B) ? ispager : !ispager;
-					}
-					/* Upsample from 8000 mono to 48000 stereo */
-					for (i = 0; i < FRAME_SIZE; i++) {
-						register short s, v;
-
-						if (o->preemphasis) {
-							s = preemph(sp[i], &o->prestate);
-						} else {
-							s = sp[i];
-						}
-						v = lpass(s, o->flpt);
-						*sp1++ = (doleft) ? v : 0;
-						*sp1++ = (doright) ? v : 0;
-						v = lpass(s, o->flpt);
-						*sp1++ = (doleft) ? v : 0;
-						*sp1++ = (doright) ? v : 0;
-						v = lpass(s, o->flpt);
-						*sp1++ = (doleft) ? v : 0;
-						*sp1++ = (doright) ? v : 0;
-						v = lpass(s, o->flpt);
-						*sp1++ = (doleft) ? v : 0;
-						*sp1++ = (doright) ? v : 0;
-						v = lpass(s, o->flpt);
-						*sp1++ = (doleft) ? v : 0;
-						*sp1++ = (doright) ? v : 0;
-						v = lpass(s, o->flpt);
-						*sp1++ = (doleft) ? v : 0;
-						*sp1++ = (doright) ? v : 0;
-					}
-					soundcard_writeframe(o, outbuf);
-					src += l;
-					o->simpleusb_write_dst = 0;
-					if (o->waspager && (!ispager)) {
-						struct ast_frame wf = {
-							.frametype = AST_FRAME_TEXT,
-							.data.ptr = ENDPAGE_STR,
-							.datalen = strlen(ENDPAGE_STR) + 1,
-							.src = __PRETTY_FUNCTION__,
-						};
-
-						ast_queue_frame(o->owner, &wf);
-					}
-					o->waspager = ispager;
-				} else {
-					/* copy residue */
-					l = f1->datalen - src;
-					memcpy(o->simpleusb_write_buf + o->simpleusb_write_dst, (char *) f1->data.ptr + src, l);
-					src += l; /* but really, we are done */
-					o->simpleusb_write_dst += l;
-				}
-			}
-			ast_frfree(f1);
-			continue;
-		}
-		break;
-	}
-
-	/* Read audio data from the USB sound device.
-	 * Sound data will arrive at 48000 samples per second
-	 * in stereo format.
-	 */
-	res = read(o->sounddev, o->simpleusb_read_buf + o->readpos, sizeof(o->simpleusb_read_buf) - o->readpos);
-	if (res < 0) {
-		/* audio data not ready */
-		if (errno != EAGAIN) {
-			o->readerrs = 0;
-			o->hasusb = 0;
-			return &ast_null_frame;
-		}
-		if (o->readerrs++ > READERR_THRESHOLD) {
-			ast_log(LOG_ERROR, "Stuck USB read channel [%s], un-sticking it!\n", o->name);
-			o->readerrs = 0;
-			o->hasusb = 0;
-			return &ast_null_frame;
-		}
-		if (o->readerrs == 1) {
-			ast_log(LOG_WARNING, "Possibly stuck USB read channel. [%s]\n", o->name);
-		}
-		return &ast_null_frame;
-	}
-
-#if DEBUG_CAPTURES == 1
-	if (o->rxcapraw && frxcapraw) {
-		fwrite(o->simpleusb_read_buf + o->readpos, 1, res, frxcapraw);
-	}
-#endif
-
-	if (o->readerrs) {
-		ast_log(LOG_WARNING, "USB read channel [%s] was not stuck.\n", o->name);
-	}
-
-	o->readerrs = 0;
-	o->readpos += res;
-	if (o->readpos < sizeof(o->simpleusb_read_buf)) { /* not enough samples */
-		return &ast_null_frame;
-	}
-
-	/* If we have been sending pager audio, see if
-	 * we are finished.
-	 */
-	if (o->waspager) {
-		num_frames = 0;
-		ast_mutex_lock(&o->txqlock);
-		AST_LIST_TRAVERSE(&o->txq, f1, frame_list) {
-			num_frames++;
-		}
-		ast_mutex_unlock(&o->txqlock);
-		if (num_frames < 1) {
+		} else if ((!o->lastrx) && (o->rxkeyed)) {
 			struct ast_frame wf = {
-				.frametype = AST_FRAME_TEXT,
-				.data.ptr = ENDPAGE_STR,
-				.datalen = sizeof(ENDPAGE_STR),
+				.frametype = AST_FRAME_CONTROL,
+				.subclass.integer = AST_CONTROL_RADIO_KEY,
 				.src = __PRETTY_FUNCTION__,
 			};
 
+			o->lastrx = 1;
+
+			if (!o->owner) {
+				break;
+			}
+
 			ast_queue_frame(o->owner, &wf);
-			o->waspager = 0;
-		}
-	}
-
-	/* Check for carrier detect - COR active */
-	cd = 1;
-	if ((o->rxcdtype == CD_HID) && (!o->rxhidsq)) {
-		cd = 0;
-	} else if ((o->rxcdtype == CD_HID_INVERT) && o->rxhidsq) {
-		cd = 0;
-	} else if ((o->rxcdtype == CD_PP) && (!o->rxppsq)) {
-		cd = 0;
-	} else if ((o->rxcdtype == CD_PP_INVERT) && o->rxppsq) {
-		cd = 0;
-	}
-
-	/* Apply cd turn-on delay, if one specified */
-	if (o->rxondelay && cd && (o->rxoncnt++ < o->rxondelay)) {
-		cd = 0;
-	} else if (!cd) {
-		o->rxoncnt = 0;
-	}
-	o->rx_cos_active = cd;
-
-	/* Check for SD - CTCSS active */
-	sd = 1;
-	if ((o->rxsdtype == SD_HID) && (!o->rxhidctcss)) {
-		sd = 0;
-	} else if ((o->rxsdtype == SD_HID_INVERT) && o->rxhidctcss) {
-		sd = 0;
-	} else if ((o->rxsdtype == SD_PP) && (!o->rxppctcss)) {
-		sd = 0;
-	} else if ((o->rxsdtype == SD_PP_INVERT) && o->rxppctcss) {
-		sd = 0;
-	}
-
-	/* See if we are overriding CTCSS to active */
-	if (o->rxctcssoverride) {
-		sd = 1;
-	}
-	o->rx_ctcss_active = sd;
-
-	/* Special case where cd and sd have been configured for no */
-	if (o->rxcdtype == CD_IGNORE && o->rxsdtype == SD_IGNORE) {
-		cd = 0;
-		sd = 0;
-	}
-
-	/* Timer for how long TX has been unkeyed - used with txoffdelay */
-	if (o->txoffdelay) {
-		if (o->txkeyed == 1) {
-			o->txoffcnt = 0; /* If keyed, set this to zero. */
-		} else {
-			o->txoffcnt++;
-			if (o->txoffcnt > MS_TO_FRAMES(TX_OFF_DELAY_MAX)) {
-				o->txoffcnt = MS_TO_FRAMES(TX_OFF_DELAY_MAX); /* limit count */
+			if (o->duplex3) {
+				ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_SW, 1, 0);
 			}
 		}
-	}
 
-	/* Check conditions and set receiver active */
-	o->rxkeyed = sd && cd && ((!o->lasttx) || o->duplex) && (o->txoffcnt >= o->txoffdelay);
-
-	/* Send a message to indicate rx signal detect conditions */
-	if (o->lastrx && (!o->rxkeyed)) {
-		struct ast_frame wf = {
-			.frametype = AST_FRAME_CONTROL,
-			.subclass.integer = AST_CONTROL_RADIO_UNKEY,
-			.src = __PRETTY_FUNCTION__,
-		};
-
-		o->lastrx = 0;
-		ast_queue_frame(o->owner, &wf);
-		if (o->duplex3) {
-			ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_SW, 0, 0);
-		}
-	} else if ((!o->lastrx) && (o->rxkeyed)) {
-		struct ast_frame wf = {
-			.frametype = AST_FRAME_CONTROL,
-			.subclass.integer = AST_CONTROL_RADIO_KEY,
-			.src = __PRETTY_FUNCTION__,
-		};
-
-		o->lastrx = 1;
-		ast_queue_frame(o->owner, &wf);
-		if (o->duplex3) {
-			ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_SW, 1, 0);
-		}
-	}
-
-	/* Check for ADC clipping and input audio statistics before any filtering is done.
-	 * FRAME_SIZE define refers to 8Ksps mono which is 160 samples per 20mS USB frame.
-	 * ast_radio_check_audio() takes the read buffer as received (48K stereo),
-	 * extracts the mono 48K channel, checks amplitude and distortion characteristics,
-	 * and returns true if clipping was detected.
-	 */
-	if (ast_radio_check_audio((short *) o->simpleusb_read_buf, &o->rxaudiostats, 12 * FRAME_SIZE)) {
-		if (o->clipledgpio) {
-			/* Set Clip LED GPIO pulsetimer if not already set */
-			if (!o->hid_gpio_pulsetimer[o->clipledgpio - 1]) {
-				o->hid_gpio_pulsetimer[o->clipledgpio - 1] = CLIP_LED_HOLD_TIME_MS;
+		/* Check for ADC clipping and input audio statistics before any filtering is done.
+		 * FRAME_SIZE define refers to 8Ksps mono which is 160 samples per 20mS USB frame.
+		 * ast_radio_check_audio() takes the read buffer as received (48K stereo),
+		 * extracts the mono 48K channel, checks amplitude and distortion characteristics,
+		 * and returns true if clipping was detected.
+		 */
+		if (ast_radio_check_audio((short *) o->simpleusb_read_buf, &o->rxaudiostats, 12 * FRAME_SIZE)) {
+			if (o->clipledgpio) {
+				/* Set Clip LED GPIO pulsetimer if not already set */
+				if (!o->hid_gpio_pulsetimer[o->clipledgpio - 1]) {
+					o->hid_gpio_pulsetimer[o->clipledgpio - 1] = CLIP_LED_HOLD_TIME_MS;
+				}
 			}
 		}
-	}
 
-	/* Downsample received audio from 48000 stereo to 8000 mono */
-	sp = (short *) o->simpleusb_read_buf;
-	sp1 = (short *) (o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET);
-	for (i = 0; i < FRAME_SIZE; i++) {
-		(void) lpass(*sp++, o->flpr);
-		sp++;
-		(void) lpass(*sp++, o->flpr);
-		sp++;
-		(void) lpass(*sp++, o->flpr);
-		sp++;
-		(void) lpass(*sp++, o->flpr);
-		sp++;
-		(void) lpass(*sp++, o->flpr);
-		sp++;
-		if (o->plfilter && o->deemphasis) {
-			*sp1++ = hpass6(deemph(lpass(*sp++, o->flpr), &o->destate), o->hpx, o->hpy);
-		} else if (o->deemphasis) {
-			*sp1++ = deemph(lpass(*sp++, o->flpr), &o->destate);
-		} else if (o->plfilter) {
-			*sp1++ = hpass(lpass(*sp++, o->flpr), o->hpx, o->hpy);
-		} else {
-			*sp1++ = lpass(*sp++, o->flpr);
-		}
-		sp++;
-	}
-
-	/* If we are in echomode and receiving audio, store
-	 * it in the echo queue for later playback.
-	 */
-	if (o->echomode && o->rxkeyed && (!o->echoing)) {
-		register int x;
-		struct usbecho *u;
-
-		ast_mutex_lock(&o->echolock);
-		x = 0;
-		/* get count of frames */
-		for (u = (struct usbecho *) o->echoq.q_forw; u != (struct usbecho *) &o->echoq; u = (struct usbecho *) u->q_forw) {
-			x++;
-		}
-
-		if (x < o->echomax) {
-			u = ast_calloc(1, sizeof(struct usbecho));
-			if (u) {
-				memcpy(u->data, (o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET), FRAME_SIZE * 2);
-				insque((struct qelem *) u, o->echoq.q_back);
+		/* Downsample received audio from 48000 mono to 8000 mono */
+		sp = (short *) o->simpleusb_read_buf;
+		sp1 = (short *) (o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET);
+		for (i = 0; i < FRAME_SIZE; i++) {
+			(void) lpass(*sp++, o->flpr);
+			(void) lpass(*sp++, o->flpr);
+			(void) lpass(*sp++, o->flpr);
+			(void) lpass(*sp++, o->flpr);
+			(void) lpass(*sp++, o->flpr);
+			if (o->plfilter && o->deemphasis) {
+				*sp1++ = hpass6(deemph(lpass(*sp++, o->flpr), &o->destate), o->hpx, o->hpy);
+			} else if (o->deemphasis) {
+				*sp1++ = deemph(lpass(*sp++, o->flpr), &o->destate);
+			} else if (o->plfilter) {
+				*sp1++ = hpass(lpass(*sp++, o->flpr), o->hpx, o->hpy);
+			} else {
+				*sp1++ = lpass(*sp++, o->flpr);
 			}
 		}
-		ast_mutex_unlock(&o->echolock);
-	}
+
+		/* If we are in echomode and receiving audio, store
+		 * it in the echo queue for later playback.
+		 */
+		if (o->echomode && o->rxkeyed && (!o->echoing)) {
+			register int x;
+			struct usbecho *u;
+
+			ast_mutex_lock(&o->echolock);
+			x = 0;
+			/* get count of frames */
+			for (u = (struct usbecho *) o->echoq.q_forw; u != (struct usbecho *) &o->echoq; u = (struct usbecho *) u->q_forw) {
+				x++;
+			}
+
+			if (x < o->echomax) {
+				u = ast_calloc(1, sizeof(struct usbecho));
+				if (u) {
+					memcpy(u->data, (o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET), FRAME_SIZE * 2);
+					insque((struct qelem *) u, o->echoq.q_back);
+				}
+			}
+			ast_mutex_unlock(&o->echolock);
+		}
 
 #if DEBUG_CAPTURES == 1
-	if (o->rxcapraw && frxcapcooked) {
-		fwrite(o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET, sizeof(short), FRAME_SIZE, frxcapcooked);
-	}
+		if (o->rxcapraw && frxcapcooked) {
+			fwrite(o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET, sizeof(short), FRAME_SIZE, frxcapcooked);
+		}
 #endif
 
-	/* reset read pointer for next frame */
-	o->readpos = 0;
-	/* Do not return the frame if the channel is not up */
-	if (ast_channel_state(c) != AST_STATE_UP) {
-		return &ast_null_frame;
-	}
-	/* ok we can build and deliver the frame to the caller */
-	f->frametype = AST_FRAME_VOICE;
-	f->subclass.format = ast_format_slin;
-	f->offset = AST_FRIENDLY_OFFSET;
-	f->samples = FRAME_SIZE;
-	f->datalen = FRAME_SIZE * 2;
-	f->data.ptr = o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET;
-	if (!o->rxkeyed) {
-		memset(f->data.ptr, 0, f->datalen);
-	}
-	/* Process the audio to see if contains DTMF */
-	if (o->usedtmf && o->dsp) {
-		f1 = ast_dsp_process(c, o->dsp, f);
-		if ((f1->frametype == AST_FRAME_DTMF_END) || (f1->frametype == AST_FRAME_DTMF_BEGIN)) {
-			if ((f1->subclass.integer == 'm') || (f1->subclass.integer == 'u')) {
-				f1->frametype = AST_FRAME_NULL;
-				f1->subclass.integer = 0;
-				return f1;
-			}
-			if (f1->frametype == AST_FRAME_DTMF_END) {
-				f1->len = ast_tvdiff_ms(ast_radio_tvnow(), o->tonetime);
-				if (option_verbose) {
-					ast_log(LOG_NOTICE, "Channel %s: Got DTMF char %c duration %ld ms\n", o->name, f1->subclass.integer, f1->len);
+		/* reset read pointer for next frame */
+		o->readpos = 0;
+		/* Do not return the frame if the channel is not up */
+		if (ast_channel_state(o->owner) != AST_STATE_UP) {
+			continue;
+		}
+		/* ok we can build and deliver the frame to the caller */
+		f->frametype = AST_FRAME_VOICE;
+		f->subclass.format = ast_format_slin;
+		f->offset = AST_FRIENDLY_OFFSET;
+		f->samples = FRAME_SIZE;
+		f->datalen = FRAME_SIZE * 2;
+		f->data.ptr = o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET;
+		if (!o->rxkeyed) {
+			memset(f->data.ptr, 0, f->datalen);
+		}
+		/* Process the audio to see if contains DTMF */
+		if (o->usedtmf && o->dsp) {
+			f1 = ast_dsp_process(o->owner, o->dsp, f);
+			if ((f1->frametype == AST_FRAME_DTMF_END) || (f1->frametype == AST_FRAME_DTMF_BEGIN)) {
+				if ((f1->subclass.integer == 'm') || (f1->subclass.integer == 'u')) {
+					f1->frametype = AST_FRAME_NULL;
+					f1->subclass.integer = 0;
+
+					if (!o->owner) {
+						break;
+					}
+
+					ast_queue_frame(o->owner, f1);
+					continue;
 				}
-				o->toneflag = 0;
-			} else {
-				if (o->toneflag) {
-					ast_frfree(f1);
-					f1 = NULL;
+				if (f1->frametype == AST_FRAME_DTMF_END) {
+					f1->len = ast_tvdiff_ms(ast_radio_tvnow(), o->tonetime);
+					if (option_verbose) {
+						ast_log(LOG_NOTICE, "Channel %s: Got DTMF char %c duration %ld ms\n", o->name, f1->subclass.integer, f1->len);
+					}
+					o->toneflag = 0;
 				} else {
-					o->tonetime = ast_radio_tvnow();
-					o->toneflag = 1;
+					if (o->toneflag) {
+						ast_frfree(f1);
+						f1 = NULL;
+					} else {
+						o->tonetime = ast_radio_tvnow();
+						o->toneflag = 1;
+					}
+				}
+				if (!o->owner) {
+					break;
+				}
+				if (f1) {
+					ast_queue_frame(o->owner, f1);
 				}
 			}
-			if (f1) {
-				return f1;
+		}
+
+		/* Raw audio samples should never be clipped or scaled for any reason. Adjustments to
+		 * audio levels should be made only in the USB interface mixer settings.
+		 * TODO: After the vast majority of existing installs have had a chance to review their
+		 * audio settings and these old scaling/clipping hacks are no longer in significant use
+		 * the legacyaudioscaling cfg and related code should be deleted.
+		 */
+		/* scale and clip values */
+		if (o->legacyaudioscaling && o->rxvoiceadj > 1.0) {
+			register int i, x;
+			register float f1;
+			register int16_t *p = (int16_t *) f->data.ptr;
+
+			for (i = 0; i < f->samples; i++) {
+				f1 = (float) p[i] * o->rxvoiceadj;
+				x = (int) f1;
+				if (x > 32767) {
+					x = 32767;
+				} else if (x < -32768) {
+					x = -32768;
+				}
+				p[i] = x;
 			}
 		}
-	}
 
-	/* Raw audio samples should never be clipped or scaled for any reason. Adjustments to
-	 * audio levels should be made only in the USB interface mixer settings.
-	 * TODO: After the vast majority of existing installs have had a chance to review their
-	 * audio settings and these old scaling/clipping hacks are no longer in significant use
-	 * the legacyaudioscaling cfg and related code should be deleted.
-	 */
-	/* scale and clip values */
-	if (o->legacyaudioscaling && o->rxvoiceadj > 1.0) {
-		register int i, x;
-		register float f1;
-		register int16_t *p = (int16_t *) f->data.ptr;
+		/* Compute the peak signal if requested */
+		if (o->measure_enabled) {
+			register int i;
+			register int32_t accum;
+			register int16_t *p = (int16_t *) f->data.ptr;
 
-		for (i = 0; i < f->samples; i++) {
-			f1 = (float) p[i] * o->rxvoiceadj;
-			x = (int) f1;
-			if (x > 32767) {
-				x = 32767;
-			} else if (x < -32768) {
-				x = -32768;
+			for (i = 0; i < f->samples; i++) {
+				accum = p[i];
+				if (accum > o->amax) {
+					o->amax = accum;
+					o->discounteru = o->discfactor;
+				} else if (--o->discounteru <= 0) {
+					o->discounteru = o->discfactor;
+					o->amax = (int32_t) ((o->amax * 32700) / 32768);
+				}
+				if (accum < o->amin) {
+					o->amin = accum;
+					o->discounterl = o->discfactor;
+				} else if (--o->discounterl <= 0) {
+					o->discounterl = o->discfactor;
+					o->amin = (int32_t) ((o->amin * 32700) / 32768);
+				}
 			}
-			p[i] = x;
+			o->apeak = (int32_t) (o->amax - o->amin) / 2;
 		}
-	}
 
-	/* Compute the peak signal if requested */
-	if (o->measure_enabled) {
-		register int i;
-		register int32_t accum;
-		register int16_t *p = (int16_t *) f->data.ptr;
-
-		for (i = 0; i < f->samples; i++) {
-			accum = p[i];
-			if (accum > o->amax) {
-				o->amax = accum;
-				o->discounteru = o->discfactor;
-			} else if (--o->discounteru <= 0) {
-				o->discounteru = o->discfactor;
-				o->amax = (int32_t) ((o->amax * 32700) / 32768);
-			}
-			if (accum < o->amin) {
-				o->amin = accum;
-				o->discounterl = o->discfactor;
-			} else if (--o->discounterl <= 0) {
-				o->discounterl = o->discfactor;
-				o->amin = (int32_t) ((o->amin * 32700) / 32768);
-			}
+		if (!o->owner) {
+			break;
 		}
-		o->apeak = (int32_t) (o->amax - o->amin) / 2;
+		ast_queue_frame(o->owner, f);
 	}
-	return f;
+
+	stop_stream(o);
+	ast_debug(5, "Audio Thread is exiting");
+	return NULL;
 }
-
 /*!
  * \brief Asterisk fixup function.
  * \param oldchan		Old asterisk channel.
@@ -2690,10 +2771,6 @@ static struct ast_channel *simpleusb_new(struct chan_simpleusb_pvt *o, char *ext
 		return NULL;
 	}
 	ast_channel_tech_set(c, &simpleusb_tech);
-	if ((o->sounddev < 0) && o->hasusb) {
-		setformat(o, O_RDWR);
-	}
-	ast_channel_internal_fd_set(c, 0, o->sounddev); /* -1 if device closed, override later */
 	ast_channel_nativeformats_set(c, simpleusb_tech.capabilities);
 	ast_channel_set_readformat(c, ast_format_slin);
 	ast_channel_set_writeformat(c, ast_format_slin);
@@ -3863,6 +3940,8 @@ static struct chan_simpleusb_pvt *store_config(struct ast_config *cfg, const cha
 			o->name = ast_strdup(ctg);
 			o->pttkick[0] = -1;
 			o->pttkick[1] = -1;
+			o->audiothread = AST_PTHREADT_NULL;
+			o->hidthread = AST_PTHREADT_NULL;
 			if (!simpleusb_active) {
 				simpleusb_active = o->name;
 			}
@@ -3883,8 +3962,6 @@ static struct chan_simpleusb_pvt *store_config(struct ast_config *cfg, const cha
 			continue;
 		}
 
-		CV_UINT("frags", o->frags);
-		CV_UINT("queuesize", o->queuesize);
 		CV_BOOL("invertptt", o->invertptt);
 		CV_F("carrierfrom", store_rxcdtype(o, (char *) v->value));
 		CV_F("ctcssfrom", store_rxsdtype(o, (char *) v->value));
@@ -4176,6 +4253,8 @@ static int reload_module(void)
 
 static int load_module(void)
 {
+	PaError res;
+
 	if (!(simpleusb_tech.capabilities = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT))) {
 		return AST_MODULE_LOAD_DECLINE;
 	}
@@ -4196,6 +4275,12 @@ static int load_module(void)
 
 	/* load our module configuration */
 	if (load_config(0)) {
+		return AST_MODULE_LOAD_DECLINE;
+	}
+
+	res = Pa_Initialize();
+	if (res != paNoError) {
+		ast_log(LOG_WARNING, "Failed to initialize audio system - (%d) %s\n", res, Pa_GetErrorText(res));
 		return AST_MODULE_LOAD_DECLINE;
 	}
 
@@ -4245,10 +4330,6 @@ static int unload_module(void)
 		}
 #endif
 
-		if (o->sounddev >= 0) {
-			close(o->sounddev);
-			o->sounddev = -1;
-		}
 		if (o->dsp) {
 			ast_dsp_free(o->dsp);
 		}

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -37,6 +37,7 @@
 #include "asterisk.h"
 
 #include <portaudio.h>
+#include <alsa/asoundlib.h>
 
 #include <stdio.h>
 #include <math.h>
@@ -196,10 +197,10 @@ static const char *const sd_signal_type[] = { "no", "usb", "usbinvert", "N/A", "
 struct chan_simpleusb_pvt {
 	struct chan_simpleusb_pvt *next;
 
-	char *name;			/* the internal name of our channel */
-	char hw_device[50]; /* hardware device name */
-	int devtype;		/* actual type of device */
-	int pttkick[2];		/* ptt kick pipe */
+	char *name;			 /* the internal name of our channel */
+	char hw_device[100]; /* hardware device name */
+	int devtype;		 /* actual type of device */
+	int pttkick[2];		 /* ptt kick pipe */
 	enum {
 		M_UNSET,
 		M_FULL,
@@ -431,7 +432,7 @@ static struct ast_channel_tech simpleusb_tech = {
 
 /*!
  * \brief Parse "hw:<card>" or "hw:<card>,<dev>" from anywhere in s.
- * Returns 1 if found; sets *card; sets *dev to parsed value or -1 if absent.
+ * \retval 1 if found; sets *card; sets *dev to parsed value or -1 if absent.
  */
 static int parse_hw_anywhere(const char *s, int *card, int *dev)
 {
@@ -616,18 +617,21 @@ static int stop_stream(struct chan_simpleusb_pvt *pvt)
 {
 	PaError err;
 
-	if (!pvt->streamstate)
+	if (!pvt->streamstate) {
 		return 0;
+	}
 
 	/* Wait for pvt->thread to exit cleanly, to avoid killing it while it's holding a lock. */
 	err = Pa_AbortStream(pvt->stream);
 	if (err != paNoError) {
 		ast_log(LOG_WARNING, "Pa_AbortStream failed: %s\n", Pa_GetErrorText(err));
 	}
+
 	err = Pa_CloseStream(pvt->stream);
 	if (err != paNoError) {
 		ast_log(LOG_WARNING, "Pa_CloseStream failed: %s\n", Pa_GetErrorText(err));
 	}
+
 	pvt->stream = NULL;
 	pvt->streamstate = 0;
 	return 0;
@@ -1105,7 +1109,7 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 			return -1;
 		}
 	} else {
-		/* use the */
+		/* use the device string */
 		ast_radio_hid_device_mklist();
 
 		/* Check to see if our specified device string

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1087,7 +1087,10 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 
 	if (o->hw_device[0]) {
 		/* already configured device, extract the device number and usb_dev */
-		if (sscanf(o->hw_device, "hw:%d", &o->devicenum) == 1) {
+		if (!strcasecmp(o->hw_device, "default")) {
+			ast_debug(5, "audiodev is defined: default");
+			o->internal_audio = 1;
+		} else if (sscanf(o->hw_device, "hw:%d", &o->devicenum) == 1) {
 			ast_debug(5, "audiodev is defined: %s, Device %d", o->hw_device, o->devicenum);
 			o->usb_dev = ast_radio_usb_device_from_alsa_card(o->devicenum);
 			if (!o->usb_dev) {
@@ -2076,8 +2079,8 @@ static int simpleusb_hangup(struct ast_channel *c)
 {
 	struct chan_simpleusb_pvt *o = ast_channel_tech_pvt(c);
 
-	ast_channel_tech_pvt_set(c, NULL);
 	o->owner = NULL;
+	ast_channel_tech_pvt_set(c, NULL);
 	ast_module_unref(ast_module_info->self);
 	o->stophid = 1;
 

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -29,6 +29,7 @@
 
 /*** MODULEINFO
 	<depend>alsa</depend>
+	<depend>portaudio</depend>
 	<depend>res_usbradio</depend>
 	<support_level>extended</support_level>
  ***/
@@ -1341,11 +1342,15 @@ static void *hidthread(void *arg)
 		if (usb_claim_interface(usb_handle, C108_HID_INTERFACE) < 0) {
 			if (usb_detach_kernel_driver_np(usb_handle, C108_HID_INTERFACE) < 0) {
 				ast_log(LOG_ERROR, "Channel %s: Is not able to detach the USB device\n", o->name);
+				usb_close(usb_handle);
+				usb_handle = NULL;
 				usleep(500000);
 				continue;
 			}
 			if (usb_claim_interface(usb_handle, C108_HID_INTERFACE) < 0) {
 				ast_log(LOG_ERROR, "Channel %s: Is not able to claim the USB device\n", o->name);
+				usb_close(usb_handle);
+				usb_handle = NULL;
 				usleep(500000);
 				continue;
 			}
@@ -1703,6 +1708,8 @@ static void *hidthread(void *arg)
 		buf[o->hid_gpio_ctl_loc] = o->hid_gpio_ctl;
 		ast_radio_hid_set_outputs(usb_handle, buf);
 		ast_mutex_unlock(&o->usblock);
+		usb_close(usb_handle);
+		usb_handle = NULL;
 	}
 	return NULL;
 }
@@ -4382,11 +4389,17 @@ static int load_module(void)
 		ast_log(LOG_NOTICE, "susb active device %s not found\n", simpleusb_active);
 		/* XXX we could default to 'dsp' perhaps ? */
 		/* XXX should cleanup allocated memory etc. */
+		Pa_Terminate();
+		ao2_cleanup(simpleusb_tech.capabilities);
+		simpleusb_tech.capabilities = NULL;
 		return AST_MODULE_LOAD_DECLINE;
 	}
 
 	if (ast_channel_register(&simpleusb_tech)) {
 		ast_log(LOG_ERROR, "Unable to register channel type 'usb'\n");
+		Pa_Terminate();
+		ao2_cleanup(simpleusb_tech.capabilities);
+		simpleusb_tech.capabilities = NULL;
 		return AST_MODULE_LOAD_DECLINE;
 	}
 

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -460,7 +460,7 @@ static PaError read_with_timeout(PaStream *s, void *buf, unsigned long frames, i
 			if ((now_ms() - start) > timeout_ms) {
 				return paTimedOut; // not a real PortAudio error code; use your own
 			}
-			usleep(1000); // 1ms
+			usleep(500); // 1ms
 			continue;
 		}
 
@@ -2496,7 +2496,7 @@ static void *simpleusb_audio_thread(void *arg)
 				if (res == paInputOverflowed) {
 					ast_debug(6, "PortAudio read overflow on channel %s\n", o->name);
 				} else {
-					ast_log(LOG_ERROR, "PortAudio became unavailable on channel %s\n", o->name);
+					ast_log(LOG_ERROR, "PortAudio became unavailable on channel %s : %s\n", o->name, Pa_GetErrorText(res));
 					break; /* Close the stream and retry */
 				}
 			}

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -2494,7 +2494,7 @@ static void *simpleusb_audio_thread(void *arg)
 					}
 				}
 
-				if (num_frames && (num_frames < 3) && (o->txkeyed || o->txtestkey)) {
+				if ((num_frames <= 3) && (o->txkeyed || o->txtestkey)) {
 					/* waiting for 3 frames in the buffer. This is "normal" */
 					last_frame_time = ast_radio_tvnow();
 				}

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1851,7 +1851,7 @@ static void *hidthread(void *arg)
 		buf[o->hid_gpio_ctl_loc] = o->hid_gpio_ctl;
 		ast_mutex_unlock(&o->usblock);
 		ast_radio_hid_set_outputs(usb_handle, buf);
-		
+
 		if (usb_handle) {
 			usb_close(usb_handle);
 			usb_handle = NULL;

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -582,20 +582,18 @@ static int open_stream(struct chan_simpleusb_pvt *o)
 static int start_stream(struct chan_simpleusb_pvt *pvt)
 {
 	PaError res;
-	int ret_val = 0;
 
 	ast_debug(5, "Starting PA Stream");
 	/* It is possible for simpleusb_hangup to be called before the
 	 * stream is started, if this is the case pvt->owner will be NULL
 	 * and start_stream should be aborted. */
 	if (pvt->streamstate || !pvt->owner)
-		goto return_val;
+		return -1;
 
 	res = open_stream(pvt);
 	if (res != paNoError) {
 		ast_log(LOG_WARNING, "Failed to open stream - (%d) %s\n", res, Pa_GetErrorText(res));
-		ret_val = -1;
-		goto return_val;
+		return -1;
 	}
 
 	res = Pa_StartStream(pvt->stream);
@@ -604,13 +602,11 @@ static int start_stream(struct chan_simpleusb_pvt *pvt)
 		Pa_CloseStream(pvt->stream);
 		pvt->stream = NULL;
 		pvt->streamstate = 0;
-		ret_val = -1;
-		goto return_val;
+		return -1;
 	}
 	pvt->streamstate = 1;
 
-return_val:
-	return ret_val;
+	return 0;
 }
 
 static int stop_stream(struct chan_simpleusb_pvt *pvt)
@@ -1379,6 +1375,8 @@ static void *hidthread(void *arg)
 		}
 		if (pipe(o->pttkick) == -1) {
 			ast_log(LOG_ERROR, "Channel %s: Is not able to create a pipe\n", o->name);
+			usb_close(usb_handle);
+			usb_handle = NULL;
 			return NULL;
 		}
 		if ((o->usb_dev->descriptor.idProduct & 0xfffc) == C108_PRODUCT_ID) {
@@ -2231,6 +2229,7 @@ static void *simpleusb_audio_thread(void *arg)
 
 				ast_queue_frame(o->owner, &wf);
 			}
+			usleep(10000);
 			continue;
 		}
 

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -110,7 +110,7 @@
  * \brief The sample rate to request from PortAudio
  *
  * \todo Make this optional.  If this is only going to talk to 8 kHz endpoints,
- *       then it makes sense to use 8 kHz natively.
+ *       then it makes sense to use 8 kHz natively if possible.
  */
 #define PA_SAMPLE_RATE 48000 /* PortAudio Sample rate: Hardware likes 48k and is divisible by 6 for a "nice" down conversion. */
 
@@ -120,13 +120,18 @@
  * At 48kHz, 960 samples gives a 20ms frames, which aligns with Asterisk's
  * common frame size after resampling to 8kHz (160 samples @ 2 bytes per sample).
  */
-#define NUM_SAMPLES 960 /* The number of 2 byte (paInt16) samples per PortAudio "frame" */
+#define PA_NUM_FRAMES \
+	960 /* The number of 2 byte (paInt16) \
+		 * samples per PortAudio "frame". \
+		 * This is 1920 bytes for stereo, \
+		 * or 960 bytes for mono \
+		 */
 
 /*! \brief Mono Input */
-#define INPUT_CHANNELS 1 /* PortAudio: Mono input for Microphone / RX */
+#define PA_INPUT_CHANNELS 1 /* PortAudio: Mono input for Microphone / RX */
 
 /*! \brief Stereo Output */
-#define OUTPUT_CHANNELS 2 /* PortAudio: Stereo output for Speaker / TX */
+#define PA_OUTPUT_CHANNELS 2 /* PortAudio: Stereo output for Speaker / TX */
 
 /*! \brief Global jitterbuffer configuration - by default, jb is disabled */
 static struct ast_jb_conf default_jbconf = {
@@ -146,7 +151,7 @@ static struct ast_jb_conf global_jbconf;
 #define ENDPAGE_STR "ENDPAGE"
 #define AMPVAL 12000
 #define AST_SAMPLE_RATE 8000 /* Asterisk sample rate (after down conversion) */
-#define DIVLCM 192000 /* Least Common Mult of 512,1200,2400,8000) */
+#define DIVLCM 192000		 /* Least Common Mult of 512,1200,2400,8000) */
 #define PREAMBLE_BITS 576
 #define MESSAGE_BITS 544 /* (17 * 32), 1 longword SYNC plus 16 longwords data */
 #define ONEVAL -AMPVAL
@@ -223,14 +228,14 @@ struct chan_simpleusb_pvt {
 
 	PaStream *stream; /*! Current PortAudio stream for this device */
 
-	/* buffers used in simpleusb_write, 2 per int */
+	/* buffers used in Pa_WriteStream, 2 per int */
 	char simpleusb_write_buf[FRAME_SIZE * 2];
 
 	int simpleusb_write_dst;
-	/* buffers used in simpleusb_read - AST_FRIENDLY_OFFSET space for headers
+	/* buffers used in Pa_ReadStream - AST_FRIENDLY_OFFSET space for headers
 	 * plus enough room for a full frame
 	 */
-	char simpleusb_read_buf[NUM_SAMPLES * 2];							 /* 2 bytes samples for PortAudio in mono - paInt16 */
+	char simpleusb_read_buf[PA_NUM_FRAMES * 2];							 /* 2 bytes samples for PortAudio in mono - paInt16 */
 	char simpleusb_read_frame_buf[FRAME_SIZE * 2 + AST_FRIENDLY_OFFSET]; /* 2 byte frames at 8k */
 	struct ast_frame read_f; /* returned by simpleusb_read */
 
@@ -451,10 +456,11 @@ static PaError Pa_ReadStream_with_timeout(PaStream *s, char *buf, long frames, i
 			return (PaError) avail;
 		}
 
+		if ((now_ms() - start) > timeout_ms) {
+			return paTimedOut;
+		}
+
 		if (avail < frames) {
-			if ((now_ms() - start) > timeout_ms) {
-				return paTimedOut;
-			}
 			usleep(500); /*.5ms */
 			continue;
 		}
@@ -561,23 +567,23 @@ static int open_stream(struct chan_simpleusb_pvt *o)
 
 	if (!strcasecmp(o->hw_device, "default")) {
 		ast_debug(1, "Opening stream with default device\n");
-		res = Pa_OpenDefaultStream(&o->stream, INPUT_CHANNELS, OUTPUT_CHANNELS, paInt16, PA_SAMPLE_RATE, NUM_SAMPLES, NULL, NULL);
+		res = Pa_OpenDefaultStream(&o->stream, PA_INPUT_CHANNELS, PA_OUTPUT_CHANNELS, paInt16, PA_SAMPLE_RATE, PA_NUM_FRAMES, NULL, NULL);
 	} else {
 		PaStreamParameters input_params = {
-			.channelCount = INPUT_CHANNELS,
+			.channelCount = PA_INPUT_CHANNELS,
 			.sampleFormat = paInt16,
 			.suggestedLatency = (1.0 / 50.0), /* 20 ms */
 			.device = paNoDevice,
 		};
 		PaStreamParameters output_params = {
-			.channelCount = OUTPUT_CHANNELS,
+			.channelCount = PA_OUTPUT_CHANNELS,
 			.sampleFormat = paInt16,
 			.suggestedLatency = (1.0 / 50.0), /* 20 ms */
 			.device = paNoDevice,
 		};
 		PaDeviceIndex idx, num_devices;
 		ast_debug(1, "Looking for device %s\n", o->hw_device);
-		ast_debug(6, "PortAudio host api count %d\n", Pa_GetHostApiCount());
+		ast_debug(5, "PortAudio host api count %d\n", Pa_GetHostApiCount());
 		num_devices = Pa_GetDeviceCount();
 		if (num_devices < 0) {
 			ast_debug(1, "No devices found\n");
@@ -614,7 +620,7 @@ static int open_stream(struct chan_simpleusb_pvt *o)
 			return res;
 		}
 		ast_debug(5, "Opening stream on device %s", o->hw_device);
-		res = Pa_OpenStream(&o->stream, &input_params, &output_params, PA_SAMPLE_RATE, NUM_SAMPLES, paNoFlag, NULL, NULL);
+		res = Pa_OpenStream(&o->stream, &input_params, &output_params, PA_SAMPLE_RATE, PA_NUM_FRAMES, paNoFlag, NULL, NULL);
 		ast_debug(5, "Stream feedback %s\n", Pa_GetErrorText(res));
 	}
 
@@ -1792,11 +1798,11 @@ static int soundcard_writeframe(struct chan_simpleusb_pvt *o, short *data)
 	 * a number of failures, to restart the output chain.
 	 */
 
-	res = Pa_WriteStream(o->stream, data, NUM_SAMPLES);
+	res = Pa_WriteStream(o->stream, data, PA_NUM_FRAMES);
 	if (res == paOutputUnderflowed) {
-		short null_buf[NUM_SAMPLES * 2] = { 0 };
+		short null_buf[PA_NUM_FRAMES * 2] = { 0 };
 		ast_debug(6, "PortAudio write stream underflow, writing a 0 frame");
-		Pa_WriteStream(o->stream, null_buf, NUM_SAMPLES);
+		Pa_WriteStream(o->stream, null_buf, PA_NUM_FRAMES);
 	} else if (res < 0) {
 		ast_debug(2, "Pa_WriteStream Error %s", Pa_GetErrorText(res));
 	}
@@ -2153,6 +2159,7 @@ static int simpleusb_hangup(struct ast_channel *c)
 	}
 
 	o->owner = NULL;
+	ast_free(o);
 	ast_channel_tech_pvt_set(c, NULL);
 	ast_module_unref(ast_module_info->self);
 
@@ -2244,13 +2251,13 @@ static void *simpleusb_audio_thread(void *arg)
 	struct ast_frame *f = &o->read_f, *f1;
 	time_t now;
 	register short *sp, *sp1;
-	short outbuf[NUM_SAMPLES * 2]; /* 2 bytes per sample on PortAudio config - paInt16 */
+	short outbuf[PA_NUM_FRAMES * 2]; /* 2 bytes per sample on PortAudio config - paInt16 */
 
-	ast_debug(5, "Audio thread is starting");
+	ast_debug(5, "Audio thread is starting\n");
 
 	while (!o->stopaudiothread) {
 		/* wait for audio device to be initialized */
-		ast_debug(5, "Audio thread entered outer loop");
+		ast_debug(5, "Audio thread entered outer loop\n");
 		if (!o->hasusb) {
 			ast_debug(5, "Audio not ready");
 			usleep(DEVICE_RETRY);
@@ -2508,7 +2515,7 @@ static void *simpleusb_audio_thread(void *arg)
 			 * in mono format.  We should always have 20ms frames, 100ms timeout
 			 * as a reasonable max wait time.
 			 */
-			res = Pa_ReadStream_with_timeout(o->stream, o->simpleusb_read_buf, NUM_SAMPLES, 60, &o->stopaudiothread);
+			res = Pa_ReadStream_with_timeout(o->stream, o->simpleusb_read_buf, PA_NUM_FRAMES, 60, &o->stopaudiothread);
 			if (res != paNoError) {
 				/* audio data not ready */
 				if (res == paInputOverflowed) {

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -2088,9 +2088,6 @@ static int simpleusb_hangup(struct ast_channel *c)
 {
 	struct chan_simpleusb_pvt *o = ast_channel_tech_pvt(c);
 
-	o->owner = NULL;
-	ast_channel_tech_pvt_set(c, NULL);
-	ast_module_unref(ast_module_info->self);
 	o->stophid = 1;
 
 	if (o->hidthread != AST_PTHREADT_NULL) {
@@ -2102,6 +2099,10 @@ static int simpleusb_hangup(struct ast_channel *c)
 		pthread_join(o->audiothread, NULL);
 		o->audiothread = AST_PTHREADT_NULL;
 	}
+
+	o->owner = NULL;
+	ast_channel_tech_pvt_set(c, NULL);
+	ast_module_unref(ast_module_info->self);
 
 	return 0;
 }
@@ -4425,8 +4426,10 @@ static int unload_module(void)
 	ast_cli_unregister_multiple(cli_simpleusb, ARRAY_LEN(cli_simpleusb));
 
 	for (o = simpleusb_default.next; o; o = o->next) {
-#if DEBUG_CAPTURES == 1
 		o->stophid = 1;
+		if (o->owner) {
+			ast_softhangup(o->owner, AST_SOFTHANGUP_APPUNLOAD);
+		}
 		if (o->audiothread != AST_PTHREADT_NULL) {
 			pthread_join(o->audiothread, NULL); /* wait for audio thread to end */
 			o->audiothread = AST_PTHREADT_NULL;
@@ -4435,25 +4438,8 @@ static int unload_module(void)
 			pthread_join(o->hidthread, NULL);
 			o->hidthread = AST_PTHREADT_NULL;
 		}
-		if (frxcapraw) {
-			fclose(frxcapraw);
-			frxcapraw = NULL;
-		}
-		if (frxcapcooked) {
-			fclose(frxcapraw);
-			frxcapcooked = NULL;
-		}
-		if (ftxcapraw) {
-			fclose(ftxcapraw);
-			ftxcapraw = NULL;
-		}
-#endif
-
 		if (o->dsp) {
 			ast_dsp_free(o->dsp);
-		}
-		if (o->owner) {
-			ast_softhangup(o->owner, AST_SOFTHANGUP_APPUNLOAD);
 		}
 		if (o->owner) { /* XXX how ??? */
 			return -1;
@@ -4461,6 +4447,21 @@ static int unload_module(void)
 
 		/* XXX what about the memory allocated ? */
 	}
+
+#if DEBUG_CAPTURES == 1
+	if (frxcapraw) {
+		fclose(frxcapraw);
+		frxcapraw = NULL;
+	}
+	if (frxcapcooked) {
+		fclose(frxcapraw);
+		frxcapcooked = NULL;
+	}
+	if (ftxcapraw) {
+		fclose(ftxcapraw);
+		ftxcapraw = NULL;
+	}
+#endif
 
 	Pa_Terminate();
 	ao2_cleanup(simpleusb_tech.capabilities);

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -122,7 +122,7 @@
  * The number of short (2 byte) with paInt16 samples per PortAudio "frame".
  * This is 1920 bytes for stereo, or 960 bytes for mono
  */
-#define PA_NUM_SAMPLES FRAME_SIZE * 6 /* Number of samples to read/write from PortAudio stream per Asterisk frame at 48k */
+#define PA_NUM_FRAMES FRAME_SIZE * 6 /* Number of samples to read/write from PortAudio stream per Asterisk frame at 48k */
 
 /*! \brief Mono Input */
 #define PA_INPUT_CHANNELS 1 /* PortAudio: Mono input for Microphone / RX */
@@ -228,7 +228,7 @@ struct chan_simpleusb_pvt {
 	char simpleusb_write_buf[FRAME_SIZE * 2]; /* buffer used for Asterisk to PA frames in 8k mono */
 
 	int simpleusb_write_dst;
-	short simpleusb_read_buf[PA_NUM_SAMPLES]; /* 1 short (2 byte) samples for PortAudio config with paInt16 * 1 channel (mono) */
+	short simpleusb_read_buf[PA_NUM_FRAMES]; /* 1 short (2 byte) samples for PortAudio config with paInt16 * 1 channel (mono) */
 	char simpleusb_read_frame_buf[FRAME_SIZE * 2 + AST_FRIENDLY_OFFSET]; /* 2 byte samples at 8k */
 	struct ast_frame read_f; /* returned by simpleusb_read */
 
@@ -560,7 +560,7 @@ static int open_stream(struct chan_simpleusb_pvt *o)
 
 	if (!strcasecmp(o->hw_device, "default")) {
 		ast_debug(1, "Opening stream with default device\n");
-		res = Pa_OpenDefaultStream(&o->stream, PA_INPUT_CHANNELS, PA_OUTPUT_CHANNELS, paInt16, PA_SAMPLE_RATE, PA_NUM_SAMPLES, NULL, NULL);
+		res = Pa_OpenDefaultStream(&o->stream, PA_INPUT_CHANNELS, PA_OUTPUT_CHANNELS, paInt16, PA_SAMPLE_RATE, PA_NUM_FRAMES, NULL, NULL);
 	} else {
 		PaStreamParameters input_params = {
 			.channelCount = PA_INPUT_CHANNELS,
@@ -613,7 +613,7 @@ static int open_stream(struct chan_simpleusb_pvt *o)
 			return res;
 		}
 		ast_debug(5, "Opening stream on device %s", o->hw_device);
-		res = Pa_OpenStream(&o->stream, &input_params, &output_params, PA_SAMPLE_RATE, PA_NUM_SAMPLES, paNoFlag, NULL, NULL);
+		res = Pa_OpenStream(&o->stream, &input_params, &output_params, PA_SAMPLE_RATE, PA_NUM_FRAMES, paNoFlag, NULL, NULL);
 		ast_debug(5, "Stream feedback %s\n", Pa_GetErrorText(res));
 	}
 
@@ -1135,7 +1135,9 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 	if (o->hw_device[0]) {
 		/* already configured device, extract the device number and usb_dev */
 		if (!strcasecmp(o->hw_device, "default")) {
-			ast_debug(5, "audiodev is defined: default\n");
+			ast_log(LOG_ERROR, "audiodev=default is not supported for SimpleUSB until HID-less startup is implemented\n");
+			ast_mutex_unlock(&usb_dev_lock);
+			return -1;
 		} else if (sscanf(o->hw_device, "hw:%d", &o->devicenum) == 1) {
 			ast_debug(5, "audiodev is defined: %s, Device %d", o->hw_device, o->devicenum);
 			o->usb_dev = ast_radio_usb_device_from_alsa_card(o->devicenum);
@@ -1751,6 +1753,11 @@ static void *hidthread(void *arg)
 		buf[o->hid_gpio_ctl_loc] = o->hid_gpio_ctl;
 		ast_radio_hid_set_outputs(usb_handle, buf);
 		ast_mutex_unlock(&o->usblock);
+
+		if (usb_handle) {
+			usb_close(usb_handle);
+			usb_handle = NULL;
+		}
 	}
 	/* clean up before exiting the thread */
 	o->lasttx = 0;
@@ -1791,11 +1798,11 @@ static int soundcard_writeframe(struct chan_simpleusb_pvt *o, short *data)
 	 * a number of failures, to restart the output chain.
 	 */
 
-	res = Pa_WriteStream(o->stream, data, PA_NUM_SAMPLES);
+	res = Pa_WriteStream(o->stream, data, PA_NUM_FRAMES);
 	if (res == paOutputUnderflowed) {
-		short null_buf[PA_NUM_SAMPLES * 2] = { 0 };
+		short null_buf[PA_NUM_FRAMES * 2] = { 0 };
 		ast_debug(6, "PortAudio write stream underflow, writing a 0 frame");
-		Pa_WriteStream(o->stream, null_buf, PA_NUM_SAMPLES);
+		Pa_WriteStream(o->stream, null_buf, PA_NUM_FRAMES);
 	} else if (res < 0) {
 		ast_debug(2, "Pa_WriteStream Error %s", Pa_GetErrorText(res));
 	}
@@ -2028,7 +2035,7 @@ static int simpleusb_text(struct ast_channel *c, const char *text)
 		/* pad end with 250ms of silence */
 		audio_samples += AST_SAMPLE_RATE / 4;
 		/* also pad up to FRAME_SIZE */
-		audio_samples += audio_samples % FRAME_SIZE;
+		audio_samples += (FRAME_SIZE - (audio_samples % FRAME_SIZE)) % FRAME_SIZE;
 		audio = ast_calloc(1, (audio_samples * sizeof(short)) + 10);
 		if (!audio) {
 			free_batch(batch);
@@ -2152,7 +2159,6 @@ static int simpleusb_hangup(struct ast_channel *c)
 	}
 
 	o->owner = NULL;
-	ast_free(o);
 	ast_channel_tech_pvt_set(c, NULL);
 	ast_module_unref(ast_module_info->self);
 
@@ -2244,7 +2250,7 @@ static void *simpleusb_audio_thread(void *arg)
 	struct ast_frame *f = &o->read_f, *f1;
 	time_t now;
 	register short *sp, *sp1;
-	short outbuf[PA_NUM_SAMPLES * 2]; /* 1 short (2 bytes) per sample on PortAudio config with paInt16 * 2 channels */
+	short outbuf[PA_NUM_FRAMES * 2]; /* 1 short (2 bytes) per sample on PortAudio config with paInt16 * 2 channels */
 
 	ast_debug(5, "Audio thread is starting\n");
 
@@ -2377,7 +2383,7 @@ static void *simpleusb_audio_thread(void *arg)
 					}
 				}
 
-				if (num_frames && (num_frames > 3 || (!o->txkeyed && !o->txtestkey)) && (frames_available >= FRAME_SIZE)) {
+				if (num_frames && (num_frames > 3 || (!o->txkeyed && !o->txtestkey)) && (frames_available >= PA_NUM_FRAMES)) {
 					ast_mutex_lock(&o->txqlock);
 					f1 = AST_LIST_REMOVE_HEAD(&o->txq, frame_list);
 					ast_mutex_unlock(&o->txqlock);
@@ -2508,7 +2514,7 @@ static void *simpleusb_audio_thread(void *arg)
 			 * in mono format.  We should always have 20ms frames, 100ms timeout
 			 * as a reasonable max wait time.
 			 */
-			res = Pa_ReadStream_with_timeout(o->stream, o->simpleusb_read_buf, PA_NUM_SAMPLES, 60, &o->stopaudiothread);
+			res = Pa_ReadStream_with_timeout(o->stream, o->simpleusb_read_buf, PA_NUM_FRAMES, 60, &o->stopaudiothread);
 			if (res != paNoError) {
 				/* audio data not ready */
 				if (res == paInputOverflowed) {
@@ -3014,7 +3020,7 @@ static struct ast_channel *simpleusb_request(const char *type, struct ast_format
 	}
 
 	if (o->owner) {
-		ast_log(LOG_NOTICE, "Channel %s: Already have a call (chan %p) on the usb channel\n", o->name, o->owner);
+		ast_log(LOG_NOTICE, "Channel %s: Already has a call (chan %p) on the usb channel\n", o->name, o->owner);
 		*cause = AST_CAUSE_BUSY;
 		return NULL;
 	}
@@ -4494,11 +4500,12 @@ static int load_module(void)
 
 static int unload_module(void)
 {
-	struct chan_simpleusb_pvt *o;
+	struct chan_simpleusb_pvt *o, *no;
 
 	stoppulser = 1;
 
-	for (o = simpleusb_default.next; o; o = o->next) {
+	for (o = simpleusb_default.next; o; o = no) {
+		no = o->next; /* Keep track of next object after free */
 		if (o->owner) {
 			ast_softhangup(o->owner, AST_SOFTHANGUP_APPUNLOAD);
 		}
@@ -4514,6 +4521,7 @@ static int unload_module(void)
 		if (o->dsp) {
 			ast_dsp_free(o->dsp);
 		}
+		ast_free(o);
 
 		/* XXX what about the memory allocated ? */
 	}

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -440,7 +440,7 @@ static int64_t now_ms(void)
 	return (int64_t) ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
 }
 
-static PaError read_with_timeout(PaStream *s, void *buf, long frames, int timeout_ms)
+static PaError Pa_ReadStream_with_timeout(PaStream *s, void *buf, long frames, int timeout_ms)
 {
 	int64_t start;
 	char *out = buf;
@@ -1078,10 +1078,6 @@ static int load_tune_config(struct chan_simpleusb_pvt *o, const struct ast_confi
 
 	devstr[0] = '\0';
 	serial[0] = '\0';
-	if (!reload) {
-		o->devstr[0] = '\0';
-		o->serial[0] = '\0';
-	}
 
 	if (!cfg) {
 		struct ast_flags zeroflag = { 0 };
@@ -2495,9 +2491,10 @@ static void *simpleusb_audio_thread(void *arg)
 
 			/* Read audio data from the USB sound device.
 			 * Sound data will arrive at 48000 samples per second
-			 * in mono format.
+			 * in mono format.  We should always have 20ms frames, 100ms timeout
+			 * as a reasonable max wait time.
 			 */
-			res = read_with_timeout(o->stream, o->simpleusb_read_buf + o->readpos, NUM_SAMPLES, 100);
+			res = Pa_ReadStream_with_timeout(o->stream, o->simpleusb_read_buf + o->readpos, NUM_SAMPLES, 100);
 			if (res != paNoError) {
 				/* audio data not ready */
 				if (res == paInputOverflowed) {
@@ -2605,7 +2602,7 @@ static void *simpleusb_audio_thread(void *arg)
 			o->rxkeyed = sd && cd && ((!o->lasttx) || o->duplex) && (o->txoffcnt >= o->txoffdelay);
 
 			/* Send a message to indicate rx signal detect conditions */
-			if (o->lastrx && (!o->rxkeyed)) {
+			if (o->lastrx && !o->rxkeyed) {
 				struct ast_frame wf = {
 					.frametype = AST_FRAME_CONTROL,
 					.subclass.integer = AST_CONTROL_RADIO_UNKEY,
@@ -2621,7 +2618,7 @@ static void *simpleusb_audio_thread(void *arg)
 				if (o->duplex3) {
 					ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_SW, 0, 0);
 				}
-			} else if ((!o->lastrx) && (o->rxkeyed)) {
+			} else if (!o->lastrx && (o->rxkeyed)) {
 				struct ast_frame wf = {
 					.frametype = AST_FRAME_CONTROL,
 					.subclass.integer = AST_CONTROL_RADIO_KEY,

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1590,6 +1590,7 @@ static void *hidthread(void *arg)
 			}
 			ast_mutex_lock(&o->usblock);
 			buf[o->hid_gpio_ctl_loc] = o->hid_gpio_ctl;
+			ast_mutex_unlock(&o->usblock);
 			ast_radio_hid_get_inputs(usb_handle, buf);
 			/* See if we are keyed */
 			keyed = !(buf[o->hid_io_cor_loc] & o->hid_io_cor);
@@ -1690,8 +1691,9 @@ static void *hidthread(void *arg)
 				}
 				o->had_gpios_in = 1;
 				o->last_gpios_in = j;
+				ast_mutex_unlock(&o->usblock);
 			}
-			ast_mutex_unlock(&o->usblock);
+			
 			/* process the parallel port GPIO */
 			if (haspp) {
 				ast_mutex_lock(&pp_lock);
@@ -1838,7 +1840,6 @@ static void *hidthread(void *arg)
 			}
 
 			ast_radio_time(&o->lasthidtime);
-			ast_mutex_unlock(&o->usblock);
 		}
 		o->lasttx = 0;
 		ast_mutex_lock(&o->usblock);

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1361,6 +1361,11 @@ static void *hidthread(void *arg)
 	struct chan_simpleusb_pvt *o = arg;
 	struct timeval then;
 	struct pollfd rfds[1];
+	int init_audio_failed = 0;
+	int init_hid_failed = 0;
+	int open_device_failed = 0;
+	int detach_failed = 0;
+	int claim_failed = 0;
 
 	ast_debug(2, "hidthread has started");
 	/* enable gpio_set so that we will write GPIO information upon start up */
@@ -1383,13 +1388,21 @@ static void *hidthread(void *arg)
 		/* try to initialize the usb device */
 		res = init_audio_device(o);
 		if (res < 0) {
-			ast_log(LOG_ERROR, "Channel %s: Failed initialize the audio device\n", o->name);
+			if (!init_audio_failed) {
+				ast_log(LOG_ERROR, "Channel %s: Failed initialize the audio device\n", o->name);
+				init_audio_failed = 1;
+			}
+
 			usleep(DEVICE_RETRY);
 			continue;
 		}
 
 		if (o->usb_dev == NULL) {
-			ast_log(LOG_ERROR, "Channel %s: Cannot initialize device %s\n", o->name, o->devstr);
+			if (!init_hid_failed) {
+				ast_log(LOG_ERROR, "Channel %s: Cannot initialize device %s\n", o->name, o->devstr);
+				init_hid_failed = 1;
+			}
+
 			usleep(DEVICE_RETRY);
 			continue;
 		}
@@ -1397,21 +1410,33 @@ static void *hidthread(void *arg)
 		/* open the usb device device */
 		usb_handle = usb_open(o->usb_dev);
 		if (usb_handle == NULL) {
-			ast_log(LOG_ERROR, "Channel %s: Cannot open device %s\n", o->name, o->devstr);
+			if (!open_device_failed) {
+				ast_log(LOG_ERROR, "Channel %s: Cannot open device %s\n", o->name, o->devstr);
+				open_device_failed = 1;
+			}
+
 			usleep(DEVICE_RETRY);
 			continue;
 		}
 		/* attempt to claim the usb hid interface and detach from the kernel */
 		if (usb_claim_interface(usb_handle, C108_HID_INTERFACE) < 0) {
 			if (usb_detach_kernel_driver_np(usb_handle, C108_HID_INTERFACE) < 0) {
-				ast_log(LOG_ERROR, "Channel %s: Is not able to detach the USB device\n", o->name);
+				if (!detach_failed) {
+					ast_log(LOG_ERROR, "Channel %s: Is not able to detach the USB device\n", o->name);
+					detach_failed = 1;
+				}
+
 				usb_close(usb_handle);
 				usb_handle = NULL;
 				usleep(DEVICE_RETRY);
 				continue;
 			}
 			if (usb_claim_interface(usb_handle, C108_HID_INTERFACE) < 0) {
-				ast_log(LOG_ERROR, "Channel %s: Is not able to claim the USB device\n", o->name);
+				if (!claim_failed) {
+					ast_log(LOG_ERROR, "Channel %s: Is not able to claim the USB device\n", o->name);
+					detach_failed = 1;
+				}
+
 				usb_close(usb_handle);
 				usb_handle = NULL;
 				usleep(DEVICE_RETRY);
@@ -1469,6 +1494,14 @@ static void *hidthread(void *arg)
 		rfds[0].events = POLLIN;
 
 		ast_radio_time(&o->lasthidtime);
+
+		/* Reset the failure flags, we succeded */
+		init_audio_failed = 0;
+		init_hid_failed = 0;
+		open_device_failed = 0;
+		detach_failed = 0;
+		claim_failed = 0;
+
 		/* Main processing loop for GPIO
 		 * This loop process every HID_POLL_RATE milliseconds.
 		 * The timer can be interrupted by writing to

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -235,7 +235,7 @@ struct chan_simpleusb_pvt {
 	/* buffers used in Pa_ReadStream - AST_FRIENDLY_OFFSET space for headers
 	 * plus enough room for a full frame
 	 */
-	char simpleusb_read_buf[PA_NUM_FRAMES * 2];							 /* 2 bytes samples for PortAudio in mono - paInt16 */
+	short simpleusb_read_buf[PA_NUM_FRAMES];							 /* 2 bytes samples for PortAudio in mono - paInt16 */
 	char simpleusb_read_frame_buf[FRAME_SIZE * 2 + AST_FRIENDLY_OFFSET]; /* 2 byte frames at 8k */
 	struct ast_frame read_f; /* returned by simpleusb_read */
 
@@ -286,8 +286,8 @@ struct chan_simpleusb_pvt {
 	int txmixbset;
 
 	/*! \brief Settings for echoing received audio */
-	int echomode;
-	int echoing;
+	char echomode;
+	char echoing;
 	ast_mutex_t echolock;
 	struct qelem echoq;
 	int echomax;
@@ -442,7 +442,7 @@ static int64_t now_ms(void)
 	return (int64_t) ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
 }
 
-static PaError Pa_ReadStream_with_timeout(PaStream *s, char *buf, long frames, int timeout_ms, volatile sig_atomic_t *stop)
+static PaError Pa_ReadStream_with_timeout(PaStream *s, short *buf, long frames, int timeout_ms, volatile sig_atomic_t *stop)
 {
 	int64_t start;
 
@@ -1537,7 +1537,7 @@ static void *hidthread(void *arg)
 			txreq = !(AST_LIST_EMPTY(&o->txq));
 			ast_mutex_unlock(&o->txqlock);
 			txreq = txreq || o->txkeyed || o->txtestkey || o->echoing;
-			if (txreq && (!o->lasttx)) {
+			if (txreq && !o->lasttx) {
 				o->hid_gpio_val |= o->hid_io_ptt;
 				if (o->invertptt) {
 					o->hid_gpio_val &= ~o->hid_io_ptt;
@@ -1546,7 +1546,7 @@ static void *hidthread(void *arg)
 				buf[o->hid_gpio_ctl_loc] = o->hid_gpio_ctl;
 				ast_radio_hid_set_outputs(usb_handle, buf);
 				ast_debug(2, "Channel %s: update PTT = %d on channel.\n", o->name, txreq);
-			} else if ((!txreq) && o->lasttx) {
+			} else if (!txreq && o->lasttx) {
 				o->hid_gpio_val &= ~o->hid_io_ptt;
 				if (o->invertptt) {
 					o->hid_gpio_val |= o->hid_io_ptt;
@@ -2251,7 +2251,7 @@ static void *simpleusb_audio_thread(void *arg)
 	struct ast_frame *f = &o->read_f, *f1;
 	time_t now;
 	register short *sp, *sp1;
-	short outbuf[PA_NUM_FRAMES * 2]; /* 2 bytes per sample on PortAudio config - paInt16 */
+	short outbuf[PA_NUM_FRAMES * 2]; /* 2 bytes per frame on PortAudio config - paInt16 * 2 channels */
 
 	ast_debug(5, "Audio thread is starting\n");
 
@@ -2658,7 +2658,7 @@ static void *simpleusb_audio_thread(void *arg)
 			 * extracts the 48K channel, checks amplitude and distortion characteristics,
 			 * and returns true if clipping was detected.
 			 */
-			if (ast_radio_check_audio((short *) o->simpleusb_read_buf, &o->rxaudiostats, 6 * FRAME_SIZE, 1)) {
+			if (ast_radio_check_audio(o->simpleusb_read_buf, &o->rxaudiostats, 6 * FRAME_SIZE, 1)) {
 				if (o->clipledgpio) {
 					/* Set Clip LED GPIO pulsetimer if not already set */
 					if (!o->hid_gpio_pulsetimer[o->clipledgpio - 1]) {
@@ -2668,7 +2668,7 @@ static void *simpleusb_audio_thread(void *arg)
 			}
 
 			/* Downsample received audio from 48000 mono to 8000 mono */
-			sp = (short *) o->simpleusb_read_buf;
+			sp = o->simpleusb_read_buf;
 			sp1 = (short *) (o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET);
 			for (i = 0; i < FRAME_SIZE; i++) {
 				(void) lpass(*sp++, o->flpr);

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -50,7 +50,6 @@
 #include <errno.h>
 #include <usb.h>
 #include <search.h>
-#include <alsa/asoundlib.h>
 #include <linux/ppdev.h>
 #include <linux/parport.h>
 #include <linux/version.h>
@@ -441,7 +440,7 @@ static int64_t now_ms(void)
 	return (int64_t) ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
 }
 
-static PaError read_with_timeout(PaStream *s, void *buf, unsigned long frames, int timeout_ms)
+static PaError read_with_timeout(PaStream *s, void *buf, long frames, int timeout_ms)
 {
 	int64_t start;
 	char *out = buf;
@@ -456,11 +455,11 @@ static PaError read_with_timeout(PaStream *s, void *buf, unsigned long frames, i
 			return (PaError) avail;
 		}
 
-		if (avail == 0) {
+		if (avail < frames) {
 			if ((now_ms() - start) > timeout_ms) {
-				return paTimedOut; // not a real PortAudio error code; use your own
+				return paTimedOut;
 			}
-			usleep(500); // 1ms
+			usleep(500); // .5ms
 			continue;
 		}
 
@@ -493,6 +492,12 @@ static int parse_hw_anywhere(const char *s, int *card, int *dev)
 		}
 
 		while (isdigit((unsigned char) *q)) {
+			if (c > 9999) {
+				/* reasonable upper bound for card numbers */
+				p = q;
+				break;
+			}
+
 			c = c * 10 + (*q - '0');
 			q++;
 		}
@@ -1443,6 +1448,8 @@ static void *hidthread(void *arg)
 			ast_log(LOG_ERROR, "Channel %s: Is not able to create a pipe\n", o->name);
 			usb_close(usb_handle);
 			usb_handle = NULL;
+			stop_stream(o);
+			o->audio_ready = 0;
 			return NULL;
 		}
 		if ((o->usb_dev->descriptor.idProduct & 0xfffc) == C108_PRODUCT_ID) {
@@ -1808,7 +1815,7 @@ static int soundcard_writeframe(struct chan_simpleusb_pvt *o, short *data)
 		ast_debug(6, "PortAudio write stream underflow, writing a 0 frame");
 		Pa_WriteStream(o->stream, null_buf, NUM_SAMPLES);
 	} else if (res < 0) {
-		ast_debug(1, "PortAudio Error %s", Pa_GetErrorText(res));
+		ast_debug(2, "Pa_WriteStream Error %s", Pa_GetErrorText(res));
 	}
 
 	/* Check Tx audio statistics. FRAME_SIZE define refers to 8Ksps mono which is 160 samples
@@ -2236,7 +2243,7 @@ static int simpleusb_write(struct ast_channel *c, struct ast_frame *f)
 static struct ast_frame *simpleusb_read(struct ast_channel *c)
 {
 	/* This should never be called... */
-	ast_log(LOG_ERROR, "Read function should not be called!");
+	ast_debug(1, "Read function should not be called!");
 	return &ast_null_frame;
 }
 
@@ -2496,7 +2503,7 @@ static void *simpleusb_audio_thread(void *arg)
 				if (res == paInputOverflowed) {
 					ast_debug(6, "PortAudio read overflow on channel %s\n", o->name);
 				} else {
-					ast_log(LOG_ERROR, "PortAudio became unavailable on channel %s : %s\n", o->name, Pa_GetErrorText(res));
+					ast_log(LOG_ERROR, "Pa_ReadStream Error on channel %s : %s\n", o->name, Pa_GetErrorText(res));
 					break; /* Close the stream and retry */
 				}
 			}
@@ -4518,7 +4525,7 @@ static int unload_module(void)
 		frxcapraw = NULL;
 	}
 	if (frxcapcooked) {
-		fclose(frxcapraw);
+		fclose(frxcapcooked);
 		frxcapcooked = NULL;
 	}
 	if (ftxcapraw) {

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -231,7 +231,7 @@ struct chan_simpleusb_pvt {
 	int simpleusb_write_dst;
 	short simpleusb_read_buf[PA_NUM_FRAMES]; /* 1 short (2 byte) samples for PortAudio config with paInt16 * 1 channel (mono) */
 	char simpleusb_read_frame_buf[FRAME_SIZE * 2 + AST_FRIENDLY_OFFSET]; /* 2 byte samples at 8k */
-	struct ast_frame read_f; /* returned by simpleusb_read */
+	struct ast_frame read_f;											 /* returned by simpleusb_read */
 
 	/* queue used to hold packets to transmit */
 	AST_LIST_HEAD_NOLOCK(, ast_frame) txq;
@@ -1217,7 +1217,6 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 						ast_log(LOG_ERROR, "Channel %s: No USB devices are available for assignment.\n", o->name);
 						o->device_error = 1;
 					}
-					ast_mutex_unlock(&usb_dev_lock);
 					usleep(DEVICE_RETRY);
 					break;
 				}
@@ -1516,7 +1515,7 @@ static void *hidthread(void *arg)
 		 * The timer can be interrupted by writing to
 		 * the pttkick pipe.
 		 */
-		while ((!o->stophidthread) && o->hasusb) {
+		while (!o->stophidthread && o->hasusb) {
 			int gpio_write = 0;
 			time_t audio_time_now = 0;
 
@@ -1526,8 +1525,6 @@ static void *hidthread(void *arg)
 				ast_radio_time(&audio_time_now);
 				if ((audio_time_now - o->lastaudiotime) > 1) {
 					ast_log(LOG_ERROR, "Channel %s: Audio process has died or is not responding.\n", o->name);
-					o->hasusb = 0;
-					break;
 				}
 			}
 
@@ -2338,6 +2335,32 @@ static struct ast_frame *simpleusb_read(struct ast_channel *c)
 }
 
 /*!
+ * \brief 		Flush the audio stream buffer.
+ * \param o		Private structure for the channel.
+ */
+static void flush_stream_buffer(struct chan_simpleusb_pvt *o)
+{
+	struct ast_frame *f;
+
+	ast_mutex_lock(&o->txqlock);
+	while ((f = AST_LIST_REMOVE_HEAD(&o->txq, frame_list))) {
+		ast_frfree(f);
+	}
+	ast_mutex_unlock(&o->txqlock);
+}
+
+/*!
+ * \brief		Cleanup the audio stream. Stop audio stream and flush the audio stream buffer.
+ * \param o		Private structure for the channel.
+ */
+static void stream_cleanup(struct chan_simpleusb_pvt *o)
+{
+	stop_stream(o);
+	o->audio_thread_ready = 0;
+	flush_stream_buffer(o);
+}
+
+/*!
  * \brief 				PortAudio processing thread.
  * \param ast			Asterisk channel.
  * \retval 				Asterisk frame.
@@ -2360,19 +2383,22 @@ static void *simpleusb_audio_thread(void *arg)
 	while (!o->stopaudiothread) {
 		/* wait for audio device to be initialized */
 		ast_debug(5, "Audio thread entered outer loop\n");
+		ast_radio_time(&o->lastaudiotime);
+
 		if (!o->hasusb) {
 			ast_debug(5, "Audio not ready");
 			usleep(DEVICE_RETRY);
 			continue;
 		}
 
-		if (start_stream(o) < 0) {
+		if (!o->streamstate && start_stream(o) < 0) {
 			ast_log(LOG_ERROR, "Channel %s: Failed to start audio stream %s\n", o->name, o->hw_device);
 			o->hasusb = 0;
 			usleep(DEVICE_RETRY);
 			continue;
 		}
 
+		flush_stream_buffer(o);
 		o->audio_thread_ready = 1;
 		last_frame_time = ast_radio_tvnow();
 
@@ -2383,6 +2409,8 @@ static void *simpleusb_audio_thread(void *arg)
 				if ((now - o->lasthidtime) > 1) {
 					ast_log(LOG_ERROR, "Channel %s: HID process has died or is not responding.\n", o->name);
 					usleep(DEVICE_RETRY);
+					o->hasusb = 0;
+					stream_cleanup(o);
 					break;
 				}
 			}
@@ -2487,7 +2515,8 @@ static void *simpleusb_audio_thread(void *arg)
 						 * all other errors require restart
 						 */
 						ast_debug(2, "Pa_GetStreamWriteAvailable error %s", Pa_GetErrorText(frames_available));
-						goto stream_restart;
+						o->hasusb = 0;
+						stream_cleanup(o);
 					}
 				}
 
@@ -2584,7 +2613,8 @@ static void *simpleusb_audio_thread(void *arg)
 									 * all other errors require restart
 									 */
 									ast_debug(2, "Pa_WriteStream error %s", Pa_GetErrorText(res));
-									goto stream_restart;
+									o->hasusb = 0;
+									stream_cleanup(o);
 								}
 							}
 
@@ -2625,6 +2655,8 @@ static void *simpleusb_audio_thread(void *arg)
 
 			if (num_frames && (ast_tvdiff_ms(ast_radio_tvnow(), last_frame_time) > MAX_FRAME_DELAY)) {
 				ast_log(LOG_ERROR, "Audio thread has not processed audio for over %d ms, restarting stream.\n", MAX_FRAME_DELAY);
+				o->hasusb = 0;
+				stream_cleanup(o);
 				break;
 			}
 
@@ -2640,6 +2672,8 @@ static void *simpleusb_audio_thread(void *arg)
 					ast_debug(6, "PortAudio read overflow on channel %s\n", o->name);
 				} else {
 					ast_log(LOG_ERROR, "Pa_ReadStream Error on channel %s : %s\n", o->name, Pa_GetErrorText(res));
+					o->hasusb = 0;
+					stream_cleanup(o);
 					break; /* Close the stream and retry */
 				}
 			}
@@ -2939,25 +2973,8 @@ static void *simpleusb_audio_thread(void *arg)
 				ast_queue_frame(o->owner, f);
 			}
 		}
-
-stream_restart:
-		o->hasusb = 0;
-		stop_stream(o);
-
-		ast_mutex_lock(&o->txqlock);
-		while ((f1 = AST_LIST_REMOVE_HEAD(&o->txq, frame_list))) {
-			ast_frfree(f1);
-		}
-
-		ast_mutex_unlock(&o->txqlock);
 	}
-
-	ast_mutex_lock(&o->txqlock);
-	while ((f1 = AST_LIST_REMOVE_HEAD(&o->txq, frame_list))) {
-		ast_frfree(f1);
-	}
-	ast_mutex_unlock(&o->txqlock);
-	o->audio_thread_ready = 0;
+	stream_cleanup(o);
 	ast_debug(2, "Audio Thread has exited");
 	return NULL;
 }

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -29,11 +29,15 @@
 
 /*** MODULEINFO
 	<depend>alsa</depend>
+	<depend>portaudio</depend>
 	<depend>res_usbradio</depend>
 	<support_level>extended</support_level>
  ***/
 
 #include "asterisk.h"
+
+#include <portaudio.h>
+#include <alsa/asoundlib.h>
 
 #include <stdio.h>
 #include <math.h>
@@ -46,7 +50,6 @@
 #include <errno.h>
 #include <usb.h>
 #include <search.h>
-#include <alsa/asoundlib.h>
 #include <linux/ppdev.h>
 #include <linux/parport.h>
 #include <linux/version.h>
@@ -76,7 +79,7 @@
 #define PP_IOPORT 0x378
 #define N_FMT(duf) "%30" #duf /* Maximum sscanf conversion to numeric strings */
 #define HID_POLL_RATE 50
-
+#define DEVICE_RETRY 500000 /* Retry time in uS when USB device is missing */
 #ifdef __linux
 #include <linux/soundcard.h>
 #elif defined(__FreeBSD__)
@@ -103,6 +106,30 @@
 #include "asterisk/format_cache.h"
 #include "asterisk/format_compatibility.h"
 
+/*!
+ * \brief The sample rate to request from PortAudio
+ *
+ * \todo Make this optional.  If this is only going to talk to 8 kHz endpoints,
+ *       then it makes sense to use 8 kHz natively if possible.
+ */
+#define PA_SAMPLE_RATE 48000 /* PortAudio Sample rate: Hardware likes 48k and is divisible by 6 for a "nice" down conversion. */
+
+/*!
+ * \brief The number of samples to configure the PortAudio stream for.
+ *
+ * At 48kHz, 960 samples gives a 20ms frame, which aligns with Asterisk's
+ * common frame size after resampling to 8kHz (160 samples @ 2 bytes per sample).
+ * The number of short (2 byte) with paInt16 samples per PortAudio "frame".
+ * This is 1920 bytes for stereo, or 960 bytes for mono
+ */
+#define PA_NUM_FRAMES FRAME_SIZE * 6 /* Number of samples to read/write from PortAudio stream per Asterisk frame at 48k */
+
+/*! \brief Mono Input */
+#define PA_INPUT_CHANNELS 1 /* PortAudio: Mono input for Microphone / RX */
+
+/*! \brief Stereo Output */
+#define PA_OUTPUT_CHANNELS 2 /* PortAudio: Stereo output for Speaker / TX */
+
 /*! \brief Global jitterbuffer configuration - by default, jb is disabled */
 static struct ast_jb_conf default_jbconf = {
 	.flags = 0,
@@ -120,13 +147,13 @@ static struct ast_jb_conf global_jbconf;
 #define PAGER_SRC "PAGER"
 #define ENDPAGE_STR "ENDPAGE"
 #define AMPVAL 12000
-#define SAMPRATE 8000 /* (Sample Rate) */
-#define DIVLCM 192000 /* (Least Common Mult of 512,1200,2400,8000) */
+#define AST_SAMPLE_RATE 8000 /* Asterisk sample rate (after down conversion) */
+#define DIVLCM 192000		 /* Least Common Mult of 512,1200,2400,8000) */
 #define PREAMBLE_BITS 576
 #define MESSAGE_BITS 544 /* (17 * 32), 1 longword SYNC plus 16 longwords data */
 #define ONEVAL -AMPVAL
 #define ZEROVAL AMPVAL
-#define DIVSAMP (DIVLCM / SAMPRATE)
+#define DIVSAMP (DIVLCM / AST_SAMPLE_RATE)
 
 #define QUEUE_SIZE 5 /* 100 milliseconds of sound card output buffer */
 
@@ -171,48 +198,38 @@ static const char *const sd_signal_type[] = { "no", "usb", "usbinvert", "N/A", "
 struct chan_simpleusb_pvt {
 	struct chan_simpleusb_pvt *next;
 
-	char *name;		  /* the internal name of our channel */
-	int devtype;	  /* actual type of device */
-	int pttkick[2];	  /* ptt kick pipe */
-	int total_blocks; /* total blocks in the output device */
-	int sounddev;
+	char *name;			 /* the internal name of our channel */
+	char hw_device[100]; /* hardware device name */
+	int devtype;		 /* actual type of device */
+	int pttkick[2];		 /* ptt kick pipe */
 	enum {
 		M_UNSET,
 		M_FULL,
 		M_READ,
 		M_WRITE
 	} duplex;
-	int hookstate;
-	unsigned int queuesize; /* max fragments in queue */
-	unsigned int frags;		/* parameter for SETFRAGMENT */
 
 	int warned; /* various flags used for warnings */
-#define WARN_used_blocks 1
-#define WARN_speed 2
-#define WARN_frag 4
-
-	char devicenum;
+	int devicenum;
 	char devstr[128];
 	char serial[128];
 	int spkrmax;
 	int micmax;
 	int micplaymax;
 
+	pthread_t audiothread;
 	pthread_t hidthread;
-	int stophid;
 
+	struct usb_device *usb_dev;
 	struct ast_channel *owner;
 
-	/* buffers used in simpleusb_write, 2 per int */
-	char simpleusb_write_buf[FRAME_SIZE * 2];
+	PaStream *stream; /*! Current PortAudio stream for this device */
+
+	char simpleusb_write_buf[FRAME_SIZE * 2]; /* buffer used for Asterisk to PA frames in 8k mono */
 
 	int simpleusb_write_dst;
-	/* buffers used in simpleusb_read - AST_FRIENDLY_OFFSET space for headers
-	 * plus enough room for a full frame
-	 */
-	char simpleusb_read_buf[FRAME_SIZE * 4 * 6]; /* 2 bytes * 2 channels * 6 for 48K */
-	char simpleusb_read_frame_buf[FRAME_SIZE * 2 + AST_FRIENDLY_OFFSET];
-	int readpos;			 /* read position above */
+	short simpleusb_read_buf[PA_NUM_FRAMES]; /* 1 short (2 byte) samples for PortAudio config with paInt16 * 1 channel (mono) */
+	char simpleusb_read_frame_buf[FRAME_SIZE * 2 + AST_FRIENDLY_OFFSET]; /* 2 byte samples at 8k */
 	struct ast_frame read_f; /* returned by simpleusb_read */
 
 	/* queue used to hold packets to transmit */
@@ -262,8 +279,8 @@ struct chan_simpleusb_pvt {
 	int txmixbset;
 
 	/*! \brief Settings for echoing received audio */
-	int echomode;
-	int echoing;
+	char echomode;
+	char echoing;
 	ast_mutex_t echolock;
 	struct qelem echoq;
 	int echomax;
@@ -292,22 +309,25 @@ struct chan_simpleusb_pvt {
 	char had_pp_in;
 
 	/* bit fields */
-	unsigned int rxcapraw:1;		/* indicator if receive capture is enabled */
-	unsigned int txcapraw:1;		/* indicator if transmit capture is enabled */
-	unsigned int measure_enabled:1; /* indicator if measure mode is enabled */
-	unsigned int device_error:1;	/* indicator set when we cannot find the USB device */
-	unsigned int newname:1;			/* indicator that we should use MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW */
-	unsigned int hasusb:1;			/* indicator for has a USB device */
-	unsigned int usbass:1;			/* indicator for USB device assigned */
-	unsigned int wanteeprom:1;		/* indicator if we should use EEPROM */
-	unsigned int usedtmf:1;			/* indicator is we should decode DTMF */
-	unsigned int invertptt:1;		/* indicator if we need to invert ptt */
-	unsigned int rxboost:1;			/* indicator if receive boost is needed */
-	unsigned int plfilter:1;		/* indicator if we need a pl filter */
-	unsigned int deemphasis:1;		/* indicator if we need deemphasis filter */
-	unsigned int preemphasis:1;		/* indicator if we need preemphasis filter */
-	unsigned int rx_cos_active:1;	/* indicator if cos is active - active state after processing */
-	unsigned int rx_ctcss_active:1; /* indicator if ctcss is active - active state after processing */
+	unsigned int streamstate:1;			   /* indicator if stream is started */
+	unsigned int rxcapraw:1;			   /* indicator if receive capture is enabled */
+	unsigned int txcapraw:1;			   /* indicator if transmit capture is enabled */
+	unsigned int measure_enabled:1;		   /* indicator if measure mode is enabled */
+	unsigned int device_error:1;		   /* indicator set when we cannot find the USB device */
+	unsigned int newname:1;				   /* indicator that we should use MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW */
+	unsigned int hasusb:1;				   /* indicator for has a USB device */
+	unsigned int usbass:1;				   /* indicator for USB device assigned */
+	unsigned int wanteeprom:1;			   /* indicator if we should use EEPROM */
+	unsigned int usedtmf:1;				   /* indicator is we should decode DTMF */
+	unsigned int invertptt:1;			   /* indicator if we need to invert ptt */
+	unsigned int rxboost:1;				   /* indicator if receive boost is needed */
+	unsigned int plfilter:1;			   /* indicator if we need a pl filter */
+	unsigned int deemphasis:1;			   /* indicator if we need deemphasis filter */
+	unsigned int preemphasis:1;			   /* indicator if we need preemphasis filter */
+	unsigned int rx_cos_active:1;		   /* indicator if cos is active - active state after processing */
+	unsigned int rx_ctcss_active:1;		   /* indicator if ctcss is active - active state after processing */
+	volatile sig_atomic_t stophidthread;   /* indicator to stop hid thread */
+	volatile sig_atomic_t stopaudiothread; /* indicator to stop audio thread */
 
 	/* EEPROM access variables */
 	unsigned short eeprom[EEPROM_USER_LEN];
@@ -315,7 +335,6 @@ struct chan_simpleusb_pvt {
 	ast_mutex_t eepromlock;
 
 	struct usb_dev_handle *usb_handle;
-	int readerrs;
 	struct timeval tonetime;
 	int toneflag;
 	int duplex3;
@@ -344,11 +363,7 @@ struct chan_simpleusb_pvt {
  * \brief Default channel descriptor
  */
 static struct chan_simpleusb_pvt simpleusb_default = {
-	.sounddev = -1,
 	.duplex = M_FULL,
-	.queuesize = QUEUE_SIZE,
-	.frags = FRAGS,
-	.readpos = 0, /* start here on reads */
 	.wanteeprom = 1,
 	.usedtmf = 1,
 	.rxondelay = 0,
@@ -366,7 +381,6 @@ static struct chan_simpleusb_pvt simpleusb_default = {
 
 static int hidhdwconfig(struct chan_simpleusb_pvt *o);
 static void mixer_write(struct chan_simpleusb_pvt *o);
-static int setformat(struct chan_simpleusb_pvt *o, int mode);
 static struct ast_channel *simpleusb_request(const char *type, struct ast_format_cap *cap,
 	const struct ast_assigned_ids *assignedids, const struct ast_channel *requestor, const char *data, int *cause);
 static int simpleusb_digit_begin(struct ast_channel *c, char digit);
@@ -383,12 +397,11 @@ static int simpleusb_setoption(struct ast_channel *chan, int option, void *data,
 static void tune_menusupport(int fd, struct chan_simpleusb_pvt *o, const char *cmd);
 static void tune_write(struct chan_simpleusb_pvt *o);
 static int _send_tx_test_tone(int fd, struct chan_simpleusb_pvt *o, int ms, int intflag);
+static void *simpleusb_audio_thread(void *arg);
 
 static char *simpleusb_active; /* the active device */
 
 static const int ppinshift[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 7, 5, 4, 0, 3 };
-
-static const char tdesc[] = "Simple USB (CM108) Radio Channel Driver";
 
 /*!
  * \brief Asterisk channel technology struct.
@@ -397,7 +410,7 @@ static const char tdesc[] = "Simple USB (CM108) Radio Channel Driver";
  */
 static struct ast_channel_tech simpleusb_tech = {
 	.type = "SimpleUSB",
-	.description = tdesc,
+	.description = "Simple USB (CM108) Radio Channel Driver",
 	.requester = simpleusb_request,
 	.send_digit_begin = simpleusb_digit_begin,
 	.send_digit_end = simpleusb_digit_end,
@@ -411,6 +424,272 @@ static struct ast_channel_tech simpleusb_tech = {
 	.fixup = simpleusb_fixup,
 	.setoption = simpleusb_setoption,
 };
+
+#include <time.h>
+#include <unistd.h>
+
+static int64_t now_ms(void)
+{
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (int64_t) ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
+static PaError Pa_ReadStream_with_timeout(PaStream *s, short *buf, long frames, int timeout_ms, volatile sig_atomic_t *stop)
+{
+	int64_t start;
+
+	start = now_ms();
+	while (!(*stop)) {
+		long avail;
+		PaError err;
+
+		avail = Pa_GetStreamReadAvailable(s);
+		if (avail < 0) {
+			return (PaError) avail;
+		}
+
+		if ((now_ms() - start) > timeout_ms) {
+			return paTimedOut;
+		}
+
+		if (avail < frames) {
+			usleep(500); /*.5ms */
+			continue;
+		}
+
+		err = Pa_ReadStream(s, buf, frames);
+		return err;
+	}
+
+	return paTimedOut;
+}
+
+/*!
+ * \brief Parse "hw:<card>" or "hw:<card>,<dev>" from anywhere in s.
+ * \retval 1 if found; sets *card; sets *dev to parsed value or -1 if absent.
+ */
+static int parse_hw_anywhere(const char *s, int *card, int *dev)
+{
+	const char *p = s;
+
+	if (!s || !card || !dev) {
+		return 0;
+	}
+
+	while ((p = strstr(p, "hw:")) != NULL) {
+		const char *q = p + 3; /* after "hw:" */
+		int c = 0;
+		int d = -1; /* dev absent by default */
+
+		/* card must start with digit */
+		if (!isdigit((unsigned char) *q)) {
+			p = q;
+			continue;
+		}
+
+		while (isdigit((unsigned char) *q)) {
+			if (c > 9999) {
+				/* reasonable upper bound for card numbers */
+				p = q;
+				break;
+			}
+
+			c = c * 10 + (*q - '0');
+			q++;
+		}
+
+		if (*q == ',') {
+			q++;
+			if (!isdigit((unsigned char) *q)) {
+				/* "hw:<card>," is malformed; skip this occurrence */
+				p = q;
+				continue;
+			}
+			d = 0;
+			while (isdigit((unsigned char) *q)) {
+				d = d * 10 + (*q - '0');
+				q++;
+			}
+		}
+
+		*card = c;
+		*dev = d;
+		return 1; /* first valid hw: occurrence */
+	}
+
+	return 0;
+}
+
+/*!
+ * \brief Match rule:
+ * - needle "hw:C" matches any "hw:C" or "hw:C,D" in haystack
+ * - needle "hw:C,D" matches only "hw:C,D" in haystack
+ */
+static int hw_match(const char *haystack, const char *needle)
+{
+	int haystack_c, haystack_d, needle_c, needle_d;
+	const char *p = haystack ? haystack : "";
+
+	if (!parse_hw_anywhere(needle, &needle_c, &needle_d)) {
+		return 0;
+	}
+
+	/* haystack may contain multiple hw: occurrences; scan all */
+	while ((p = strstr(p, "hw:")) != NULL) {
+		if (parse_hw_anywhere(p, &haystack_c, &haystack_d)) {
+			if (haystack_c == needle_c) {
+				if (needle_d < 0) {
+					/* needle is "hw:C" -> accept any dev (including absent) */
+					return 1;
+				} else if (haystack_d == needle_d) {
+					/* needle is "hw:C,D" -> require exact dev match */
+					return 1;
+				}
+			}
+		}
+		p += 3; /* move forward to find next occurrence */
+	}
+
+	return 0;
+}
+
+static int open_stream(struct chan_simpleusb_pvt *o)
+{
+	PaError res = paInternalError;
+	const PaStreamInfo *si;
+
+	if (!strcasecmp(o->hw_device, "default")) {
+		ast_debug(1, "Opening stream with default device\n");
+		res = Pa_OpenDefaultStream(&o->stream, PA_INPUT_CHANNELS, PA_OUTPUT_CHANNELS, paInt16, PA_SAMPLE_RATE, PA_NUM_FRAMES, NULL, NULL);
+	} else {
+		PaStreamParameters input_params = {
+			.channelCount = PA_INPUT_CHANNELS,
+			.sampleFormat = paInt16,
+			.suggestedLatency = (1.0 / 50.0), /* 20 ms */
+			.device = paNoDevice,
+		};
+		PaStreamParameters output_params = {
+			.channelCount = PA_OUTPUT_CHANNELS,
+			.sampleFormat = paInt16,
+			.suggestedLatency = (1.0 / 50.0), /* 20 ms */
+			.device = paNoDevice,
+		};
+		PaDeviceIndex idx, num_devices;
+		ast_debug(1, "Looking for device %s\n", o->hw_device);
+		ast_debug(5, "PortAudio host api count %d\n", Pa_GetHostApiCount());
+		num_devices = Pa_GetDeviceCount();
+		if (num_devices < 0) {
+			ast_debug(1, "No devices found\n");
+			return res;
+		} else {
+			ast_debug(6, "%d Devices found\n", num_devices);
+		}
+
+		for (idx = 0; idx < num_devices && (input_params.device == paNoDevice || output_params.device == paNoDevice); idx++) {
+			const PaDeviceInfo *dev = Pa_GetDeviceInfo(idx);
+			ast_debug(1, "Found device %s\n", dev->name);
+			if (dev->maxInputChannels) {
+				if (hw_match(dev->name, o->hw_device)) {
+					ast_debug(5, "Found input device %s\n", dev->name);
+					input_params.device = idx;
+				}
+			}
+
+			if (dev->maxOutputChannels) {
+				if (hw_match(dev->name, o->hw_device)) {
+					ast_debug(5, "Found output device %s\n", dev->name);
+					output_params.device = idx;
+				}
+			}
+		}
+
+		if (input_params.device == paNoDevice) {
+			ast_log(LOG_ERROR, "No input device found for simpleusb device '%s'\n", o->name);
+			return res;
+		}
+
+		if (output_params.device == paNoDevice) {
+			ast_log(LOG_ERROR, "No output device found for simpleusb device '%s'\n", o->name);
+			return res;
+		}
+		ast_debug(5, "Opening stream on device %s", o->hw_device);
+		res = Pa_OpenStream(&o->stream, &input_params, &output_params, PA_SAMPLE_RATE, PA_NUM_FRAMES, paNoFlag, NULL, NULL);
+		ast_debug(5, "Stream feedback: %s\n", Pa_GetErrorText(res));
+		if (res == paNoError) {
+			si = Pa_GetStreamInfo(o->stream);
+			if (si) {
+				ast_debug(5, "Stream output latency: %.3f ms\n", si->outputLatency * 1000.0);
+				ast_debug(5, "Stream input latency: %.3f ms\n", si->inputLatency * 1000.0);
+			}
+		}
+	}
+
+	return res;
+}
+
+static int start_stream(struct chan_simpleusb_pvt *pvt)
+{
+	PaError res;
+
+	ast_debug(5, "Starting PA Stream");
+	/* It is possible for simpleusb_hangup to be called before the
+	 * stream is started, if this is the case pvt->owner will be NULL
+	 * and start_stream should be aborted. */
+	if (pvt->streamstate || !pvt->owner)
+		return -1;
+
+	res = Pa_Initialize();
+	if (res != paNoError) {
+		ast_log(LOG_WARNING, "Failed to initialize audio system - (%d) %s\n", res, Pa_GetErrorText(res));
+		return -1;
+	}
+
+	res = open_stream(pvt);
+	if (res != paNoError) {
+		ast_log(LOG_WARNING, "Failed to open stream - (%d) %s\n", res, Pa_GetErrorText(res));
+		Pa_Terminate();
+		return -1;
+	}
+
+	res = Pa_StartStream(pvt->stream);
+	if (res != paNoError) {
+		ast_log(LOG_WARNING, "Failed to start stream - (%d) %s\n", res, Pa_GetErrorText(res));
+		Pa_CloseStream(pvt->stream);
+		pvt->stream = NULL;
+		pvt->streamstate = 0;
+		Pa_Terminate();
+		return -1;
+	}
+
+	pvt->streamstate = 1;
+	return 0;
+}
+
+static int stop_stream(struct chan_simpleusb_pvt *pvt)
+{
+	PaError err;
+
+	if (!pvt->streamstate) {
+		return 0;
+	}
+
+	/* Abort and close the stream */
+	err = Pa_AbortStream(pvt->stream);
+	if (err != paNoError) {
+		ast_log(LOG_WARNING, "Pa_AbortStream failed: %s\n", Pa_GetErrorText(err));
+	}
+
+	err = Pa_CloseStream(pvt->stream);
+	if (err != paNoError) {
+		ast_log(LOG_WARNING, "Pa_CloseStream failed: %s\n", Pa_GetErrorText(err));
+	}
+
+	pvt->stream = NULL;
+	pvt->streamstate = 0;
+	Pa_Terminate();
+	return 0;
+}
 
 /*!
  * \brief FIR Low pass filter.
@@ -782,7 +1061,7 @@ static void *pulserthread(void *arg)
 		}
 		ast_mutex_unlock(&pp_lock);
 	}
-	pthread_exit(0);
+	return NULL;
 }
 
 /*!
@@ -806,10 +1085,6 @@ static int load_tune_config(struct chan_simpleusb_pvt *o, const struct ast_confi
 
 	devstr[0] = '\0';
 	serial[0] = '\0';
-	if (!reload) {
-		o->devstr[0] = '\0';
-		o->serial[0] = '\0';
-	}
 
 	if (!cfg) {
 		struct ast_flags zeroflag = { 0 };
@@ -830,6 +1105,9 @@ static int load_tune_config(struct chan_simpleusb_pvt *o, const struct ast_confi
 		CV_UINT("txmixbset", o->txmixbset);
 		CV_STR("devstr", devstr);
 		CV_STR("serial", serial);
+		if (o->devstr[0] == '\0') {
+			CV_STR("audiodev", o->hw_device); /* use audiodevice as opposed to the usb device path (devstr) */
+		}
 		CV_END;
 	}
 	if (!reload) {
@@ -847,76 +1125,43 @@ static int load_tune_config(struct chan_simpleusb_pvt *o, const struct ast_confi
 	return 0;
 }
 
-/*!
- * \brief USB sound device GPIO processing thread
- * This thread is responsible for finding and associating the node with the
- * associated usb sound card device.  It performs setup and initialization of
- * the USB device.
- *
- * The CM-XXX USB devices can support up to 8 GPIO pins that can be input or output.
- * It continuously polls the input GPIO pins on the device to see if they have changed.
- * The default GPIOs for COS, and CTCSS provide the basic functionality. An asterisk
- * text frame is raised in the format 'GPIO%d %d' when GPIOs change. Polling generally
- * occurs every HID_POLL_RATE milliseconds.
- *
- * The output PTT (push to talk) GPIO, along with other GPIO outputs are updated as
- * required.
- *
- * If the user has enabled the parallel port for GPIOs, they are polled and updated
- * as appropriate.  An asterisk text frame is raised in the format 'PP%d %d' when
- * GPIOs change. (Parallel port support is not available for all platforms.)
- *
- * This routine also reads and writes to the EPROM attached to the USB device.  The
- * EPROM holds the configuration information (sound level settings) for this device.
- *
- * This routine updates the lasthidtimer during setup and processing.  In the event
- * that this timer update does not occur over a period of 3 seconds, app_rpt will
- * kill the node and restart everything.  This helps to detect problems with a
- * hung USB device.
- *
- * \param argv		chan_simpleusb_pvt structure associated with this thread.
+/*! \brief Find and initialize the audio device.
+ * \param o pointer to private struct
  */
-static void *hidthread(void *arg)
+static int init_audio_device(struct chan_simpleusb_pvt *o)
 {
-	unsigned char buf[4], bufsave[4], keyed, ctcssed, txreq;
-	char *s, lasttxtmp;
-	register int i, j, k;
-	int res;
-	struct usb_device *usb_dev;
-	struct usb_dev_handle *usb_handle;
-	struct chan_simpleusb_pvt *o = arg, *ao;
-	struct timeval then;
-	struct pollfd rfds[1];
+	char serial[sizeof(o->serial)] = { '\0' };
+	char *s;
+	struct chan_simpleusb_pvt *ao;
+	register int i;
 
-	usb_dev = NULL;
-	usb_handle = NULL;
-	/* enable gpio_set so that we will write GPIO information upon start up */
-	o->gpio_set = 1;
+	ast_radio_time(&o->lasthidtime);
+	ast_mutex_lock(&usb_dev_lock);
+	o->hasusb = 0;
+	o->usbass = 0;
+	o->devicenum = 0;
+	o->usb_dev = NULL;
 
-#ifdef HAVE_SYS_IO
-	if (haspp == 2) {
-		ioperm(pbase, 2, 1);
-	}
-#endif
-	/* This is the main loop for this thread.
-	 * It performs setup and initialization of the usb device.
-	 * After setup is complete and the device can be accessed,
-	 * it enters a processing loop responsible for interacting
-	 * with the usb hid device
-	 */
-	while (!o->stophid) {
-		char serial[sizeof(o->serial)] = { '\0' };
+	if (o->hw_device[0]) {
+		/* already configured device, extract the device number and usb_dev */
+		if (!strcasecmp(o->hw_device, "default")) {
+			ast_log(LOG_ERROR, "audiodev=default is not supported for SimpleUSB until HID-less startup is implemented\n");
+			ast_mutex_unlock(&usb_dev_lock);
+			return -1;
+		} else if (sscanf(o->hw_device, "hw:%d", &o->devicenum) == 1) {
+			ast_debug(5, "audiodev is defined: %s, Device %d", o->hw_device, o->devicenum);
+			o->usb_dev = ast_radio_usb_device_from_alsa_card(o->devicenum);
+			if (!o->usb_dev) {
+				ast_debug(5, "Unable to find usb device associated with %s\n", o->hw_device);
+			}
 
-		ast_radio_time(&o->lasthidtime);
-		ast_mutex_lock(&usb_dev_lock);
-		o->hasusb = 0;
-		o->usbass = 0;
-		o->devicenum = 0;
-		if (usb_handle) {
-			usb_close(usb_handle);
+		} else {
+			ast_log(LOG_ERROR, "Incorrect audio parameter audiodev (should be hw:0 format), found %s\n", o->hw_device);
+			ast_mutex_unlock(&usb_dev_lock);
+			return -1;
 		}
-		usb_handle = NULL;
-		usb_dev = NULL;
+	} else {
+		/* use the device string */
 		ast_radio_hid_device_mklist();
 
 		/* Check to see if our specified device string
@@ -971,7 +1216,7 @@ static void *hidthread(void *arg)
 						o->device_error = 1;
 					}
 					ast_mutex_unlock(&usb_dev_lock);
-					usleep(500000);
+					usleep(DEVICE_RETRY);
 					break;
 				}
 				/* We found an available device - see if it already in use */
@@ -993,7 +1238,7 @@ static void *hidthread(void *arg)
 				break;
 			}
 			if (ast_strlen_zero(o->devstr)) {
-				continue;
+				return -1;
 			}
 		}
 
@@ -1004,20 +1249,20 @@ static void *hidthread(void *arg)
 			 * configured channels.
 			 */
 			s = find_installed_usb_match();
+
 			if (ast_strlen_zero(s)) {
 				if (!o->device_error) {
 					ast_log(LOG_ERROR, "Channel %s: Device string %s was not found.\n", o->name, o->devstr);
 					o->device_error = 1;
 				}
 				ast_mutex_unlock(&usb_dev_lock);
-				usleep(500000);
-				continue;
+				return -1;
 			}
+
 			i = ast_radio_usb_get_usbdev(s);
 			if (i < 0) {
 				ast_mutex_unlock(&usb_dev_lock);
-				usleep(500000);
-				continue;
+				return -1;
 			}
 			/* See if this device is already assigned to another usb channel */
 			for (ao = simpleusb_default.next; ao && ao->name; ao = ao->next) {
@@ -1025,12 +1270,13 @@ static void *hidthread(void *arg)
 					break;
 				}
 			}
+
 			if (ao) {
 				ast_log(LOG_ERROR, "Channel %s: Device string %s is already assigned to channel %s", o->name, s, ao->name);
 				ast_mutex_unlock(&usb_dev_lock);
-				usleep(500000);
-				continue;
+				return -1;
 			}
+
 			ast_log(LOG_NOTICE, "Channel %s: Assigned USB device %s to simpleusb channel\n", o->name, s);
 			ast_copy_string(o->devstr, s, sizeof(o->devstr));
 		}
@@ -1040,56 +1286,164 @@ static void *hidthread(void *arg)
 				break;
 			}
 		}
+
 		if (ao) {
 			ast_log(LOG_ERROR, "Channel %s: Device string %s is already assigned to channel %s", o->name, o->devstr, ao->name);
 			ast_mutex_unlock(&usb_dev_lock);
-			usleep(500000);
-			continue;
+			return -1;
 		}
+
 		/* get the index to the device and assign it to our channel */
 		i = ast_radio_usb_get_usbdev(o->devstr);
 		if (i < 0) {
 			ast_mutex_unlock(&usb_dev_lock);
-			usleep(500000);
-			continue;
+			return -1;
 		}
+		snprintf(o->hw_device, sizeof(o->hw_device), "hw:%d", i);
 		o->devicenum = i;
-		o->device_error = 0;
-		ast_radio_time(&o->lasthidtime);
-		o->usbass = 1;
-		ast_mutex_unlock(&usb_dev_lock);
-		/* set the audio mixer values */
-		o->micmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL);
-		o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL);
-		o->micplaymax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_VOL);
-		if (o->spkrmax == -1) {
-			o->newname = 1;
-			o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW);
+		o->usb_dev = ast_radio_hid_device_init(o->devstr);
+		if (!o->usb_dev) {
+			ast_log(LOG_ERROR, "Unable to find usb device associated with %s", o->devstr);
+			ast_mutex_unlock(&usb_dev_lock);
+			return -1;
 		}
-		/* initialize the usb device */
-		usb_dev = ast_radio_hid_device_init(o->devstr);
-		if (usb_dev == NULL) {
-			ast_log(LOG_ERROR, "Channel %s: Cannot initialize device %s\n", o->name, o->devstr);
-			usleep(500000);
+	}
+
+	o->device_error = 0;
+	ast_radio_time(&o->lasthidtime);
+	o->usbass = 1;
+	ast_mutex_unlock(&usb_dev_lock);
+	/* set the audio mixer values */
+	o->micmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL);
+	o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL);
+	o->micplaymax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_VOL);
+
+	if (o->spkrmax == -1) {
+		o->newname = 1;
+		o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW);
+	}
+
+	return 0;
+}
+
+/*!
+ * \brief USB sound device GPIO processing thread
+ * This thread is responsible for finding and associating the node with the
+ * associated usb sound card device.  It performs setup and initialization of
+ * the USB device.
+ *
+ * The CM-XXX USB devices can support up to 8 GPIO pins that can be input or output.
+ * It continuously polls the input GPIO pins on the device to see if they have changed.
+ * The default GPIOs for COS, and CTCSS provide the basic functionality. An asterisk
+ * text frame is raised in the format 'GPIO%d %d' when GPIOs change. Polling generally
+ * occurs every HID_POLL_RATE milliseconds.
+ *
+ * The output PTT (push to talk) GPIO, along with other GPIO outputs are updated as
+ * required.
+ *
+ * If the user has enabled the parallel port for GPIOs, they are polled and updated
+ * as appropriate.  An asterisk text frame is raised in the format 'PP%d %d' when
+ * GPIOs change. (Parallel port support is not available for all platforms.)
+ *
+ * This routine also reads and writes to the EPROM attached to the USB device.  The
+ * EPROM holds the configuration information (sound level settings) for this device.
+ *
+ * This routine updates the lasthidtimer during setup and processing.  In the event
+ * that this timer update does not occur over a period of 3 seconds, app_rpt will
+ * kill the node and restart everything.  This helps to detect problems with a
+ * hung USB device.
+ *
+ * \param argv		chan_simpleusb_pvt structure associated with this thread.
+ */
+static void *hidthread(void *arg)
+{
+	unsigned char buf[4], bufsave[4], keyed, ctcssed, txreq;
+	char lasttxtmp;
+	register int i, j, k;
+	int res;
+	struct usb_dev_handle *usb_handle = NULL;
+	struct chan_simpleusb_pvt *o = arg;
+	struct timeval then;
+	struct pollfd rfds[1];
+	int init_audio_failed = 0;
+	int init_hid_failed = 0;
+	int open_device_failed = 0;
+	int detach_failed = 0;
+	int claim_failed = 0;
+
+	ast_debug(2, "hidthread has started");
+	/* enable gpio_set so that we will write GPIO information upon start up */
+	o->gpio_set = 1;
+
+#ifdef HAVE_SYS_IO
+	if (haspp == 2) {
+		ioperm(pbase, 2, 1);
+	}
+#endif
+	/* This is the main loop for this thread.
+	 * It performs setup and initialization of the usb device.
+	 * After setup is complete and the device can be accessed,
+	 * it enters a processing loop responsible for interacting
+	 * with the usb hid device
+	 */
+	while (!o->stophidthread) {
+		ast_debug(5, "hidthread is entering outer loop");
+
+		/* try to initialize the usb device */
+		res = init_audio_device(o);
+		if (res < 0) {
+			if (!init_audio_failed) {
+				ast_log(LOG_ERROR, "Channel %s: Failed initialize the audio device\n", o->name);
+				init_audio_failed = 1;
+			}
+
+			usleep(DEVICE_RETRY);
 			continue;
 		}
+
+		if (o->usb_dev == NULL) {
+			if (!init_hid_failed) {
+				ast_log(LOG_ERROR, "Channel %s: Cannot initialize device %s\n", o->name, o->devstr);
+				init_hid_failed = 1;
+			}
+
+			usleep(DEVICE_RETRY);
+			continue;
+		}
+
 		/* open the usb device device */
-		usb_handle = usb_open(usb_dev);
+		usb_handle = usb_open(o->usb_dev);
 		if (usb_handle == NULL) {
-			ast_log(LOG_ERROR, "Channel %s: Cannot open device %s\n", o->name, o->devstr);
-			usleep(500000);
+			if (!open_device_failed) {
+				ast_log(LOG_ERROR, "Channel %s: Cannot open device %s\n", o->name, o->devstr);
+				open_device_failed = 1;
+			}
+
+			usleep(DEVICE_RETRY);
 			continue;
 		}
 		/* attempt to claim the usb hid interface and detach from the kernel */
 		if (usb_claim_interface(usb_handle, C108_HID_INTERFACE) < 0) {
 			if (usb_detach_kernel_driver_np(usb_handle, C108_HID_INTERFACE) < 0) {
-				ast_log(LOG_ERROR, "Channel %s: Is not able to detach the USB device\n", o->name);
-				usleep(500000);
+				if (!detach_failed) {
+					ast_log(LOG_ERROR, "Channel %s: Is not able to detach the USB device\n", o->name);
+					detach_failed = 1;
+				}
+
+				usb_close(usb_handle);
+				usb_handle = NULL;
+				usleep(DEVICE_RETRY);
 				continue;
 			}
 			if (usb_claim_interface(usb_handle, C108_HID_INTERFACE) < 0) {
-				ast_log(LOG_ERROR, "Channel %s: Is not able to claim the USB device\n", o->name);
-				usleep(500000);
+				if (!claim_failed) {
+					ast_log(LOG_ERROR, "Channel %s: Is not able to claim the USB device\n", o->name);
+					detach_failed = 1;
+				}
+
+				usb_close(usb_handle);
+				usb_handle = NULL;
+				usleep(DEVICE_RETRY);
 				continue;
 			}
 		}
@@ -1113,14 +1467,17 @@ static void *hidthread(void *arg)
 		}
 		if (pipe2(o->pttkick, O_NONBLOCK) == -1) {
 			ast_log(LOG_ERROR, "Channel %s: Is not able to create a pipe\n", o->name);
-			pthread_exit(NULL);
+			usb_close(usb_handle);
+			usb_handle = NULL;
+			return NULL;
 		}
 
-		if ((usb_dev->descriptor.idProduct & 0xfffc) == C108_PRODUCT_ID) {
+		if ((o->usb_dev->descriptor.idProduct & 0xfffc) == C108_PRODUCT_ID) {
 			o->devtype = C108_PRODUCT_ID;
 		} else {
-			o->devtype = usb_dev->descriptor.idProduct;
+			o->devtype = o->usb_dev->descriptor.idProduct;
 		}
+
 		ast_debug(5, "Channel %s: Starting normally.\n", o->name);
 		ast_debug(5, "Channel %s: Attached to usb device %s.\n", o->name, o->devstr);
 
@@ -1134,21 +1491,29 @@ static void *hidthread(void *arg)
 		}
 		ast_mutex_unlock(&o->eepromlock);
 
-		setformat(o, O_RDWR);
 		o->hasusb = 1;
 		o->had_gpios_in = 0;
-
 		memset(&rfds, 0, sizeof(rfds));
 		rfds[0].fd = o->pttkick[0];
 		rfds[0].events = POLLIN;
 
 		ast_radio_time(&o->lasthidtime);
+
+		/* Reset the failure flags, we succeeded */
+		init_audio_failed = 0;
+		init_hid_failed = 0;
+		open_device_failed = 0;
+		detach_failed = 0;
+		claim_failed = 0;
+
 		/* Main processing loop for GPIO
 		 * This loop process every HID_POLL_RATE milliseconds.
 		 * The timer can be interrupted by writing to
 		 * the pttkick pipe.
 		 */
-		while ((!o->stophid) && o->hasusb) {
+		while ((!o->stophidthread) && o->hasusb) {
+			int hid_write = 0;
+
 			then = ast_radio_tvnow();
 			/* poll the pttkick pipe - timeout after HID_POLL_RATE milliseconds */
 			res = ast_poll(rfds, 1, HID_POLL_RATE);
@@ -1159,8 +1524,14 @@ static void *hidthread(void *arg)
 			}
 			if (rfds[0].revents) {
 				char c;
+				int nbytes = 0;
+				int bytes;
 
-				int bytes = read(o->pttkick[0], &c, 1);
+				/* Get all events in the buffer - if we missed a state change it will not make
+				 * it to the hardware anyways.
+				 */
+				ioctl(o->pttkick[0], FIONREAD, &nbytes);
+				bytes = read(o->pttkick[0], &c, nbytes);
 				if (bytes < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
 					ast_log(LOG_ERROR, "Channel %s: pttkick read failed: %s\n", o->name, strerror(errno));
 				} else if (bytes == 0) {
@@ -1210,27 +1581,26 @@ static void *hidthread(void *arg)
 				ast_debug(2, "Channel %s: Update rxhidctcss = %d\n", o->name, ctcssed);
 				o->rxhidctcss = ctcssed;
 			}
-			ast_mutex_lock(&o->txqlock);
+
 			txreq = !(AST_LIST_EMPTY(&o->txq));
-			ast_mutex_unlock(&o->txqlock);
 			txreq = txreq || o->txkeyed || o->txtestkey || o->echoing;
-			if (txreq && (!o->lasttx)) {
+			if (txreq && !o->lasttx) {
 				o->hid_gpio_val |= o->hid_io_ptt;
 				if (o->invertptt) {
 					o->hid_gpio_val &= ~o->hid_io_ptt;
 				}
 				buf[o->hid_gpio_loc] = o->hid_gpio_val;
 				buf[o->hid_gpio_ctl_loc] = o->hid_gpio_ctl;
-				ast_radio_hid_set_outputs(usb_handle, buf);
+				hid_write = 1;
 				ast_debug(2, "Channel %s: update PTT = %d on channel.\n", o->name, txreq);
-			} else if ((!txreq) && o->lasttx) {
+			} else if (!txreq && o->lasttx) {
 				o->hid_gpio_val &= ~o->hid_io_ptt;
 				if (o->invertptt) {
 					o->hid_gpio_val |= o->hid_io_ptt;
 				}
 				buf[o->hid_gpio_loc] = o->hid_gpio_val;
 				buf[o->hid_gpio_ctl_loc] = o->hid_gpio_ctl;
-				ast_radio_hid_set_outputs(usb_handle, buf);
+				hid_write = 1;
 				ast_debug(2, "Channel %s: update PTT = %d.\n", o->name, txreq);
 			}
 			lasttxtmp = o->lasttx;
@@ -1279,7 +1649,10 @@ static void *hidthread(void *arg)
 						sprintf(buf1, "GPIO%d %d\n", i + 1, (j & (1 << i)) ? 1 : 0);
 						fr.data.ptr = buf1;
 						fr.datalen = strlen(buf1);
-						ast_queue_frame(o->owner, &fr);
+
+						if (o->owner) {
+							ast_queue_frame(o->owner, &fr);
+						}
 					}
 				}
 				o->had_gpios_in = 1;
@@ -1322,12 +1695,17 @@ static void *hidthread(void *arg)
 							sprintf(buf1, "PP%d %d\n", i, (j & (1 << ppinshift[i])) ? 1 : 0);
 							fr.data.ptr = buf1;
 							fr.datalen = strlen(buf1);
-							ast_queue_frame(o->owner, &fr);
+
+							if (o->owner) {
+								ast_queue_frame(o->owner, &fr);
+							}
 						}
 					}
+
 					o->had_pp_in = 1;
 					o->last_pp_in = j;
 				}
+
 				o->rxppsq = o->rxppctcss = 0;
 				for (i = 10; i <= 15; i++) {
 					if ((o->pps[i]) && (!strcasecmp(o->pps[i], "cor")) && (PP_MASK & (1 << i))) {
@@ -1361,13 +1739,13 @@ static void *hidthread(void *arg)
 			if (o->hid_gpio_pulsemask || o->hid_gpio_lastmask) { /* if anything inverted (temporarily) */
 				buf[o->hid_gpio_loc] = o->hid_gpio_val ^ o->hid_gpio_pulsemask;
 				buf[o->hid_gpio_ctl_loc] = o->hid_gpio_ctl;
-				ast_radio_hid_set_outputs(usb_handle, buf);
+				hid_write = 1;
 			}
 			if (o->gpio_set) {
 				o->gpio_set = 0;
 				buf[o->hid_gpio_loc] = o->hid_gpio_val ^ o->hid_gpio_pulsemask;
 				buf[o->hid_gpio_ctl_loc] = o->hid_gpio_ctl;
-				ast_radio_hid_set_outputs(usb_handle, buf);
+				hid_write = 1;
 			}
 			k = 0;
 			if (haspp) {
@@ -1412,8 +1790,13 @@ static void *hidthread(void *arg)
 				buf[o->hid_gpio_loc] = o->hid_gpio_val ^ o->hid_gpio_pulsemask;
 				buf[o->hid_gpio_ctl_loc] = o->hid_gpio_ctl;
 				memcpy(bufsave, buf, sizeof(buf));
+				hid_write = 1;
+			}
+
+			if (hid_write) {
 				ast_radio_hid_set_outputs(usb_handle, buf);
 			}
+
 			ast_radio_time(&o->lasthidtime);
 			ast_mutex_unlock(&o->usblock);
 		}
@@ -1427,6 +1810,11 @@ static void *hidthread(void *arg)
 		buf[o->hid_gpio_ctl_loc] = o->hid_gpio_ctl;
 		ast_radio_hid_set_outputs(usb_handle, buf);
 		ast_mutex_unlock(&o->usblock);
+
+		if (usb_handle) {
+			usb_close(usb_handle);
+			usb_handle = NULL;
+		}
 	}
 	/* clean up before exiting the thread */
 	o->lasttx = 0;
@@ -1440,43 +1828,12 @@ static void *hidthread(void *arg)
 		buf[o->hid_gpio_ctl_loc] = o->hid_gpio_ctl;
 		ast_radio_hid_set_outputs(usb_handle, buf);
 		ast_mutex_unlock(&o->usblock);
-	}
-	pthread_exit(0);
-}
-
-/*!
- * \brief Get the number of blocks used in the audio output channel.
- * \param o		Channel private data.
- * \returns		Number of blocks that have been used.
- */
-static int used_blocks(struct chan_simpleusb_pvt *o)
-{
-	struct audio_buf_info info;
-
-	if (ioctl(o->sounddev, SNDCTL_DSP_GETOSPACE, &info)) {
-		if (!(o->warned & WARN_used_blocks)) {
-			ast_log(LOG_WARNING, "Channel %s: Error reading output space.\n", o->name);
-			o->warned |= WARN_used_blocks;
-		}
-		return 1;
+		usb_close(usb_handle);
+		usb_handle = NULL;
 	}
 
-	/* Set the total blocks */
-	if (o->total_blocks == 0) {
-		ast_debug(1, "Channel %s: fragment total %d, size %d, available %d, bytes %d\n", o->name, info.fragstotal, info.fragsize,
-			info.fragments, info.bytes);
-		o->total_blocks = info.fragments;
-		/* Check the queue size, it cannot exceed the total fragments */
-		if (o->queuesize >= info.fragstotal) {
-			o->queuesize = info.fragstotal - 1;
-			if (o->queuesize < 2) {
-				o->queuesize = QUEUE_SIZE;
-			}
-			ast_debug(1, "Channel %s: Queue size reset to %d\n", o->name, o->queuesize);
-		}
-	}
-
-	return o->total_blocks - info.fragments;
+	ast_debug(2, "hidthread has exited");
+	return NULL;
 }
 
 /*!
@@ -1489,32 +1846,22 @@ static int used_blocks(struct chan_simpleusb_pvt *o)
  */
 static int soundcard_writeframe(struct chan_simpleusb_pvt *o, short *data)
 {
-	int res;
+	PaError res;
 
-	/* If the sound device is not open, setformat will open the device */
-	if (o->sounddev < 0) {
-		setformat(o, O_RDWR);
-	}
-	if (o->sounddev < 0) {
-		return 0; /* not fatal */
-	}
 	/*
 	 * Nothing complex to manage the audio device queue.
 	 * If the buffer is full just drop the extra, otherwise write.
 	 * In some cases it might be useful to write anyways after
 	 * a number of failures, to restart the output chain.
 	 */
-	res = used_blocks(o);
-	if (res > o->queuesize) { /* no room to write a block */
-		ast_log(LOG_WARNING, "Channel %s: Sound device write buffer overflow - used %d blocks\n", o->name, res);
-		return 0;
-	}
 
-	res = write(o->sounddev, ((void *) data), FRAME_SIZE * 2 * 2 * 6);
-	if (res < 0) {
-		ast_log(LOG_ERROR, "Channel %s: Sound card write error %s\n", o->name, strerror(errno));
-	} else if (res != FRAME_SIZE * 2 * 2 * 6) {
-		ast_log(LOG_ERROR, "Channel %s: Sound card wrote %d bytes of %d\n", o->name, res, (FRAME_SIZE * 2 * 2 * 6));
+	res = Pa_WriteStream(o->stream, data, PA_NUM_FRAMES);
+	if (res == paOutputUnderflowed) {
+		short null_buf[PA_NUM_FRAMES * 2] = { 0 };
+		ast_debug(6, "PortAudio write stream underflow, writing a 0 frame");
+		Pa_WriteStream(o->stream, null_buf, PA_NUM_FRAMES);
+	} else if (res < 0) {
+		ast_debug(2, "Pa_WriteStream Error %s", Pa_GetErrorText(res));
 	}
 
 	/* Check Tx audio statistics. FRAME_SIZE define refers to 8Ksps mono which is 160 samples
@@ -1524,117 +1871,9 @@ static int soundcard_writeframe(struct chan_simpleusb_pvt *o, short *data)
 	 * nice to log a warning but as this does not relate to outgoing network audio it's not
 	 * a major issue. User can check the Tx Audio Stats utility if desired.
 	 */
-	ast_radio_check_audio(data, &o->txaudiostats, 12 * FRAME_SIZE);
+	ast_radio_check_audio(data, &o->txaudiostats, 12 * FRAME_SIZE, 0);
 
 	return res;
-}
-
-/*!
- * \brief Open the sound card device.
- * If the device is already open, this will close the device
- * and open it again.
- * It initializes the device based on our requirements and triggers
- * reads and writes.
- * \param o		chan_usbradio_pvt.
- * \param mode	The mode to open the file.  This is the flags argument to open.
- * \retval 0	Success.
- * \retval -1	Failed.
- */
-static int setformat(struct chan_simpleusb_pvt *o, int mode)
-{
-	int fmt, desired, res, fd;
-	char device[100];
-
-	/* If the device is open, close it */
-	if (o->sounddev >= 0) {
-		ioctl(o->sounddev, SNDCTL_DSP_RESET, 0);
-		close(o->sounddev);
-		o->duplex = M_UNSET;
-		o->sounddev = -1;
-	}
-	if (mode == O_CLOSE) { /* we are done */
-		return 0;
-	}
-
-	strcpy(device, "/dev/dsp");
-	if (o->devicenum) {
-		sprintf(device, "/dev/dsp%d", o->devicenum);
-	}
-	/* open the device */
-	fd = o->sounddev = open(device, mode | O_NONBLOCK);
-	if (fd < 0) {
-		ast_log(LOG_ERROR, "Channel %s: Unable to open DSP device %d: %s.\n", o->name, o->devicenum, strerror(errno));
-		return -1;
-	}
-	if (o->owner) {
-		ast_channel_internal_fd_set(o->owner, 0, fd);
-	}
-
-#if __BYTE_ORDER == __LITTLE_ENDIAN
-	fmt = AFMT_S16_LE;
-#else
-	fmt = AFMT_S16_BE;
-#endif
-	res = ioctl(fd, SNDCTL_DSP_SETFMT, &fmt);
-	if (res < 0) {
-		ast_log(LOG_WARNING, "Channel %s: Unable to set format to 16-bit signed\n", o->name);
-		return -1;
-	}
-	/* set our duplex mode based on the way we opened the device. */
-	switch (mode) {
-	case O_RDWR:
-		res = ioctl(fd, SNDCTL_DSP_SETDUPLEX, 0);
-		/* Check to see if duplex set (FreeBSD Bug) */
-		res = ioctl(fd, SNDCTL_DSP_GETCAPS, &fmt);
-		if (res == 0 && (fmt & DSP_CAP_DUPLEX)) {
-			o->duplex = M_FULL;
-		};
-		break;
-	case O_WRONLY:
-		o->duplex = M_WRITE;
-		break;
-	case O_RDONLY:
-		o->duplex = M_READ;
-		break;
-	}
-
-	fmt = 1;
-	res = ioctl(fd, SNDCTL_DSP_STEREO, &fmt);
-	if (res < 0) {
-		ast_log(LOG_WARNING, "Channel %s: Failed to set audio device to stereo\n", o->name);
-		return -1;
-	}
-	fmt = desired = 48000; /* 48000 Hz desired */
-	res = ioctl(fd, SNDCTL_DSP_SPEED, &fmt);
-	if (res < 0) {
-		ast_log(LOG_WARNING, "Channel %s: Failed to set audio device sample rate.\n", o->name);
-		return -1;
-	}
-	if (fmt != desired) {
-		if (!(o->warned & WARN_speed)) {
-			ast_log(LOG_WARNING, "Channel %s: Requested %d Hz, got %d Hz -- sound may be choppy.\n", o->name, desired, fmt);
-			o->warned |= WARN_speed;
-		}
-	}
-	/*
-	 * on Freebsd, SETFRAGMENT does not work very well on some cards.
-	 * Default to use 256 bytes, let the user override
-	 */
-	if (o->frags) {
-		fmt = o->frags;
-		res = ioctl(fd, SNDCTL_DSP_SETFRAGMENT, &fmt);
-		if (res < 0) {
-			if (!(o->warned & WARN_frag)) {
-				ast_log(LOG_WARNING, "Channel %s: Unable to set fragment size -- sound may be choppy.\n", o->name);
-				o->warned |= WARN_frag;
-			}
-		}
-	}
-	/* on some cards, we need SNDCTL_DSP_SETTRIGGER to start outputting */
-	res = PCM_ENABLE_INPUT | PCM_ENABLE_OUTPUT;
-	res = ioctl(fd, SNDCTL_DSP_SETTRIGGER, &res);
-	/* it may fail if we are in half duplex, never mind */
-	return 0;
 }
 
 /*!
@@ -1849,11 +2088,11 @@ static int simpleusb_text(struct ast_channel *c, const char *text)
 			i++;
 		}
 		/* get number of samples to alloc for audio */
-		audio_samples = (SAMPRATE * (PREAMBLE_BITS + (MESSAGE_BITS * i))) / baud;
+		audio_samples = (AST_SAMPLE_RATE * (PREAMBLE_BITS + (MESSAGE_BITS * i))) / baud;
 		/* pad end with 250ms of silence */
-		audio_samples += SAMPRATE / 4;
+		audio_samples += AST_SAMPLE_RATE / 4;
 		/* also pad up to FRAME_SIZE */
-		audio_samples += audio_samples % FRAME_SIZE;
+		audio_samples += (FRAME_SIZE - (audio_samples % FRAME_SIZE)) % FRAME_SIZE;
 		audio = ast_calloc(1, (audio_samples * sizeof(short)) + 10);
 		if (!audio) {
 			free_batch(batch);
@@ -1917,10 +2156,29 @@ static int simpleusb_text(struct ast_channel *c, const char *text)
 static int simpleusb_call(struct ast_channel *c, const char *dest, int timeout)
 {
 	struct chan_simpleusb_pvt *o = ast_channel_tech_pvt(c);
+	int res;
 
-	o->stophid = 0;
+	o->stophidthread = 0;
+	o->stopaudiothread = 0;
 	ast_radio_time(&o->lasthidtime);
-	ast_pthread_create(&o->hidthread, NULL, hidthread, o);
+
+	res = ast_pthread_create(&o->hidthread, NULL, hidthread, o);
+	if (res) {
+		ast_log(LOG_ERROR, "Channel %s: Failed to create HID thread: %s\n", o->name, strerror(res));
+		return -1;
+	}
+
+	res = ast_pthread_create(&o->audiothread, NULL, simpleusb_audio_thread, o);
+	if (res) {
+		ast_log(LOG_ERROR, "Channel %s: Failed to create audio thread: %s\n", o->name, strerror(res));
+		o->stophidthread = 1;
+		if (o->hidthread != AST_PTHREADT_NULL) {
+			pthread_join(o->hidthread, NULL);
+			o->hidthread = AST_PTHREADT_NULL;
+		}
+		return -1;
+	}
+
 	ast_setstate(c, AST_STATE_UP);
 	return 0;
 }
@@ -1945,15 +2203,22 @@ static int simpleusb_hangup(struct ast_channel *c)
 {
 	struct chan_simpleusb_pvt *o = ast_channel_tech_pvt(c);
 
-	ast_channel_tech_pvt_set(c, NULL);
-	o->owner = NULL;
-	ast_module_unref(ast_module_info->self);
-	if (o->hookstate) {
-		o->hookstate = 0;
-		setformat(o, O_CLOSE);
+	o->stopaudiothread = 1;
+	if (o->audiothread != AST_PTHREADT_NULL) {
+		pthread_join(o->audiothread, NULL);
+		o->audiothread = AST_PTHREADT_NULL;
 	}
-	o->stophid = 1;
-	pthread_join(o->hidthread, NULL);
+
+	o->stophidthread = 1;
+	if (o->hidthread != AST_PTHREADT_NULL) {
+		pthread_join(o->hidthread, NULL);
+		o->hidthread = AST_PTHREADT_NULL;
+	}
+
+	o->owner = NULL;
+	ast_channel_tech_pvt_set(c, NULL);
+	ast_module_unref(ast_module_info->self);
+
 	return 0;
 }
 
@@ -1972,12 +2237,7 @@ static int simpleusb_write(struct ast_channel *c, struct ast_frame *f)
 	if (!o->hasusb) {
 		return 0;
 	}
-	if (o->sounddev < 0) {
-		setformat(o, O_RDWR);
-	}
-	if (o->sounddev < 0) {
-		return 0; /* not fatal */
-	}
+
 	/*
 	 * we could receive a block which is not a multiple of our
 	 * FRAME_SIZE, so buffer it locally and write to the device
@@ -2025,538 +2285,614 @@ static int simpleusb_write(struct ast_channel *c, struct ast_frame *f)
  * \param ast			Asterisk channel.
  * \retval 				Asterisk frame.
  */
+
 static struct ast_frame *simpleusb_read(struct ast_channel *c)
 {
-	int res, cd, sd, src, num_frames, ispager, doleft, doright;
+	/* This should never be called... */
+	ast_debug(1, "Read function should not be called!");
+	return &ast_null_frame;
+}
+
+/*!
+ * \brief 				PortAudio processing thread.
+ * \param ast			Asterisk channel.
+ * \retval 				Asterisk frame.
+ */
+static void *simpleusb_audio_thread(void *arg)
+{
+	int cd, sd, src, num_frames, ispager, doleft, doright;
+	PaError res;
 	register int i;
-	struct chan_simpleusb_pvt *o = ast_channel_tech_pvt(c);
+	struct chan_simpleusb_pvt *o = arg;
 	struct ast_frame *f = &o->read_f, *f1;
 	time_t now;
 	register short *sp, *sp1;
-	short outbuf[FRAME_SIZE * 2 * 6];
+	short outbuf[PA_NUM_FRAMES * 2]; /* 1 short (2 bytes) per sample on PortAudio config with paInt16 * 2 channels */
 
-	/* check if the hid thread is still processing */
-	if (o->lasthidtime) {
-		ast_radio_time(&now);
-		if ((now - o->lasthidtime) > 3) {
-			ast_log(LOG_ERROR, "Channel %s: HID process has died or is not responding.\n", o->name);
-			return NULL;
-		}
-	}
-	/* Set frame defaults */
-	memset(f, 0, sizeof(struct ast_frame));
-	f->frametype = AST_FRAME_NULL;
-	f->src = __PRETTY_FUNCTION__;
+	ast_debug(5, "Audio thread is starting\n");
 
-	/* if USB device not ready, just return NULL frame */
-	if (!o->hasusb) {
-		if (o->rxkeyed) {
-			struct ast_frame wf = {
-				.frametype = AST_FRAME_CONTROL,
-				.subclass.integer = AST_CONTROL_RADIO_UNKEY,
-				.src = __PRETTY_FUNCTION__,
-			};
-
-			o->lastrx = 0;
-			o->rxkeyed = 0;
-			ast_queue_frame(o->owner, &wf);
-		}
-		return &ast_null_frame;
-	}
-
-	/* If we have stopped echoing, clear the echo queue */
-	if (!o->echomode) {
-		struct qelem *q;
-
-		ast_mutex_lock(&o->echolock);
-		o->echoing = 0;
-		while (o->echoq.q_forw != &o->echoq) {
-			q = o->echoq.q_forw;
-			remque(q);
-			ast_free(q);
-		}
-		ast_mutex_unlock(&o->echolock);
-	}
-
-	/* If we are in echomode and we have stopped receiving audio
-	 * queue up the packets we have stored in the echo queue
-	 * for playback.
-	 */
-	if (o->echomode && (!o->rxkeyed)) {
-		struct usbecho *u;
-
-		ast_mutex_lock(&o->echolock);
-		/* if there is something in the queue */
-		if (o->echoq.q_forw != &o->echoq) {
-			u = (struct usbecho *) o->echoq.q_forw;
-			remque((struct qelem *) u);
-			f->frametype = AST_FRAME_VOICE;
-			f->subclass.format = ast_format_slin;
-			f->samples = FRAME_SIZE;
-			f->datalen = FRAME_SIZE * 2;
-			f->offset = AST_FRIENDLY_OFFSET;
-			f->data.ptr = o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET;
-			memcpy(f->data.ptr, u->data, FRAME_SIZE * 2);
-			ast_free(u);
-			f1 = ast_frdup(f);
-			if (!f1) {
-				ast_mutex_unlock(&o->echolock);
-				return &ast_null_frame;
-			}
-			memset(&f1->frame_list, 0, sizeof(f1->frame_list));
-			ast_mutex_lock(&o->txqlock);
-			AST_LIST_INSERT_TAIL(&o->txq, f1, frame_list);
-			ast_mutex_unlock(&o->txqlock);
-			o->echoing = 1;
-		} else {
-			o->echoing = 0;
-		}
-		ast_mutex_unlock(&o->echolock);
-	}
-
-	/* Process the transmit queue */
-	for (;;) {
-		num_frames = 0;
-		ast_mutex_lock(&o->txqlock);
-		AST_LIST_TRAVERSE(&o->txq, f1, frame_list) {
-			num_frames++;
-		}
-		ast_mutex_unlock(&o->txqlock);
-		i = used_blocks(o);
-		if (o->txkeyed) {
-			ast_debug(7, "blocks used %d, Dest Buffer %d", i, o->simpleusb_write_dst);
-		}
-		if (num_frames && (num_frames > 3 || (!o->txkeyed && !o->txtestkey)) && i <= o->queuesize) {
-			if (i == 0) { /* We are not keeping the buffer full, add 1 frame */
-				memset(outbuf, 0, sizeof(outbuf));
-				soundcard_writeframe(o, outbuf);
-				ast_debug(7, "A null frame has been added");
-			}
-			ast_mutex_lock(&o->txqlock);
-			f1 = AST_LIST_REMOVE_HEAD(&o->txq, frame_list);
-			ast_mutex_unlock(&o->txqlock);
-
-			src = 0; /* read position into f1->data */
-			while (src < f1->datalen) {
-				/* Compute spare room in the buffer */
-				int l = sizeof(o->simpleusb_write_buf) - o->simpleusb_write_dst;
-
-				if (f1->datalen - src >= l) {
-					/* enough to fill a frame */
-					memcpy(o->simpleusb_write_buf + o->simpleusb_write_dst, (char *) f1->data.ptr + src, l);
-					/* Below is an attempt to match levels to the original CM108 IC which has
-					 * been out of production for over 10 years. Scaling audio to 109.375% will
-					 * result in clipping! Any adjustments for CM1xxx gain differences should be
-					 * made in the mixer settings, not in the audio stream.
-					 * TODO: After the vast majority of existing installs have had a chance to review their
-					 * audio settings and these old scaling/clipping hacks are no longer in significant use
-					 * the legacyaudioscaling cfg and related code should be deleted.
-					 */
-					/* Adjust the audio level for CM119 A/B devices */
-					if (o->legacyaudioscaling && o->devtype != C108_PRODUCT_ID) {
-						register int v;
-
-						sp = (short *) o->simpleusb_write_buf;
-						for (i = 0; i < FRAME_SIZE; i++) {
-							v = *sp;
-							v += v >> 3;   /* add *.125 giving * 1.125 */
-							v -= *sp >> 5; /* subtract *.03125 giving * 1.09375 */
-							if (v > 32765.0) {
-								v = 32765.0;
-							} else if (v < -32765.0) {
-								v = -32765.0;
-							}
-							*sp++ = v;
-						}
-					}
-
-					sp = (short *) o->simpleusb_write_buf;
-					sp1 = outbuf;
-					doright = 1;
-					doleft = 1;
-					ispager = 0;
-					if (f1->src && (!strcmp(f1->src, PAGER_SRC))) {
-						ispager = 1;
-					}
-					/* If pager audio, determine which channel to store audio */
-					if (o->pager != PAGER_NONE) {
-						doleft = (o->pager == PAGER_A) ? ispager : !ispager;
-						doright = (o->pager == PAGER_B) ? ispager : !ispager;
-					}
-					/* Upsample from 8000 mono to 48000 stereo */
-					for (i = 0; i < FRAME_SIZE; i++) {
-						register short s, v;
-
-						if (o->preemphasis) {
-							s = preemph(sp[i], &o->prestate);
-						} else {
-							s = sp[i];
-						}
-						v = lpass(s, o->flpt);
-						*sp1++ = (doleft) ? v : 0;
-						*sp1++ = (doright) ? v : 0;
-						v = lpass(s, o->flpt);
-						*sp1++ = (doleft) ? v : 0;
-						*sp1++ = (doright) ? v : 0;
-						v = lpass(s, o->flpt);
-						*sp1++ = (doleft) ? v : 0;
-						*sp1++ = (doright) ? v : 0;
-						v = lpass(s, o->flpt);
-						*sp1++ = (doleft) ? v : 0;
-						*sp1++ = (doright) ? v : 0;
-						v = lpass(s, o->flpt);
-						*sp1++ = (doleft) ? v : 0;
-						*sp1++ = (doright) ? v : 0;
-						v = lpass(s, o->flpt);
-						*sp1++ = (doleft) ? v : 0;
-						*sp1++ = (doright) ? v : 0;
-					}
-					soundcard_writeframe(o, outbuf);
-					src += l;
-					o->simpleusb_write_dst = 0;
-					if (o->waspager && (!ispager)) {
-						struct ast_frame wf = {
-							.frametype = AST_FRAME_TEXT,
-							.data.ptr = ENDPAGE_STR,
-							.datalen = strlen(ENDPAGE_STR) + 1,
-							.src = __PRETTY_FUNCTION__,
-						};
-
-						ast_queue_frame(o->owner, &wf);
-					}
-					o->waspager = ispager;
-				} else {
-					/* copy residue */
-					l = f1->datalen - src;
-					memcpy(o->simpleusb_write_buf + o->simpleusb_write_dst, (char *) f1->data.ptr + src, l);
-					src += l; /* but really, we are done */
-					o->simpleusb_write_dst += l;
-				}
-			}
-			ast_frfree(f1);
+	while (!o->stopaudiothread) {
+		/* wait for audio device to be initialized */
+		ast_debug(5, "Audio thread entered outer loop\n");
+		if (!o->hasusb) {
+			ast_debug(5, "Audio not ready");
+			usleep(DEVICE_RETRY);
 			continue;
 		}
-		break;
-	}
 
-	/* Read audio data from the USB sound device.
-	 * Sound data will arrive at 48000 samples per second
-	 * in stereo format.
-	 */
-	res = read(o->sounddev, o->simpleusb_read_buf + o->readpos, sizeof(o->simpleusb_read_buf) - o->readpos);
-	if (res < 0) {
-		/* audio data not ready */
-		if (errno != EAGAIN) {
-			o->readerrs = 0;
+		if (start_stream(o) < 0) {
+			ast_log(LOG_ERROR, "Channel %s: Failed to start audio stream %s\n", o->name, o->hw_device);
 			o->hasusb = 0;
-			return &ast_null_frame;
-		}
-		if (o->readerrs++ > READERR_THRESHOLD) {
-			ast_log(LOG_ERROR, "Stuck USB read channel [%s], un-sticking it!\n", o->name);
-			o->readerrs = 0;
-			o->hasusb = 0;
-			return &ast_null_frame;
-		}
-		if (o->readerrs == 1) {
-			ast_log(LOG_WARNING, "Possibly stuck USB read channel. [%s]\n", o->name);
-		}
-		return &ast_null_frame;
-	}
-
-#if DEBUG_CAPTURES == 1
-	if (o->rxcapraw && frxcapraw) {
-		fwrite(o->simpleusb_read_buf + o->readpos, 1, res, frxcapraw);
-	}
-#endif
-
-	if (o->readerrs) {
-		ast_log(LOG_WARNING, "USB read channel [%s] was not stuck.\n", o->name);
-	}
-
-	o->readerrs = 0;
-	o->readpos += res;
-	if (o->readpos < sizeof(o->simpleusb_read_buf)) { /* not enough samples */
-		return &ast_null_frame;
-	}
-
-	/* If we have been sending pager audio, see if
-	 * we are finished.
-	 */
-	if (o->waspager) {
-		num_frames = 0;
-		ast_mutex_lock(&o->txqlock);
-		AST_LIST_TRAVERSE(&o->txq, f1, frame_list) {
-			num_frames++;
-		}
-		ast_mutex_unlock(&o->txqlock);
-		if (num_frames < 1) {
-			struct ast_frame wf = {
-				.frametype = AST_FRAME_TEXT,
-				.data.ptr = ENDPAGE_STR,
-				.datalen = sizeof(ENDPAGE_STR),
-				.src = __PRETTY_FUNCTION__,
-			};
-
-			ast_queue_frame(o->owner, &wf);
-			o->waspager = 0;
-		}
-	}
-
-	/* Check for carrier detect - COR active */
-	cd = 1;
-	if ((o->rxcdtype == CD_HID) && (!o->rxhidsq)) {
-		cd = 0;
-	} else if ((o->rxcdtype == CD_HID_INVERT) && o->rxhidsq) {
-		cd = 0;
-	} else if ((o->rxcdtype == CD_PP) && (!o->rxppsq)) {
-		cd = 0;
-	} else if ((o->rxcdtype == CD_PP_INVERT) && o->rxppsq) {
-		cd = 0;
-	}
-
-	/* Apply cd turn-on delay, if one specified */
-	if (o->rxondelay && cd && (o->rxoncnt++ < o->rxondelay)) {
-		cd = 0;
-	} else if (!cd) {
-		o->rxoncnt = 0;
-	}
-	o->rx_cos_active = cd;
-
-	/* Check for SD - CTCSS active */
-	sd = 1;
-	if ((o->rxsdtype == SD_HID) && (!o->rxhidctcss)) {
-		sd = 0;
-	} else if ((o->rxsdtype == SD_HID_INVERT) && o->rxhidctcss) {
-		sd = 0;
-	} else if ((o->rxsdtype == SD_PP) && (!o->rxppctcss)) {
-		sd = 0;
-	} else if ((o->rxsdtype == SD_PP_INVERT) && o->rxppctcss) {
-		sd = 0;
-	}
-
-	/* See if we are overriding CTCSS to active */
-	if (o->rxctcssoverride) {
-		sd = 1;
-	}
-	o->rx_ctcss_active = sd;
-
-	/* Special case where cd and sd have been configured for no */
-	if (o->rxcdtype == CD_IGNORE && o->rxsdtype == SD_IGNORE) {
-		cd = 0;
-		sd = 0;
-	}
-
-	/* Timer for how long TX has been unkeyed - used with txoffdelay */
-	if (o->txoffdelay) {
-		if (o->txkeyed == 1) {
-			o->txoffcnt = 0; /* If keyed, set this to zero. */
-		} else {
-			o->txoffcnt++;
-			if (o->txoffcnt > MS_TO_FRAMES(TX_OFF_DELAY_MAX)) {
-				o->txoffcnt = MS_TO_FRAMES(TX_OFF_DELAY_MAX); /* limit count */
-			}
-		}
-	}
-
-	/* Check conditions and set receiver active */
-	o->rxkeyed = sd && cd && ((!o->lasttx) || o->duplex) && (o->txoffcnt >= o->txoffdelay);
-
-	/* Send a message to indicate rx signal detect conditions */
-	if (o->lastrx && (!o->rxkeyed)) {
-		struct ast_frame wf = {
-			.frametype = AST_FRAME_CONTROL,
-			.subclass.integer = AST_CONTROL_RADIO_UNKEY,
-			.src = __PRETTY_FUNCTION__,
-		};
-
-		o->lastrx = 0;
-		ast_queue_frame(o->owner, &wf);
-		if (o->duplex3) {
-			ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_SW, 0, 0);
-		}
-	} else if ((!o->lastrx) && (o->rxkeyed)) {
-		struct ast_frame wf = {
-			.frametype = AST_FRAME_CONTROL,
-			.subclass.integer = AST_CONTROL_RADIO_KEY,
-			.src = __PRETTY_FUNCTION__,
-		};
-
-		o->lastrx = 1;
-		ast_queue_frame(o->owner, &wf);
-		if (o->duplex3) {
-			ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_SW, 1, 0);
-		}
-	}
-
-	/* Check for ADC clipping and input audio statistics before any filtering is done.
-	 * FRAME_SIZE define refers to 8Ksps mono which is 160 samples per 20mS USB frame.
-	 * ast_radio_check_audio() takes the read buffer as received (48K stereo),
-	 * extracts the mono 48K channel, checks amplitude and distortion characteristics,
-	 * and returns true if clipping was detected.
-	 */
-	if (ast_radio_check_audio((short *) o->simpleusb_read_buf, &o->rxaudiostats, 12 * FRAME_SIZE)) {
-		if (o->clipledgpio) {
-			/* Set Clip LED GPIO pulsetimer if not already set */
-			if (!o->hid_gpio_pulsetimer[o->clipledgpio - 1]) {
-				o->hid_gpio_pulsetimer[o->clipledgpio - 1] = CLIP_LED_HOLD_TIME_MS;
-			}
-		}
-	}
-
-	/* Downsample received audio from 48000 stereo to 8000 mono */
-	sp = (short *) o->simpleusb_read_buf;
-	sp1 = (short *) (o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET);
-	for (i = 0; i < FRAME_SIZE; i++) {
-		(void) lpass(*sp++, o->flpr);
-		sp++;
-		(void) lpass(*sp++, o->flpr);
-		sp++;
-		(void) lpass(*sp++, o->flpr);
-		sp++;
-		(void) lpass(*sp++, o->flpr);
-		sp++;
-		(void) lpass(*sp++, o->flpr);
-		sp++;
-		if (o->plfilter && o->deemphasis) {
-			*sp1++ = hpass6(deemph(lpass(*sp++, o->flpr), &o->destate), o->hpx, o->hpy);
-		} else if (o->deemphasis) {
-			*sp1++ = deemph(lpass(*sp++, o->flpr), &o->destate);
-		} else if (o->plfilter) {
-			*sp1++ = hpass(lpass(*sp++, o->flpr), o->hpx, o->hpy);
-		} else {
-			*sp1++ = lpass(*sp++, o->flpr);
-		}
-		sp++;
-	}
-
-	/* If we are in echomode and receiving audio, store
-	 * it in the echo queue for later playback.
-	 */
-	if (o->echomode && o->rxkeyed && (!o->echoing)) {
-		register int x;
-		struct usbecho *u;
-
-		ast_mutex_lock(&o->echolock);
-		x = 0;
-		/* get count of frames */
-		for (u = (struct usbecho *) o->echoq.q_forw; u != (struct usbecho *) &o->echoq; u = (struct usbecho *) u->q_forw) {
-			x++;
+			usleep(DEVICE_RETRY);
+			continue;
 		}
 
-		if (x < o->echomax) {
-			u = ast_calloc(1, sizeof(struct usbecho));
-			if (u) {
-				memcpy(u->data, (o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET), FRAME_SIZE * 2);
-				insque((struct qelem *) u, o->echoq.q_back);
-			}
-		}
-		ast_mutex_unlock(&o->echolock);
-	}
-
-#if DEBUG_CAPTURES == 1
-	if (o->rxcapraw && frxcapcooked) {
-		fwrite(o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET, sizeof(short), FRAME_SIZE, frxcapcooked);
-	}
-#endif
-
-	/* reset read pointer for next frame */
-	o->readpos = 0;
-	/* Do not return the frame if the channel is not up */
-	if (ast_channel_state(c) != AST_STATE_UP) {
-		return &ast_null_frame;
-	}
-	/* ok we can build and deliver the frame to the caller */
-	f->frametype = AST_FRAME_VOICE;
-	f->subclass.format = ast_format_slin;
-	f->offset = AST_FRIENDLY_OFFSET;
-	f->samples = FRAME_SIZE;
-	f->datalen = FRAME_SIZE * 2;
-	f->data.ptr = o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET;
-	if (!o->rxkeyed) {
-		memset(f->data.ptr, 0, f->datalen);
-	}
-	/* Process the audio to see if contains DTMF */
-	if (o->usedtmf && o->dsp) {
-		f1 = ast_dsp_process(c, o->dsp, f);
-		if ((f1->frametype == AST_FRAME_DTMF_END) || (f1->frametype == AST_FRAME_DTMF_BEGIN)) {
-			if ((f1->subclass.integer == 'm') || (f1->subclass.integer == 'u')) {
-				f1->frametype = AST_FRAME_NULL;
-				f1->subclass.integer = 0;
-				return f1;
-			}
-			if (f1->frametype == AST_FRAME_DTMF_END) {
-				f1->len = ast_tvdiff_ms(ast_radio_tvnow(), o->tonetime);
-				if (option_verbose) {
-					ast_log(LOG_NOTICE, "Channel %s: Got DTMF char %c duration %ld ms\n", o->name, f1->subclass.integer, f1->len);
+		while (!o->stopaudiothread && o->hasusb) {
+			/* check if the hid thread is still processing */
+			if (o->lasthidtime) {
+				ast_radio_time(&now);
+				if ((now - o->lasthidtime) > 3) {
+					ast_log(LOG_ERROR, "Channel %s: HID process has died or is not responding.\n", o->name);
+					usleep(DEVICE_RETRY);
+					break;
 				}
-				o->toneflag = 0;
-			} else {
-				if (o->toneflag) {
-					ast_frfree(f1);
-					f1 = NULL;
+			}
+			/* Set frame defaults */
+			memset(f, 0, sizeof(struct ast_frame));
+			f->frametype = AST_FRAME_NULL;
+			f->src = __PRETTY_FUNCTION__;
+			/* if USB device not ready, just return NULL frame */
+			if (!o->hasusb) {
+				if (o->rxkeyed) {
+					struct ast_frame wf = {
+						.frametype = AST_FRAME_CONTROL,
+						.subclass.integer = AST_CONTROL_RADIO_UNKEY,
+						.src = __PRETTY_FUNCTION__,
+					};
+
+					o->lastrx = 0;
+					o->rxkeyed = 0;
+
+					if (o->owner) {
+						ast_queue_frame(o->owner, &wf);
+					}
+				}
+
+				continue;
+			}
+
+			/* If we have stopped echoing, clear the echo queue */
+			if (!o->echomode) {
+				struct qelem *q;
+
+				ast_mutex_lock(&o->echolock);
+				o->echoing = 0;
+				while (o->echoq.q_forw != &o->echoq) {
+					q = o->echoq.q_forw;
+					remque(q);
+					ast_free(q);
+				}
+				ast_mutex_unlock(&o->echolock);
+			}
+
+			/* If we are in echomode and we have stopped receiving audio
+			 * queue up the packets we have stored in the echo queue
+			 * for playback.
+			 */
+			if (o->echomode && (!o->rxkeyed)) {
+				struct usbecho *u;
+
+				ast_mutex_lock(&o->echolock);
+				/* if there is something in the queue */
+				if (o->echoq.q_forw != &o->echoq) {
+					u = (struct usbecho *) o->echoq.q_forw;
+					remque((struct qelem *) u);
+					f->frametype = AST_FRAME_VOICE;
+					f->subclass.format = ast_format_slin;
+					f->samples = FRAME_SIZE;
+					f->datalen = FRAME_SIZE * 2;
+					f->offset = AST_FRIENDLY_OFFSET;
+					f->data.ptr = o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET;
+					memcpy(f->data.ptr, u->data, FRAME_SIZE * 2);
+					ast_free(u);
+					f1 = ast_frdup(f);
+					if (!f1) {
+						ast_mutex_unlock(&o->echolock);
+						continue;
+					}
+					memset(&f1->frame_list, 0, sizeof(f1->frame_list));
+					ast_mutex_lock(&o->txqlock);
+					AST_LIST_INSERT_TAIL(&o->txq, f1, frame_list);
+					ast_mutex_unlock(&o->txqlock);
+					o->echoing = 1;
 				} else {
-					o->tonetime = ast_radio_tvnow();
-					o->toneflag = 1;
+					o->echoing = 0;
+				}
+				ast_mutex_unlock(&o->echolock);
+			}
+
+			/* Process the transmit queue */
+			for (;;) {
+				long frames_available;
+
+				num_frames = 0;
+				ast_mutex_lock(&o->txqlock);
+				AST_LIST_TRAVERSE(&o->txq, f1, frame_list) {
+					num_frames++;
+				}
+
+				ast_mutex_unlock(&o->txqlock);
+				if (o->txkeyed) {
+					ast_debug(7, "blocks used %d, Dest Buffer %d", num_frames, o->simpleusb_write_dst);
+				}
+				/* Check for room in the write buffer.  If the device goes unavailable or
+				 * there is not room in the buffer, Pa_WriteStream will hang.
+				 */
+				frames_available = Pa_GetStreamWriteAvailable(o->stream);
+
+				if (frames_available < 0) {
+					if (frames_available != paOutputUnderflowed) {
+						/* Underflow handled in soundcard_writeframe
+						 * all other errors require restart
+						 */
+						ast_debug(2, "Pa_GetStreamWriteAvailable error %s", Pa_GetErrorText(frames_available));
+						goto stream_restart;
+					}
+				}
+
+				if (num_frames && (num_frames > 3 || (!o->txkeyed && !o->txtestkey)) && (frames_available >= PA_NUM_FRAMES)) {
+					ast_mutex_lock(&o->txqlock);
+					f1 = AST_LIST_REMOVE_HEAD(&o->txq, frame_list);
+					ast_mutex_unlock(&o->txqlock);
+
+					src = 0; /* read position into f1->data */
+					while (src < f1->datalen) {
+						/* Compute spare room in the buffer */
+						int l = sizeof(o->simpleusb_write_buf) - o->simpleusb_write_dst;
+
+						if (f1->datalen - src >= l) {
+							/* enough to fill a frame */
+							memcpy(o->simpleusb_write_buf + o->simpleusb_write_dst, (char *) f1->data.ptr + src, l);
+							/* Below is an attempt to match levels to the original CM108 IC which has
+							 * been out of production for over 10 years. Scaling audio to 109.375% will
+							 * result in clipping! Any adjustments for CM1xxx gain differences should be
+							 * made in the mixer settings, not in the audio stream.
+							 * TODO: After the vast majority of existing installs have had a chance to review their
+							 * audio settings and these old scaling/clipping hacks are no longer in significant use
+							 * the legacyaudioscaling cfg and related code should be deleted.
+							 */
+							/* Adjust the audio level for CM119 A/B devices */
+							if (o->legacyaudioscaling && o->devtype != C108_PRODUCT_ID) {
+								register int v;
+
+								sp = (short *) o->simpleusb_write_buf;
+								for (i = 0; i < FRAME_SIZE; i++) {
+									v = *sp;
+									v += v >> 3;   /* add *.125 giving * 1.125 */
+									v -= *sp >> 5; /* subtract *.03125 giving * 1.09375 */
+									if (v > 32765.0) {
+										v = 32765.0;
+									} else if (v < -32765.0) {
+										v = -32765.0;
+									}
+									*sp++ = v;
+								}
+							}
+
+							sp = (short *) o->simpleusb_write_buf;
+							sp1 = outbuf;
+							doright = 1;
+							doleft = 1;
+							ispager = 0;
+							if (f1->src && (!strcmp(f1->src, PAGER_SRC))) {
+								ispager = 1;
+							}
+							/* If pager audio, determine which channel to store audio */
+							if (o->pager != PAGER_NONE) {
+								doleft = (o->pager == PAGER_A) ? ispager : !ispager;
+								doright = (o->pager == PAGER_B) ? ispager : !ispager;
+							}
+							/* Upsample from 8000 mono to 48000 stereo */
+							for (i = 0; i < FRAME_SIZE; i++) {
+								register short s, v;
+
+								if (o->preemphasis) {
+									s = preemph(sp[i], &o->prestate);
+								} else {
+									s = sp[i];
+								}
+								v = lpass(s, o->flpt);
+								*sp1++ = (doleft) ? v : 0;
+								*sp1++ = (doright) ? v : 0;
+								v = lpass(s, o->flpt);
+								*sp1++ = (doleft) ? v : 0;
+								*sp1++ = (doright) ? v : 0;
+								v = lpass(s, o->flpt);
+								*sp1++ = (doleft) ? v : 0;
+								*sp1++ = (doright) ? v : 0;
+								v = lpass(s, o->flpt);
+								*sp1++ = (doleft) ? v : 0;
+								*sp1++ = (doright) ? v : 0;
+								v = lpass(s, o->flpt);
+								*sp1++ = (doleft) ? v : 0;
+								*sp1++ = (doright) ? v : 0;
+								v = lpass(s, o->flpt);
+								*sp1++ = (doleft) ? v : 0;
+								*sp1++ = (doright) ? v : 0;
+							}
+
+							res = soundcard_writeframe(o, outbuf);
+							if (res != paNoError) {
+								/* audio data not ready */
+								if (res != paOutputUnderflowed) {
+									/* Underflow handled in soundcard_writeframe
+									 * all other errors require restart
+									 */
+									ast_debug(2, "Pa_WriteStream error %s", Pa_GetErrorText(res));
+									goto stream_restart;
+								}
+							}
+
+							src += l;
+							o->simpleusb_write_dst = 0;
+							if (o->waspager && (!ispager)) {
+								struct ast_frame wf = {
+									.frametype = AST_FRAME_TEXT,
+									.data.ptr = ENDPAGE_STR,
+									.datalen = strlen(ENDPAGE_STR) + 1,
+									.src = __PRETTY_FUNCTION__,
+								};
+
+								if (o->owner) {
+									ast_queue_frame(o->owner, &wf);
+								}
+
+								o->waspager = ispager;
+								continue;
+							}
+
+							o->waspager = ispager;
+						} else {
+							/* copy residue */
+							l = f1->datalen - src;
+							memcpy(o->simpleusb_write_buf + o->simpleusb_write_dst, (char *) f1->data.ptr + src, l);
+							src += l; /* but really, we are done */
+							o->simpleusb_write_dst += l;
+						}
+					}
+					ast_frfree(f1);
+					continue;
+				}
+				break;
+			}
+
+			/* Read audio data from the USB sound device.
+			 * Sound data will arrive at 48000 samples per second
+			 * in mono format.  We should always have 20ms frames, 100ms timeout
+			 * as a reasonable max wait time.
+			 */
+			res = Pa_ReadStream_with_timeout(o->stream, o->simpleusb_read_buf, PA_NUM_FRAMES, 60, &o->stopaudiothread);
+			if (res != paNoError) {
+				/* audio data not ready */
+				if (res == paInputOverflowed) {
+					ast_debug(6, "PortAudio read overflow on channel %s\n", o->name);
+				} else {
+					ast_log(LOG_ERROR, "Pa_ReadStream Error on channel %s : %s\n", o->name, Pa_GetErrorText(res));
+					break; /* Close the stream and retry */
 				}
 			}
-			if (f1) {
-				return f1;
+
+#if DEBUG_CAPTURES == 1
+			if (o->rxcapraw && frxcapraw) {
+				fwrite(o->simpleusb_read_buf, sizeof(short), FRAME_SIZE * 6, frxcapraw);
 			}
+#endif
+
+			/* If we have been sending pager audio, see if
+			 * we are finished.
+			 */
+			if (o->waspager) {
+				num_frames = 0;
+				ast_mutex_lock(&o->txqlock);
+				AST_LIST_TRAVERSE(&o->txq, f1, frame_list) {
+					num_frames++;
+				}
+				ast_mutex_unlock(&o->txqlock);
+				if (num_frames < 1) {
+					struct ast_frame wf = {
+						.frametype = AST_FRAME_TEXT,
+						.data.ptr = ENDPAGE_STR,
+						.datalen = sizeof(ENDPAGE_STR),
+						.src = __PRETTY_FUNCTION__,
+					};
+
+					if (o->owner) {
+						ast_queue_frame(o->owner, &wf);
+					}
+
+					o->waspager = 0;
+				}
+			}
+
+			/* Check for carrier detect - COR active */
+			cd = 1;
+			if ((o->rxcdtype == CD_HID) && (!o->rxhidsq)) {
+				cd = 0;
+			} else if ((o->rxcdtype == CD_HID_INVERT) && o->rxhidsq) {
+				cd = 0;
+			} else if ((o->rxcdtype == CD_PP) && (!o->rxppsq)) {
+				cd = 0;
+			} else if ((o->rxcdtype == CD_PP_INVERT) && o->rxppsq) {
+				cd = 0;
+			}
+
+			/* Apply cd turn-on delay, if one specified */
+			if (o->rxondelay && cd && (o->rxoncnt++ < o->rxondelay)) {
+				cd = 0;
+			} else if (!cd) {
+				o->rxoncnt = 0;
+			}
+			o->rx_cos_active = cd;
+
+			/* Check for SD - CTCSS active */
+			sd = 1;
+			if ((o->rxsdtype == SD_HID) && (!o->rxhidctcss)) {
+				sd = 0;
+			} else if ((o->rxsdtype == SD_HID_INVERT) && o->rxhidctcss) {
+				sd = 0;
+			} else if ((o->rxsdtype == SD_PP) && (!o->rxppctcss)) {
+				sd = 0;
+			} else if ((o->rxsdtype == SD_PP_INVERT) && o->rxppctcss) {
+				sd = 0;
+			}
+
+			/* See if we are overriding CTCSS to active */
+			if (o->rxctcssoverride) {
+				sd = 1;
+			}
+			o->rx_ctcss_active = sd;
+
+			/* Special case where cd and sd have been configured for no */
+			if (o->rxcdtype == CD_IGNORE && o->rxsdtype == SD_IGNORE) {
+				cd = 0;
+				sd = 0;
+			}
+
+			/* Timer for how long TX has been unkeyed - used with txoffdelay */
+			if (o->txoffdelay) {
+				if (o->txkeyed == 1) {
+					o->txoffcnt = 0; /* If keyed, set this to zero. */
+				} else {
+					o->txoffcnt++;
+					if (o->txoffcnt > MS_TO_FRAMES(TX_OFF_DELAY_MAX)) {
+						o->txoffcnt = MS_TO_FRAMES(TX_OFF_DELAY_MAX); /* limit count */
+					}
+				}
+			}
+
+			/* Check conditions and set receiver active */
+			o->rxkeyed = sd && cd && ((!o->lasttx) || o->duplex) && (o->txoffcnt >= o->txoffdelay);
+
+			/* Send a message to indicate rx signal detect conditions */
+			if (o->lastrx && !o->rxkeyed) {
+				struct ast_frame wf = {
+					.frametype = AST_FRAME_CONTROL,
+					.subclass.integer = AST_CONTROL_RADIO_UNKEY,
+					.src = __PRETTY_FUNCTION__,
+				};
+
+				o->lastrx = 0;
+
+				if (o->owner) {
+					ast_queue_frame(o->owner, &wf);
+				}
+
+				if (o->duplex3) {
+					ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_SW, 0, 0);
+				}
+			} else if (!o->lastrx && o->rxkeyed) {
+				struct ast_frame wf = {
+					.frametype = AST_FRAME_CONTROL,
+					.subclass.integer = AST_CONTROL_RADIO_KEY,
+					.src = __PRETTY_FUNCTION__,
+				};
+
+				o->lastrx = 1;
+
+				if (o->owner) {
+					ast_queue_frame(o->owner, &wf);
+				}
+
+				if (o->duplex3) {
+					ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_SW, 1, 0);
+				}
+			}
+
+			/* Check for ADC clipping and input audio statistics before any filtering is done.
+			 * FRAME_SIZE define refers to 8Ksps mono which is 160 samples per 20mS USB frame.
+			 * ast_radio_check_audio() takes the read buffer as received (48K stereo or mono),
+			 * extracts the 48K channel, checks amplitude and distortion characteristics,
+			 * and returns true if clipping was detected.
+			 */
+			if (ast_radio_check_audio(o->simpleusb_read_buf, &o->rxaudiostats, 6 * FRAME_SIZE, 1)) {
+				if (o->clipledgpio) {
+					/* Set Clip LED GPIO pulsetimer if not already set */
+					if (!o->hid_gpio_pulsetimer[o->clipledgpio - 1]) {
+						o->hid_gpio_pulsetimer[o->clipledgpio - 1] = CLIP_LED_HOLD_TIME_MS;
+					}
+				}
+			}
+
+			/* Downsample received audio from 48000 mono to 8000 mono */
+			sp = o->simpleusb_read_buf;
+			sp1 = (short *) (o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET);
+			for (i = 0; i < FRAME_SIZE; i++) {
+				(void) lpass(*sp++, o->flpr);
+				(void) lpass(*sp++, o->flpr);
+				(void) lpass(*sp++, o->flpr);
+				(void) lpass(*sp++, o->flpr);
+				(void) lpass(*sp++, o->flpr);
+				if (o->plfilter && o->deemphasis) {
+					*sp1++ = hpass6(deemph(lpass(*sp++, o->flpr), &o->destate), o->hpx, o->hpy);
+				} else if (o->deemphasis) {
+					*sp1++ = deemph(lpass(*sp++, o->flpr), &o->destate);
+				} else if (o->plfilter) {
+					*sp1++ = hpass(lpass(*sp++, o->flpr), o->hpx, o->hpy);
+				} else {
+					*sp1++ = lpass(*sp++, o->flpr);
+				}
+			}
+
+			/* If we are in echomode and receiving audio, store
+			 * it in the echo queue for later playback.
+			 */
+			if (o->echomode && o->rxkeyed && (!o->echoing)) {
+				register int x;
+				struct usbecho *u;
+
+				ast_mutex_lock(&o->echolock);
+				x = 0;
+				/* get count of frames */
+				for (u = (struct usbecho *) o->echoq.q_forw; u != (struct usbecho *) &o->echoq; u = (struct usbecho *) u->q_forw) {
+					x++;
+				}
+
+				if (x < o->echomax) {
+					u = ast_calloc(1, sizeof(struct usbecho));
+					if (u) {
+						memcpy(u->data, (o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET), FRAME_SIZE * 2);
+						insque((struct qelem *) u, o->echoq.q_back);
+					}
+				}
+				ast_mutex_unlock(&o->echolock);
+			}
+
+#if DEBUG_CAPTURES == 1
+			if (o->rxcapraw && frxcapcooked) {
+				fwrite(o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET, sizeof(short), FRAME_SIZE, frxcapcooked);
+			}
+#endif
+
+			/* reset read pointer for next frame */
+			/* Do not return the frame if the channel is not up */
+			if (ast_channel_state(o->owner) != AST_STATE_UP) {
+				continue;
+			}
+			/* ok we can build and deliver the frame to the caller */
+			f->frametype = AST_FRAME_VOICE;
+			f->subclass.format = ast_format_slin;
+			f->offset = AST_FRIENDLY_OFFSET;
+			f->samples = FRAME_SIZE;
+			f->datalen = FRAME_SIZE * 2;
+			f->data.ptr = o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET;
+			if (!o->rxkeyed) {
+				memset(f->data.ptr, 0, f->datalen);
+			}
+			/* Process the audio to see if contains DTMF */
+			if (o->usedtmf && o->dsp) {
+				f1 = ast_dsp_process(o->owner, o->dsp, f);
+				if ((f1->frametype == AST_FRAME_DTMF_END) || (f1->frametype == AST_FRAME_DTMF_BEGIN)) {
+					if ((f1->subclass.integer == 'm') || (f1->subclass.integer == 'u')) {
+						f1->frametype = AST_FRAME_NULL;
+						f1->subclass.integer = 0;
+
+						if (o->owner) {
+							ast_queue_frame(o->owner, f1);
+						}
+
+						continue;
+					}
+					if (f1->frametype == AST_FRAME_DTMF_END) {
+						f1->len = ast_tvdiff_ms(ast_radio_tvnow(), o->tonetime);
+						if (option_verbose) {
+							ast_log(LOG_NOTICE, "Channel %s: Got DTMF char %c duration %ld ms\n", o->name, f1->subclass.integer, f1->len);
+						}
+						o->toneflag = 0;
+					} else {
+						if (o->toneflag) {
+							ast_frfree(f1);
+							f1 = NULL;
+						} else {
+							o->tonetime = ast_radio_tvnow();
+							o->toneflag = 1;
+						}
+					}
+					if (o->owner && f1) {
+						ast_queue_frame(o->owner, f1);
+					}
+				}
+			}
+
+			/* Raw audio samples should never be clipped or scaled for any reason. Adjustments to
+			 * audio levels should be made only in the USB interface mixer settings.
+			 * TODO: After the vast majority of existing installs have had a chance to review their
+			 * audio settings and these old scaling/clipping hacks are no longer in significant use
+			 * the legacyaudioscaling cfg and related code should be deleted.
+			 */
+			/* scale and clip values */
+			if (o->legacyaudioscaling && o->rxvoiceadj > 1.0) {
+				register int i, x;
+				register float f1;
+				register int16_t *p = (int16_t *) f->data.ptr;
+
+				for (i = 0; i < f->samples; i++) {
+					f1 = (float) p[i] * o->rxvoiceadj;
+					x = (int) f1;
+					if (x > 32767) {
+						x = 32767;
+					} else if (x < -32768) {
+						x = -32768;
+					}
+					p[i] = x;
+				}
+			}
+
+			/* Compute the peak signal if requested */
+			if (o->measure_enabled) {
+				register int i;
+				register int32_t accum;
+				register int16_t *p = (int16_t *) f->data.ptr;
+
+				for (i = 0; i < f->samples; i++) {
+					accum = p[i];
+					if (accum > o->amax) {
+						o->amax = accum;
+						o->discounteru = o->discfactor;
+					} else if (--o->discounteru <= 0) {
+						o->discounteru = o->discfactor;
+						o->amax = (int32_t) ((o->amax * 32700) / 32768);
+					}
+					if (accum < o->amin) {
+						o->amin = accum;
+						o->discounterl = o->discfactor;
+					} else if (--o->discounterl <= 0) {
+						o->discounterl = o->discfactor;
+						o->amin = (int32_t) ((o->amin * 32700) / 32768);
+					}
+				}
+				o->apeak = (int32_t) (o->amax - o->amin) / 2;
+			}
+
+			if (o->owner) {
+				ast_queue_frame(o->owner, f);
+			}
+		}
+
+stream_restart:
+		o->hasusb = 0;
+		stop_stream(o);
+
+		while ((f1 = AST_LIST_REMOVE_HEAD(&o->txq, frame_list))) {
+			ast_frfree(f1);
 		}
 	}
 
-	/* Raw audio samples should never be clipped or scaled for any reason. Adjustments to
-	 * audio levels should be made only in the USB interface mixer settings.
-	 * TODO: After the vast majority of existing installs have had a chance to review their
-	 * audio settings and these old scaling/clipping hacks are no longer in significant use
-	 * the legacyaudioscaling cfg and related code should be deleted.
-	 */
-	/* scale and clip values */
-	if (o->legacyaudioscaling && o->rxvoiceadj > 1.0) {
-		register int i, x;
-		register float f1;
-		register int16_t *p = (int16_t *) f->data.ptr;
-
-		for (i = 0; i < f->samples; i++) {
-			f1 = (float) p[i] * o->rxvoiceadj;
-			x = (int) f1;
-			if (x > 32767) {
-				x = 32767;
-			} else if (x < -32768) {
-				x = -32768;
-			}
-			p[i] = x;
-		}
+	while ((f1 = AST_LIST_REMOVE_HEAD(&o->txq, frame_list))) {
+		ast_frfree(f1);
 	}
-
-	/* Compute the peak signal if requested */
-	if (o->measure_enabled) {
-		register int i;
-		register int32_t accum;
-		register int16_t *p = (int16_t *) f->data.ptr;
-
-		for (i = 0; i < f->samples; i++) {
-			accum = p[i];
-			if (accum > o->amax) {
-				o->amax = accum;
-				o->discounteru = o->discfactor;
-			} else if (--o->discounteru <= 0) {
-				o->discounteru = o->discfactor;
-				o->amax = (int32_t) ((o->amax * 32700) / 32768);
-			}
-			if (accum < o->amin) {
-				o->amin = accum;
-				o->discounterl = o->discfactor;
-			} else if (--o->discounterl <= 0) {
-				o->discounterl = o->discfactor;
-				o->amin = (int32_t) ((o->amin * 32700) / 32768);
-			}
-		}
-		o->apeak = (int32_t) (o->amax - o->amin) / 2;
-	}
-	return f;
+	ast_debug(2, "Audio Thread has exited");
+	return NULL;
 }
-
 /*!
  * \brief Asterisk fixup function.
  * \param oldchan		Old asterisk channel.
@@ -2695,10 +3031,6 @@ static struct ast_channel *simpleusb_new(struct chan_simpleusb_pvt *o, char *ext
 		return NULL;
 	}
 	ast_channel_tech_set(c, &simpleusb_tech);
-	if ((o->sounddev < 0) && o->hasusb) {
-		setformat(o, O_RDWR);
-	}
-	ast_channel_internal_fd_set(c, 0, o->sounddev); /* -1 if device closed, override later */
 	ast_channel_nativeformats_set(c, simpleusb_tech.capabilities);
 	ast_channel_set_readformat(c, ast_format_slin);
 	ast_channel_set_writeformat(c, ast_format_slin);
@@ -2752,7 +3084,7 @@ static struct ast_channel *simpleusb_request(const char *type, struct ast_format
 	}
 
 	if (o->owner) {
-		ast_log(LOG_NOTICE, "Channel %s: Already have a call (chan %p) on the usb channel\n", o->name, o->owner);
+		ast_log(LOG_NOTICE, "Channel %s: Already has a call (chan %p) on the usb channel\n", o->name, o->owner);
 		*cause = AST_CAUSE_BUSY;
 		return NULL;
 	}
@@ -3868,6 +4200,9 @@ static struct chan_simpleusb_pvt *store_config(struct ast_config *cfg, const cha
 			o->name = ast_strdup(ctg);
 			o->pttkick[0] = -1;
 			o->pttkick[1] = -1;
+			o->audiothread = AST_PTHREADT_NULL;
+			o->hidthread = AST_PTHREADT_NULL;
+			o->hw_device[0] = '\0';
 			if (!simpleusb_active) {
 				simpleusb_active = o->name;
 			}
@@ -3888,8 +4223,6 @@ static struct chan_simpleusb_pvt *store_config(struct ast_config *cfg, const cha
 			continue;
 		}
 
-		CV_UINT("frags", o->frags);
-		CV_UINT("queuesize", o->queuesize);
 		CV_BOOL("invertptt", o->invertptt);
 		CV_F("carrierfrom", store_rxcdtype(o, (char *) v->value));
 		CV_F("ctcssfrom", store_rxsdtype(o, (char *) v->value));
@@ -4208,11 +4541,15 @@ static int load_module(void)
 		ast_log(LOG_NOTICE, "susb active device %s not found\n", simpleusb_active);
 		/* XXX we could default to 'dsp' perhaps ? */
 		/* XXX should cleanup allocated memory etc. */
+		ao2_cleanup(simpleusb_tech.capabilities);
+		simpleusb_tech.capabilities = NULL;
 		return AST_MODULE_LOAD_DECLINE;
 	}
 
 	if (ast_channel_register(&simpleusb_tech)) {
 		ast_log(LOG_ERROR, "Unable to register channel type 'usb'\n");
+		ao2_cleanup(simpleusb_tech.capabilities);
+		simpleusb_tech.capabilities = NULL;
 		return AST_MODULE_LOAD_DECLINE;
 	}
 
@@ -4227,46 +4564,48 @@ static int load_module(void)
 
 static int unload_module(void)
 {
-	struct chan_simpleusb_pvt *o;
+	struct chan_simpleusb_pvt *o, *no;
 
 	stoppulser = 1;
 
-	ast_channel_unregister(&simpleusb_tech);
-	ast_cli_unregister_multiple(cli_simpleusb, ARRAY_LEN(cli_simpleusb));
+	for (o = simpleusb_default.next; o; o = no) {
+		no = o->next; /* Keep track of next object after free */
+		if (o->owner) {
+			ast_softhangup(o->owner, AST_SOFTHANGUP_APPUNLOAD);
+		}
 
-	for (o = simpleusb_default.next; o; o = o->next) {
-#if DEBUG_CAPTURES == 1
-		if (frxcapraw) {
-			fclose(frxcapraw);
-			frxcapraw = NULL;
+		if (o->audiothread != AST_PTHREADT_NULL) {
+			pthread_join(o->audiothread, NULL); /* wait for audio thread to end */
+			o->audiothread = AST_PTHREADT_NULL;
 		}
-		if (frxcapcooked) {
-			fclose(frxcapraw);
-			frxcapcooked = NULL;
-		}
-		if (ftxcapraw) {
-			fclose(ftxcapraw);
-			ftxcapraw = NULL;
-		}
-#endif
-
-		if (o->sounddev >= 0) {
-			close(o->sounddev);
-			o->sounddev = -1;
+		if (o->hidthread != AST_PTHREADT_NULL) {
+			pthread_join(o->hidthread, NULL);
+			o->hidthread = AST_PTHREADT_NULL;
 		}
 		if (o->dsp) {
 			ast_dsp_free(o->dsp);
 		}
-		if (o->owner) {
-			ast_softhangup(o->owner, AST_SOFTHANGUP_APPUNLOAD);
-		}
-		if (o->owner) { /* XXX how ??? */
-			return -1;
-		}
-		/* XXX what about the thread ? */
+		ast_free(o);
+
 		/* XXX what about the memory allocated ? */
 	}
 
+#if DEBUG_CAPTURES == 1
+	if (frxcapraw) {
+		fclose(frxcapraw);
+		frxcapraw = NULL;
+	}
+	if (frxcapcooked) {
+		fclose(frxcapcooked);
+		frxcapcooked = NULL;
+	}
+	if (ftxcapraw) {
+		fclose(ftxcapraw);
+		ftxcapraw = NULL;
+	}
+#endif
+	ast_channel_unregister(&simpleusb_tech);
+	ast_cli_unregister_multiple(cli_simpleusb, ARRAY_LEN(cli_simpleusb));
 	ao2_cleanup(simpleusb_tech.capabilities);
 	simpleusb_tech.capabilities = NULL;
 

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1156,6 +1156,8 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 			o->usb_dev = ast_radio_usb_device_from_alsa_card(o->devicenum);
 			if (!o->usb_dev) {
 				ast_debug(5, "Unable to find usb device associated with %s\n", o->hw_device);
+				ast_mutex_unlock(&usb_dev_lock);
+				return -1;
 			}
 
 		} else {
@@ -1241,6 +1243,7 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 				break;
 			}
 			if (ast_strlen_zero(o->devstr)) {
+				ast_mutex_unlock(&usb_dev_lock);
 				return -1;
 			}
 		}

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1693,7 +1693,7 @@ static void *hidthread(void *arg)
 				o->last_gpios_in = j;
 				ast_mutex_unlock(&o->usblock);
 			}
-			
+
 			/* process the parallel port GPIO */
 			if (haspp) {
 				ast_mutex_lock(&pp_lock);

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -428,9 +428,6 @@ static struct ast_channel_tech simpleusb_tech = {
 	.setoption = simpleusb_setoption,
 };
 
-#include <time.h>
-#include <unistd.h>
-
 static int64_t now_ms(void)
 {
 	struct timespec ts;
@@ -1852,9 +1849,9 @@ static void *hidthread(void *arg)
 		}
 		buf[o->hid_gpio_loc] = o->hid_gpio_val;
 		buf[o->hid_gpio_ctl_loc] = o->hid_gpio_ctl;
-		ast_radio_hid_set_outputs(usb_handle, buf);
 		ast_mutex_unlock(&o->usblock);
-
+		ast_radio_hid_set_outputs(usb_handle, buf);
+		
 		if (usb_handle) {
 			usb_close(usb_handle);
 			usb_handle = NULL;

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1753,7 +1753,7 @@ static int soundcard_writeframe(struct chan_simpleusb_pvt *o, short *data)
 	 * nice to log a warning but as this does not relate to outgoing network audio it's not
 	 * a major issue. User can check the Tx Audio Stats utility if desired.
 	 */
-	ast_radio_check_audio(data, &o->txaudiostats, 12 * FRAME_SIZE);
+	ast_radio_check_audio(data, &o->txaudiostats, 12 * FRAME_SIZE, 0);
 
 	return res;
 }
@@ -2560,11 +2560,11 @@ static void *simpleusb_audio_thread(void *arg)
 
 		/* Check for ADC clipping and input audio statistics before any filtering is done.
 		 * FRAME_SIZE define refers to 8Ksps mono which is 160 samples per 20mS USB frame.
-		 * ast_radio_check_audio() takes the read buffer as received (48K stereo),
-		 * extracts the mono 48K channel, checks amplitude and distortion characteristics,
+		 * ast_radio_check_audio() takes the read buffer as received (48K stereo or mono),
+		 * extracts the 48K channel, checks amplitude and distortion characteristics,
 		 * and returns true if clipping was detected.
 		 */
-		if (ast_radio_check_audio((short *) o->simpleusb_read_buf, &o->rxaudiostats, 12 * FRAME_SIZE)) {
+		if (ast_radio_check_audio((short *) o->simpleusb_read_buf, &o->rxaudiostats, 6 * FRAME_SIZE, 1)) {
 			if (o->clipledgpio) {
 				/* Set Clip LED GPIO pulsetimer if not already set */
 				if (!o->hid_gpio_pulsetimer[o->clipledgpio - 1]) {

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -115,17 +115,14 @@
 #define PA_SAMPLE_RATE 48000 /* PortAudio Sample rate: Hardware likes 48k and is divisible by 6 for a "nice" down conversion. */
 
 /*!
- * \brief The number of samples to configure the portaudio stream for
+ * \brief The number of samples to configure the PortAudio stream for.
  *
- * At 48kHz, 960 samples gives a 20ms frames, which aligns with Asterisk's
+ * At 48kHz, 960 samples gives a 20ms frame, which aligns with Asterisk's
  * common frame size after resampling to 8kHz (160 samples @ 2 bytes per sample).
+ * The number of short (2 byte) with paInt16 samples per PortAudio "frame".
+ * This is 1920 bytes for stereo, or 960 bytes for mono
  */
-#define PA_NUM_FRAMES \
-	960 /* The number of 2 byte (paInt16) \
-		 * samples per PortAudio "frame". \
-		 * This is 1920 bytes for stereo, \
-		 * or 960 bytes for mono \
-		 */
+#define PA_NUM_SAMPLES FRAME_SIZE * 6 /* Number of samples to read/write from PortAudio stream per Asterisk frame at 48k */
 
 /*! \brief Mono Input */
 #define PA_INPUT_CHANNELS 1 /* PortAudio: Mono input for Microphone / RX */
@@ -228,15 +225,11 @@ struct chan_simpleusb_pvt {
 
 	PaStream *stream; /*! Current PortAudio stream for this device */
 
-	/* buffers used in Pa_WriteStream, 2 per int */
-	char simpleusb_write_buf[FRAME_SIZE * 2];
+	char simpleusb_write_buf[FRAME_SIZE * 2]; /* buffer used for Asterisk to PA frames in 8k mono */
 
 	int simpleusb_write_dst;
-	/* buffers used in Pa_ReadStream - AST_FRIENDLY_OFFSET space for headers
-	 * plus enough room for a full frame
-	 */
-	short simpleusb_read_buf[PA_NUM_FRAMES];							 /* 2 bytes samples for PortAudio in mono - paInt16 */
-	char simpleusb_read_frame_buf[FRAME_SIZE * 2 + AST_FRIENDLY_OFFSET]; /* 2 byte frames at 8k */
+	short simpleusb_read_buf[PA_NUM_SAMPLES]; /* 1 short (2 byte) samples for PortAudio config with paInt16 * 1 channel (mono) */
+	char simpleusb_read_frame_buf[FRAME_SIZE * 2 + AST_FRIENDLY_OFFSET]; /* 2 byte samples at 8k */
 	struct ast_frame read_f; /* returned by simpleusb_read */
 
 	/* queue used to hold packets to transmit */
@@ -567,7 +560,7 @@ static int open_stream(struct chan_simpleusb_pvt *o)
 
 	if (!strcasecmp(o->hw_device, "default")) {
 		ast_debug(1, "Opening stream with default device\n");
-		res = Pa_OpenDefaultStream(&o->stream, PA_INPUT_CHANNELS, PA_OUTPUT_CHANNELS, paInt16, PA_SAMPLE_RATE, PA_NUM_FRAMES, NULL, NULL);
+		res = Pa_OpenDefaultStream(&o->stream, PA_INPUT_CHANNELS, PA_OUTPUT_CHANNELS, paInt16, PA_SAMPLE_RATE, PA_NUM_SAMPLES, NULL, NULL);
 	} else {
 		PaStreamParameters input_params = {
 			.channelCount = PA_INPUT_CHANNELS,
@@ -620,7 +613,7 @@ static int open_stream(struct chan_simpleusb_pvt *o)
 			return res;
 		}
 		ast_debug(5, "Opening stream on device %s", o->hw_device);
-		res = Pa_OpenStream(&o->stream, &input_params, &output_params, PA_SAMPLE_RATE, PA_NUM_FRAMES, paNoFlag, NULL, NULL);
+		res = Pa_OpenStream(&o->stream, &input_params, &output_params, PA_SAMPLE_RATE, PA_NUM_SAMPLES, paNoFlag, NULL, NULL);
 		ast_debug(5, "Stream feedback %s\n", Pa_GetErrorText(res));
 	}
 
@@ -1798,11 +1791,11 @@ static int soundcard_writeframe(struct chan_simpleusb_pvt *o, short *data)
 	 * a number of failures, to restart the output chain.
 	 */
 
-	res = Pa_WriteStream(o->stream, data, PA_NUM_FRAMES);
+	res = Pa_WriteStream(o->stream, data, PA_NUM_SAMPLES);
 	if (res == paOutputUnderflowed) {
-		short null_buf[PA_NUM_FRAMES * 2] = { 0 };
+		short null_buf[PA_NUM_SAMPLES * 2] = { 0 };
 		ast_debug(6, "PortAudio write stream underflow, writing a 0 frame");
-		Pa_WriteStream(o->stream, null_buf, PA_NUM_FRAMES);
+		Pa_WriteStream(o->stream, null_buf, PA_NUM_SAMPLES);
 	} else if (res < 0) {
 		ast_debug(2, "Pa_WriteStream Error %s", Pa_GetErrorText(res));
 	}
@@ -2251,7 +2244,7 @@ static void *simpleusb_audio_thread(void *arg)
 	struct ast_frame *f = &o->read_f, *f1;
 	time_t now;
 	register short *sp, *sp1;
-	short outbuf[PA_NUM_FRAMES * 2]; /* 2 bytes per frame on PortAudio config - paInt16 * 2 channels */
+	short outbuf[PA_NUM_SAMPLES * 2]; /* 1 short (2 bytes) per sample on PortAudio config with paInt16 * 2 channels */
 
 	ast_debug(5, "Audio thread is starting\n");
 
@@ -2515,7 +2508,7 @@ static void *simpleusb_audio_thread(void *arg)
 			 * in mono format.  We should always have 20ms frames, 100ms timeout
 			 * as a reasonable max wait time.
 			 */
-			res = Pa_ReadStream_with_timeout(o->stream, o->simpleusb_read_buf, PA_NUM_FRAMES, 60, &o->stopaudiothread);
+			res = Pa_ReadStream_with_timeout(o->stream, o->simpleusb_read_buf, PA_NUM_SAMPLES, 60, &o->stopaudiothread);
 			if (res != paNoError) {
 				/* audio data not ready */
 				if (res == paInputOverflowed) {

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -112,7 +112,7 @@
  * \todo Make this optional.  If this is only going to talk to 8 kHz endpoints,
  *       then it makes sense to use 8 kHz natively.
  */
-#define SAMPLE_RATE 48000 /* PortAudio Sample rate: Hardware likes 48k and is divisible by 6 for a "nice" down conversion. */
+#define PA_SAMPLE_RATE 48000 /* PortAudio Sample rate: Hardware likes 48k and is divisible by 6 for a "nice" down conversion. */
 
 /*!
  * \brief The number of samples to configure the portaudio stream for
@@ -145,13 +145,13 @@ static struct ast_jb_conf global_jbconf;
 #define PAGER_SRC "PAGER"
 #define ENDPAGE_STR "ENDPAGE"
 #define AMPVAL 12000
-#define SAMPRATE 8000 /* Asterisk sample rate (after down conversion) */
+#define AST_SAMPLE_RATE 8000 /* Asterisk sample rate (after down conversion) */
 #define DIVLCM 192000 /* Least Common Mult of 512,1200,2400,8000) */
 #define PREAMBLE_BITS 576
 #define MESSAGE_BITS 544 /* (17 * 32), 1 longword SYNC plus 16 longwords data */
 #define ONEVAL -AMPVAL
 #define ZEROVAL AMPVAL
-#define DIVSAMP (DIVLCM / SAMPRATE)
+#define DIVSAMP (DIVLCM / AST_SAMPLE_RATE)
 
 #define QUEUE_SIZE 5 /* 100 milliseconds of sound card output buffer */
 
@@ -230,7 +230,7 @@ struct chan_simpleusb_pvt {
 	/* buffers used in simpleusb_read - AST_FRIENDLY_OFFSET space for headers
 	 * plus enough room for a full frame
 	 */
-	char simpleusb_read_buf[NUM_SAMPLES * 2];							 /* 1 byte samples for PortAudio in mono - paInt16 */
+	char simpleusb_read_buf[NUM_SAMPLES * 2];							 /* 2 bytes samples for PortAudio in mono - paInt16 */
 	char simpleusb_read_frame_buf[FRAME_SIZE * 2 + AST_FRIENDLY_OFFSET]; /* 2 byte frames at 8k */
 	struct ast_frame read_f; /* returned by simpleusb_read */
 
@@ -561,7 +561,7 @@ static int open_stream(struct chan_simpleusb_pvt *o)
 
 	if (!strcasecmp(o->hw_device, "default")) {
 		ast_debug(1, "Opening stream with default device\n");
-		res = Pa_OpenDefaultStream(&o->stream, INPUT_CHANNELS, OUTPUT_CHANNELS, paInt16, SAMPLE_RATE, NUM_SAMPLES, NULL, NULL);
+		res = Pa_OpenDefaultStream(&o->stream, INPUT_CHANNELS, OUTPUT_CHANNELS, paInt16, PA_SAMPLE_RATE, NUM_SAMPLES, NULL, NULL);
 	} else {
 		PaStreamParameters input_params = {
 			.channelCount = INPUT_CHANNELS,
@@ -576,7 +576,7 @@ static int open_stream(struct chan_simpleusb_pvt *o)
 			.device = paNoDevice,
 		};
 		PaDeviceIndex idx, num_devices;
-		ast_debug(1, "Looking for device %s", o->hw_device);
+		ast_debug(1, "Looking for device %s\n", o->hw_device);
 		ast_debug(6, "PortAudio host api count %d\n", Pa_GetHostApiCount());
 		num_devices = Pa_GetDeviceCount();
 		if (num_devices < 0) {
@@ -614,7 +614,7 @@ static int open_stream(struct chan_simpleusb_pvt *o)
 			return res;
 		}
 		ast_debug(5, "Opening stream on device %s", o->hw_device);
-		res = Pa_OpenStream(&o->stream, &input_params, &output_params, SAMPLE_RATE, NUM_SAMPLES, paNoFlag, NULL, NULL);
+		res = Pa_OpenStream(&o->stream, &input_params, &output_params, PA_SAMPLE_RATE, NUM_SAMPLES, paNoFlag, NULL, NULL);
 		ast_debug(5, "Stream feedback %s\n", Pa_GetErrorText(res));
 	}
 
@@ -667,7 +667,7 @@ static int stop_stream(struct chan_simpleusb_pvt *pvt)
 		return 0;
 	}
 
-	/* Wait for pvt->thread to exit cleanly, to avoid killing it while it's holding a lock. */
+	/* Abort and close the stream */
 	err = Pa_AbortStream(pvt->stream);
 	if (err != paNoError) {
 		ast_log(LOG_WARNING, "Pa_AbortStream failed: %s\n", Pa_GetErrorText(err));
@@ -1136,16 +1136,16 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 	if (o->hw_device[0]) {
 		/* already configured device, extract the device number and usb_dev */
 		if (!strcasecmp(o->hw_device, "default")) {
-			ast_debug(5, "audiodev is defined: default");
+			ast_debug(5, "audiodev is defined: default\n");
 		} else if (sscanf(o->hw_device, "hw:%d", &o->devicenum) == 1) {
 			ast_debug(5, "audiodev is defined: %s, Device %d", o->hw_device, o->devicenum);
 			o->usb_dev = ast_radio_usb_device_from_alsa_card(o->devicenum);
 			if (!o->usb_dev) {
-				ast_debug(5, "Unable to find usb device associated with %s", o->hw_device);
+				ast_debug(5, "Unable to find usb device associated with %s\n", o->hw_device);
 			}
 
 		} else {
-			ast_log(LOG_ERROR, "Incorrect audio parameter audiodev (should be hw:0 format), found %s", o->hw_device);
+			ast_log(LOG_ERROR, "Incorrect audio parameter audiodev (should be hw:0 format), found %s\n", o->hw_device);
 			ast_mutex_unlock(&usb_dev_lock);
 			return -1;
 		}
@@ -2025,9 +2025,9 @@ static int simpleusb_text(struct ast_channel *c, const char *text)
 			i++;
 		}
 		/* get number of samples to alloc for audio */
-		audio_samples = (SAMPRATE * (PREAMBLE_BITS + (MESSAGE_BITS * i))) / baud;
+		audio_samples = (AST_SAMPLE_RATE * (PREAMBLE_BITS + (MESSAGE_BITS * i))) / baud;
 		/* pad end with 250ms of silence */
-		audio_samples += SAMPRATE / 4;
+		audio_samples += AST_SAMPLE_RATE / 4;
 		/* also pad up to FRAME_SIZE */
 		audio_samples += audio_samples % FRAME_SIZE;
 		audio = ast_calloc(1, (audio_samples * sizeof(short)) + 10);

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -319,7 +319,6 @@ struct chan_simpleusb_pvt {
 	unsigned int device_error:1;	/* indicator set when we cannot find the USB device */
 	unsigned int newname:1;			/* indicator that we should use MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW */
 	unsigned int hasusb:1;			/* indicator for has a USB device */
-	unsigned int internal_audio:1;	/* indicator for non usb audio device */
 	unsigned int usbass:1;			/* indicator for USB device assigned */
 	unsigned int wanteeprom:1;		/* indicator if we should use EEPROM */
 	unsigned int usedtmf:1;			/* indicator is we should decode DTMF */
@@ -1134,19 +1133,16 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 	o->usbass = 0;
 	o->devicenum = 0;
 	o->usb_dev = NULL;
-	o->internal_audio = 0;
 
 	if (o->hw_device[0]) {
 		/* already configured device, extract the device number and usb_dev */
 		if (!strcasecmp(o->hw_device, "default")) {
 			ast_debug(5, "audiodev is defined: default");
-			o->internal_audio = 1;
 		} else if (sscanf(o->hw_device, "hw:%d", &o->devicenum) == 1) {
 			ast_debug(5, "audiodev is defined: %s, Device %d", o->hw_device, o->devicenum);
 			o->usb_dev = ast_radio_usb_device_from_alsa_card(o->devicenum);
 			if (!o->usb_dev) {
 				ast_debug(5, "Unable to find usb device associated with %s", o->hw_device);
-				o->internal_audio = 1;
 			}
 
 		} else {
@@ -1392,12 +1388,12 @@ static void *hidthread(void *arg)
 			continue;
 		}
 
-		o->audio_ready = 1;
 		if (o->usb_dev == NULL) {
 			ast_log(LOG_ERROR, "Channel %s: Cannot initialize device %s\n", o->name, o->devstr);
 			usleep(DEVICE_RETRY);
 			continue;
 		}
+
 		/* open the usb device device */
 		usb_handle = usb_open(o->usb_dev);
 		if (usb_handle == NULL) {
@@ -1468,7 +1464,7 @@ static void *hidthread(void *arg)
 
 		o->hasusb = 1;
 		o->had_gpios_in = 0;
-
+		o->audio_ready = 1;
 		memset(&rfds, 0, sizeof(rfds));
 		rfds[0].fd = o->pttkick[1];
 		rfds[0].events = POLLIN;
@@ -2184,7 +2180,7 @@ static int simpleusb_write(struct ast_channel *c, struct ast_frame *f)
 	struct chan_simpleusb_pvt *o = ast_channel_tech_pvt(c);
 	struct ast_frame *f1;
 
-	if (!o->hasusb && !o->internal_audio) {
+	if (!o->hasusb) {
 		return 0;
 	}
 
@@ -2271,7 +2267,7 @@ static void *simpleusb_audio_thread(void *arg)
 
 		while (!o->stopthreads && o->audio_ready) {
 			/* check if the hid thread is still processing */
-			if (o->lasthidtime && !o->internal_audio) {
+			if (o->lasthidtime) {
 				ast_radio_time(&now);
 				if ((now - o->lasthidtime) > 3) {
 					ast_log(LOG_ERROR, "Channel %s: HID process has died or is not responding.\n", o->name);
@@ -2284,7 +2280,7 @@ static void *simpleusb_audio_thread(void *arg)
 			f->frametype = AST_FRAME_NULL;
 			f->src = __PRETTY_FUNCTION__;
 			/* if USB device not ready, just return NULL frame */
-			if (!o->hasusb && !o->internal_audio) {
+			if (!o->hasusb) {
 				if (o->rxkeyed) {
 					struct ast_frame wf = {
 						.frametype = AST_FRAME_CONTROL,
@@ -2355,16 +2351,34 @@ static void *simpleusb_audio_thread(void *arg)
 
 			/* Process the transmit queue */
 			for (;;) {
+				long frames_available;
+
 				num_frames = 0;
 				ast_mutex_lock(&o->txqlock);
 				AST_LIST_TRAVERSE(&o->txq, f1, frame_list) {
 					num_frames++;
 				}
+
 				ast_mutex_unlock(&o->txqlock);
 				if (o->txkeyed) {
 					ast_debug(7, "blocks used %d, Dest Buffer %d", num_frames, o->simpleusb_write_dst);
 				}
-				if (num_frames && (num_frames > 3 || (!o->txkeyed && !o->txtestkey))) {
+				/* Check for room in the write buffer.  If the device goes unavailable or
+				 * there is not room in the buffer, Pa_WriteStream will hang.
+				 */
+				frames_available = Pa_GetStreamWriteAvailable(o->stream);
+
+				if (frames_available < 0) {
+					if (frames_available != paOutputUnderflowed) {
+						/* Underflow handled in soundcard_writeframe
+						 * all other errors require restart
+						 */
+						ast_debug(2, "Pa_GetStreamWriteAvailable error %s", Pa_GetErrorText(frames_available));
+						goto stream_restart;
+					}
+				}
+
+				if (num_frames && (num_frames > 3 || (!o->txkeyed && !o->txtestkey)) && (frames_available >= FRAME_SIZE)) {
 					ast_mutex_lock(&o->txqlock);
 					f1 = AST_LIST_REMOVE_HEAD(&o->txq, frame_list);
 					ast_mutex_unlock(&o->txqlock);
@@ -2452,6 +2466,7 @@ static void *simpleusb_audio_thread(void *arg)
 									/* Underflow handled in soundcard_writeframe
 									 * all other errors require restart
 									 */
+									ast_debug(2, "Pa_WriteStream error %s", Pa_GetErrorText(res));
 									goto stream_restart;
 								}
 							}
@@ -2494,7 +2509,7 @@ static void *simpleusb_audio_thread(void *arg)
 			 * in mono format.  We should always have 20ms frames, 100ms timeout
 			 * as a reasonable max wait time.
 			 */
-			res = Pa_ReadStream_with_timeout(o->stream, o->simpleusb_read_buf + o->readpos, NUM_SAMPLES, 100);
+			res = Pa_ReadStream_with_timeout(o->stream, o->simpleusb_read_buf + o->readpos, NUM_SAMPLES, 60);
 			if (res != paNoError) {
 				/* audio data not ready */
 				if (res == paInputOverflowed) {

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -80,6 +80,7 @@
 #define N_FMT(duf) "%30" #duf /* Maximum sscanf conversion to numeric strings */
 #define HID_POLL_RATE 50
 #define DEVICE_RETRY 500000 /* Retry time in uS when USB device is missing */
+#define MAX_FRAME_DELAY 200 /* 200ms (.2s) max time to queue audio frames before resetting usb audio */
 #ifdef __linux
 #include <linux/soundcard.h>
 #elif defined(__FreeBSD__)
@@ -249,8 +250,10 @@ struct chan_simpleusb_pvt {
 	char lasttx;
 	char txkeyed; /* tx key request from upper layers */
 	char txtestkey;
+	char audio_thread_ready;
 
 	time_t lasthidtime;
+	time_t lastaudiotime;
 	struct ast_dsp *dsp;
 
 	short flpt[NTAPS + 1];
@@ -435,7 +438,7 @@ static int64_t now_ms(void)
 	return (int64_t) ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
 }
 
-static PaError Pa_ReadStream_with_timeout(PaStream *s, short *buf, long frames, int timeout_ms, volatile sig_atomic_t *stop)
+static PaError Pa_ReadStream_with_timeout(PaStream *s, short *buf, unsigned long frames, int timeout_ms, volatile sig_atomic_t *stop)
 {
 	int64_t start;
 
@@ -1019,7 +1022,7 @@ static char *find_installed_usb_match(void)
 static void *pulserthread(void *arg)
 {
 	struct timeval now, then;
-	register int i, j, k;
+	int i, j, k;
 
 #ifdef HAVE_SYS_IO
 	if (haspp == 2) {
@@ -1359,7 +1362,7 @@ static void *hidthread(void *arg)
 {
 	unsigned char buf[4], bufsave[4], keyed, ctcssed, txreq;
 	char lasttxtmp;
-	register int i, j, k;
+	int i, j, k;
 	int res;
 	struct usb_dev_handle *usb_handle = NULL;
 	struct chan_simpleusb_pvt *o = arg;
@@ -1438,7 +1441,7 @@ static void *hidthread(void *arg)
 			if (usb_claim_interface(usb_handle, C108_HID_INTERFACE) < 0) {
 				if (!claim_failed) {
 					ast_log(LOG_ERROR, "Channel %s: Is not able to claim the USB device\n", o->name);
-					detach_failed = 1;
+					claim_failed = 1;
 				}
 
 				usb_close(usb_handle);
@@ -1449,8 +1452,10 @@ static void *hidthread(void *arg)
 		}
 		/* write initial value to GPIO */
 		memset(buf, 0, sizeof(buf));
+		ast_mutex_lock(&o->usblock);
 		buf[o->hid_gpio_ctl_loc] = o->hid_gpio_ctl;
 		buf[o->hid_gpio_loc] = o->hid_gpio_val;
+		ast_mutex_unlock(&o->usblock);
 		ast_radio_hid_set_outputs(usb_handle, buf);
 		memcpy(bufsave, buf, sizeof(buf));
 		/* setup the pttkick pipe
@@ -1512,9 +1517,20 @@ static void *hidthread(void *arg)
 		 * the pttkick pipe.
 		 */
 		while ((!o->stophidthread) && o->hasusb) {
-			int hid_write = 0;
+			int gpio_write = 0;
+			time_t audio_time_now = 0;
 
 			then = ast_radio_tvnow();
+			if (o->lastaudiotime) {
+				/* HID thread monitors audio thread */
+				ast_radio_time(&audio_time_now);
+				if ((audio_time_now - o->lastaudiotime) > 1) {
+					ast_log(LOG_ERROR, "Channel %s: Audio process has died or is not responding.\n", o->name);
+					o->hasusb = 0;
+					break;
+				}
+			}
+
 			/* poll the pttkick pipe - timeout after HID_POLL_RATE milliseconds */
 			res = ast_poll(rfds, 1, HID_POLL_RATE);
 			if (res < 0) {
@@ -1525,17 +1541,23 @@ static void *hidthread(void *arg)
 			if (rfds[0].revents) {
 				char c;
 				int nbytes = 0;
-				int bytes;
+				int bytes, i;
 
 				/* Get all events in the buffer - if we missed a state change it will not make
 				 * it to the hardware anyways.
 				 */
-				ioctl(o->pttkick[0], FIONREAD, &nbytes);
-				bytes = read(o->pttkick[0], &c, nbytes);
-				if (bytes < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
-					ast_log(LOG_ERROR, "Channel %s: pttkick read failed: %s\n", o->name, strerror(errno));
-				} else if (bytes == 0) {
-					ast_log(LOG_ERROR, "Channel %s: pttkick pipe closed unexpectedly\n", o->name);
+				if (ioctl(o->pttkick[0], FIONREAD, &nbytes) == -1) {
+					ast_log(LOG_ERROR, "Channel %s: FIONREAD failed: %s\n", o->name, strerror(errno));
+					nbytes = 0;
+				}
+
+				for (i = 0; i < nbytes; i++) {
+					bytes = read(o->pttkick[0], &c, 1);
+					if (bytes < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+						ast_log(LOG_ERROR, "Channel %s: pttkick read failed: %s\n", o->name, strerror(errno));
+					} else if (bytes == 0) {
+						ast_log(LOG_ERROR, "Channel %s: pttkick pipe closed unexpectedly\n", o->name);
+					}
 				}
 			}
 			/* see if we need to process an eeprom read or write */
@@ -1584,26 +1606,32 @@ static void *hidthread(void *arg)
 
 			txreq = !(AST_LIST_EMPTY(&o->txq));
 			txreq = txreq || o->txkeyed || o->txtestkey || o->echoing;
-			if (txreq && !o->lasttx) {
+			lasttxtmp = o->lasttx;
+
+			if (txreq && !lasttxtmp) {
+				ast_mutex_lock(&o->usblock);
 				o->hid_gpio_val |= o->hid_io_ptt;
 				if (o->invertptt) {
 					o->hid_gpio_val &= ~o->hid_io_ptt;
 				}
 				buf[o->hid_gpio_loc] = o->hid_gpio_val;
 				buf[o->hid_gpio_ctl_loc] = o->hid_gpio_ctl;
-				hid_write = 1;
+				ast_mutex_unlock(&o->usblock);
+				gpio_write = 1;
 				ast_debug(2, "Channel %s: update PTT = %d on channel.\n", o->name, txreq);
-			} else if (!txreq && o->lasttx) {
+			} else if (!txreq && lasttxtmp) {
+				ast_mutex_lock(&o->usblock);
 				o->hid_gpio_val &= ~o->hid_io_ptt;
 				if (o->invertptt) {
 					o->hid_gpio_val |= o->hid_io_ptt;
 				}
 				buf[o->hid_gpio_loc] = o->hid_gpio_val;
 				buf[o->hid_gpio_ctl_loc] = o->hid_gpio_ctl;
-				hid_write = 1;
+				ast_mutex_unlock(&o->usblock);
+				gpio_write = 1;
 				ast_debug(2, "Channel %s: update PTT = %d.\n", o->name, txreq);
 			}
-			lasttxtmp = o->lasttx;
+
 			o->lasttx = txreq;
 			ast_radio_time(&o->lasthidtime);
 			/* Get the GPIO information */
@@ -1631,6 +1659,7 @@ static void *hidthread(void *arg)
 					.src = __PRETTY_FUNCTION__,
 				};
 
+				ast_mutex_lock(&o->usblock);
 				for (i = 0; i < GPIO_PINCOUNT; i++) {
 					/* skip if not specified */
 					if (!o->gpios[i]) {
@@ -1651,13 +1680,18 @@ static void *hidthread(void *arg)
 						fr.datalen = strlen(buf1);
 
 						if (o->owner) {
-							ast_queue_frame(o->owner, &fr);
+							struct ast_channel *owner = o->owner;
+
+							ast_mutex_unlock(&o->usblock);
+							ast_queue_frame(owner, &fr);
+							ast_mutex_lock(&o->usblock);
 						}
 					}
 				}
 				o->had_gpios_in = 1;
 				o->last_gpios_in = j;
 			}
+			ast_mutex_unlock(&o->usblock);
 			/* process the parallel port GPIO */
 			if (haspp) {
 				ast_mutex_lock(&pp_lock);
@@ -1697,7 +1731,9 @@ static void *hidthread(void *arg)
 							fr.datalen = strlen(buf1);
 
 							if (o->owner) {
-								ast_queue_frame(o->owner, &fr);
+								struct ast_channel *owner = o->owner;
+
+								ast_queue_frame(owner, &fr);
 							}
 						}
 					}
@@ -1720,6 +1756,7 @@ static void *hidthread(void *arg)
 				}
 			}
 			j = ast_tvdiff_ms(ast_radio_tvnow(), then);
+			ast_mutex_lock(&o->usblock);
 			/* make output inversion mask (for pulseage) */
 			o->hid_gpio_lastmask = o->hid_gpio_pulsemask;
 			o->hid_gpio_pulsemask = 0;
@@ -1739,14 +1776,15 @@ static void *hidthread(void *arg)
 			if (o->hid_gpio_pulsemask || o->hid_gpio_lastmask) { /* if anything inverted (temporarily) */
 				buf[o->hid_gpio_loc] = o->hid_gpio_val ^ o->hid_gpio_pulsemask;
 				buf[o->hid_gpio_ctl_loc] = o->hid_gpio_ctl;
-				hid_write = 1;
+				gpio_write = 1;
 			}
 			if (o->gpio_set) {
 				o->gpio_set = 0;
 				buf[o->hid_gpio_loc] = o->hid_gpio_val ^ o->hid_gpio_pulsemask;
 				buf[o->hid_gpio_ctl_loc] = o->hid_gpio_ctl;
-				hid_write = 1;
+				gpio_write = 1;
 			}
+			ast_mutex_unlock(&o->usblock);
 			k = 0;
 			if (haspp) {
 				for (i = 2; i <= 9; i++) {
@@ -1765,6 +1803,7 @@ static void *hidthread(void *arg)
 				ast_debug(2, "Channel %s: tx set to %d\n", o->name, o->lasttx);
 				o->hid_gpio_val &= ~o->hid_io_ptt;
 				ast_mutex_lock(&pp_lock);
+				ast_mutex_lock(&o->usblock);
 				if (k) {
 					pp_val &= ~k;
 				}
@@ -1786,14 +1825,15 @@ static void *hidthread(void *arg)
 				if (k) {
 					ast_radio_ppwrite(haspp, ppfd, pbase, pport, pp_val);
 				}
-				ast_mutex_unlock(&pp_lock);
 				buf[o->hid_gpio_loc] = o->hid_gpio_val ^ o->hid_gpio_pulsemask;
 				buf[o->hid_gpio_ctl_loc] = o->hid_gpio_ctl;
+				ast_mutex_unlock(&o->usblock);
+				ast_mutex_unlock(&pp_lock);
 				memcpy(bufsave, buf, sizeof(buf));
-				hid_write = 1;
+				gpio_write = 1;
 			}
 
-			if (hid_write) {
+			if (gpio_write) {
 				ast_radio_hid_set_outputs(usb_handle, buf);
 			}
 
@@ -2160,6 +2200,8 @@ static int simpleusb_call(struct ast_channel *c, const char *dest, int timeout)
 
 	o->stophidthread = 0;
 	o->stopaudiothread = 0;
+	o->audio_thread_ready = 0;
+
 	ast_radio_time(&o->lasthidtime);
 
 	res = ast_pthread_create(&o->hidthread, NULL, hidthread, o);
@@ -2234,7 +2276,7 @@ static int simpleusb_write(struct ast_channel *c, struct ast_frame *f)
 	struct chan_simpleusb_pvt *o = ast_channel_tech_pvt(c);
 	struct ast_frame *f1;
 
-	if (!o->hasusb) {
+	if (!o->hasusb || !o->audio_thread_ready) {
 		return 0;
 	}
 
@@ -2259,11 +2301,11 @@ static int simpleusb_write(struct ast_channel *c, struct ast_frame *f)
 	}
 #endif
 
-	if ((!o->txkeyed) && (!o->txtestkey)) {
+	if (!o->txkeyed && !o->txtestkey) {
 		return 0;
 	}
 
-	if ((!o->txtestkey) && o->echoing) {
+	if (!o->txtestkey && o->echoing) {
 		return 0;
 	}
 
@@ -2272,6 +2314,7 @@ static int simpleusb_write(struct ast_channel *c, struct ast_frame *f)
 	if (!f1) {
 		return 0;
 	}
+
 	memset(&f1->frame_list, 0, sizeof(f1->frame_list));
 	ast_mutex_lock(&o->txqlock);
 	AST_LIST_INSERT_TAIL(&o->txq, f1, frame_list);
@@ -2302,14 +2345,16 @@ static void *simpleusb_audio_thread(void *arg)
 {
 	int cd, sd, src, num_frames, ispager, doleft, doright;
 	PaError res;
-	register int i;
+	int i;
 	struct chan_simpleusb_pvt *o = arg;
 	struct ast_frame *f = &o->read_f, *f1;
 	time_t now;
-	register short *sp, *sp1;
+	struct timeval last_frame_time;
+	short *sp, *sp1;
 	short outbuf[PA_NUM_FRAMES * 2]; /* 1 short (2 bytes) per sample on PortAudio config with paInt16 * 2 channels */
 
 	ast_debug(5, "Audio thread is starting\n");
+	ast_radio_time(&o->lastaudiotime);
 
 	while (!o->stopaudiothread) {
 		/* wait for audio device to be initialized */
@@ -2327,16 +2372,21 @@ static void *simpleusb_audio_thread(void *arg)
 			continue;
 		}
 
+		o->audio_thread_ready = 1;
+		last_frame_time = ast_radio_tvnow();
+
 		while (!o->stopaudiothread && o->hasusb) {
 			/* check if the hid thread is still processing */
 			if (o->lasthidtime) {
 				ast_radio_time(&now);
-				if ((now - o->lasthidtime) > 3) {
+				if ((now - o->lasthidtime) > 1) {
 					ast_log(LOG_ERROR, "Channel %s: HID process has died or is not responding.\n", o->name);
 					usleep(DEVICE_RETRY);
 					break;
 				}
 			}
+
+			ast_radio_time(&o->lastaudiotime);
 			/* Set frame defaults */
 			memset(f, 0, sizeof(struct ast_frame));
 			f->frametype = AST_FRAME_NULL;
@@ -2440,11 +2490,15 @@ static void *simpleusb_audio_thread(void *arg)
 					}
 				}
 
+				if (num_frames && (num_frames < 3) && (o->txkeyed || o->txtestkey)) {
+					/* waiting for 3 frames in the buffer. This is "normal" */
+					last_frame_time = ast_radio_tvnow();
+				}
+
 				if (num_frames && (num_frames > 3 || (!o->txkeyed && !o->txtestkey)) && (frames_available >= PA_NUM_FRAMES)) {
 					ast_mutex_lock(&o->txqlock);
 					f1 = AST_LIST_REMOVE_HEAD(&o->txq, frame_list);
 					ast_mutex_unlock(&o->txqlock);
-
 					src = 0; /* read position into f1->data */
 					while (src < f1->datalen) {
 						/* Compute spare room in the buffer */
@@ -2533,6 +2587,7 @@ static void *simpleusb_audio_thread(void *arg)
 								}
 							}
 
+							last_frame_time = ast_radio_tvnow();
 							src += l;
 							o->simpleusb_write_dst = 0;
 							if (o->waspager && (!ispager)) {
@@ -2563,15 +2618,21 @@ static void *simpleusb_audio_thread(void *arg)
 					ast_frfree(f1);
 					continue;
 				}
+
+				break;
+			}
+
+			if (num_frames && (ast_tvdiff_ms(ast_radio_tvnow(), last_frame_time) > MAX_FRAME_DELAY)) {
+				ast_log(LOG_ERROR, "Audio thread has not processed audio for over %d ms, restarting stream.\n", MAX_FRAME_DELAY);
 				break;
 			}
 
 			/* Read audio data from the USB sound device.
 			 * Sound data will arrive at 48000 samples per second
-			 * in mono format.  We should always have 20ms frames, 100ms timeout
+			 * in mono format.  We should always have 20ms frames, 40ms timeout
 			 * as a reasonable max wait time.
 			 */
-			res = Pa_ReadStream_with_timeout(o->stream, o->simpleusb_read_buf, PA_NUM_FRAMES, 60, &o->stopaudiothread);
+			res = Pa_ReadStream_with_timeout(o->stream, o->simpleusb_read_buf, PA_NUM_FRAMES, 40, &o->stopaudiothread);
 			if (res != paNoError) {
 				/* audio data not ready */
 				if (res == paInputOverflowed) {
@@ -2882,14 +2943,20 @@ stream_restart:
 		o->hasusb = 0;
 		stop_stream(o);
 
+		ast_mutex_lock(&o->txqlock);
 		while ((f1 = AST_LIST_REMOVE_HEAD(&o->txq, frame_list))) {
 			ast_frfree(f1);
 		}
+
+		ast_mutex_unlock(&o->txqlock);
 	}
 
+	ast_mutex_lock(&o->txqlock);
 	while ((f1 = AST_LIST_REMOVE_HEAD(&o->txq, frame_list))) {
 		ast_frfree(f1);
 	}
+	ast_mutex_unlock(&o->txqlock);
+	o->audio_thread_ready = 0;
 	ast_debug(2, "Audio Thread has exited");
 	return NULL;
 }

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -230,9 +230,8 @@ struct chan_simpleusb_pvt {
 	/* buffers used in simpleusb_read - AST_FRIENDLY_OFFSET space for headers
 	 * plus enough room for a full frame
 	 */
-	char simpleusb_read_buf[NUM_SAMPLES * 2];							 /* 2 byte samples for PortAudio - paInt16 */
+	char simpleusb_read_buf[NUM_SAMPLES * 2];							 /* 1 byte samples for PortAudio in mono - paInt16 */
 	char simpleusb_read_frame_buf[FRAME_SIZE * 2 + AST_FRIENDLY_OFFSET]; /* 2 byte frames at 8k */
-	int readpos;			 /* read position above */
 	struct ast_frame read_f; /* returned by simpleusb_read */
 
 	/* queue used to hold packets to transmit */
@@ -312,25 +311,25 @@ struct chan_simpleusb_pvt {
 	char had_pp_in;
 
 	/* bit fields */
-	unsigned int streamstate:1;		/* indicator if stream is started */
-	unsigned int rxcapraw:1;		/* indicator if receive capture is enabled */
-	unsigned int txcapraw:1;		/* indicator if transmit capture is enabled */
-	unsigned int measure_enabled:1; /* indicator if measure mode is enabled */
-	unsigned int device_error:1;	/* indicator set when we cannot find the USB device */
-	unsigned int newname:1;			/* indicator that we should use MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW */
-	unsigned int hasusb:1;			/* indicator for has a USB device */
-	unsigned int usbass:1;			/* indicator for USB device assigned */
-	unsigned int wanteeprom:1;		/* indicator if we should use EEPROM */
-	unsigned int usedtmf:1;			/* indicator is we should decode DTMF */
-	unsigned int invertptt:1;		/* indicator if we need to invert ptt */
-	unsigned int rxboost:1;			/* indicator if receive boost is needed */
-	unsigned int plfilter:1;		/* indicator if we need a pl filter */
-	unsigned int deemphasis:1;		/* indicator if we need deemphasis filter */
-	unsigned int preemphasis:1;		/* indicator if we need preemphasis filter */
-	unsigned int rx_cos_active:1;	/* indicator if cos is active - active state after processing */
-	unsigned int rx_ctcss_active:1; /* indicator if ctcss is active - active state after processing */
-	unsigned int audio_ready:1;		/* indicator if audio device has been initialized */
-	unsigned int stopthreads:1;		/* indicator to stop usb/audio threads */
+	unsigned int streamstate:1;			   /* indicator if stream is started */
+	unsigned int rxcapraw:1;			   /* indicator if receive capture is enabled */
+	unsigned int txcapraw:1;			   /* indicator if transmit capture is enabled */
+	unsigned int measure_enabled:1;		   /* indicator if measure mode is enabled */
+	unsigned int device_error:1;		   /* indicator set when we cannot find the USB device */
+	unsigned int newname:1;				   /* indicator that we should use MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW */
+	unsigned int hasusb:1;				   /* indicator for has a USB device */
+	unsigned int usbass:1;				   /* indicator for USB device assigned */
+	unsigned int wanteeprom:1;			   /* indicator if we should use EEPROM */
+	unsigned int usedtmf:1;				   /* indicator is we should decode DTMF */
+	unsigned int invertptt:1;			   /* indicator if we need to invert ptt */
+	unsigned int rxboost:1;				   /* indicator if receive boost is needed */
+	unsigned int plfilter:1;			   /* indicator if we need a pl filter */
+	unsigned int deemphasis:1;			   /* indicator if we need deemphasis filter */
+	unsigned int preemphasis:1;			   /* indicator if we need preemphasis filter */
+	unsigned int rx_cos_active:1;		   /* indicator if cos is active - active state after processing */
+	unsigned int rx_ctcss_active:1;		   /* indicator if ctcss is active - active state after processing */
+	volatile sig_atomic_t stophidthread;   /* indicator to stop hid thread */
+	volatile sig_atomic_t stopaudiothread; /* indicator to stop audio thread */
 
 	/* EEPROM access variables */
 	unsigned short eeprom[EEPROM_USER_LEN];
@@ -367,7 +366,6 @@ struct chan_simpleusb_pvt {
  */
 static struct chan_simpleusb_pvt simpleusb_default = {
 	.duplex = M_FULL,
-	.readpos = 0, /* start here on reads */
 	.wanteeprom = 1,
 	.usedtmf = 1,
 	.rxondelay = 0,
@@ -439,13 +437,12 @@ static int64_t now_ms(void)
 	return (int64_t) ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
 }
 
-static PaError Pa_ReadStream_with_timeout(PaStream *s, void *buf, long frames, int timeout_ms)
+static PaError Pa_ReadStream_with_timeout(PaStream *s, char *buf, long frames, int timeout_ms, volatile sig_atomic_t *stop)
 {
 	int64_t start;
-	char *out = buf;
 
 	start = now_ms();
-	while (1) {
+	while (!(*stop)) {
 		long avail;
 		PaError err;
 
@@ -458,13 +455,15 @@ static PaError Pa_ReadStream_with_timeout(PaStream *s, void *buf, long frames, i
 			if ((now_ms() - start) > timeout_ms) {
 				return paTimedOut;
 			}
-			usleep(500); // .5ms
+			usleep(500); /*.5ms */
 			continue;
 		}
 
-		err = Pa_ReadStream(s, out, frames);
+		err = Pa_ReadStream(s, buf, frames);
 		return err;
 	}
+
+	return paTimedOut;
 }
 
 /*!
@@ -1371,19 +1370,13 @@ static void *hidthread(void *arg)
 	 * it enters a processing loop responsible for interacting
 	 * with the usb hid device
 	 */
-	while (!o->stopthreads) {
-		ast_debug(2, "hidthread is restarting/starting");
+	while (!o->stophidthread) {
+		ast_debug(5, "hidthread is entering outer loop");
 
 		/* try to initialize the usb device */
 		res = init_audio_device(o);
 		if (res < 0) {
 			ast_log(LOG_ERROR, "Channel %s: Failed initialize the audio device\n", o->name);
-			usleep(DEVICE_RETRY);
-			continue;
-		}
-
-		if (start_stream(o) < 0) {
-			ast_log(LOG_ERROR, "Channel %s: Failed to start audio stream %s\n", o->name, o->hw_device);
 			usleep(DEVICE_RETRY);
 			continue;
 		}
@@ -1440,15 +1433,15 @@ static void *hidthread(void *arg)
 			ast_log(LOG_ERROR, "Channel %s: Is not able to create a pipe\n", o->name);
 			usb_close(usb_handle);
 			usb_handle = NULL;
-			stop_stream(o);
-			o->audio_ready = 0;
 			return NULL;
 		}
+
 		if ((o->usb_dev->descriptor.idProduct & 0xfffc) == C108_PRODUCT_ID) {
 			o->devtype = C108_PRODUCT_ID;
 		} else {
 			o->devtype = o->usb_dev->descriptor.idProduct;
 		}
+
 		ast_debug(5, "Channel %s: Starting normally.\n", o->name);
 		ast_debug(5, "Channel %s: Attached to usb device %s.\n", o->name, o->devstr);
 
@@ -1464,7 +1457,6 @@ static void *hidthread(void *arg)
 
 		o->hasusb = 1;
 		o->had_gpios_in = 0;
-		o->audio_ready = 1;
 		memset(&rfds, 0, sizeof(rfds));
 		rfds[0].fd = o->pttkick[1];
 		rfds[0].events = POLLIN;
@@ -1475,7 +1467,7 @@ static void *hidthread(void *arg)
 		 * The timer can be interrupted by writing to
 		 * the pttkick pipe.
 		 */
-		while ((!o->stopthreads) && o->hasusb) {
+		while ((!o->stophidthread) && o->hasusb) {
 			then = ast_radio_tvnow();
 			/* poll the pttkick pipe - timeout after HID_POLL_RATE milliseconds */
 			res = ast_poll(rfds, 1, HID_POLL_RATE);
@@ -1760,7 +1752,6 @@ static void *hidthread(void *arg)
 		buf[o->hid_gpio_ctl_loc] = o->hid_gpio_ctl;
 		ast_radio_hid_set_outputs(usb_handle, buf);
 		ast_mutex_unlock(&o->usblock);
-		stop_stream(o);
 	}
 	/* clean up before exiting the thread */
 	o->lasttx = 0;
@@ -2104,8 +2095,8 @@ static int simpleusb_call(struct ast_channel *c, const char *dest, int timeout)
 	struct chan_simpleusb_pvt *o = ast_channel_tech_pvt(c);
 	int res;
 
-	o->stopthreads = 0;
-	o->audio_ready = 0;
+	o->stophidthread = 0;
+	o->stopaudiothread = 0;
 	ast_radio_time(&o->lasthidtime);
 
 	res = ast_pthread_create(&o->hidthread, NULL, hidthread, o);
@@ -2117,7 +2108,7 @@ static int simpleusb_call(struct ast_channel *c, const char *dest, int timeout)
 	res = ast_pthread_create(&o->audiothread, NULL, simpleusb_audio_thread, o);
 	if (res) {
 		ast_log(LOG_ERROR, "Channel %s: Failed to create audio thread: %s\n", o->name, strerror(res));
-		o->stopthreads = 1;
+		o->stophidthread = 1;
 		if (o->hidthread != AST_PTHREADT_NULL) {
 			pthread_join(o->hidthread, NULL);
 			o->hidthread = AST_PTHREADT_NULL;
@@ -2149,16 +2140,16 @@ static int simpleusb_hangup(struct ast_channel *c)
 {
 	struct chan_simpleusb_pvt *o = ast_channel_tech_pvt(c);
 
-	o->stopthreads = 1;
-
-	if (o->hidthread != AST_PTHREADT_NULL) {
-		pthread_join(o->hidthread, NULL);
-		o->hidthread = AST_PTHREADT_NULL;
-	}
-
+	o->stopaudiothread = 1;
 	if (o->audiothread != AST_PTHREADT_NULL) {
 		pthread_join(o->audiothread, NULL);
 		o->audiothread = AST_PTHREADT_NULL;
+	}
+
+	o->stophidthread = 1;
+	if (o->hidthread != AST_PTHREADT_NULL) {
+		pthread_join(o->hidthread, NULL);
+		o->hidthread = AST_PTHREADT_NULL;
 	}
 
 	o->owner = NULL;
@@ -2257,22 +2248,30 @@ static void *simpleusb_audio_thread(void *arg)
 
 	ast_debug(5, "Audio thread is starting");
 
-	while (!o->stopthreads) {
+	while (!o->stopaudiothread) {
 		/* wait for audio device to be initialized */
-		if (!o->audio_ready) {
+		ast_debug(5, "Audio thread entered outer loop");
+		if (!o->hasusb) {
 			ast_debug(5, "Audio not ready");
 			usleep(DEVICE_RETRY);
 			continue;
 		}
 
-		while (!o->stopthreads && o->audio_ready) {
+		if (start_stream(o) < 0) {
+			ast_log(LOG_ERROR, "Channel %s: Failed to start audio stream %s\n", o->name, o->hw_device);
+			o->hasusb = 0;
+			usleep(DEVICE_RETRY);
+			continue;
+		}
+
+		while (!o->stopaudiothread && o->hasusb) {
 			/* check if the hid thread is still processing */
 			if (o->lasthidtime) {
 				ast_radio_time(&now);
 				if ((now - o->lasthidtime) > 3) {
 					ast_log(LOG_ERROR, "Channel %s: HID process has died or is not responding.\n", o->name);
 					usleep(DEVICE_RETRY);
-					continue;
+					break;
 				}
 			}
 			/* Set frame defaults */
@@ -2509,7 +2508,7 @@ static void *simpleusb_audio_thread(void *arg)
 			 * in mono format.  We should always have 20ms frames, 100ms timeout
 			 * as a reasonable max wait time.
 			 */
-			res = Pa_ReadStream_with_timeout(o->stream, o->simpleusb_read_buf + o->readpos, NUM_SAMPLES, 60);
+			res = Pa_ReadStream_with_timeout(o->stream, o->simpleusb_read_buf, NUM_SAMPLES, 60, &o->stopaudiothread);
 			if (res != paNoError) {
 				/* audio data not ready */
 				if (res == paInputOverflowed) {
@@ -2522,14 +2521,9 @@ static void *simpleusb_audio_thread(void *arg)
 
 #if DEBUG_CAPTURES == 1
 			if (o->rxcapraw && frxcapraw) {
-				fwrite(o->simpleusb_read_buf + o->readpos, sizeof(short), FRAME_SIZE * 6, frxcapraw);
+				fwrite(o->simpleusb_read_buf, sizeof(short), FRAME_SIZE * 6, frxcapraw);
 			}
 #endif
-
-			o->readpos += FRAME_SIZE * 6 * 2;
-			if (o->readpos < sizeof(o->simpleusb_read_buf)) { /* not enough samples */
-				continue;
-			}
 
 			/* If we have been sending pager audio, see if
 			 * we are finished.
@@ -2633,7 +2627,7 @@ static void *simpleusb_audio_thread(void *arg)
 				if (o->duplex3) {
 					ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_SW, 0, 0);
 				}
-			} else if (!o->lastrx && (o->rxkeyed)) {
+			} else if (!o->lastrx && o->rxkeyed) {
 				struct ast_frame wf = {
 					.frametype = AST_FRAME_CONTROL,
 					.subclass.integer = AST_CONTROL_RADIO_KEY,
@@ -2717,7 +2711,6 @@ static void *simpleusb_audio_thread(void *arg)
 #endif
 
 			/* reset read pointer for next frame */
-			o->readpos = 0;
 			/* Do not return the frame if the channel is not up */
 			if (ast_channel_state(o->owner) != AST_STATE_UP) {
 				continue;
@@ -2823,8 +2816,8 @@ static void *simpleusb_audio_thread(void *arg)
 		}
 
 stream_restart:
-		o->audio_ready = 0;
 		o->hasusb = 0;
+		stop_stream(o);
 	}
 
 	ast_debug(2, "Audio Thread has exited");
@@ -4505,14 +4498,11 @@ static int unload_module(void)
 
 	stoppulser = 1;
 
-	ast_channel_unregister(&simpleusb_tech);
-	ast_cli_unregister_multiple(cli_simpleusb, ARRAY_LEN(cli_simpleusb));
-
 	for (o = simpleusb_default.next; o; o = o->next) {
-		o->stopthreads = 1;
 		if (o->owner) {
 			ast_softhangup(o->owner, AST_SOFTHANGUP_APPUNLOAD);
 		}
+
 		if (o->audiothread != AST_PTHREADT_NULL) {
 			pthread_join(o->audiothread, NULL); /* wait for audio thread to end */
 			o->audiothread = AST_PTHREADT_NULL;
@@ -4523,9 +4513,6 @@ static int unload_module(void)
 		}
 		if (o->dsp) {
 			ast_dsp_free(o->dsp);
-		}
-		if (o->owner) { /* XXX how ??? */
-			return -1;
 		}
 
 		/* XXX what about the memory allocated ? */
@@ -4545,7 +4532,8 @@ static int unload_module(void)
 		ftxcapraw = NULL;
 	}
 #endif
-
+	ast_channel_unregister(&simpleusb_tech);
+	ast_cli_unregister_multiple(cli_simpleusb, ARRAY_LEN(cli_simpleusb));
 	ao2_cleanup(simpleusb_tech.capabilities);
 	simpleusb_tech.capabilities = NULL;
 

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -557,6 +557,7 @@ static int hw_match(const char *haystack, const char *needle)
 static int open_stream(struct chan_simpleusb_pvt *o)
 {
 	PaError res = paInternalError;
+	const PaStreamInfo *si;
 
 	if (!strcasecmp(o->hw_device, "default")) {
 		ast_debug(1, "Opening stream with default device\n");
@@ -614,7 +615,12 @@ static int open_stream(struct chan_simpleusb_pvt *o)
 		}
 		ast_debug(5, "Opening stream on device %s", o->hw_device);
 		res = Pa_OpenStream(&o->stream, &input_params, &output_params, PA_SAMPLE_RATE, PA_NUM_FRAMES, paNoFlag, NULL, NULL);
-		ast_debug(5, "Stream feedback %s\n", Pa_GetErrorText(res));
+		ast_debug(5, "Stream feedback: %s\n", Pa_GetErrorText(res));
+		si = Pa_GetStreamInfo(o->stream);
+		if (si) {
+			ast_debug(5, "Stream output latency: %.3f ms\n", si->outputLatency * 1000.0);
+			ast_debug(5, "Stream input latency: %.3f ms\n", si->inputLatency * 1000.0);
+		}
 	}
 
 	return res;

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1495,7 +1495,7 @@ static void *hidthread(void *arg)
 
 		ast_radio_time(&o->lasthidtime);
 
-		/* Reset the failure flags, we succeded */
+		/* Reset the failure flags, we succeeded */
 		init_audio_failed = 0;
 		init_hid_failed = 0;
 		open_device_failed = 0;

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -4426,6 +4426,15 @@ static int unload_module(void)
 
 	for (o = simpleusb_default.next; o; o = o->next) {
 #if DEBUG_CAPTURES == 1
+		o->stophid = 1;
+		if (o->audiothread != AST_PTHREADT_NULL) {
+			pthread_join(o->audiothread, NULL); /* wait for audio thread to end */
+			o->audiothread = AST_PTHREADT_NULL;
+		}
+		if (o->hidthread != AST_PTHREADT_NULL) {
+			pthread_join(o->hidthread, NULL);
+			o->hidthread = AST_PTHREADT_NULL;
+		}
 		if (frxcapraw) {
 			fclose(frxcapraw);
 			frxcapraw = NULL;
@@ -4449,7 +4458,7 @@ static int unload_module(void)
 		if (o->owner) { /* XXX how ??? */
 			return -1;
 		}
-		/* XXX what about the thread ? */
+
 		/* XXX what about the memory allocated ? */
 	}
 

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -80,7 +80,7 @@
 #define PP_IOPORT 0x378
 #define N_FMT(duf) "%30" #duf /* Maximum sscanf conversion to numeric strings */
 #define HID_POLL_RATE 50
-
+#define DEVICE_RETRY 500000 /* Retry time in uS when USB device is missing */
 #ifdef __linux
 #include <linux/soundcard.h>
 #elif defined(__FreeBSD__)
@@ -218,7 +218,6 @@ struct chan_simpleusb_pvt {
 
 	pthread_t audiothread;
 	pthread_t hidthread;
-	int stophid;
 
 	struct usb_device *usb_dev;
 	struct ast_channel *owner;
@@ -332,6 +331,8 @@ struct chan_simpleusb_pvt {
 	unsigned int preemphasis:1;		/* indicator if we need preemphasis filter */
 	unsigned int rx_cos_active:1;	/* indicator if cos is active - active state after processing */
 	unsigned int rx_ctcss_active:1; /* indicator if ctcss is active - active state after processing */
+	unsigned int audio_ready:1;		/* indicator if audio device has been initialized */
+	unsigned int stopthreads:1;		/* indicator to stop usb/audio threads */
 
 	/* EEPROM access variables */
 	unsigned short eeprom[EEPROM_USER_LEN];
@@ -429,6 +430,44 @@ static struct ast_channel_tech simpleusb_tech = {
 	.fixup = simpleusb_fixup,
 	.setoption = simpleusb_setoption,
 };
+
+#include <time.h>
+#include <unistd.h>
+
+static int64_t now_ms(void)
+{
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (int64_t) ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
+static PaError read_with_timeout(PaStream *s, void *buf, unsigned long frames, int timeout_ms)
+{
+	int64_t start;
+	char *out = buf;
+
+	start = now_ms();
+	while (1) {
+		long avail;
+		PaError err;
+
+		avail = Pa_GetStreamReadAvailable(s);
+		if (avail < 0) {
+			return (PaError) avail;
+		}
+
+		if (avail == 0) {
+			if ((now_ms() - start) > timeout_ms) {
+				return paTimedOut; // not a real PortAudio error code; use your own
+			}
+			usleep(1000); // 1ms
+			continue;
+		}
+
+		err = Pa_ReadStream(s, out, frames);
+		return err;
+	}
+}
 
 /*!
  * \brief Parse "hw:<card>" or "hw:<card>,<dev>" from anywhere in s.
@@ -590,9 +629,16 @@ static int start_stream(struct chan_simpleusb_pvt *pvt)
 	if (pvt->streamstate || !pvt->owner)
 		return -1;
 
+	res = Pa_Initialize();
+	if (res != paNoError) {
+		ast_log(LOG_WARNING, "Failed to initialize audio system - (%d) %s\n", res, Pa_GetErrorText(res));
+		return -1;
+	}
+
 	res = open_stream(pvt);
 	if (res != paNoError) {
 		ast_log(LOG_WARNING, "Failed to open stream - (%d) %s\n", res, Pa_GetErrorText(res));
+		Pa_Terminate();
 		return -1;
 	}
 
@@ -602,10 +648,11 @@ static int start_stream(struct chan_simpleusb_pvt *pvt)
 		Pa_CloseStream(pvt->stream);
 		pvt->stream = NULL;
 		pvt->streamstate = 0;
+		Pa_Terminate();
 		return -1;
 	}
-	pvt->streamstate = 1;
 
+	pvt->streamstate = 1;
 	return 0;
 }
 
@@ -630,6 +677,7 @@ static int stop_stream(struct chan_simpleusb_pvt *pvt)
 
 	pvt->stream = NULL;
 	pvt->streamstate = 0;
+	Pa_Terminate();
 	return 0;
 }
 
@@ -1022,7 +1070,6 @@ static int load_tune_config(struct chan_simpleusb_pvt *o, const struct ast_confi
 	o->rxmixerset = 500;
 	o->txmixaset = 500;
 	o->txmixbset = 500;
-	o->hw_device[0] = '\0';
 
 	devstr[0] = '\0';
 	serial[0] = '\0';
@@ -1050,7 +1097,9 @@ static int load_tune_config(struct chan_simpleusb_pvt *o, const struct ast_confi
 		CV_UINT("txmixbset", o->txmixbset);
 		CV_STR("devstr", devstr);
 		CV_STR("serial", serial);
-		CV_STR("audiodev", o->hw_device); /* use audiodevice as opposed to the usb device path (devstr) */
+		if (o->devstr[0] == '\0') {
+			CV_STR("audiodev", o->hw_device); /* use audiodevice as opposed to the usb device path (devstr) */
+		}
 		CV_END;
 	}
 	if (!reload) {
@@ -1160,7 +1209,7 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 						o->device_error = 1;
 					}
 					ast_mutex_unlock(&usb_dev_lock);
-					usleep(500000);
+					usleep(DEVICE_RETRY);
 					break;
 				}
 				/* We found an available device - see if it already in use */
@@ -1310,6 +1359,7 @@ static void *hidthread(void *arg)
 	struct timeval then;
 	struct pollfd rfds[1];
 
+	ast_debug(2, "hidthread has started");
 	/* enable gpio_set so that we will write GPIO information upon start up */
 	o->gpio_set = 1;
 
@@ -1324,18 +1374,34 @@ static void *hidthread(void *arg)
 	 * it enters a processing loop responsible for interacting
 	 * with the usb hid device
 	 */
-	while (!o->stophid) {
-		/* initialize the usb device */
+	while (!o->stopthreads) {
+		ast_debug(2, "hidthread is restarting/starting");
+
+		/* try to initialize the usb device */
+		res = init_audio_device(o);
+		if (res < 0) {
+			ast_log(LOG_ERROR, "Channel %s: Failed initialize the audio device\n", o->name);
+			usleep(DEVICE_RETRY);
+			continue;
+		}
+
+		if (start_stream(o) < 0) {
+			ast_log(LOG_ERROR, "Channel %s: Failed to start audio stream %s\n", o->name, o->hw_device);
+			usleep(DEVICE_RETRY);
+			continue;
+		}
+
+		o->audio_ready = 1;
 		if (o->usb_dev == NULL) {
 			ast_log(LOG_ERROR, "Channel %s: Cannot initialize device %s\n", o->name, o->devstr);
-			usleep(500000);
+			usleep(DEVICE_RETRY);
 			continue;
 		}
 		/* open the usb device device */
 		usb_handle = usb_open(o->usb_dev);
 		if (usb_handle == NULL) {
 			ast_log(LOG_ERROR, "Channel %s: Cannot open device %s\n", o->name, o->devstr);
-			usleep(500000);
+			usleep(DEVICE_RETRY);
 			continue;
 		}
 		/* attempt to claim the usb hid interface and detach from the kernel */
@@ -1344,14 +1410,14 @@ static void *hidthread(void *arg)
 				ast_log(LOG_ERROR, "Channel %s: Is not able to detach the USB device\n", o->name);
 				usb_close(usb_handle);
 				usb_handle = NULL;
-				usleep(500000);
+				usleep(DEVICE_RETRY);
 				continue;
 			}
 			if (usb_claim_interface(usb_handle, C108_HID_INTERFACE) < 0) {
 				ast_log(LOG_ERROR, "Channel %s: Is not able to claim the USB device\n", o->name);
 				usb_close(usb_handle);
 				usb_handle = NULL;
-				usleep(500000);
+				usleep(DEVICE_RETRY);
 				continue;
 			}
 		}
@@ -1410,7 +1476,7 @@ static void *hidthread(void *arg)
 		 * The timer can be interrupted by writing to
 		 * the pttkick pipe.
 		 */
-		while ((!o->stophid) && o->hasusb) {
+		while ((!o->stopthreads) && o->hasusb) {
 			then = ast_radio_tvnow();
 			/* poll the pttkick pipe - timeout after HID_POLL_RATE milliseconds */
 			res = ast_poll(rfds, 1, HID_POLL_RATE);
@@ -1540,11 +1606,9 @@ static void *hidthread(void *arg)
 						fr.data.ptr = buf1;
 						fr.datalen = strlen(buf1);
 
-						if (!o->owner) {
-							break;
+						if (o->owner) {
+							ast_queue_frame(o->owner, &fr);
 						}
-
-						ast_queue_frame(o->owner, &fr);
 					}
 				}
 				o->had_gpios_in = 1;
@@ -1588,16 +1652,16 @@ static void *hidthread(void *arg)
 							fr.data.ptr = buf1;
 							fr.datalen = strlen(buf1);
 
-							if (!o->owner) {
-								break;
+							if (o->owner) {
+								ast_queue_frame(o->owner, &fr);
 							}
-
-							ast_queue_frame(o->owner, &fr);
 						}
 					}
+
 					o->had_pp_in = 1;
 					o->last_pp_in = j;
 				}
+
 				o->rxppsq = o->rxppctcss = 0;
 				for (i = 10; i <= 15; i++) {
 					if ((o->pps[i]) && (!strcasecmp(o->pps[i], "cor")) && (PP_MASK & (1 << i))) {
@@ -1697,6 +1761,7 @@ static void *hidthread(void *arg)
 		buf[o->hid_gpio_ctl_loc] = o->hid_gpio_ctl;
 		ast_radio_hid_set_outputs(usb_handle, buf);
 		ast_mutex_unlock(&o->usblock);
+		stop_stream(o);
 	}
 	/* clean up before exiting the thread */
 	o->lasttx = 0;
@@ -1713,6 +1778,8 @@ static void *hidthread(void *arg)
 		usb_close(usb_handle);
 		usb_handle = NULL;
 	}
+
+	ast_debug(2, "hidthread has exited");
 	return NULL;
 }
 
@@ -2038,25 +2105,20 @@ static int simpleusb_call(struct ast_channel *c, const char *dest, int timeout)
 	struct chan_simpleusb_pvt *o = ast_channel_tech_pvt(c);
 	int res;
 
-	o->stophid = 0;
+	o->stopthreads = 0;
+	o->audio_ready = 0;
 	ast_radio_time(&o->lasthidtime);
-	res = init_audio_device(o);
-	if (res < 0) {
-		ast_log(LOG_ERROR, "Channel %s: Failed initialize the audio device\n", o->name);
+
+	res = ast_pthread_create(&o->hidthread, NULL, hidthread, o);
+	if (res) {
+		ast_log(LOG_ERROR, "Channel %s: Failed to create HID thread: %s\n", o->name, strerror(res));
 		return -1;
-	}
-	if (!o->internal_audio) {
-		res = ast_pthread_create(&o->hidthread, NULL, hidthread, o);
-		if (res) {
-			ast_log(LOG_ERROR, "Channel %s: Failed to create HID thread: %s\n", o->name, strerror(res));
-			return -1;
-		}
 	}
 
 	res = ast_pthread_create(&o->audiothread, NULL, simpleusb_audio_thread, o);
 	if (res) {
 		ast_log(LOG_ERROR, "Channel %s: Failed to create audio thread: %s\n", o->name, strerror(res));
-		o->stophid = 1;
+		o->stopthreads = 1;
 		if (o->hidthread != AST_PTHREADT_NULL) {
 			pthread_join(o->hidthread, NULL);
 			o->hidthread = AST_PTHREADT_NULL;
@@ -2088,7 +2150,7 @@ static int simpleusb_hangup(struct ast_channel *c)
 {
 	struct chan_simpleusb_pvt *o = ast_channel_tech_pvt(c);
 
-	o->stophid = 1;
+	o->stopthreads = 1;
 
 	if (o->hidthread != AST_PTHREADT_NULL) {
 		pthread_join(o->hidthread, NULL);
@@ -2195,26 +2257,348 @@ static void *simpleusb_audio_thread(void *arg)
 	short outbuf[NUM_SAMPLES * 2]; /* 2 bytes per sample on PortAudio config - paInt16 */
 
 	ast_debug(5, "Audio thread is starting");
-	if (start_stream(o) < 0) {
-		ast_log(LOG_ERROR, "Channel %s: Failed to start audio stream\n", o->name);
-		return NULL;
-	}
-	while (!o->stophid) {
-		/* check if the hid thread is still processing */
-		if (o->lasthidtime && !o->internal_audio) {
-			ast_radio_time(&now);
-			if ((now - o->lasthidtime) > 3) {
-				ast_log(LOG_ERROR, "Channel %s: HID process has died or is not responding.\n", o->name);
+
+	while (!o->stopthreads) {
+		/* wait for audio device to be initialized */
+		if (!o->audio_ready) {
+			ast_debug(5, "Audio not ready");
+			usleep(DEVICE_RETRY);
+			continue;
+		}
+
+		while (!o->stopthreads && o->audio_ready) {
+			/* check if the hid thread is still processing */
+			if (o->lasthidtime && !o->internal_audio) {
+				ast_radio_time(&now);
+				if ((now - o->lasthidtime) > 3) {
+					ast_log(LOG_ERROR, "Channel %s: HID process has died or is not responding.\n", o->name);
+					usleep(DEVICE_RETRY);
+					continue;
+				}
+			}
+			/* Set frame defaults */
+			memset(f, 0, sizeof(struct ast_frame));
+			f->frametype = AST_FRAME_NULL;
+			f->src = __PRETTY_FUNCTION__;
+			/* if USB device not ready, just return NULL frame */
+			if (!o->hasusb && !o->internal_audio) {
+				if (o->rxkeyed) {
+					struct ast_frame wf = {
+						.frametype = AST_FRAME_CONTROL,
+						.subclass.integer = AST_CONTROL_RADIO_UNKEY,
+						.src = __PRETTY_FUNCTION__,
+					};
+
+					o->lastrx = 0;
+					o->rxkeyed = 0;
+
+					if (o->owner) {
+						ast_queue_frame(o->owner, &wf);
+					}
+				}
+
+				continue;
+			}
+
+			/* If we have stopped echoing, clear the echo queue */
+			if (!o->echomode) {
+				struct qelem *q;
+
+				ast_mutex_lock(&o->echolock);
+				o->echoing = 0;
+				while (o->echoq.q_forw != &o->echoq) {
+					q = o->echoq.q_forw;
+					remque(q);
+					ast_free(q);
+				}
+				ast_mutex_unlock(&o->echolock);
+			}
+
+			/* If we are in echomode and we have stopped receiving audio
+			 * queue up the packets we have stored in the echo queue
+			 * for playback.
+			 */
+			if (o->echomode && (!o->rxkeyed)) {
+				struct usbecho *u;
+
+				ast_mutex_lock(&o->echolock);
+				/* if there is something in the queue */
+				if (o->echoq.q_forw != &o->echoq) {
+					u = (struct usbecho *) o->echoq.q_forw;
+					remque((struct qelem *) u);
+					f->frametype = AST_FRAME_VOICE;
+					f->subclass.format = ast_format_slin;
+					f->samples = FRAME_SIZE;
+					f->datalen = FRAME_SIZE * 2;
+					f->offset = AST_FRIENDLY_OFFSET;
+					f->data.ptr = o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET;
+					memcpy(f->data.ptr, u->data, FRAME_SIZE * 2);
+					ast_free(u);
+					f1 = ast_frdup(f);
+					if (!f1) {
+						ast_mutex_unlock(&o->echolock);
+						continue;
+					}
+					memset(&f1->frame_list, 0, sizeof(f1->frame_list));
+					ast_mutex_lock(&o->txqlock);
+					AST_LIST_INSERT_TAIL(&o->txq, f1, frame_list);
+					ast_mutex_unlock(&o->txqlock);
+					o->echoing = 1;
+				} else {
+					o->echoing = 0;
+				}
+				ast_mutex_unlock(&o->echolock);
+			}
+
+			/* Process the transmit queue */
+			for (;;) {
+				num_frames = 0;
+				ast_mutex_lock(&o->txqlock);
+				AST_LIST_TRAVERSE(&o->txq, f1, frame_list) {
+					num_frames++;
+				}
+				ast_mutex_unlock(&o->txqlock);
+				if (o->txkeyed) {
+					ast_debug(7, "blocks used %d, Dest Buffer %d", num_frames, o->simpleusb_write_dst);
+				}
+				if (num_frames && (num_frames > 3 || (!o->txkeyed && !o->txtestkey))) {
+					ast_mutex_lock(&o->txqlock);
+					f1 = AST_LIST_REMOVE_HEAD(&o->txq, frame_list);
+					ast_mutex_unlock(&o->txqlock);
+
+					src = 0; /* read position into f1->data */
+					while (src < f1->datalen) {
+						/* Compute spare room in the buffer */
+						int l = sizeof(o->simpleusb_write_buf) - o->simpleusb_write_dst;
+
+						if (f1->datalen - src >= l) {
+							/* enough to fill a frame */
+							memcpy(o->simpleusb_write_buf + o->simpleusb_write_dst, (char *) f1->data.ptr + src, l);
+							/* Below is an attempt to match levels to the original CM108 IC which has
+							 * been out of production for over 10 years. Scaling audio to 109.375% will
+							 * result in clipping! Any adjustments for CM1xxx gain differences should be
+							 * made in the mixer settings, not in the audio stream.
+							 * TODO: After the vast majority of existing installs have had a chance to review their
+							 * audio settings and these old scaling/clipping hacks are no longer in significant use
+							 * the legacyaudioscaling cfg and related code should be deleted.
+							 */
+							/* Adjust the audio level for CM119 A/B devices */
+							if (o->legacyaudioscaling && o->devtype != C108_PRODUCT_ID) {
+								register int v;
+
+								sp = (short *) o->simpleusb_write_buf;
+								for (i = 0; i < FRAME_SIZE; i++) {
+									v = *sp;
+									v += v >> 3;   /* add *.125 giving * 1.125 */
+									v -= *sp >> 5; /* subtract *.03125 giving * 1.09375 */
+									if (v > 32765.0) {
+										v = 32765.0;
+									} else if (v < -32765.0) {
+										v = -32765.0;
+									}
+									*sp++ = v;
+								}
+							}
+
+							sp = (short *) o->simpleusb_write_buf;
+							sp1 = outbuf;
+							doright = 1;
+							doleft = 1;
+							ispager = 0;
+							if (f1->src && (!strcmp(f1->src, PAGER_SRC))) {
+								ispager = 1;
+							}
+							/* If pager audio, determine which channel to store audio */
+							if (o->pager != PAGER_NONE) {
+								doleft = (o->pager == PAGER_A) ? ispager : !ispager;
+								doright = (o->pager == PAGER_B) ? ispager : !ispager;
+							}
+							/* Upsample from 8000 mono to 48000 stereo */
+							for (i = 0; i < FRAME_SIZE; i++) {
+								register short s, v;
+
+								if (o->preemphasis) {
+									s = preemph(sp[i], &o->prestate);
+								} else {
+									s = sp[i];
+								}
+								v = lpass(s, o->flpt);
+								*sp1++ = (doleft) ? v : 0;
+								*sp1++ = (doright) ? v : 0;
+								v = lpass(s, o->flpt);
+								*sp1++ = (doleft) ? v : 0;
+								*sp1++ = (doright) ? v : 0;
+								v = lpass(s, o->flpt);
+								*sp1++ = (doleft) ? v : 0;
+								*sp1++ = (doright) ? v : 0;
+								v = lpass(s, o->flpt);
+								*sp1++ = (doleft) ? v : 0;
+								*sp1++ = (doright) ? v : 0;
+								v = lpass(s, o->flpt);
+								*sp1++ = (doleft) ? v : 0;
+								*sp1++ = (doright) ? v : 0;
+								v = lpass(s, o->flpt);
+								*sp1++ = (doleft) ? v : 0;
+								*sp1++ = (doright) ? v : 0;
+							}
+
+							res = soundcard_writeframe(o, outbuf);
+							if (res != paNoError) {
+								/* audio data not ready */
+								if (res != paOutputUnderflowed) {
+									/* Underflow handled in soundcard_writeframe
+									 * all other errors require restart
+									 */
+									goto stream_restart;
+								}
+							}
+
+							src += l;
+							o->simpleusb_write_dst = 0;
+							if (o->waspager && (!ispager)) {
+								struct ast_frame wf = {
+									.frametype = AST_FRAME_TEXT,
+									.data.ptr = ENDPAGE_STR,
+									.datalen = strlen(ENDPAGE_STR) + 1,
+									.src = __PRETTY_FUNCTION__,
+								};
+
+								if (o->owner) {
+									ast_queue_frame(o->owner, &wf);
+								}
+
+								o->waspager = ispager;
+								continue;
+							}
+
+							o->waspager = ispager;
+						} else {
+							/* copy residue */
+							l = f1->datalen - src;
+							memcpy(o->simpleusb_write_buf + o->simpleusb_write_dst, (char *) f1->data.ptr + src, l);
+							src += l; /* but really, we are done */
+							o->simpleusb_write_dst += l;
+						}
+					}
+					ast_frfree(f1);
+					continue;
+				}
 				break;
 			}
-		}
-		/* Set frame defaults */
-		memset(f, 0, sizeof(struct ast_frame));
-		f->frametype = AST_FRAME_NULL;
-		f->src = __PRETTY_FUNCTION__;
-		/* if USB device not ready, just return NULL frame */
-		if (!o->hasusb && !o->internal_audio) {
-			if (o->rxkeyed) {
+
+			/* Read audio data from the USB sound device.
+			 * Sound data will arrive at 48000 samples per second
+			 * in mono format.
+			 */
+			res = read_with_timeout(o->stream, o->simpleusb_read_buf + o->readpos, NUM_SAMPLES, 100);
+			if (res != paNoError) {
+				/* audio data not ready */
+				if (res == paInputOverflowed) {
+					ast_debug(6, "PortAudio read overflow on channel %s\n", o->name);
+				} else {
+					ast_log(LOG_ERROR, "PortAudio became unavailable on channel %s\n", o->name);
+					break; /* Close the stream and retry */
+				}
+			}
+
+#if DEBUG_CAPTURES == 1
+			if (o->rxcapraw && frxcapraw) {
+				fwrite(o->simpleusb_read_buf + o->readpos, sizeof(short), FRAME_SIZE * 6, frxcapraw);
+			}
+#endif
+
+			o->readpos += FRAME_SIZE * 6 * 2;
+			if (o->readpos < sizeof(o->simpleusb_read_buf)) { /* not enough samples */
+				continue;
+			}
+
+			/* If we have been sending pager audio, see if
+			 * we are finished.
+			 */
+			if (o->waspager) {
+				num_frames = 0;
+				ast_mutex_lock(&o->txqlock);
+				AST_LIST_TRAVERSE(&o->txq, f1, frame_list) {
+					num_frames++;
+				}
+				ast_mutex_unlock(&o->txqlock);
+				if (num_frames < 1) {
+					struct ast_frame wf = {
+						.frametype = AST_FRAME_TEXT,
+						.data.ptr = ENDPAGE_STR,
+						.datalen = sizeof(ENDPAGE_STR),
+						.src = __PRETTY_FUNCTION__,
+					};
+
+					if (o->owner) {
+						ast_queue_frame(o->owner, &wf);
+					}
+
+					o->waspager = 0;
+				}
+			}
+
+			/* Check for carrier detect - COR active */
+			cd = 1;
+			if ((o->rxcdtype == CD_HID) && (!o->rxhidsq)) {
+				cd = 0;
+			} else if ((o->rxcdtype == CD_HID_INVERT) && o->rxhidsq) {
+				cd = 0;
+			} else if ((o->rxcdtype == CD_PP) && (!o->rxppsq)) {
+				cd = 0;
+			} else if ((o->rxcdtype == CD_PP_INVERT) && o->rxppsq) {
+				cd = 0;
+			}
+
+			/* Apply cd turn-on delay, if one specified */
+			if (o->rxondelay && cd && (o->rxoncnt++ < o->rxondelay)) {
+				cd = 0;
+			} else if (!cd) {
+				o->rxoncnt = 0;
+			}
+			o->rx_cos_active = cd;
+
+			/* Check for SD - CTCSS active */
+			sd = 1;
+			if ((o->rxsdtype == SD_HID) && (!o->rxhidctcss)) {
+				sd = 0;
+			} else if ((o->rxsdtype == SD_HID_INVERT) && o->rxhidctcss) {
+				sd = 0;
+			} else if ((o->rxsdtype == SD_PP) && (!o->rxppctcss)) {
+				sd = 0;
+			} else if ((o->rxsdtype == SD_PP_INVERT) && o->rxppctcss) {
+				sd = 0;
+			}
+
+			/* See if we are overriding CTCSS to active */
+			if (o->rxctcssoverride) {
+				sd = 1;
+			}
+			o->rx_ctcss_active = sd;
+
+			/* Special case where cd and sd have been configured for no */
+			if (o->rxcdtype == CD_IGNORE && o->rxsdtype == SD_IGNORE) {
+				cd = 0;
+				sd = 0;
+			}
+
+			/* Timer for how long TX has been unkeyed - used with txoffdelay */
+			if (o->txoffdelay) {
+				if (o->txkeyed == 1) {
+					o->txoffcnt = 0; /* If keyed, set this to zero. */
+				} else {
+					o->txoffcnt++;
+					if (o->txoffcnt > MS_TO_FRAMES(TX_OFF_DELAY_MAX)) {
+						o->txoffcnt = MS_TO_FRAMES(TX_OFF_DELAY_MAX); /* limit count */
+					}
+				}
+			}
+
+			/* Check conditions and set receiver active */
+			o->rxkeyed = sd && cd && ((!o->lasttx) || o->duplex) && (o->txoffcnt >= o->txoffdelay);
+
+			/* Send a message to indicate rx signal detect conditions */
+			if (o->lastrx && (!o->rxkeyed)) {
 				struct ast_frame wf = {
 					.frametype = AST_FRAME_CONTROL,
 					.subclass.integer = AST_CONTROL_RADIO_UNKEY,
@@ -2222,520 +2606,209 @@ static void *simpleusb_audio_thread(void *arg)
 				};
 
 				o->lastrx = 0;
-				o->rxkeyed = 0;
 
-				if (!o->owner) {
-					break;
+				if (o->owner) {
+					ast_queue_frame(o->owner, &wf);
 				}
 
-				ast_queue_frame(o->owner, &wf);
-			}
-			usleep(10000);
-			continue;
-		}
-
-		/* If we have stopped echoing, clear the echo queue */
-		if (!o->echomode) {
-			struct qelem *q;
-
-			ast_mutex_lock(&o->echolock);
-			o->echoing = 0;
-			while (o->echoq.q_forw != &o->echoq) {
-				q = o->echoq.q_forw;
-				remque(q);
-				ast_free(q);
-			}
-			ast_mutex_unlock(&o->echolock);
-		}
-
-		/* If we are in echomode and we have stopped receiving audio
-		 * queue up the packets we have stored in the echo queue
-		 * for playback.
-		 */
-		if (o->echomode && (!o->rxkeyed)) {
-			struct usbecho *u;
-
-			ast_mutex_lock(&o->echolock);
-			/* if there is something in the queue */
-			if (o->echoq.q_forw != &o->echoq) {
-				u = (struct usbecho *) o->echoq.q_forw;
-				remque((struct qelem *) u);
-				f->frametype = AST_FRAME_VOICE;
-				f->subclass.format = ast_format_slin;
-				f->samples = FRAME_SIZE;
-				f->datalen = FRAME_SIZE * 2;
-				f->offset = AST_FRIENDLY_OFFSET;
-				f->data.ptr = o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET;
-				memcpy(f->data.ptr, u->data, FRAME_SIZE * 2);
-				ast_free(u);
-				f1 = ast_frdup(f);
-				if (!f1) {
-					ast_mutex_unlock(&o->echolock);
-					continue;
+				if (o->duplex3) {
+					ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_SW, 0, 0);
 				}
-				memset(&f1->frame_list, 0, sizeof(f1->frame_list));
-				ast_mutex_lock(&o->txqlock);
-				AST_LIST_INSERT_TAIL(&o->txq, f1, frame_list);
-				ast_mutex_unlock(&o->txqlock);
-				o->echoing = 1;
-			} else {
-				o->echoing = 0;
-			}
-			ast_mutex_unlock(&o->echolock);
-		}
-
-		/* Process the transmit queue */
-		for (;;) {
-			num_frames = 0;
-			ast_mutex_lock(&o->txqlock);
-			AST_LIST_TRAVERSE(&o->txq, f1, frame_list) {
-				num_frames++;
-			}
-			ast_mutex_unlock(&o->txqlock);
-			if (o->txkeyed) {
-				ast_debug(7, "blocks used %d, Dest Buffer %d", num_frames, o->simpleusb_write_dst);
-			}
-			if (num_frames && (num_frames > 3 || (!o->txkeyed && !o->txtestkey))) {
-				ast_mutex_lock(&o->txqlock);
-				f1 = AST_LIST_REMOVE_HEAD(&o->txq, frame_list);
-				ast_mutex_unlock(&o->txqlock);
-
-				src = 0; /* read position into f1->data */
-				while (src < f1->datalen) {
-					/* Compute spare room in the buffer */
-					int l = sizeof(o->simpleusb_write_buf) - o->simpleusb_write_dst;
-
-					if (f1->datalen - src >= l) {
-						/* enough to fill a frame */
-						memcpy(o->simpleusb_write_buf + o->simpleusb_write_dst, (char *) f1->data.ptr + src, l);
-						/* Below is an attempt to match levels to the original CM108 IC which has
-						 * been out of production for over 10 years. Scaling audio to 109.375% will
-						 * result in clipping! Any adjustments for CM1xxx gain differences should be
-						 * made in the mixer settings, not in the audio stream.
-						 * TODO: After the vast majority of existing installs have had a chance to review their
-						 * audio settings and these old scaling/clipping hacks are no longer in significant use
-						 * the legacyaudioscaling cfg and related code should be deleted.
-						 */
-						/* Adjust the audio level for CM119 A/B devices */
-						if (o->legacyaudioscaling && o->devtype != C108_PRODUCT_ID) {
-							register int v;
-
-							sp = (short *) o->simpleusb_write_buf;
-							for (i = 0; i < FRAME_SIZE; i++) {
-								v = *sp;
-								v += v >> 3;   /* add *.125 giving * 1.125 */
-								v -= *sp >> 5; /* subtract *.03125 giving * 1.09375 */
-								if (v > 32765.0) {
-									v = 32765.0;
-								} else if (v < -32765.0) {
-									v = -32765.0;
-								}
-								*sp++ = v;
-							}
-						}
-
-						sp = (short *) o->simpleusb_write_buf;
-						sp1 = outbuf;
-						doright = 1;
-						doleft = 1;
-						ispager = 0;
-						if (f1->src && (!strcmp(f1->src, PAGER_SRC))) {
-							ispager = 1;
-						}
-						/* If pager audio, determine which channel to store audio */
-						if (o->pager != PAGER_NONE) {
-							doleft = (o->pager == PAGER_A) ? ispager : !ispager;
-							doright = (o->pager == PAGER_B) ? ispager : !ispager;
-						}
-						/* Upsample from 8000 mono to 48000 stereo */
-						for (i = 0; i < FRAME_SIZE; i++) {
-							register short s, v;
-
-							if (o->preemphasis) {
-								s = preemph(sp[i], &o->prestate);
-							} else {
-								s = sp[i];
-							}
-							v = lpass(s, o->flpt);
-							*sp1++ = (doleft) ? v : 0;
-							*sp1++ = (doright) ? v : 0;
-							v = lpass(s, o->flpt);
-							*sp1++ = (doleft) ? v : 0;
-							*sp1++ = (doright) ? v : 0;
-							v = lpass(s, o->flpt);
-							*sp1++ = (doleft) ? v : 0;
-							*sp1++ = (doright) ? v : 0;
-							v = lpass(s, o->flpt);
-							*sp1++ = (doleft) ? v : 0;
-							*sp1++ = (doright) ? v : 0;
-							v = lpass(s, o->flpt);
-							*sp1++ = (doleft) ? v : 0;
-							*sp1++ = (doright) ? v : 0;
-							v = lpass(s, o->flpt);
-							*sp1++ = (doleft) ? v : 0;
-							*sp1++ = (doright) ? v : 0;
-						}
-						soundcard_writeframe(o, outbuf);
-						src += l;
-						o->simpleusb_write_dst = 0;
-						if (o->waspager && (!ispager)) {
-							struct ast_frame wf = {
-								.frametype = AST_FRAME_TEXT,
-								.data.ptr = ENDPAGE_STR,
-								.datalen = strlen(ENDPAGE_STR) + 1,
-								.src = __PRETTY_FUNCTION__,
-							};
-
-							if (!o->owner) {
-								break;
-							}
-
-							ast_queue_frame(o->owner, &wf);
-							o->waspager = ispager;
-							continue;
-						}
-						o->waspager = ispager;
-					} else {
-						/* copy residue */
-						l = f1->datalen - src;
-						memcpy(o->simpleusb_write_buf + o->simpleusb_write_dst, (char *) f1->data.ptr + src, l);
-						src += l; /* but really, we are done */
-						o->simpleusb_write_dst += l;
-					}
-				}
-				ast_frfree(f1);
-				continue;
-			}
-			break;
-		}
-
-		/* Read audio data from the USB sound device.
-		 * Sound data will arrive at 48000 samples per second
-		 * in mono format.
-		 */
-		res = Pa_ReadStream(o->stream, o->simpleusb_read_buf + o->readpos, NUM_SAMPLES);
-		if (res != paNoError) {
-			/* audio data not ready */
-			if (res == paInputOverflowed) {
-				ast_debug(6, "PortAudio read overflow on channel %s\n", o->name);
-				continue;
-			}
-			ast_debug(4, "PortAudio read error on channel %s: %s\n", o->name, Pa_GetErrorText(res));
-			continue;
-		}
-
-#if DEBUG_CAPTURES == 1
-		if (o->rxcapraw && frxcapraw) {
-			fwrite(o->simpleusb_read_buf + o->readpos, sizeof(short), FRAME_SIZE * 6, frxcapraw);
-		}
-#endif
-
-		o->readpos += FRAME_SIZE * 6 * 2;
-		if (o->readpos < sizeof(o->simpleusb_read_buf)) { /* not enough samples */
-			continue;
-		}
-
-		/* If we have been sending pager audio, see if
-		 * we are finished.
-		 */
-		if (o->waspager) {
-			num_frames = 0;
-			ast_mutex_lock(&o->txqlock);
-			AST_LIST_TRAVERSE(&o->txq, f1, frame_list) {
-				num_frames++;
-			}
-			ast_mutex_unlock(&o->txqlock);
-			if (num_frames < 1) {
+			} else if ((!o->lastrx) && (o->rxkeyed)) {
 				struct ast_frame wf = {
-					.frametype = AST_FRAME_TEXT,
-					.data.ptr = ENDPAGE_STR,
-					.datalen = sizeof(ENDPAGE_STR),
+					.frametype = AST_FRAME_CONTROL,
+					.subclass.integer = AST_CONTROL_RADIO_KEY,
 					.src = __PRETTY_FUNCTION__,
 				};
 
-				if (!o->owner) {
-					break;
+				o->lastrx = 1;
+
+				if (o->owner) {
+					ast_queue_frame(o->owner, &wf);
 				}
 
-				ast_queue_frame(o->owner, &wf);
-				o->waspager = 0;
-			}
-		}
-
-		/* Check for carrier detect - COR active */
-		cd = 1;
-		if ((o->rxcdtype == CD_HID) && (!o->rxhidsq)) {
-			cd = 0;
-		} else if ((o->rxcdtype == CD_HID_INVERT) && o->rxhidsq) {
-			cd = 0;
-		} else if ((o->rxcdtype == CD_PP) && (!o->rxppsq)) {
-			cd = 0;
-		} else if ((o->rxcdtype == CD_PP_INVERT) && o->rxppsq) {
-			cd = 0;
-		}
-
-		/* Apply cd turn-on delay, if one specified */
-		if (o->rxondelay && cd && (o->rxoncnt++ < o->rxondelay)) {
-			cd = 0;
-		} else if (!cd) {
-			o->rxoncnt = 0;
-		}
-		o->rx_cos_active = cd;
-
-		/* Check for SD - CTCSS active */
-		sd = 1;
-		if ((o->rxsdtype == SD_HID) && (!o->rxhidctcss)) {
-			sd = 0;
-		} else if ((o->rxsdtype == SD_HID_INVERT) && o->rxhidctcss) {
-			sd = 0;
-		} else if ((o->rxsdtype == SD_PP) && (!o->rxppctcss)) {
-			sd = 0;
-		} else if ((o->rxsdtype == SD_PP_INVERT) && o->rxppctcss) {
-			sd = 0;
-		}
-
-		/* See if we are overriding CTCSS to active */
-		if (o->rxctcssoverride) {
-			sd = 1;
-		}
-		o->rx_ctcss_active = sd;
-
-		/* Special case where cd and sd have been configured for no */
-		if (o->rxcdtype == CD_IGNORE && o->rxsdtype == SD_IGNORE) {
-			cd = 0;
-			sd = 0;
-		}
-
-		/* Timer for how long TX has been unkeyed - used with txoffdelay */
-		if (o->txoffdelay) {
-			if (o->txkeyed == 1) {
-				o->txoffcnt = 0; /* If keyed, set this to zero. */
-			} else {
-				o->txoffcnt++;
-				if (o->txoffcnt > MS_TO_FRAMES(TX_OFF_DELAY_MAX)) {
-					o->txoffcnt = MS_TO_FRAMES(TX_OFF_DELAY_MAX); /* limit count */
+				if (o->duplex3) {
+					ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_SW, 1, 0);
 				}
 			}
-		}
 
-		/* Check conditions and set receiver active */
-		o->rxkeyed = sd && cd && ((!o->lasttx) || o->duplex) && (o->txoffcnt >= o->txoffdelay);
-
-		/* Send a message to indicate rx signal detect conditions */
-		if (o->lastrx && (!o->rxkeyed)) {
-			struct ast_frame wf = {
-				.frametype = AST_FRAME_CONTROL,
-				.subclass.integer = AST_CONTROL_RADIO_UNKEY,
-				.src = __PRETTY_FUNCTION__,
-			};
-
-			o->lastrx = 0;
-
-			if (!o->owner) {
-				break;
-			}
-
-			ast_queue_frame(o->owner, &wf);
-			if (o->duplex3) {
-				ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_SW, 0, 0);
-			}
-		} else if ((!o->lastrx) && (o->rxkeyed)) {
-			struct ast_frame wf = {
-				.frametype = AST_FRAME_CONTROL,
-				.subclass.integer = AST_CONTROL_RADIO_KEY,
-				.src = __PRETTY_FUNCTION__,
-			};
-
-			o->lastrx = 1;
-
-			if (!o->owner) {
-				break;
-			}
-
-			ast_queue_frame(o->owner, &wf);
-			if (o->duplex3) {
-				ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_SW, 1, 0);
-			}
-		}
-
-		/* Check for ADC clipping and input audio statistics before any filtering is done.
-		 * FRAME_SIZE define refers to 8Ksps mono which is 160 samples per 20mS USB frame.
-		 * ast_radio_check_audio() takes the read buffer as received (48K stereo or mono),
-		 * extracts the 48K channel, checks amplitude and distortion characteristics,
-		 * and returns true if clipping was detected.
-		 */
-		if (ast_radio_check_audio((short *) o->simpleusb_read_buf, &o->rxaudiostats, 6 * FRAME_SIZE, 1)) {
-			if (o->clipledgpio) {
-				/* Set Clip LED GPIO pulsetimer if not already set */
-				if (!o->hid_gpio_pulsetimer[o->clipledgpio - 1]) {
-					o->hid_gpio_pulsetimer[o->clipledgpio - 1] = CLIP_LED_HOLD_TIME_MS;
+			/* Check for ADC clipping and input audio statistics before any filtering is done.
+			 * FRAME_SIZE define refers to 8Ksps mono which is 160 samples per 20mS USB frame.
+			 * ast_radio_check_audio() takes the read buffer as received (48K stereo or mono),
+			 * extracts the 48K channel, checks amplitude and distortion characteristics,
+			 * and returns true if clipping was detected.
+			 */
+			if (ast_radio_check_audio((short *) o->simpleusb_read_buf, &o->rxaudiostats, 6 * FRAME_SIZE, 1)) {
+				if (o->clipledgpio) {
+					/* Set Clip LED GPIO pulsetimer if not already set */
+					if (!o->hid_gpio_pulsetimer[o->clipledgpio - 1]) {
+						o->hid_gpio_pulsetimer[o->clipledgpio - 1] = CLIP_LED_HOLD_TIME_MS;
+					}
 				}
 			}
-		}
 
-		/* Downsample received audio from 48000 mono to 8000 mono */
-		sp = (short *) o->simpleusb_read_buf;
-		sp1 = (short *) (o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET);
-		for (i = 0; i < FRAME_SIZE; i++) {
-			(void) lpass(*sp++, o->flpr);
-			(void) lpass(*sp++, o->flpr);
-			(void) lpass(*sp++, o->flpr);
-			(void) lpass(*sp++, o->flpr);
-			(void) lpass(*sp++, o->flpr);
-			if (o->plfilter && o->deemphasis) {
-				*sp1++ = hpass6(deemph(lpass(*sp++, o->flpr), &o->destate), o->hpx, o->hpy);
-			} else if (o->deemphasis) {
-				*sp1++ = deemph(lpass(*sp++, o->flpr), &o->destate);
-			} else if (o->plfilter) {
-				*sp1++ = hpass(lpass(*sp++, o->flpr), o->hpx, o->hpy);
-			} else {
-				*sp1++ = lpass(*sp++, o->flpr);
-			}
-		}
-
-		/* If we are in echomode and receiving audio, store
-		 * it in the echo queue for later playback.
-		 */
-		if (o->echomode && o->rxkeyed && (!o->echoing)) {
-			register int x;
-			struct usbecho *u;
-
-			ast_mutex_lock(&o->echolock);
-			x = 0;
-			/* get count of frames */
-			for (u = (struct usbecho *) o->echoq.q_forw; u != (struct usbecho *) &o->echoq; u = (struct usbecho *) u->q_forw) {
-				x++;
-			}
-
-			if (x < o->echomax) {
-				u = ast_calloc(1, sizeof(struct usbecho));
-				if (u) {
-					memcpy(u->data, (o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET), FRAME_SIZE * 2);
-					insque((struct qelem *) u, o->echoq.q_back);
+			/* Downsample received audio from 48000 mono to 8000 mono */
+			sp = (short *) o->simpleusb_read_buf;
+			sp1 = (short *) (o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET);
+			for (i = 0; i < FRAME_SIZE; i++) {
+				(void) lpass(*sp++, o->flpr);
+				(void) lpass(*sp++, o->flpr);
+				(void) lpass(*sp++, o->flpr);
+				(void) lpass(*sp++, o->flpr);
+				(void) lpass(*sp++, o->flpr);
+				if (o->plfilter && o->deemphasis) {
+					*sp1++ = hpass6(deemph(lpass(*sp++, o->flpr), &o->destate), o->hpx, o->hpy);
+				} else if (o->deemphasis) {
+					*sp1++ = deemph(lpass(*sp++, o->flpr), &o->destate);
+				} else if (o->plfilter) {
+					*sp1++ = hpass(lpass(*sp++, o->flpr), o->hpx, o->hpy);
+				} else {
+					*sp1++ = lpass(*sp++, o->flpr);
 				}
 			}
-			ast_mutex_unlock(&o->echolock);
-		}
+
+			/* If we are in echomode and receiving audio, store
+			 * it in the echo queue for later playback.
+			 */
+			if (o->echomode && o->rxkeyed && (!o->echoing)) {
+				register int x;
+				struct usbecho *u;
+
+				ast_mutex_lock(&o->echolock);
+				x = 0;
+				/* get count of frames */
+				for (u = (struct usbecho *) o->echoq.q_forw; u != (struct usbecho *) &o->echoq; u = (struct usbecho *) u->q_forw) {
+					x++;
+				}
+
+				if (x < o->echomax) {
+					u = ast_calloc(1, sizeof(struct usbecho));
+					if (u) {
+						memcpy(u->data, (o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET), FRAME_SIZE * 2);
+						insque((struct qelem *) u, o->echoq.q_back);
+					}
+				}
+				ast_mutex_unlock(&o->echolock);
+			}
 
 #if DEBUG_CAPTURES == 1
-		if (o->rxcapraw && frxcapcooked) {
-			fwrite(o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET, sizeof(short), FRAME_SIZE, frxcapcooked);
-		}
+			if (o->rxcapraw && frxcapcooked) {
+				fwrite(o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET, sizeof(short), FRAME_SIZE, frxcapcooked);
+			}
 #endif
 
-		/* reset read pointer for next frame */
-		o->readpos = 0;
-		/* Do not return the frame if the channel is not up */
-		if (ast_channel_state(o->owner) != AST_STATE_UP) {
-			continue;
-		}
-		/* ok we can build and deliver the frame to the caller */
-		f->frametype = AST_FRAME_VOICE;
-		f->subclass.format = ast_format_slin;
-		f->offset = AST_FRIENDLY_OFFSET;
-		f->samples = FRAME_SIZE;
-		f->datalen = FRAME_SIZE * 2;
-		f->data.ptr = o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET;
-		if (!o->rxkeyed) {
-			memset(f->data.ptr, 0, f->datalen);
-		}
-		/* Process the audio to see if contains DTMF */
-		if (o->usedtmf && o->dsp) {
-			f1 = ast_dsp_process(o->owner, o->dsp, f);
-			if ((f1->frametype == AST_FRAME_DTMF_END) || (f1->frametype == AST_FRAME_DTMF_BEGIN)) {
-				if ((f1->subclass.integer == 'm') || (f1->subclass.integer == 'u')) {
-					f1->frametype = AST_FRAME_NULL;
-					f1->subclass.integer = 0;
+			/* reset read pointer for next frame */
+			o->readpos = 0;
+			/* Do not return the frame if the channel is not up */
+			if (ast_channel_state(o->owner) != AST_STATE_UP) {
+				continue;
+			}
+			/* ok we can build and deliver the frame to the caller */
+			f->frametype = AST_FRAME_VOICE;
+			f->subclass.format = ast_format_slin;
+			f->offset = AST_FRIENDLY_OFFSET;
+			f->samples = FRAME_SIZE;
+			f->datalen = FRAME_SIZE * 2;
+			f->data.ptr = o->simpleusb_read_frame_buf + AST_FRIENDLY_OFFSET;
+			if (!o->rxkeyed) {
+				memset(f->data.ptr, 0, f->datalen);
+			}
+			/* Process the audio to see if contains DTMF */
+			if (o->usedtmf && o->dsp) {
+				f1 = ast_dsp_process(o->owner, o->dsp, f);
+				if ((f1->frametype == AST_FRAME_DTMF_END) || (f1->frametype == AST_FRAME_DTMF_BEGIN)) {
+					if ((f1->subclass.integer == 'm') || (f1->subclass.integer == 'u')) {
+						f1->frametype = AST_FRAME_NULL;
+						f1->subclass.integer = 0;
 
-					if (!o->owner) {
-						break;
-					}
+						if (o->owner) {
+							ast_queue_frame(o->owner, f1);
+						}
 
-					ast_queue_frame(o->owner, f1);
-					continue;
-				}
-				if (f1->frametype == AST_FRAME_DTMF_END) {
-					f1->len = ast_tvdiff_ms(ast_radio_tvnow(), o->tonetime);
-					if (option_verbose) {
-						ast_log(LOG_NOTICE, "Channel %s: Got DTMF char %c duration %ld ms\n", o->name, f1->subclass.integer, f1->len);
+						continue;
 					}
-					o->toneflag = 0;
-				} else {
-					if (o->toneflag) {
-						ast_frfree(f1);
-						f1 = NULL;
+					if (f1->frametype == AST_FRAME_DTMF_END) {
+						f1->len = ast_tvdiff_ms(ast_radio_tvnow(), o->tonetime);
+						if (option_verbose) {
+							ast_log(LOG_NOTICE, "Channel %s: Got DTMF char %c duration %ld ms\n", o->name, f1->subclass.integer, f1->len);
+						}
+						o->toneflag = 0;
 					} else {
-						o->tonetime = ast_radio_tvnow();
-						o->toneflag = 1;
+						if (o->toneflag) {
+							ast_frfree(f1);
+							f1 = NULL;
+						} else {
+							o->tonetime = ast_radio_tvnow();
+							o->toneflag = 1;
+						}
+					}
+					if (o->owner && f1) {
+						ast_queue_frame(o->owner, f1);
 					}
 				}
-				if (!o->owner) {
-					break;
+			}
+
+			/* Raw audio samples should never be clipped or scaled for any reason. Adjustments to
+			 * audio levels should be made only in the USB interface mixer settings.
+			 * TODO: After the vast majority of existing installs have had a chance to review their
+			 * audio settings and these old scaling/clipping hacks are no longer in significant use
+			 * the legacyaudioscaling cfg and related code should be deleted.
+			 */
+			/* scale and clip values */
+			if (o->legacyaudioscaling && o->rxvoiceadj > 1.0) {
+				register int i, x;
+				register float f1;
+				register int16_t *p = (int16_t *) f->data.ptr;
+
+				for (i = 0; i < f->samples; i++) {
+					f1 = (float) p[i] * o->rxvoiceadj;
+					x = (int) f1;
+					if (x > 32767) {
+						x = 32767;
+					} else if (x < -32768) {
+						x = -32768;
+					}
+					p[i] = x;
 				}
-				if (f1) {
-					ast_queue_frame(o->owner, f1);
+			}
+
+			/* Compute the peak signal if requested */
+			if (o->measure_enabled) {
+				register int i;
+				register int32_t accum;
+				register int16_t *p = (int16_t *) f->data.ptr;
+
+				for (i = 0; i < f->samples; i++) {
+					accum = p[i];
+					if (accum > o->amax) {
+						o->amax = accum;
+						o->discounteru = o->discfactor;
+					} else if (--o->discounteru <= 0) {
+						o->discounteru = o->discfactor;
+						o->amax = (int32_t) ((o->amax * 32700) / 32768);
+					}
+					if (accum < o->amin) {
+						o->amin = accum;
+						o->discounterl = o->discfactor;
+					} else if (--o->discounterl <= 0) {
+						o->discounterl = o->discfactor;
+						o->amin = (int32_t) ((o->amin * 32700) / 32768);
+					}
 				}
+				o->apeak = (int32_t) (o->amax - o->amin) / 2;
+			}
+
+			if (o->owner) {
+				ast_queue_frame(o->owner, f);
 			}
 		}
 
-		/* Raw audio samples should never be clipped or scaled for any reason. Adjustments to
-		 * audio levels should be made only in the USB interface mixer settings.
-		 * TODO: After the vast majority of existing installs have had a chance to review their
-		 * audio settings and these old scaling/clipping hacks are no longer in significant use
-		 * the legacyaudioscaling cfg and related code should be deleted.
-		 */
-		/* scale and clip values */
-		if (o->legacyaudioscaling && o->rxvoiceadj > 1.0) {
-			register int i, x;
-			register float f1;
-			register int16_t *p = (int16_t *) f->data.ptr;
-
-			for (i = 0; i < f->samples; i++) {
-				f1 = (float) p[i] * o->rxvoiceadj;
-				x = (int) f1;
-				if (x > 32767) {
-					x = 32767;
-				} else if (x < -32768) {
-					x = -32768;
-				}
-				p[i] = x;
-			}
-		}
-
-		/* Compute the peak signal if requested */
-		if (o->measure_enabled) {
-			register int i;
-			register int32_t accum;
-			register int16_t *p = (int16_t *) f->data.ptr;
-
-			for (i = 0; i < f->samples; i++) {
-				accum = p[i];
-				if (accum > o->amax) {
-					o->amax = accum;
-					o->discounteru = o->discfactor;
-				} else if (--o->discounteru <= 0) {
-					o->discounteru = o->discfactor;
-					o->amax = (int32_t) ((o->amax * 32700) / 32768);
-				}
-				if (accum < o->amin) {
-					o->amin = accum;
-					o->discounterl = o->discfactor;
-				} else if (--o->discounterl <= 0) {
-					o->discounterl = o->discfactor;
-					o->amin = (int32_t) ((o->amin * 32700) / 32768);
-				}
-			}
-			o->apeak = (int32_t) (o->amax - o->amin) / 2;
-		}
-
-		if (!o->owner) {
-			break;
-		}
-		ast_queue_frame(o->owner, f);
+stream_restart:
+		o->audio_ready = 0;
+		o->hasusb = 0;
 	}
 
-	stop_stream(o);
-	ast_debug(5, "Audio Thread is exiting");
+	ast_debug(2, "Audio Thread has exited");
 	return NULL;
 }
 /*!
@@ -4047,6 +4120,7 @@ static struct chan_simpleusb_pvt *store_config(struct ast_config *cfg, const cha
 			o->pttkick[1] = -1;
 			o->audiothread = AST_PTHREADT_NULL;
 			o->hidthread = AST_PTHREADT_NULL;
+			o->hw_device[0] = '\0';
 			if (!simpleusb_active) {
 				simpleusb_active = o->name;
 			}
@@ -4358,8 +4432,6 @@ static int reload_module(void)
 
 static int load_module(void)
 {
-	PaError res;
-
 	if (!(simpleusb_tech.capabilities = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT))) {
 		return AST_MODULE_LOAD_DECLINE;
 	}
@@ -4383,17 +4455,10 @@ static int load_module(void)
 		return AST_MODULE_LOAD_DECLINE;
 	}
 
-	res = Pa_Initialize();
-	if (res != paNoError) {
-		ast_log(LOG_WARNING, "Failed to initialize audio system - (%d) %s\n", res, Pa_GetErrorText(res));
-		return AST_MODULE_LOAD_DECLINE;
-	}
-
 	if (find_desc(simpleusb_active) == NULL) {
 		ast_log(LOG_NOTICE, "susb active device %s not found\n", simpleusb_active);
 		/* XXX we could default to 'dsp' perhaps ? */
 		/* XXX should cleanup allocated memory etc. */
-		Pa_Terminate();
 		ao2_cleanup(simpleusb_tech.capabilities);
 		simpleusb_tech.capabilities = NULL;
 		return AST_MODULE_LOAD_DECLINE;
@@ -4401,7 +4466,6 @@ static int load_module(void)
 
 	if (ast_channel_register(&simpleusb_tech)) {
 		ast_log(LOG_ERROR, "Unable to register channel type 'usb'\n");
-		Pa_Terminate();
 		ao2_cleanup(simpleusb_tech.capabilities);
 		simpleusb_tech.capabilities = NULL;
 		return AST_MODULE_LOAD_DECLINE;
@@ -4426,7 +4490,7 @@ static int unload_module(void)
 	ast_cli_unregister_multiple(cli_simpleusb, ARRAY_LEN(cli_simpleusb));
 
 	for (o = simpleusb_default.next; o; o = o->next) {
-		o->stophid = 1;
+		o->stopthreads = 1;
 		if (o->owner) {
 			ast_softhangup(o->owner, AST_SOFTHANGUP_APPUNLOAD);
 		}
@@ -4463,7 +4527,6 @@ static int unload_module(void)
 	}
 #endif
 
-	Pa_Terminate();
 	ao2_cleanup(simpleusb_tech.capabilities);
 	simpleusb_tech.capabilities = NULL;
 

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -2095,7 +2095,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	 * extracts the mono 48K channel, checks amplitude and distortion characteristics,
 	 * and returns true if clipping was detected.
 	 */
-	if (ast_radio_check_audio((short *) o->usbradio_read_buf, &o->rxaudiostats, 12 * FRAME_SIZE)) {
+	if (ast_radio_check_audio((short *) o->usbradio_read_buf, &o->rxaudiostats, 12 * FRAME_SIZE, 0)) {
 		if (o->clipledgpio) {
 			/* Set Clip LED GPIO pulsetimer if not already set */
 			if (!o->hid_gpio_pulsetimer[o->clipledgpio - 1]) {
@@ -2199,7 +2199,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	 * nice to log a warning but as this does not relate to outgoing network audio it's not
 	 * a major issue. User can check the Tx Audio Stats utility if desired.
 	 */
-	ast_radio_check_audio((short *) o->usbradio_write_buf, &o->txaudiostats, 12 * FRAME_SIZE);
+	ast_radio_check_audio((short *) o->usbradio_write_buf, &o->txaudiostats, 12 * FRAME_SIZE, 0);
 
 #if DEBUG_CAPTURES == 1 && XPMR_DEBUG0 == 1
 	if (frxcaptrace && o->rxcap2 && o->pmrChan->b.radioactive) {

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -2107,7 +2107,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	 * extracts the mono 48K channel, checks amplitude and distortion characteristics,
 	 * and returns true if clipping was detected.
 	 */
-	if (ast_radio_check_audio((short *) o->usbradio_read_buf, &o->rxaudiostats, 12 * FRAME_SIZE)) {
+	if (ast_radio_check_audio((short *) o->usbradio_read_buf, &o->rxaudiostats, 12 * FRAME_SIZE, 0)) {
 		if (o->clipledgpio) {
 			/* Set Clip LED GPIO pulsetimer if not already set */
 			if (!o->hid_gpio_pulsetimer[o->clipledgpio - 1]) {
@@ -2211,7 +2211,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	 * nice to log a warning but as this does not relate to outgoing network audio it's not
 	 * a major issue. User can check the Tx Audio Stats utility if desired.
 	 */
-	ast_radio_check_audio((short *) o->usbradio_write_buf, &o->txaudiostats, 12 * FRAME_SIZE);
+	ast_radio_check_audio((short *) o->usbradio_write_buf, &o->txaudiostats, 12 * FRAME_SIZE, 0);
 
 #if DEBUG_CAPTURES == 1 && XPMR_DEBUG0 == 1
 	if (frxcaptrace && o->rxcap2 && o->pmrChan->b.radioactive) {

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -402,14 +402,14 @@ char context[100];
 #define PAGER_SRC "PAGER"
 #define ENDPAGE_STR "ENDPAGE"
 #define AMPVAL 30000
-#define SAMPRATE 8000 /* (Sample Rate) */
+#define AST_SAMPLE_RATE 8000 /* (Sample Rate) */
 #define DIVLCM 192000 /* (A common multiple of 512,1200,2400,8000) */
 #define PREAMBLE_BITS 576
 #define MESSAGE_BITS 544 /* (17 * 32), 1 longword SYNC plus 16 longwords data */
 /* We have to send "inverted"... probably because of inverting AMP in Voter board. */
 #define ONEVAL AMPVAL
 #define ZEROVAL -AMPVAL
-#define DIVSAMP (DIVLCM / SAMPRATE)
+#define DIVSAMP (DIVLCM / AST_SAMPLE_RATE)
 
 /* Defines voter payload types. */
 #define VOTER_PAYLOAD_AUTH 0
@@ -1224,9 +1224,9 @@ static int voter_text(struct ast_channel *ast, const char *text)
 			i++;
 		}
 		/* Get number of samples to alloc for audio. */
-		audio_samples = (SAMPRATE * (PREAMBLE_BITS + (MESSAGE_BITS * i))) / baud;
+		audio_samples = (AST_SAMPLE_RATE * (PREAMBLE_BITS + (MESSAGE_BITS * i))) / baud;
 		/* Pad end with 250ms of silence on each side. */
-		audio_samples += SAMPRATE / 2;
+		audio_samples += AST_SAMPLE_RATE / 2;
 		/* Also pad up to FRAME_SIZE. */
 		audio_samples += audio_samples % FRAME_SIZE;
 		audio = ast_calloc(1, (audio_samples * sizeof(short)) + 10);
@@ -1236,7 +1236,7 @@ static int voter_text(struct ast_channel *ast, const char *text)
 		}
 		divdiv = DIVLCM / baud;
 		divcnt = 0;
-		audio_ptr = SAMPRATE / 4;
+		audio_ptr = AST_SAMPLE_RATE / 4;
 		for (i = 0; i < (PREAMBLE_BITS / 32); i++) {
 			mkpsamples(audio, 0xaaaaaaaa, &audio_ptr, &divcnt, divdiv);
 		}

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -401,14 +401,14 @@ char context[100];
 #define PAGER_SRC "PAGER"
 #define ENDPAGE_STR "ENDPAGE"
 #define AMPVAL 30000
-#define SAMPRATE 8000 /* (Sample Rate) */
+#define AST_SAMPLE_RATE 8000 /* (Sample Rate) */
 #define DIVLCM 192000 /* (A common multiple of 512,1200,2400,8000) */
 #define PREAMBLE_BITS 576
 #define MESSAGE_BITS 544 /* (17 * 32), 1 longword SYNC plus 16 longwords data */
 /* We have to send "inverted"... probably because of inverting AMP in Voter board. */
 #define ONEVAL AMPVAL
 #define ZEROVAL -AMPVAL
-#define DIVSAMP (DIVLCM / SAMPRATE)
+#define DIVSAMP (DIVLCM / AST_SAMPLE_RATE)
 
 /* Defines voter payload types. */
 #define VOTER_PAYLOAD_AUTH 0
@@ -1223,9 +1223,9 @@ static int voter_text(struct ast_channel *ast, const char *text)
 			i++;
 		}
 		/* Get number of samples to alloc for audio. */
-		audio_samples = (SAMPRATE * (PREAMBLE_BITS + (MESSAGE_BITS * i))) / baud;
+		audio_samples = (AST_SAMPLE_RATE * (PREAMBLE_BITS + (MESSAGE_BITS * i))) / baud;
 		/* Pad end with 250ms of silence on each side. */
-		audio_samples += SAMPRATE / 2;
+		audio_samples += AST_SAMPLE_RATE / 2;
 		/* Also pad up to FRAME_SIZE. */
 		audio_samples += audio_samples % FRAME_SIZE;
 		audio = ast_calloc(1, (audio_samples * sizeof(short)) + 10);
@@ -1235,7 +1235,7 @@ static int voter_text(struct ast_channel *ast, const char *text)
 		}
 		divdiv = DIVLCM / baud;
 		divcnt = 0;
-		audio_ptr = SAMPRATE / 4;
+		audio_ptr = AST_SAMPLE_RATE / 4;
 		for (i = 0; i < (PREAMBLE_BITS / 32); i++) {
 			mkpsamples(audio, 0xaaaaaaaa, &audio_ptr, &divcnt, divdiv);
 		}

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -516,3 +516,15 @@ int ast_radio_check_audio(short *sbuf, struct audiostatistics *o, short len);
  * \return  		None
  */
 void ast_radio_print_audio_stats(int fd, struct audiostatistics *o, const char *prefix_text);
+
+/*!
+ * \brief Returns the libusb device that backs ALSA /proc/asound/card<cardno>/usbbus.
+ * On success: returns a pointer to a libusb struct usb_device.
+ * On failure: returns NULL.
+ *
+ * \note
+ * - Uses libusb-0.1 enumeration (usb_init/usb_find_busses/usb_find_devices).
+ * - The returned pointer is owned by libusb's internal device list.
+ * \param cardno The ALSA card number as found in HW:<cardno>
+ */
+struct usb_device *ast_radio_usb_device_from_alsa_card(int cardno);

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -520,8 +520,8 @@ void ast_radio_print_audio_stats(int fd, struct audiostatistics *o, const char *
 
 /*!
  * \brief Returns the libusb device that backs ALSA /proc/asound/card<cardno>/usbbus.
- * On success: returns a pointer to a libusb struct usb_device.
- * On failure: returns NULL.
+ * \retval usb_device *  Pointer to the libusb device on success.
+ * \retval NULL          If device could not be found.
  *
  * \note
  * - Uses libusb-0.1 enumeration (usb_init/usb_find_busses/usb_find_devices).

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -488,7 +488,7 @@ struct timeval ast_radio_tvnow(void);
  * \param sbuf  	Rx audio sample buffer in 48k stereo or mono
  * \param o	    	Rx Audio Stats data structure
  * \param len   	Length of data in sbuf
- * \param mono  	True if sbuf is mono, False if sbuf is stero
+ * \param mono  	True if sbuf is mono, False if sbuf is stereo
  * \return 	    	1 if clipping detected, 0 otherwise
  */
 #define CLIP_LED_HOLD_TIME_MS 500

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -485,13 +485,14 @@ struct timeval ast_radio_tvnow(void);
  *   These define total signal power and peak-to-average power ratio
  *
  * \author      	NR9V
- * \param sbuf  	Rx audio sample buffer
+ * \param sbuf  	Rx audio sample buffer in 48k stereo or mono
  * \param o	    	Rx Audio Stats data structure
  * \param len   	Length of data in sbuf
+ * \param mono  	True if sbuf is mono, False if sbuf is stereo
  * \return 	    	1 if clipping detected, 0 otherwise
  */
 #define CLIP_LED_HOLD_TIME_MS 500
-int ast_radio_check_audio(short *sbuf, struct audiostatistics *o, short len);
+int ast_radio_check_audio(short *sbuf, struct audiostatistics *o, short len, short mono);
 
 /*!
  * \brief Display receive audio statistics.
@@ -516,3 +517,15 @@ int ast_radio_check_audio(short *sbuf, struct audiostatistics *o, short len);
  * \return  		None
  */
 void ast_radio_print_audio_stats(int fd, struct audiostatistics *o, const char *prefix_text);
+
+/*!
+ * \brief Returns the libusb device that backs ALSA /proc/asound/card<cardno>/usbbus.
+ * \retval usb_device *  Pointer to the libusb device on success.
+ * \retval NULL          If device could not be found.
+ *
+ * \note
+ * - Uses libusb-0.1 enumeration (usb_init/usb_find_busses/usb_find_devices).
+ * - The returned pointer is owned by libusb's internal device list.
+ * \param cardno The ALSA card number as found in HW:<cardno>
+ */
+struct usb_device *ast_radio_usb_device_from_alsa_card(int cardno);

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -485,13 +485,14 @@ struct timeval ast_radio_tvnow(void);
  *   These define total signal power and peak-to-average power ratio
  *
  * \author      	NR9V
- * \param sbuf  	Rx audio sample buffer
+ * \param sbuf  	Rx audio sample buffer in 48k stereo or mono
  * \param o	    	Rx Audio Stats data structure
  * \param len   	Length of data in sbuf
+ * \param mono  	True if sbuf is mono, False if sbuf is stero
  * \return 	    	1 if clipping detected, 0 otherwise
  */
 #define CLIP_LED_HOLD_TIME_MS 500
-int ast_radio_check_audio(short *sbuf, struct audiostatistics *o, short len);
+int ast_radio_check_audio(short *sbuf, struct audiostatistics *o, short len, short mono);
 
 /*!
  * \brief Display receive audio statistics.

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -911,6 +911,78 @@ static void cleanup_user_devices(void)
 	AST_RWLIST_UNLOCK(&user_devices);
 }
 
+static int read_card_usbbus(int cardno, char *out, size_t outsz)
+{
+	char path[128];
+	FILE *fp;
+	size_t n;
+
+	if (outsz < 2) {
+		return -1;
+	}
+
+	snprintf(path, sizeof(path), "/proc/asound/card%d/usbbus", cardno);
+
+	fp = fopen(path, "r");
+	if (!fp) {
+		return -1;
+	}
+
+	if (!fgets(out, outsz, fp)) {
+		fclose(fp);
+		return -1;
+	}
+	fclose(fp);
+
+	/* trim trailing whitespace/newlines */
+	n = strlen(out);
+	while (n > 0 && isspace((unsigned char) out[n - 1])) {
+		out[--n] = '\0';
+	}
+
+	return (n > 0) ? 0 : -1;
+}
+
+/*
+ * Returns the libusb device that backs ALSA /proc/asound/card<cardno>/usbbus.
+ * On success: returns a pointer to a libusb struct usb_device.
+ * On failure: returns NULL.
+ *
+ * Notes:
+ * - Uses libusb-0.1 enumeration (usb_init/usb_find_busses/usb_find_devices).
+ * - The returned pointer is owned by libusb's internal device list.
+ */
+struct usb_device *ast_radio_usb_device_from_alsa_card(int cardno)
+{
+	char target[64]; /* usually "001/005" fits easily */
+	struct usb_bus *bus;
+	struct usb_device *dev;
+
+	if (read_card_usbbus(cardno, target, sizeof(target)) != 0) {
+		ast_debug(3, "Unable to read usbbus for card %d (may not be a USB device)\n", cardno);
+		return NULL;
+	}
+
+	usb_init();
+	usb_find_busses();
+	usb_find_devices();
+
+	for (bus = usb_busses; bus; bus = bus->next) {
+		for (dev = bus->devices; dev; dev = dev->next) {
+			char cur[sizeof(bus->dirname) + sizeof(dev->filename) + 1];
+
+			snprintf(cur, sizeof(cur), "%s/%s", bus->dirname, dev->filename);
+
+			/* usbbus content is typically case-insensitive */
+			if (strcasecmp(cur, target) == 0) {
+				return dev;
+			}
+		}
+	}
+	ast_debug(1, "No USB device found matching bus path '%s' for card %d\n", target, cardno);
+	return NULL;
+}
+
 /* Load our configuration */
 static int load_config(int reload)
 {

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -475,70 +475,71 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 	usb_find_devices();
 	for (usb_bus = usb_busses; usb_bus; usb_bus = usb_bus->next) {
 		for (dev = usb_bus->devices; dev; dev = dev->next) {
-			if (is_known_device(dev) || is_user_device(dev)) {
-				sprintf(devstr, "%s/%s", usb_bus->dirname, dev->filename);
-				for (i = 0; i < 32; i++) {
-					sprintf(str, "/proc/asound/card%d/usbbus", i);
-					fp = fopen(str, "r");
-					if (!fp) {
-						continue;
-					}
-					if ((!fgets(desdev, sizeof(desdev) - 1, fp)) || (!desdev[0])) {
-						fclose(fp);
-						continue;
-					}
-					fclose(fp);
-					if (desdev[strlen(desdev) - 1] == '\n') {
-						desdev[strlen(desdev) - 1] = 0;
-					}
-					if (strcasecmp(desdev, devstr)) {
-						continue;
-					}
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 20)) && !defined(AST_BUILDOPT_LIMEY)
-					sprintf(str, "/sys/class/sound/card%d/device", i);
-					memset(desdev, 0, sizeof(desdev));
-					if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
-						continue;
-					}
-					cp = strrchr(desdev, '/');
-					if (!cp) {
-						continue;
-					}
-					cp++;
-#else
-					if (i) {
-						sprintf(str, "/sys/class/sound/dsp%d/device", i);
-					} else {
-						strcpy(str, "/sys/class/sound/dsp/device");
-					}
-					memset(desdev, 0, sizeof(desdev));
-					if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
-						sprintf(str, "/sys/class/sound/controlC%d/device", i);
-						memset(desdev, 0, sizeof(desdev));
-						if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
-							continue;
-						}
-					}
-					cp = strrchr(desdev, '/');
-					if (cp) {
-						*cp = 0;
-					} else {
-						continue;
-					}
-					cp = strrchr(desdev, '/');
-					if (!cp) {
-						continue;
-					}
-					cp++;
-#endif
-					break;
-				}
-				if (i >= 32) {
+			if (!(is_known_device(dev) || is_user_device(dev))) {
+				continue;
+			}
+			sprintf(devstr, "%s/%s", usb_bus->dirname, dev->filename);
+			for (i = 0; i < 32; i++) {
+				sprintf(str, "/proc/asound/card%d/usbbus", i);
+				fp = fopen(str, "r");
+				if (!fp) {
 					continue;
 				}
-				if (!strcmp(cp, desired_device)) {
-					return dev;
+				if ((!fgets(desdev, sizeof(desdev) - 1, fp)) || (!desdev[0])) {
+					fclose(fp);
+					continue;
 				}
+				fclose(fp);
+				if (desdev[strlen(desdev) - 1] == '\n') {
+					desdev[strlen(desdev) - 1] = 0;
+				}
+				if (strcasecmp(desdev, devstr)) {
+					continue;
+				}
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 20)) && !defined(AST_BUILDOPT_LIMEY)
+				sprintf(str, "/sys/class/sound/card%d/device", i);
+				memset(desdev, 0, sizeof(desdev));
+				if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
+					continue;
+				}
+				cp = strrchr(desdev, '/');
+				if (!cp) {
+					continue;
+				}
+				cp++;
+#else
+				if (i) {
+					sprintf(str, "/sys/class/sound/dsp%d/device", i);
+				} else {
+					strcpy(str, "/sys/class/sound/dsp/device");
+				}
+				memset(desdev, 0, sizeof(desdev));
+				if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
+					sprintf(str, "/sys/class/sound/controlC%d/device", i);
+					memset(desdev, 0, sizeof(desdev));
+					if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
+						continue;
+					}
+				}
+				cp = strrchr(desdev, '/');
+				if (cp) {
+					*cp = 0;
+				} else {
+					continue;
+				}
+				cp = strrchr(desdev, '/');
+				if (!cp) {
+					continue;
+				}
+				cp++;
+#endif
+				break;
+			}
+			if (i >= 32) {
+				continue;
+			}
+			if (!strcmp(cp, desired_device)) {
+				return dev;
 			}
 		}
 	}

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -999,6 +999,10 @@ struct usb_device *ast_radio_usb_device_from_alsa_card(int cardno)
 		for (dev = bus->devices; dev; dev = dev->next) {
 			char cur[sizeof(bus->dirname) + sizeof(dev->filename) + 1];
 
+			if (!(is_known_device(dev) || is_user_device(dev))) {
+				continue;
+			}
+
 			snprintf(cur, sizeof(cur), "%s/%s", bus->dirname, dev->filename);
 
 			/* usbbus content is typically case-insensitive */

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -130,22 +130,27 @@ int ast_radio_amixer_max(int devnum, char *param)
 	snd_ctl_elem_info_t *info;
 
 	sprintf(str, "hw:%d", devnum);
+
 	if (snd_hctl_open(&hctl, str, 0)) {
 		return -1;
 	}
+
 	snd_hctl_load(hctl);
 	snd_ctl_elem_id_alloca(&id);
 	snd_ctl_elem_id_set_interface(id, SND_CTL_ELEM_IFACE_MIXER);
 	snd_ctl_elem_id_set_name(id, param);
+
 	elem = snd_hctl_find_elem(hctl, id);
 	if (!elem) {
 		snd_hctl_close(hctl);
 		return -1;
 	}
+
 	snd_ctl_elem_info_alloca(&info);
 	snd_hctl_elem_info(elem, info);
 	type = snd_ctl_elem_info_get_type(info);
 	rv = 0;
+
 	switch (type) {
 	case SND_CTL_ELEM_TYPE_INTEGER:
 		rv = snd_ctl_elem_info_get_max(info);
@@ -154,6 +159,7 @@ int ast_radio_amixer_max(int devnum, char *param)
 		rv = 1;
 		break;
 	}
+
 	snd_hctl_close(hctl);
 	return rv;
 }
@@ -169,23 +175,28 @@ int ast_radio_setamixer(int devnum, char *param, int v1, int v2)
 	snd_ctl_elem_info_t *info;
 
 	sprintf(str, "hw:%d", devnum);
+
 	if (snd_hctl_open(&hctl, str, 0)) {
 		return -1;
 	}
+
 	snd_hctl_load(hctl);
 	snd_ctl_elem_id_alloca(&id);
 	snd_ctl_elem_id_set_interface(id, SND_CTL_ELEM_IFACE_MIXER);
 	snd_ctl_elem_id_set_name(id, param);
+
 	elem = snd_hctl_find_elem(hctl, id);
 	if (!elem) {
 		snd_hctl_close(hctl);
 		return -1;
 	}
+
 	snd_ctl_elem_info_alloca(&info);
 	snd_hctl_elem_info(elem, info);
 	type = snd_ctl_elem_info_get_type(info);
 	snd_ctl_elem_value_alloca(&control);
 	snd_ctl_elem_value_set_id(control, id);
+
 	switch (type) {
 	case SND_CTL_ELEM_TYPE_INTEGER:
 		snd_ctl_elem_value_set_integer(control, 0, v1);
@@ -197,10 +208,12 @@ int ast_radio_setamixer(int devnum, char *param, int v1, int v2)
 		snd_ctl_elem_value_set_integer(control, 0, (v1 != 0));
 		break;
 	}
+
 	if (snd_hctl_elem_write(elem, control)) {
 		snd_hctl_close(hctl);
 		return -1;
 	}
+
 	snd_hctl_close(hctl);
 	return 0;
 }
@@ -290,6 +303,7 @@ unsigned short ast_radio_get_eeprom(struct usb_dev_handle *handle, unsigned shor
 	unsigned short cs;
 
 	cs = 0xffff;
+
 	for (i = EEPROM_START_ADDR; i <= EEPROM_START_ADDR + EEPROM_USER_CS_ADDR; i++) {
 		cs += buf[i - EEPROM_START_ADDR] = read_eeprom(handle, i);
 	}
@@ -304,10 +318,12 @@ void ast_radio_put_eeprom(struct usb_dev_handle *handle, unsigned short *buf)
 
 	cs = 0xffff;
 	buf[EEPROM_USER_MAGIC_ADDR] = EEPROM_MAGIC;
+
 	for (i = EEPROM_START_ADDR; i < EEPROM_START_ADDR + EEPROM_USER_CS_ADDR; i++) {
 		write_eeprom(handle, i, buf[i - EEPROM_START_ADDR]);
 		cs += buf[i - EEPROM_START_ADDR];
 	}
+
 	buf[EEPROM_USER_CS_ADDR] = (65535 - cs) + 1;
 	write_eeprom(handle, i, buf[EEPROM_USER_CS_ADDR]);
 }
@@ -357,20 +373,55 @@ static int is_user_device(struct usb_device *dev)
 	return device ? 1 : 0;
 }
 
+static int read_card_usbbus(int cardno, char *out, size_t outsz)
+{
+	char path[128];
+	FILE *fp;
+	size_t n;
+
+	if (outsz < 2) {
+		return -1;
+	}
+
+	snprintf(path, sizeof(path), "/proc/asound/card%d/usbbus", cardno);
+
+	fp = fopen(path, "r");
+	if (!fp) {
+		return -1;
+	}
+
+	if (!fgets(out, outsz, fp)) {
+		fclose(fp);
+		return -1;
+	}
+
+	fclose(fp);
+
+	/* trim trailing whitespace/newlines */
+	n = strlen(out);
+
+	while (n > 0 && isspace((unsigned char) out[n - 1])) {
+		out[--n] = '\0';
+	}
+
+	return (n > 0) ? 0 : -1;
+}
+
 int ast_radio_hid_device_mklist(void)
 {
 	struct usb_bus *usb_bus;
 	struct usb_device *dev;
 	char devstr[10000], str[200], desdev[200], *cp;
 	int i;
-	FILE *fp;
 
 	ast_mutex_lock(&usb_list_lock);
+
 	/* See usb_device_list definition for the format */
 	if (usb_device_list) {
 		ast_free(usb_device_list);
 	}
 	usb_device_list = ast_calloc(1, 2);
+
 	if (!usb_device_list) {
 		ast_mutex_unlock(&usb_list_lock);
 		return -1;
@@ -384,28 +435,26 @@ int ast_radio_hid_device_mklist(void)
 			if (is_known_device(dev) || is_user_device(dev)) {
 				sprintf(devstr, "%s/%s", usb_bus->dirname, dev->filename);
 				for (i = 0; i < 32; i++) {
-					sprintf(str, "/proc/asound/card%d/usbbus", i);
-					fp = fopen(str, "r");
-					if (!fp) {
+					if (read_card_usbbus(i, desdev, sizeof(desdev))) {
 						continue;
 					}
-					if ((!fgets(desdev, sizeof(desdev) - 1, fp)) || (!desdev[0])) {
-						fclose(fp);
-						continue;
-					}
-					fclose(fp);
+
 					if (desdev[strlen(desdev) - 1] == '\n') {
 						desdev[strlen(desdev) - 1] = 0;
 					}
+
 					if (strcasecmp(desdev, devstr)) {
 						continue;
 					}
+
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 20)) && !defined(AST_BUILDOPT_LIMEY)
 					sprintf(str, "/sys/class/sound/card%d/device", i);
 					memset(desdev, 0, sizeof(desdev));
+
 					if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
 						continue;
 					}
+
 					cp = strrchr(desdev, '/');
 					if (!cp) {
 						continue;
@@ -417,6 +466,7 @@ int ast_radio_hid_device_mklist(void)
 					} else {
 						strcpy(str, "/sys/class/sound/dsp/device");
 					}
+
 					memset(desdev, 0, sizeof(desdev));
 					if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
 						sprintf(str, "/sys/class/sound/controlC%d/device", i);
@@ -425,12 +475,15 @@ int ast_radio_hid_device_mklist(void)
 							continue;
 						}
 					}
+
 					cp = strrchr(desdev, '/');
+
 					if (cp) {
 						*cp = 0;
 					} else {
 						continue;
 					}
+
 					cp = strrchr(desdev, '/');
 					if (!cp) {
 						continue;
@@ -439,20 +492,26 @@ int ast_radio_hid_device_mklist(void)
 #endif
 					break;
 				}
+
 				if (i >= 32) {
 					ast_mutex_unlock(&usb_list_lock);
 					return -1;
 				}
+
 				usb_device_list = ast_realloc(usb_device_list, usb_device_list_size + 2 + strlen(cp));
+
 				if (!usb_device_list) {
 					ast_mutex_unlock(&usb_list_lock);
 					return -1;
 				}
+
 				usb_device_list_size += strlen(cp) + 2;
 				i = 0;
+
 				while (usb_device_list[i]) {
 					i += strlen(usb_device_list + i) + 1;
 				}
+
 				strcat(usb_device_list + i, cp);
 				usb_device_list[strlen(cp) + i + 1] = 0;
 			}
@@ -910,38 +969,6 @@ static void cleanup_user_devices(void)
 		ast_free(device);
 	}
 	AST_RWLIST_UNLOCK(&user_devices);
-}
-
-static int read_card_usbbus(int cardno, char *out, size_t outsz)
-{
-	char path[128];
-	FILE *fp;
-	size_t n;
-
-	if (outsz < 2) {
-		return -1;
-	}
-
-	snprintf(path, sizeof(path), "/proc/asound/card%d/usbbus", cardno);
-
-	fp = fopen(path, "r");
-	if (!fp) {
-		return -1;
-	}
-
-	if (!fgets(out, outsz, fp)) {
-		fclose(fp);
-		return -1;
-	}
-	fclose(fp);
-
-	/* trim trailing whitespace/newlines */
-	n = strlen(out);
-	while (n > 0 && isspace((unsigned char) out[n - 1])) {
-		out[--n] = '\0';
-	}
-
-	return (n > 0) ? 0 : -1;
 }
 
 /*

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -130,22 +130,31 @@ int ast_radio_amixer_max(int devnum, char *param)
 	snd_ctl_elem_info_t *info;
 
 	snprintf(str, sizeof(str), "hw:%d", devnum);
-	if (snd_hctl_open(&hctl, str, 0)) {
+
+	if (snd_hctl_open(&hctl, str, 0) < 0) {
 		return -1;
 	}
-	snd_hctl_load(hctl);
+
+	if (snd_hctl_load(hctl) < 0) {
+		snd_hctl_close(hctl);
+		return -1;
+	}
+
 	snd_ctl_elem_id_alloca(&id);
 	snd_ctl_elem_id_set_interface(id, SND_CTL_ELEM_IFACE_MIXER);
 	snd_ctl_elem_id_set_name(id, param);
+
 	elem = snd_hctl_find_elem(hctl, id);
 	if (!elem) {
 		snd_hctl_close(hctl);
 		return -1;
 	}
+
 	snd_ctl_elem_info_alloca(&info);
 	snd_hctl_elem_info(elem, info);
 	type = snd_ctl_elem_info_get_type(info);
 	rv = 0;
+
 	switch (type) {
 	case SND_CTL_ELEM_TYPE_INTEGER:
 		rv = snd_ctl_elem_info_get_max(info);
@@ -154,6 +163,7 @@ int ast_radio_amixer_max(int devnum, char *param)
 		rv = 1;
 		break;
 	}
+
 	snd_hctl_close(hctl);
 	return rv;
 }
@@ -169,23 +179,31 @@ int ast_radio_setamixer(int devnum, char *param, int v1, int v2)
 	snd_ctl_elem_info_t *info;
 
 	snprintf(str, sizeof(str), "hw:%d", devnum);
-	if (snd_hctl_open(&hctl, str, 0)) {
+
+	if (snd_hctl_open(&hctl, str, 0) < 0) {
 		return -1;
 	}
-	snd_hctl_load(hctl);
+
+	if (snd_hctl_load(hctl) < 0) {
+		snd_hctl_close(hctl);
+		return -1;
+	}
 	snd_ctl_elem_id_alloca(&id);
 	snd_ctl_elem_id_set_interface(id, SND_CTL_ELEM_IFACE_MIXER);
 	snd_ctl_elem_id_set_name(id, param);
+
 	elem = snd_hctl_find_elem(hctl, id);
 	if (!elem) {
 		snd_hctl_close(hctl);
 		return -1;
 	}
+
 	snd_ctl_elem_info_alloca(&info);
 	snd_hctl_elem_info(elem, info);
 	type = snd_ctl_elem_info_get_type(info);
 	snd_ctl_elem_value_alloca(&control);
 	snd_ctl_elem_value_set_id(control, id);
+
 	switch (type) {
 	case SND_CTL_ELEM_TYPE_INTEGER:
 		snd_ctl_elem_value_set_integer(control, 0, v1);
@@ -197,24 +215,32 @@ int ast_radio_setamixer(int devnum, char *param, int v1, int v2)
 		snd_ctl_elem_value_set_integer(control, 0, (v1 != 0));
 		break;
 	}
+
 	if (snd_hctl_elem_write(elem, control)) {
 		snd_hctl_close(hctl);
 		return -1;
 	}
+
 	snd_hctl_close(hctl);
 	return 0;
 }
 
 void ast_radio_hid_set_outputs(struct usb_dev_handle *handle, unsigned char *outputs)
 {
-	usleep(1500);
+	/* This appears to prevent issues with the CM-109 chipset when switching modes too fast
+	 * Originally 1500, Issues with Uno-Q and Pi5? Adjusted to 3000
+	 */
+	usleep(3000);
 	usb_control_msg(handle, USB_ENDPOINT_OUT + USB_TYPE_CLASS + USB_RECIP_INTERFACE, HID_REPORT_SET, 0 + (HID_RT_OUTPUT << 8),
 		C108_HID_INTERFACE, (char *) outputs, 4, 5000);
 }
 
 void ast_radio_hid_get_inputs(struct usb_dev_handle *handle, unsigned char *inputs)
 {
-	usleep(1500);
+	/* This appears to prevent issues with the CM-109 chipset when switching modes too fast
+	 * Originally 1500, Issues with Uno-Q and Pi5? Adjusted to 3000
+	 */
+	usleep(3000);
 	usb_control_msg(handle, USB_ENDPOINT_IN + USB_TYPE_CLASS + USB_RECIP_INTERFACE, HID_REPORT_GET, 0 + (HID_RT_INPUT << 8),
 		C108_HID_INTERFACE, (char *) inputs, 4, 5000);
 }
@@ -290,6 +316,7 @@ unsigned short ast_radio_get_eeprom(struct usb_dev_handle *handle, unsigned shor
 	unsigned short cs;
 
 	cs = 0xffff;
+
 	for (i = EEPROM_START_ADDR; i <= EEPROM_START_ADDR + EEPROM_USER_CS_ADDR; i++) {
 		cs += buf[i - EEPROM_START_ADDR] = read_eeprom(handle, i);
 	}
@@ -304,10 +331,12 @@ void ast_radio_put_eeprom(struct usb_dev_handle *handle, unsigned short *buf)
 
 	cs = 0xffff;
 	buf[EEPROM_USER_MAGIC_ADDR] = EEPROM_MAGIC;
+
 	for (i = EEPROM_START_ADDR; i < EEPROM_START_ADDR + EEPROM_USER_CS_ADDR; i++) {
 		write_eeprom(handle, i, buf[i - EEPROM_START_ADDR]);
 		cs += buf[i - EEPROM_START_ADDR];
 	}
+
 	buf[EEPROM_USER_CS_ADDR] = (65535 - cs) + 1;
 	write_eeprom(handle, i, buf[EEPROM_USER_CS_ADDR]);
 }
@@ -357,20 +386,56 @@ static int is_user_device(struct usb_device *dev)
 	return device ? 1 : 0;
 }
 
+static int read_card_usbbus(int cardno, char *out, int outsz)
+{
+	char path[128];
+	FILE *fp;
+	size_t n;
+
+	if (outsz < 2) {
+		return -1;
+	}
+
+	snprintf(path, sizeof(path), "/proc/asound/card%d/usbbus", cardno);
+
+	fp = fopen(path, "r");
+	if (!fp) {
+		return -1;
+	}
+
+	if (!fgets(out, outsz, fp) || !out[0]) {
+		fclose(fp);
+		return -1;
+	}
+
+	fclose(fp);
+
+	/* trim trailing whitespace/newlines */
+	n = strlen(out);
+
+	while (n > 0 && isspace((unsigned char) out[n - 1])) {
+		out[--n] = '\0';
+	}
+
+	return (n > 0) ? 0 : -1;
+}
+
 int ast_radio_hid_device_mklist(void)
 {
 	struct usb_bus *usb_bus;
 	struct usb_device *dev;
 	char devstr[10000], str[200], desdev[200], *cp;
 	int i;
-	FILE *fp;
 
 	ast_mutex_lock(&usb_list_lock);
+
 	/* See usb_device_list definition for the format */
 	if (usb_device_list) {
 		ast_free(usb_device_list);
 	}
+	usb_device_list_size = 0;
 	usb_device_list = ast_calloc(1, 2);
+
 	if (!usb_device_list) {
 		ast_mutex_unlock(&usb_list_lock);
 		return -1;
@@ -381,54 +446,59 @@ int ast_radio_hid_device_mklist(void)
 	usb_find_devices();
 	for (usb_bus = usb_busses; usb_bus; usb_bus = usb_bus->next) {
 		for (dev = usb_bus->devices; dev; dev = dev->next) {
-			if (is_known_device(dev) || is_user_device(dev)) {
-				snprintf(devstr, sizeof(devstr), "%s/%s", usb_bus->dirname, dev->filename);
-				for (i = 0; i < 32; i++) {
-					snprintf(str, sizeof(str), "/proc/asound/card%d/usbbus", i);
-					fp = fopen(str, "r");
-					if (!fp) {
-						continue;
-					}
-					if ((!fgets(desdev, sizeof(desdev) - 1, fp)) || (!desdev[0])) {
-						fclose(fp);
-						continue;
-					}
-					fclose(fp);
-					if (desdev[strlen(desdev) - 1] == '\n') {
-						desdev[strlen(desdev) - 1] = 0;
-					}
-					if (strcasecmp(desdev, devstr)) {
-						continue;
-					}
-					snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
-					memset(desdev, 0, sizeof(desdev));
-					if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
-						continue;
-					}
-					cp = strrchr(desdev, '/');
-					if (!cp) {
-						continue;
-					}
-					cp++;
-					break;
-				}
-				if (i >= 32) {
-					ast_mutex_unlock(&usb_list_lock);
-					return -1;
-				}
-				usb_device_list = ast_realloc(usb_device_list, usb_device_list_size + 2 + strlen(cp));
-				if (!usb_device_list) {
-					ast_mutex_unlock(&usb_list_lock);
-					return -1;
-				}
-				usb_device_list_size += strlen(cp) + 2;
-				i = 0;
-				while (usb_device_list[i]) {
-					i += strlen(usb_device_list + i) + 1;
-				}
-				strcat(usb_device_list + i, cp);
-				usb_device_list[strlen(cp) + i + 1] = 0;
+			char *new_list;
+
+			if (!(is_known_device(dev) || is_user_device(dev))) {
+				continue;
 			}
+
+			snprintf(devstr, sizeof(devstr), "%s/%s", usb_bus->dirname, dev->filename);
+			for (i = 0; i < 32; i++) {
+				if (read_card_usbbus(i, desdev, sizeof(desdev))) {
+					continue;
+				}
+
+				if (strcasecmp(desdev, devstr)) {
+					continue;
+				}
+
+				snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
+				memset(desdev, 0, sizeof(desdev));
+
+				if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
+					continue;
+				}
+
+				cp = strrchr(desdev, '/');
+				if (!cp) {
+					continue;
+				}
+				cp++;
+				break;
+			}
+
+			if (i >= 32) {
+				ast_mutex_unlock(&usb_list_lock);
+				return -1;
+			}
+
+			new_list = ast_realloc(usb_device_list, usb_device_list_size + 2 + strlen(cp));
+
+			if (!new_list) {
+				ast_mutex_unlock(&usb_list_lock);
+				return -1;
+			}
+
+			usb_device_list = new_list;
+			usb_device_list_size += strlen(cp) + 2;
+			i = 0;
+
+			while (usb_device_list[i]) {
+				i += strlen(usb_device_list + i) + 1;
+			}
+
+			strcat(usb_device_list + i, cp);
+			usb_device_list[strlen(cp) + i + 1] = 0;
 		}
 	}
 	ast_mutex_unlock(&usb_list_lock);
@@ -441,50 +511,45 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 	struct usb_device *dev;
 	char devstr[10000], str[200], desdev[200], *cp;
 	int i;
-	FILE *fp;
 
 	usb_init();
 	usb_find_busses();
 	usb_find_devices();
 	for (usb_bus = usb_busses; usb_bus; usb_bus = usb_bus->next) {
 		for (dev = usb_bus->devices; dev; dev = dev->next) {
-			if (is_known_device(dev) || is_user_device(dev)) {
-				snprintf(devstr, sizeof(devstr), "%s/%s", usb_bus->dirname, dev->filename);
-				for (i = 0; i < 32; i++) {
-					snprintf(str, sizeof(str), "/proc/asound/card%d/usbbus", i);
-					fp = fopen(str, "r");
-					if (!fp) {
-						continue;
-					}
-					if ((!fgets(desdev, sizeof(desdev) - 1, fp)) || (!desdev[0])) {
-						fclose(fp);
-						continue;
-					}
-					fclose(fp);
-					if (desdev[strlen(desdev) - 1] == '\n') {
-						desdev[strlen(desdev) - 1] = 0;
-					}
-					if (strcasecmp(desdev, devstr)) {
-						continue;
-					}
-					snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
-					memset(desdev, 0, sizeof(desdev));
-					if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
-						continue;
-					}
-					cp = strrchr(desdev, '/');
-					if (!cp) {
-						continue;
-					}
-					cp++;
-					break;
-				}
-				if (i >= 32) {
+			if (!(is_known_device(dev) || is_user_device(dev))) {
+				continue;
+			}
+
+			snprintf(devstr, sizeof(devstr), "%s/%s", usb_bus->dirname, dev->filename);
+
+			for (i = 0; i < 32; i++) {
+				if (read_card_usbbus(i, desdev, sizeof(desdev))) {
 					continue;
 				}
-				if (!strcmp(cp, desired_device)) {
-					return dev;
+
+				if (strcasecmp(desdev, devstr)) {
+					continue;
 				}
+				snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
+				memset(desdev, 0, sizeof(desdev));
+				if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
+					continue;
+				}
+				cp = strrchr(desdev, '/');
+				if (!cp) {
+					continue;
+				}
+				cp++;
+				break;
+			}
+
+			if (i >= 32) {
+				continue;
+			}
+
+			if (!strcmp(cp, desired_device)) {
+				return dev;
 			}
 		}
 	}
@@ -731,46 +796,76 @@ struct timeval ast_radio_tvnow(void)
 
 #define CLIP_SAMP_THRESH 0x7eb0
 #define CLIP_EVENT_MIN_SAMPLES 3
-int ast_radio_check_audio(short *sbuf, struct audiostatistics *o, short len)
+int ast_radio_check_audio(short *sbuf, struct audiostatistics *o, short len, short mono)
 {
 	unsigned short i, j, val, max = 0, seq_clips = 0;
 	double pwr = 0.0;
 	short buf[FRAME_SIZE], last_clip = -1;
 
-	/* validate len and index */
-	if (len > 12 * FRAME_SIZE) {
-		len = 12 * FRAME_SIZE;
-	}
 	if (o->index >= AUDIO_STATS_LEN) {
 		o->index = 0;
 	}
-	/* Downsample from 48000 stereo to 8000 mono */
-	for (i = 10, j = 0; i < len; i += 12) {
-		buf[j++] = sbuf[i];
+
+	if (mono) {
+		/* validate len and index for mono audio */
+		if (len > 6 * FRAME_SIZE) {
+			len = 6 * FRAME_SIZE;
+		}
+
+		/* Downsample from 48000 mono to 8000 mono */
+		for (i = 5, j = 0; i < len; i += 6) {
+			buf[j++] = sbuf[i];
+		}
+		len /= 6;
+	} else {
+		/* validate len and index for stereo audio */
+		if (len > 12 * FRAME_SIZE) {
+			len = 12 * FRAME_SIZE;
+		}
+
+		/* Downsample from 48000 stereo to 8000 mono */
+		for (i = 10, j = 0; i < len; i += 12) {
+			buf[j++] = sbuf[i];
+		}
+		len /= 12;
 	}
-	len /= 12;
+
 	/* len should now be 160 */
+	if (len == 0) {
+		/* Something went wrong */
+		if (++o->index >= AUDIO_STATS_LEN) {
+			o->index = 0;
+		}
+		return 0;
+	}
+
 	for (i = 0; i < len; i++) {
 		val = abs(buf[i]);
 		if (val) {
 			if (val > max) {
 				max = val;
 			}
+
 			pwr += (double) (val * val);
+
 			if (val > CLIP_SAMP_THRESH) {
 				if (last_clip >= 0 && last_clip + 1 == i) {
 					seq_clips++;
 				}
+
 				last_clip = i;
 			}
 		}
 	}
+
 	o->maxbuf[o->index] = max;
 	o->pwrbuf[o->index] = (unsigned int) (pwr / (double) len);
 	o->clipbuf[o->index] = seq_clips;
+
 	if (++o->index >= AUDIO_STATS_LEN) {
 		o->index = 0;
 	}
+
 	/* return 1 if clipping was detected */
 	return (seq_clips >= CLIP_EVENT_MIN_SAMPLES);
 }
@@ -829,6 +924,50 @@ static void cleanup_user_devices(void)
 		ast_free(device);
 	}
 	AST_RWLIST_UNLOCK(&user_devices);
+}
+
+/*
+ * Returns the libusb device that backs ALSA /proc/asound/card<cardno>/usbbus.
+ * On success: returns a pointer to a libusb struct usb_device.
+ * On failure: returns NULL.
+ *
+ * Notes:
+ * - Uses libusb-0.1 enumeration (usb_init/usb_find_busses/usb_find_devices).
+ * - The returned pointer is owned by libusb's internal device list.
+ */
+struct usb_device *ast_radio_usb_device_from_alsa_card(int cardno)
+{
+	char target[64]; /* usually "001/005" fits easily */
+	struct usb_bus *bus;
+	struct usb_device *dev;
+
+	if (read_card_usbbus(cardno, target, sizeof(target)) != 0) {
+		ast_debug(3, "Unable to read usbbus for card %d (may not be a USB device)\n", cardno);
+		return NULL;
+	}
+
+	usb_init();
+	usb_find_busses();
+	usb_find_devices();
+
+	for (bus = usb_busses; bus; bus = bus->next) {
+		for (dev = bus->devices; dev; dev = dev->next) {
+			char cur[sizeof(bus->dirname) + sizeof(dev->filename) + 1];
+
+			if (!(is_known_device(dev) || is_user_device(dev))) {
+				continue;
+			}
+
+			snprintf(cur, sizeof(cur), "%s/%s", bus->dirname, dev->filename);
+
+			/* usbbus content is typically case-insensitive */
+			if (strcasecmp(cur, target) == 0) {
+				return dev;
+			}
+		}
+	}
+	ast_debug(1, "No USB device found matching bus path '%s' for card %d\n", target, cardno);
+	return NULL;
 }
 
 /* Load our configuration */

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -523,7 +523,6 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 	struct usb_device *dev;
 	char devstr[10000], str[200], desdev[200], *cp;
 	int i;
-	FILE *fp;
 
 	usb_init();
 	usb_find_busses();

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -872,24 +872,40 @@ struct timeval ast_radio_tvnow(void)
 
 #define CLIP_SAMP_THRESH 0x7eb0
 #define CLIP_EVENT_MIN_SAMPLES 3
-int ast_radio_check_audio(short *sbuf, struct audiostatistics *o, short len)
+int ast_radio_check_audio(short *sbuf, struct audiostatistics *o, short len, short mono)
 {
 	unsigned short i, j, val, max = 0, seq_clips = 0;
 	double pwr = 0.0;
 	short buf[FRAME_SIZE], last_clip = -1;
 
-	/* validate len and index */
-	if (len > 12 * FRAME_SIZE) {
-		len = 12 * FRAME_SIZE;
-	}
 	if (o->index >= AUDIO_STATS_LEN) {
 		o->index = 0;
 	}
-	/* Downsample from 48000 stereo to 8000 mono */
-	for (i = 10, j = 0; i < len; i += 12) {
-		buf[j++] = sbuf[i];
+
+	if (mono) {
+		/* validate len and index */
+		if (len > 6 * FRAME_SIZE) {
+			len = 6 * FRAME_SIZE;
+		}
+
+		/* Downsample from 48000 mono to 8000 mono */
+		for (i = 5, j = 0; i < len; i += 6) {
+			buf[j++] = sbuf[i];
+		}
+		len /= 6;
+	} else {
+		/* validate len and index */
+		if (len > 12 * FRAME_SIZE) {
+			len = 12 * FRAME_SIZE;
+		}
+
+		/* Downsample from 48000 stereo to 8000 mono */
+		for (i = 10, j = 0; i < len; i += 12) {
+			buf[j++] = sbuf[i];
+		}
+		len /= 12;
 	}
-	len /= 12;
+
 	/* len should now be 160 */
 	for (i = 0; i < len; i++) {
 		val = abs(buf[i]);
@@ -897,21 +913,27 @@ int ast_radio_check_audio(short *sbuf, struct audiostatistics *o, short len)
 			if (val > max) {
 				max = val;
 			}
+
 			pwr += (double) (val * val);
+
 			if (val > CLIP_SAMP_THRESH) {
 				if (last_clip >= 0 && last_clip + 1 == i) {
 					seq_clips++;
 				}
+
 				last_clip = i;
 			}
 		}
 	}
+
 	o->maxbuf[o->index] = max;
 	o->pwrbuf[o->index] = (unsigned int) (pwr / (double) len);
 	o->clipbuf[o->index] = seq_clips;
+
 	if (++o->index >= AUDIO_STATS_LEN) {
 		o->index = 0;
 	}
+
 	/* return 1 if clipping was detected */
 	return (seq_clips >= CLIP_EVENT_MIN_SAMPLES);
 }

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -131,11 +131,15 @@ int ast_radio_amixer_max(int devnum, char *param)
 
 	sprintf(str, "hw:%d", devnum);
 
-	if (snd_hctl_open(&hctl, str, 0)) {
+	if (snd_hctl_open(&hctl, str, 0) < 0) {
 		return -1;
 	}
 
-	snd_hctl_load(hctl);
+	if (snd_hctl_load(hctl) < 0) {
+		snd_hctl_close(hctl);
+		return -1;
+	}
+
 	snd_ctl_elem_id_alloca(&id);
 	snd_ctl_elem_id_set_interface(id, SND_CTL_ELEM_IFACE_MIXER);
 	snd_ctl_elem_id_set_name(id, param);
@@ -176,11 +180,14 @@ int ast_radio_setamixer(int devnum, char *param, int v1, int v2)
 
 	sprintf(str, "hw:%d", devnum);
 
-	if (snd_hctl_open(&hctl, str, 0)) {
+	if (snd_hctl_open(&hctl, str, 0) < 0) {
 		return -1;
 	}
 
-	snd_hctl_load(hctl);
+	if (snd_hctl_load(hctl) < 0) {
+		snd_hctl_close(hctl);
+		return -1;
+	}
 	snd_ctl_elem_id_alloca(&id);
 	snd_ctl_elem_id_set_interface(id, SND_CTL_ELEM_IFACE_MIXER);
 	snd_ctl_elem_id_set_name(id, param);
@@ -420,6 +427,7 @@ int ast_radio_hid_device_mklist(void)
 	if (usb_device_list) {
 		ast_free(usb_device_list);
 	}
+	usb_device_list_size = 0;
 	usb_device_list = ast_calloc(1, 2);
 
 	if (!usb_device_list) {

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -380,7 +380,7 @@ static int is_user_device(struct usb_device *dev)
 	return device ? 1 : 0;
 }
 
-static int read_card_usbbus(int cardno, char *out, size_t outsz)
+static int read_card_usbbus(int cardno, char *out, int outsz)
 {
 	char path[128];
 	FILE *fp;
@@ -908,6 +908,14 @@ int ast_radio_check_audio(short *sbuf, struct audiostatistics *o, short len, sho
 	}
 
 	/* len should now be 160 */
+	if (len == 0) {
+		/* Something went wrong */
+		if (++o->index >= AUDIO_STATS_LEN) {
+			o->index = 0;
+		}
+		return 0;
+	}
+
 	for (i = 0; i < len; i++) {
 		val = abs(buf[i]);
 		if (val) {

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -390,7 +390,7 @@ static int read_card_usbbus(int cardno, char *out, size_t outsz)
 		return -1;
 	}
 
-	if (!fgets(out, outsz, fp)) {
+	if (!fgets(out, outsz, fp) || !out[0]) {
 		fclose(fp);
 		return -1;
 	}
@@ -432,85 +432,87 @@ int ast_radio_hid_device_mklist(void)
 	usb_find_devices();
 	for (usb_bus = usb_busses; usb_bus; usb_bus = usb_bus->next) {
 		for (dev = usb_bus->devices; dev; dev = dev->next) {
-			if (is_known_device(dev) || is_user_device(dev)) {
-				sprintf(devstr, "%s/%s", usb_bus->dirname, dev->filename);
-				for (i = 0; i < 32; i++) {
-					if (read_card_usbbus(i, desdev, sizeof(desdev))) {
-						continue;
-					}
+			if (!dev || !(is_known_device(dev) || is_user_device(dev))) {
+				continue;
+			}
 
-					if (strcasecmp(desdev, devstr)) {
-						continue;
-					}
+			snprintf(devstr, sizeof(devstr), "%s/%s", usb_bus->dirname, dev->filename);
+			for (i = 0; i < 32; i++) {
+				if (read_card_usbbus(i, desdev, sizeof(desdev))) {
+					continue;
+				}
+
+				if (strcasecmp(desdev, devstr)) {
+					continue;
+				}
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 20)) && !defined(AST_BUILDOPT_LIMEY)
-					sprintf(str, "/sys/class/sound/card%d/device", i);
-					memset(desdev, 0, sizeof(desdev));
+				sprintf(str, "/sys/class/sound/card%d/device", i);
+				memset(desdev, 0, sizeof(desdev));
 
-					if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
-						continue;
-					}
+				if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
+					continue;
+				}
 
-					cp = strrchr(desdev, '/');
-					if (!cp) {
-						continue;
-					}
-					cp++;
+				cp = strrchr(desdev, '/');
+				if (!cp) {
+					continue;
+				}
+				cp++;
 #else
-					if (i) {
-						sprintf(str, "/sys/class/sound/dsp%d/device", i);
-					} else {
-						strcpy(str, "/sys/class/sound/dsp/device");
-					}
+				if (i) {
+					sprintf(str, "/sys/class/sound/dsp%d/device", i);
+				} else {
+					strcpy(str, "/sys/class/sound/dsp/device");
+				}
 
+				memset(desdev, 0, sizeof(desdev));
+				if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
+					sprintf(str, "/sys/class/sound/controlC%d/device", i);
 					memset(desdev, 0, sizeof(desdev));
 					if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
-						sprintf(str, "/sys/class/sound/controlC%d/device", i);
-						memset(desdev, 0, sizeof(desdev));
-						if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
-							continue;
-						}
-					}
-
-					cp = strrchr(desdev, '/');
-
-					if (cp) {
-						*cp = 0;
-					} else {
 						continue;
 					}
+				}
 
-					cp = strrchr(desdev, '/');
-					if (!cp) {
-						continue;
-					}
-					cp++;
+				cp = strrchr(desdev, '/');
+
+				if (cp) {
+					*cp = 0;
+				} else {
+					continue;
+				}
+
+				cp = strrchr(desdev, '/');
+				if (!cp) {
+					continue;
+				}
+				cp++;
 #endif
-					break;
-				}
-
-				if (i >= 32) {
-					ast_mutex_unlock(&usb_list_lock);
-					return -1;
-				}
-
-				usb_device_list = ast_realloc(usb_device_list, usb_device_list_size + 2 + strlen(cp));
-
-				if (!usb_device_list) {
-					ast_mutex_unlock(&usb_list_lock);
-					return -1;
-				}
-
-				usb_device_list_size += strlen(cp) + 2;
-				i = 0;
-
-				while (usb_device_list[i]) {
-					i += strlen(usb_device_list + i) + 1;
-				}
-
-				strcat(usb_device_list + i, cp);
-				usb_device_list[strlen(cp) + i + 1] = 0;
+				break;
 			}
+
+			if (i >= 32) {
+				ast_mutex_unlock(&usb_list_lock);
+				return -1;
+			}
+
+			usb_device_list = ast_realloc(usb_device_list, usb_device_list_size + 2 + strlen(cp));
+
+			if (!usb_device_list) {
+				ast_mutex_unlock(&usb_list_lock);
+				return -1;
+			}
+
+			usb_device_list_size += strlen(cp) + 2;
+			i = 0;
+
+			while (usb_device_list[i]) {
+				i += strlen(usb_device_list + i) + 1;
+			}
+
+			strcat(usb_device_list + i, cp);
+			usb_device_list[strlen(cp) + i + 1] = 0;
 		}
 	}
 	ast_mutex_unlock(&usb_list_lock);
@@ -529,11 +531,11 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 	usb_find_devices();
 	for (usb_bus = usb_busses; usb_bus; usb_bus = usb_bus->next) {
 		for (dev = usb_bus->devices; dev; dev = dev->next) {
-			if (!(is_known_device(dev) || is_user_device(dev))) {
+			if (!dev || !(is_known_device(dev) || is_user_device(dev))) {
 				continue;
 			}
 
-			sprintf(devstr, "%s/%s", usb_bus->dirname, dev->filename);
+			snprintf(devstr, sizeof(devstr), "%s/%s", usb_bus->dirname, dev->filename);
 
 			for (i = 0; i < 32; i++) {
 				if (read_card_usbbus(i, desdev, sizeof(desdev))) {

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -434,7 +434,7 @@ int ast_radio_hid_device_mklist(void)
 		for (dev = usb_bus->devices; dev; dev = dev->next) {
 			char *new_list;
 
-			if (!dev || !(is_known_device(dev) || is_user_device(dev))) {
+			if (!(is_known_device(dev) || is_user_device(dev))) {
 				continue;
 			}
 
@@ -534,7 +534,7 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 	usb_find_devices();
 	for (usb_bus = usb_busses; usb_bus; usb_bus = usb_bus->next) {
 		for (dev = usb_bus->devices; dev; dev = dev->next) {
-			if (!dev || !(is_known_device(dev) || is_user_device(dev))) {
+			if (!(is_known_device(dev) || is_user_device(dev))) {
 				continue;
 			}
 

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -439,10 +439,6 @@ int ast_radio_hid_device_mklist(void)
 						continue;
 					}
 
-					if (desdev[strlen(desdev) - 1] == '\n') {
-						desdev[strlen(desdev) - 1] = 0;
-					}
-
 					if (strcasecmp(desdev, devstr)) {
 						continue;
 					}
@@ -537,21 +533,12 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 			if (!(is_known_device(dev) || is_user_device(dev))) {
 				continue;
 			}
-			sprintf(devstr, "%s/%s", usb_bus->dirname, dev->filename);
+
 			for (i = 0; i < 32; i++) {
-				sprintf(str, "/proc/asound/card%d/usbbus", i);
-				fp = fopen(str, "r");
-				if (!fp) {
+				if (read_card_usbbus(i, desdev, sizeof(desdev))) {
 					continue;
 				}
-				if ((!fgets(desdev, sizeof(desdev) - 1, fp)) || (!desdev[0])) {
-					fclose(fp);
-					continue;
-				}
-				fclose(fp);
-				if (desdev[strlen(desdev) - 1] == '\n') {
-					desdev[strlen(desdev) - 1] = 0;
-				}
+
 				if (strcasecmp(desdev, devstr)) {
 					continue;
 				}

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -478,8 +478,7 @@ int ast_radio_hid_device_mklist(void)
 			}
 
 			if (i >= 32) {
-				ast_mutex_unlock(&usb_list_lock);
-				return -1;
+				continue;
 			}
 
 			new_list = ast_realloc(usb_device_list, usb_device_list_size + 2 + strlen(cp));

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -528,6 +528,7 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 	usb_find_busses();
 	usb_find_devices();
 	for (usb_bus = usb_busses; usb_bus; usb_bus = usb_bus->next) {
+		sprintf(devstr, "%s/%s", usb_bus->dirname, dev->filename);
 		for (dev = usb_bus->devices; dev; dev = dev->next) {
 			if (!(is_known_device(dev) || is_user_device(dev))) {
 				continue;

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -876,7 +876,7 @@ int ast_radio_check_audio(short *sbuf, struct audiostatistics *o, short len, sho
 	}
 
 	if (mono) {
-		/* validate len and index */
+		/* validate len and index for mono audio */
 		if (len > 6 * FRAME_SIZE) {
 			len = 6 * FRAME_SIZE;
 		}
@@ -887,7 +887,7 @@ int ast_radio_check_audio(short *sbuf, struct audiostatistics *o, short len, sho
 		}
 		len /= 6;
 	} else {
-		/* validate len and index */
+		/* validate len and index for stereo audio */
 		if (len > 12 * FRAME_SIZE) {
 			len = 12 * FRAME_SIZE;
 		}

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -432,6 +432,8 @@ int ast_radio_hid_device_mklist(void)
 	usb_find_devices();
 	for (usb_bus = usb_busses; usb_bus; usb_bus = usb_bus->next) {
 		for (dev = usb_bus->devices; dev; dev = dev->next) {
+			char *new_list;
+
 			if (!dev || !(is_known_device(dev) || is_user_device(dev))) {
 				continue;
 			}
@@ -497,13 +499,14 @@ int ast_radio_hid_device_mklist(void)
 				return -1;
 			}
 
-			usb_device_list = ast_realloc(usb_device_list, usb_device_list_size + 2 + strlen(cp));
+			new_list = ast_realloc(usb_device_list, usb_device_list_size + 2 + strlen(cp));
 
-			if (!usb_device_list) {
+			if (!new_list) {
 				ast_mutex_unlock(&usb_list_lock);
 				return -1;
 			}
 
+			usb_device_list = new_list;
 			usb_device_list_size += strlen(cp) + 2;
 			i = 0;
 

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -528,11 +528,12 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 	usb_find_busses();
 	usb_find_devices();
 	for (usb_bus = usb_busses; usb_bus; usb_bus = usb_bus->next) {
-		sprintf(devstr, "%s/%s", usb_bus->dirname, dev->filename);
 		for (dev = usb_bus->devices; dev; dev = dev->next) {
 			if (!(is_known_device(dev) || is_user_device(dev))) {
 				continue;
 			}
+
+			sprintf(devstr, "%s/%s", usb_bus->dirname, dev->filename);
 
 			for (i = 0; i < 32; i++) {
 				if (read_card_usbbus(i, desdev, sizeof(desdev))) {


### PR DESCRIPTION
Add PortAudio thread
Refactor startup of HID thread
Allow use of hw:xxx to configure usb

This allows ASL to work on any modern kernel by eliminating the obsolete `/dev/dsp` interface.

Add a USB buffer "monitor" to handle the mysterious condition were the audio buffer stops draining causing the TX output to remain active.  When the buffer exceeds 200ms the stream is now reset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * PortAudio-based audio I/O support
  * New `audiodev` option to select target audio hardware
  * Public API to map an ALSA card to the underlying USB device
  * `ast_radio_check_audio` now explicitly accepts a mono/stereo indicator

* **Changes**
  * Replaces legacy OSS/DSP audio flow with threaded PortAudio streaming and improved underflow handling
  * Refines USB/ALSA device discovery and HID timing
  * Improves radio audio/statistics processing (including mono downsampling)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->