### PR TITLE
rpt_serial: replace for() loops with usleep() for parallel port timing

### DIFF
--- a/apps/app_rpt/rpt_serial.c
+++ b/apps/app_rpt/rpt_serial.c
@@ -430,6 +430,7 @@ static int rbi_pltocode(char *str)
 static void rbi_out_parallel(struct rpt *myrpt, unsigned char *data)
 {
 #ifdef HAVE_SYS_IO
+#ifdef __i386__
 	int i, j;
 	unsigned char od, d;
 	static volatile long long delayvar;
@@ -453,6 +454,7 @@ static void rbi_out_parallel(struct rpt *myrpt, unsigned char *data)
 	/* >= 50 us */
 	usleep(50);
 
+#endif /* __i386__ */
 #endif /* HAVE_SYS_IO */
 }
 

--- a/apps/app_rpt/rpt_serial.c
+++ b/apps/app_rpt/rpt_serial.c
@@ -430,7 +430,6 @@ static int rbi_pltocode(char *str)
 static void rbi_out_parallel(struct rpt *myrpt, unsigned char *data)
 {
 #ifdef HAVE_SYS_IO
-#ifdef __i386__
 	int i, j;
 	unsigned char od, d;
 	static volatile long long delayvar;
@@ -454,7 +453,6 @@ static void rbi_out_parallel(struct rpt *myrpt, unsigned char *data)
 	/* >= 50 us */
 	usleep(50);
 
-#endif /* __i386__ */
 #endif /* HAVE_SYS_IO */
 }
 

--- a/apps/app_rpt/rpt_serial.c
+++ b/apps/app_rpt/rpt_serial.c
@@ -441,26 +441,18 @@ static void rbi_out_parallel(struct rpt *myrpt, unsigned char *data)
 			d = od & 1;
 			outb(d, myrpt->p.iobase);
 			/* >= 15 us */
-			for (delayvar = 1; delayvar < 15000; delayvar++) {
-				;
-			}
+			usleep(15);
 			od >>= 1;
 			outb(d | 2, myrpt->p.iobase);
 			/* >= 30 us */
-			for (delayvar = 1; delayvar < 30000; delayvar++) {
-				;
-			}
+			usleep(30);
 			outb(d, myrpt->p.iobase);
 			/* >= 10 us */
-			for (delayvar = 1; delayvar < 10000; delayvar++) {
-				;
-			}
+			usleep(10);
 		}
 	}
 	/* >= 50 us */
-	for (delayvar = 1; delayvar < 50000; delayvar++) {
-		;
-	}
+	usleep(50);
 
 #endif /* __i386__ */
 #endif /* HAVE_SYS_IO */

--- a/apps/app_rpt/rpt_serial.c
+++ b/apps/app_rpt/rpt_serial.c
@@ -7,7 +7,6 @@
 
 #include "asterisk.h"
 
-#include <stdio.h>
 #include <termios.h>
 
 #include "asterisk/utils.h"

--- a/apps/app_rpt/rpt_serial.c
+++ b/apps/app_rpt/rpt_serial.c
@@ -7,7 +7,21 @@
 
 #include "asterisk.h"
 
+#include <stdio.h>
+#include <ctype.h>
+#include <math.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <sys/time.h>
+#include <stdlib.h>
 #include <termios.h>
+#include <errno.h>
+#include <usb.h>
+#include <linux/ppdev.h>
+#include <linux/parport.h>
+#include <linux/version.h>
 
 #ifdef HAVE_SYS_IO
 #include <sys/io.h>

--- a/apps/app_rpt/rpt_serial.c
+++ b/apps/app_rpt/rpt_serial.c
@@ -9,6 +9,10 @@
 
 #include <termios.h>
 
+#ifdef HAVE_SYS_IO
+#include <sys/io.h>
+#endif
+
 #include "asterisk/utils.h"
 #include "asterisk/lock.h"
 #include "asterisk/file.h"

--- a/apps/app_rpt/rpt_serial.c
+++ b/apps/app_rpt/rpt_serial.c
@@ -7,6 +7,7 @@
 
 #include "asterisk.h"
 
+#include <stdio.h>
 #include <termios.h>
 
 #include "asterisk/utils.h"

--- a/apps/app_rpt/rpt_serial.c
+++ b/apps/app_rpt/rpt_serial.c
@@ -7,25 +7,7 @@
 
 #include "asterisk.h"
 
-#include <stdio.h>
-#include <ctype.h>
-#include <math.h>
-#include <string.h>
-#include <unistd.h>
-#include <sys/ioctl.h>
-#include <fcntl.h>
-#include <sys/time.h>
-#include <stdlib.h>
 #include <termios.h>
-#include <errno.h>
-#include <usb.h>
-#include <linux/ppdev.h>
-#include <linux/parport.h>
-#include <linux/version.h>
-
-#ifdef HAVE_SYS_IO
-#include <sys/io.h>
-#endif
 
 #include "asterisk/utils.h"
 #include "asterisk/lock.h"
@@ -470,6 +452,8 @@ static void rbi_out_parallel(struct rpt *myrpt, unsigned char *data)
 	}
 	/* >= 50 us */
 	usleep(50);
+#else
+	;
 
 #endif /* HAVE_SYS_IO */
 }

--- a/apps/app_rpt/rpt_serial.c
+++ b/apps/app_rpt/rpt_serial.c
@@ -9,6 +9,10 @@
 
 #include <termios.h>
 
+#ifdef HAVE_SYS_IO
+#include <sys/io.h>
+#endif
+
 #include "asterisk/utils.h"
 #include "asterisk/lock.h"
 #include "asterisk/file.h"
@@ -453,8 +457,7 @@ static void rbi_out_parallel(struct rpt *myrpt, unsigned char *data)
 	/* >= 50 us */
 	usleep(50);
 #else
-	;
-
+	ast_log(LOG_ERROR, "Parallel port I/O is not supported on this architecture\n");
 #endif /* HAVE_SYS_IO */
 }
 

--- a/apps/app_rpt/rpt_serial.c
+++ b/apps/app_rpt/rpt_serial.c
@@ -434,7 +434,6 @@ static int rbi_pltocode(char *str)
 static void rbi_out_parallel(struct rpt *myrpt, unsigned char *data)
 {
 #ifdef HAVE_SYS_IO
-#ifdef __i386__
 	int i, j;
 	unsigned char od, d;
 	static volatile long long delayvar;
@@ -458,7 +457,6 @@ static void rbi_out_parallel(struct rpt *myrpt, unsigned char *data)
 	/* >= 50 us */
 	usleep(50);
 
-#endif /* __i386__ */
 #endif /* HAVE_SYS_IO */
 }
 

--- a/apps/app_rpt/rpt_serial.c
+++ b/apps/app_rpt/rpt_serial.c
@@ -9,9 +9,7 @@
 
 #include <termios.h>
 
-#ifdef HAVE_SYS_IO
 #include <sys/io.h>
-#endif
 
 #include "asterisk/utils.h"
 #include "asterisk/lock.h"
@@ -436,7 +434,6 @@ static void rbi_out_parallel(struct rpt *myrpt, unsigned char *data)
 #ifdef HAVE_SYS_IO
 	int i, j;
 	unsigned char od, d;
-	static volatile long long delayvar;
 
 	for (i = 0; i < 5; i++) {
 		od = *data++;

--- a/apps/app_rpt/rpt_serial.c
+++ b/apps/app_rpt/rpt_serial.c
@@ -9,8 +9,6 @@
 
 #include <termios.h>
 
-#include <sys/io.h>
-
 #include "asterisk/utils.h"
 #include "asterisk/lock.h"
 #include "asterisk/file.h"
@@ -18,6 +16,11 @@
 #include "asterisk/channel.h"
 
 #include "app_rpt.h"
+
+#ifdef HAVE_SYS_IO
+#include <sys/io.h>
+#endif
+
 #include "rpt_serial.h"
 #include "rpt_channel.h" /* use send_usb_txt */
 #include "rpt_xcat.h"


### PR DESCRIPTION
Fixes: #1016

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved timing efficiency by replacing CPU-intensive delay loops with system sleep functions, reducing unnecessary CPU usage while maintaining the same operational delays and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->