### PR TITLE
rpt_gps: failover to general_def_position if either coordinate is missing

### DIFF
--- a/apps/app_gps.c
+++ b/apps/app_gps.c
@@ -1198,7 +1198,7 @@ static void *aprstt_sender_thread(void *data)
 	int i, j, ttlist, ttoffset, ttslot, myoffset;
 	char *ctg, c;
 	char *deflat, *deflon, *defelev, ttsplit, *ttlat, *ttlon;
-	const char *val;
+	const char *val, *resolved_lat, *resolved_lon;
 	char fname[200], lat[25], theircall[20], overlay;
 	FILE *mfp;
 	struct stat mystat;
@@ -1278,9 +1278,8 @@ static void *aprstt_sender_thread(void *data)
 	 * fallback is general_def_position if either
 	 * resolved coordinate is missing
 	 */
-#if 1
-	const char *resolved_lat = ttlat ? ttlat : deflat;
-	const char *resolved_lon = ttlon ? ttlon : deflon;
+	resolved_lat = ttlat ? ttlat : deflat;
+	resolved_lon = ttlon ? ttlon : deflon;
 
 	if (!strcmp(ctg, "general") || !resolved_lat || !resolved_lon) {
 		this_def_position = general_def_position;
@@ -1298,24 +1297,6 @@ static void *aprstt_sender_thread(void *data)
 			strcpy(this_def_position.elevation, "000.0");
 		}
 	}
-#else
-	if (!strcmp(ctg, "general") || !deflat || !deflon) {
-		this_def_position = general_def_position;
-	} else {
-		this_def_position.is_valid = 1;
-		lat_decimal_to_DMS(strtof(deflat, NULL), this_def_position.latitude, sizeof(this_def_position.latitude));
-		lon_decimal_to_DMS(strtof(deflon, NULL), this_def_position.longitude, sizeof(this_def_position.longitude));
-		/* See if we have a default elevation */
-		if (defelev) {
-			float eleva, elevd;
-			eleva = strtof(defelev, NULL);
-			elevd = (eleva - floor(eleva)) * 10 + 0.5;
-			snprintf(this_def_position.elevation, sizeof(this_def_position.elevation), "%03d.%1d", (int) eleva, (int) elevd);
-		} else {
-			strcpy(this_def_position.elevation, "000.0");
-		}
-	}
-#endif
 
 	if (!strcmp(ctg, "general") || !deflat || !deflon) {
 		this_def_position = general_def_position;

--- a/apps/app_gps.c
+++ b/apps/app_gps.c
@@ -1298,23 +1298,6 @@ static void *aprstt_sender_thread(void *data)
 		}
 	}
 
-	if (!strcmp(ctg, "general") || !deflat || !deflon) {
-		this_def_position = general_def_position;
-	} else {
-		this_def_position.is_valid = 1;
-		lat_decimal_to_DMS(strtof((ttlat ? ttlat : deflat), NULL), this_def_position.latitude, sizeof(this_def_position.latitude));
-		lon_decimal_to_DMS(strtof((ttlon ? ttlon : deflon), NULL), this_def_position.longitude, sizeof(this_def_position.longitude));
-		/* See if we have a default elevation */
-		if (defelev) {
-			float eleva, elevd;
-			eleva = strtof(defelev, NULL);
-			elevd = (eleva - floor(eleva)) * 10 + 0.5;
-			snprintf(this_def_position.elevation, sizeof(this_def_position.elevation), "%03d.%1d", (int) eleva, (int) elevd);
-		} else {
-			strcpy(this_def_position.elevation, "000.0");
-		}
-	}
-
 	/*
 	 * Open the common block file for this section.
 	 * We will store the callsign and last update time.

--- a/apps/app_gps.c
+++ b/apps/app_gps.c
@@ -1273,7 +1273,50 @@ static void *aprstt_sender_thread(void *data)
 	 * If it is [general], we already have the defaults
 	 * otherwise, we need to build the specific defaults
 	 * for this section.
+	 *
+	 * Resolve to ttlat/ttlon first
+	 * fallback is general_def_position if either
+	 * resolved coordinate is missing
 	 */
+#if 1
+	const char *resolved_lat = ttlat ? ttlat : deflat;
+	const char *resolved_lon = ttlon ? ttlon : deflon;
+
+	if (!strcmp(ctg, "general") || !resolved_lat || !resolved_lon) {
+		this_def_position = general_def_position;
+	} else {
+		this_def_position.is_valid = 1;
+		lat_decimal_to_DMS(strtof(resolved_lat, NULL), this_def_position.latitude, sizeof(this_def_position.latitude));
+		lon_decimal_to_DMS(strtof(resolved_lon, NULL), this_def_position.longitude, sizeof(this_def_position.longitude));
+		/* See if we have a default elevation */
+		if (defelev) {
+			float eleva, elevd;
+			eleva = strtof(defelev, NULL);
+			elevd = (eleva - floor(eleva)) * 10 + 0.5;
+			snprintf(this_def_position.elevation, sizeof(this_def_position.elevation), "%03d.%1d", (int) eleva, (int) elevd);
+		} else {
+			strcpy(this_def_position.elevation, "000.0");
+		}
+	}
+#else
+	if (!strcmp(ctg, "general") || !deflat || !deflon) {
+		this_def_position = general_def_position;
+	} else {
+		this_def_position.is_valid = 1;
+		lat_decimal_to_DMS(strtof(deflat, NULL), this_def_position.latitude, sizeof(this_def_position.latitude));
+		lon_decimal_to_DMS(strtof(deflon, NULL), this_def_position.longitude, sizeof(this_def_position.longitude));
+		/* See if we have a default elevation */
+		if (defelev) {
+			float eleva, elevd;
+			eleva = strtof(defelev, NULL);
+			elevd = (eleva - floor(eleva)) * 10 + 0.5;
+			snprintf(this_def_position.elevation, sizeof(this_def_position.elevation), "%03d.%1d", (int) eleva, (int) elevd);
+		} else {
+			strcpy(this_def_position.elevation, "000.0");
+		}
+	}
+#endif
+
 	if (!strcmp(ctg, "general") || !deflat || !deflon) {
 		this_def_position = general_def_position;
 	} else {

--- a/apps/app_gps.c
+++ b/apps/app_gps.c
@@ -1127,7 +1127,7 @@ static void *aprs_sender_thread(void *data)
 	 * otherwise, we need to build the specific defaults
 	 * for this section.
 	 */
-	if (!strcmp(ctg, "general") || (!deflat && !deflon)) {
+	if (!strcmp(ctg, "general") || !deflat || !deflon) {
 		this_def_position = general_def_position;
 	} else {
 		this_def_position.is_valid = 1;
@@ -1274,7 +1274,7 @@ static void *aprstt_sender_thread(void *data)
 	 * otherwise, we need to build the specific defaults
 	 * for this section.
 	 */
-	if (!strcmp(ctg, "general") || (!deflat && !deflon)) {
+	if (!strcmp(ctg, "general") || !deflat || !deflon) {
 		this_def_position = general_def_position;
 	} else {
 		this_def_position.is_valid = 1;


### PR DESCRIPTION
Current behavior only fails over if both coordinates are missing.

Fixes: #1015

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved GPS position fallback behavior to use default coordinates when coordinate data is incomplete or unavailable, rather than only when data is entirely absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->