### PR TITLE
chan_usrp: process text frames before voice frames

### DIFF
--- a/channels/chan_usrp.c
+++ b/channels/chan_usrp.c
@@ -493,14 +493,19 @@ static struct ast_frame *usrp_xread(struct ast_channel *ast)
 			pvt->rxseq = seq + 1;
 			/* Pass received text messages to Asterisk */
 			if (bufhdrp->type == USRP_TYPE_TEXT) {
-				struct ast_frame wf = {
-					.frametype = AST_FRAME_TEXT,
-					.data.ptr = bufdata,
-					.datalen = strlen(bufdata) + 1,
-					.src = __PRETTY_FUNCTION__,
-				};
+				if (datalen > 0) {
+					size_t textlen = strnlen(bufdata, datalen);
+					struct ast_frame wf = {
+						.frametype = AST_FRAME_TEXT,
+						.data.ptr = bufdata,
+						.datalen = textlen + 1,
+						.src = __PRETTY_FUNCTION__,
+					};
 
-				ast_queue_frame(ast, &wf);
+					/* Ensure NUL-termination within the receive buffer */
+					bufdata[textlen] = '\0';
+					ast_queue_frame(ast, &wf);
+				}
 			} else if (datalen == USRP_VOICE_FRAME_SIZE) {
 				qp = ast_malloc(sizeof(struct usrp_rxq));
 				if (qp) {

--- a/channels/chan_usrp.c
+++ b/channels/chan_usrp.c
@@ -491,25 +491,22 @@ static struct ast_frame *usrp_xread(struct ast_channel *ast)
 				ast_log(LOG_NOTICE, "Channel %s: Possible data loss, expected seq %lu received %lu\n", ast_channel_name(ast), pvt->rxseq, seq);
 			}
 			pvt->rxseq = seq + 1;
-			/* TODO: TEXT processing added N4IRR */
-			if (datalen == USRP_VOICE_FRAME_SIZE) {
-				/* Pass received text messages to Asterisk */
-				if (bufhdrp->type == USRP_TYPE_TEXT) {
-					struct ast_frame wf = {
-						.frametype = AST_FRAME_TEXT,
-						.data.ptr = bufdata,
-						.datalen = strlen(bufdata) + 1,
-						.src = __PRETTY_FUNCTION__,
-					};
+			/* Pass received text messages to Asterisk */
+			if (bufhdrp->type == USRP_TYPE_TEXT) {
+				struct ast_frame wf = {
+					.frametype = AST_FRAME_TEXT,
+					.data.ptr = bufdata,
+					.datalen = strlen(bufdata) + 1,
+					.src = __PRETTY_FUNCTION__,
+				};
 
-					ast_queue_frame(ast, &wf);
-				} else {
-					qp = ast_malloc(sizeof(struct usrp_rxq));
-					if (qp) {
-						/* Queue the received voice frame for processing */
-						memcpy(qp->buf, bufdata, sizeof(qp->buf));
-						insque((struct qelem *) qp, (struct qelem *) pvt->rxq.qe_back);
-					}
+				ast_queue_frame(ast, &wf);
+			} else if (datalen == USRP_VOICE_FRAME_SIZE) {
+				qp = ast_malloc(sizeof(struct usrp_rxq));
+				if (qp) {
+					/* Queue the received voice frame for processing */
+					memcpy(qp->buf, bufdata, sizeof(qp->buf));
+					insque((struct qelem *) qp, (struct qelem *) pvt->rxq.qe_back);
 				}
 			}
 		}


### PR DESCRIPTION
Text frames are incorrectly gated by voice-frame length.

USRP_TYPE_TEXT handling is inside datalen == USRP_VOICE_FRAME_SIZE, so valid text packets with different lengths are dropped. Split type handling before/independent of the voice-size check.

Fixes: #1031

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced text message handling in USRP channels to be processed independently from voice frame size requirements, ensuring text content is consistently queued and delivered to the system without dependency on voice packet sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->