### PR TITLE
chan_echolink: Remove intermediate queue and general refactor for multi thread

### DIFF
--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -1364,7 +1364,6 @@ static int el_call(struct ast_channel *ast, const char *dest, int timeout)
 	do_new_call(instp, p, "OUTBOUND", "OUTBOUND");
 	process_cmd(buf, sizeof(buf), "127.0.0.1", instp);
 	ast_mutex_unlock(&instp->lock);
-	p->owner = ast;
 	ast_setstate(ast, AST_STATE_RINGING);
 
 	return 0;
@@ -2427,6 +2426,7 @@ static struct ast_channel *el_request(const char *type, struct ast_format_cap *c
 			el_destroy(p);
 		}
 	}
+	p->owner = tmp;
 	return tmp;
 }
 
@@ -3300,15 +3300,18 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 				ast_mutex_unlock(&el_db_lock);
 				return -1;
 			}
-			pvt->owner = chan;
+
 			ast_queue_frame(chan, &fr);
 			el_node_key->rx_ctrl_packets++;
 			ast_mutex_lock(&instp->lock);
 			time(&now);
+
 			if (instp->starttime < (now - EL_APRS_START_DELAY)) {
 				instp->aprstime = now;
 			}
+
 			ast_mutex_unlock(&instp->lock);
+
 		} else {
 			el_node_key->pvt = pvt;
 			ast_copy_string(el_node_key->pvt->ip, instp->el_node_test.ip, EL_IP_SIZE);
@@ -3317,9 +3320,11 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 			ast_mutex_lock(&instp->lock);
 			strcpy(instp->lastcall, mynode->callsign);
 			time(&now);
+
 			if (instp->starttime < (now - EL_APRS_START_DELAY)) {
 				instp->aprstime = now;
 			}
+
 			ast_mutex_unlock(&instp->lock);
 		}
 

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -458,6 +458,7 @@ struct el_instance {
 	struct timeval current_talker_start_time;
 	struct timeval current_talker_last_time;
 	pthread_t el_reader_thread;
+	pthread_t el_register_thread;
 };
 
 /*!
@@ -521,7 +522,6 @@ static void *el_db_nodenum = NULL;
 static void *el_db_ipaddr = NULL;
 
 /* Echolink registration thread */
-static pthread_t el_register_thread = 0;
 static pthread_t el_directory_thread = 0;
 static int run_forever = 1;
 static int el_sleeptime = 0;
@@ -1414,6 +1414,7 @@ static void el_destroy(void *obj)
 	if (p->u) {
 		ast_module_user_remove(p->u);
 	}
+	ast_mutex_destroy(&p->lock);
 }
 
 /*!
@@ -1447,6 +1448,7 @@ static struct el_pvt *el_alloc(const char *data)
 		p->keepalive = KEEPALIVE_TIME;
 		p->instp = instances[n];
 		p->dsp = ast_dsp_new();
+		ast_mutex_init(&p->lock);
 
 		if (!p->dsp) {
 			ast_log(LOG_ERROR, "Cannot get DSP!\n");
@@ -1466,9 +1468,8 @@ static struct el_pvt *el_alloc(const char *data)
 			ao2_cleanup(p);
 			return NULL;
 		}
-
-		ast_mutex_init(&p->lock);
 	}
+
 	return p;
 }
 
@@ -1519,7 +1520,6 @@ static int el_hangup(struct ast_channel *chan)
 	}
 
 	ast_channel_tech_pvt_set(chan, NULL);
-	ast_mutex_destroy(&p->lock);
 	ao2_ref(p, -1);
 	ast_setstate(chan, AST_STATE_DOWN);
 
@@ -2000,8 +2000,9 @@ static void process_unkey_timers(const void *nodep, const VISIT which, void *clo
 		if (p->rxkey <= 0) {
 			/* The timer has expired, queue up an unkey for the channel */
 			struct ast_channel *chan;
-
+			ast_mutex_lock(&p->lock);
 			chan = p->owner ? ast_channel_ref(p->owner) : NULL;
+			ast_mutex_unlock(&p->lock);
 			if (chan) {
 				struct pending_ctrl item = {
 					.chan = chan,
@@ -2343,7 +2344,7 @@ static void process_cmd(char *buf, int buf_len, const char *fromip, struct el_in
 			pack_length = rtcp_make_bye(pack, sizeof(pack), "bye");
 			n = 20;
 			ast_copy_string(key.ip, arg1, sizeof(key.ip));
-			if (find_delete(&key, NULL)) {
+			if (find_delete(&key, instp)) {
 				for (i = 0; i < n; i++) {
 					sendto(instp->ctrl_sock, pack, pack_length, 0, (struct sockaddr *) &sin, sizeof(sin));
 				}
@@ -3506,7 +3507,7 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *p, const char *
 
 	ast_mutex_lock(&el_nodelist_lock);
 
-	if (tsearch(el_node_key, &el_node_list, compare_ip)) {
+	if (tfind(el_node_key, &el_node_list, compare_ip)) {
 		ast_debug(1, "New Call - Callsign %s, IP Address %s, Node %i, Name %s.\n", el_node_key->call, el_node_key->ip,
 			el_node_key->nodenum, el_node_key->name);
 
@@ -3571,7 +3572,7 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *p, const char *
 
 		ast_mutex_unlock(&el_nodelist_lock);
 		ast_mutex_unlock(&el_db_lock);
-
+		tsearch(el_node_key, &el_node_list, compare_ip); /* Add the node to the list  after everything is "happy" */
 		return 0;
 	}
 
@@ -3845,6 +3846,7 @@ static void *el_reader(void *data)
 			instp->rx_ctrl_packets++;
 			fromlen = sizeof(struct sockaddr_in);
 			recvlen = recvfrom(instp->ctrl_sock, buf, sizeof(buf) - 1, 0, (struct sockaddr *) &sin, &fromlen);
+			ast_copy_string(node_lookup.ip, ast_inet_ntoa(sin.sin_addr), EL_IP_SIZE);
 			if (recvlen > 0) {
 				buf[recvlen] = '\0';
 				if (is_rtcp_sdes((unsigned char *) buf, recvlen)) {
@@ -4216,7 +4218,6 @@ static int store_config(struct ast_config *cfg, char *ctg)
 		return -1;
 	}
 
-	ast_mutex_init(&instp->lock);
 	instp->audio_sock = -1;
 	instp->ctrl_sock = -1;
 	instp->fdr = -1;
@@ -4506,7 +4507,7 @@ static int store_config(struct ast_config *cfg, char *ctg)
 	}
 
 	/* start the registration thread */
-	ast_pthread_create(&el_register_thread, NULL, el_register, instp);
+	ast_pthread_create(&instp->el_register_thread, NULL, el_register, instp);
 	ast_pthread_create(&instp->el_reader_thread, NULL, el_reader, instp);
 	instances[ninstances++] = instp;
 
@@ -4531,7 +4532,6 @@ static int unload_module(void)
 
 	/* Wait for all threads to exit */
 	pthread_join(el_directory_thread, NULL);
-	pthread_join(el_register_thread, NULL);
 
 	ast_debug(1, "We have %d Echolink instance%s.\n", ninstances, ESS(ninstances));
 
@@ -4547,6 +4547,7 @@ static int unload_module(void)
 		}
 		if (instances[n]->el_reader_thread) {
 			pthread_join(instances[n]->el_reader_thread, NULL);
+			pthread_join(instances[n]->el_register_thread, NULL);
 			ast_mutex_destroy(&instances[n]->lock);
 		}
 		if (instances[n]->denylist[0]) {

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -1409,8 +1409,6 @@ static void el_destroy(void *obj)
 	if (pvt->u) {
 		ast_module_user_remove(pvt->u);
 	}
-
-	ast_free(pvt);
 }
 
 /*!
@@ -1446,6 +1444,7 @@ static struct el_pvt *el_alloc(const char *data)
 		pvt->dsp = ast_dsp_new();
 		if (!pvt->dsp) {
 			ast_log(LOG_ERROR, "Cannot get DSP!\n");
+			ao2_cleanup(pvt);
 			return NULL;
 		}
 		pvt->hangup = 0;
@@ -1454,6 +1453,7 @@ static struct el_pvt *el_alloc(const char *data)
 		pvt->xpath = ast_translator_build_path(ast_format_slin, ast_format_gsm);
 		if (!pvt->xpath) {
 			ast_log(LOG_ERROR, "Cannot get translator!\n");
+			ao2_cleanup(pvt);
 			return NULL;
 		}
 	}
@@ -3748,6 +3748,7 @@ static void *el_reader(void *data)
 		if (i < 0) {
 			ast_log(LOG_ERROR, "Fatal error, poll returned %d: %s\n", i, strerror(errno));
 			run_forever = 0;
+			ast_mutex_lock(&instp->lock);
 			break;
 		}
 
@@ -4464,16 +4465,6 @@ static int unload_module(void)
 	pthread_join(el_directory_thread, NULL);
 	pthread_join(el_register_thread, NULL);
 
-	if (el_node_list) {
-		ast_mutex_lock(&el_nodelist_lock);
-		tdestroy(el_node_list, free_node);
-		ast_mutex_unlock(&el_nodelist_lock);
-	}
-
-	if (el_db_callsign) {
-		el_db_delete_all_nodes();
-	}
-
 	ast_debug(1, "We have %d Echolink instance%s.\n", ninstances, ESS(ninstances));
 
 	for (n = 0; n < ninstances; n++) {
@@ -4495,6 +4486,16 @@ static int unload_module(void)
 		if (instances[n]->permitlist[0]) {
 			ast_free(instances[n]->permitlist[0]);
 		}
+	}
+
+	if (el_node_list) {
+		ast_mutex_lock(&el_nodelist_lock);
+		tdestroy(el_node_list, free_node);
+		ast_mutex_unlock(&el_nodelist_lock);
+	}
+
+	if (el_db_callsign) {
+		el_db_delete_all_nodes();
 	}
 
 	ast_cli_unregister_multiple(el_cli, sizeof(el_cli) / sizeof(struct ast_cli_entry));

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -1402,10 +1402,7 @@ static void el_destroy(void *obj)
 		ast_free(p->linkstr);
 	}
 
-	ast_mutex_lock(&p->lock);
 	p->linkstr = NULL;
-	p->owner = NULL;
-	ast_mutex_unlock(&p->lock);
 
 	ast_mutex_lock(&el_nodelist_lock);
 	twalk(el_node_list, send_info);
@@ -2000,6 +1997,7 @@ static void process_unkey_timers(const void *nodep, const VISIT which, void *clo
 		if (p->rxkey <= 0) {
 			/* The timer has expired, queue up an unkey for the channel */
 			struct ast_channel *chan;
+
 			ast_mutex_lock(&p->lock);
 			chan = p->owner ? ast_channel_ref(p->owner) : NULL;
 			ast_mutex_unlock(&p->lock);

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -2001,7 +2001,7 @@ static void process_unkey_timers(const void *nodep, const VISIT which, void *clo
 			pvt->rxkey = 0;
 		}
 
-		ao2_ref(pvt, -1);
+		ao2_cleanup(pvt);
 	}
 }
 
@@ -3453,6 +3453,8 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 	mynode = el_db_find_ipaddr(el_node_key->ip);
 	if (!mynode) {
 		ast_log(LOG_ERROR, "Cannot find database entry for IP address %s, Callsign %s.\n", el_node_key->ip, call);
+		ao2_cleanup(el_node_key->pvt);
+		el_node_key->pvt = NULL;
 		ast_free(el_node_key);
 		ast_mutex_unlock(&el_db_lock);
 		return 1;
@@ -3480,6 +3482,8 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 			pvt = el_alloc(instp->name);
 			if (!pvt) {
 				ast_log(LOG_ERROR, "Cannot alloc el channel %s.\n", instp->name);
+				ao2_cleanup(el_node_key->pvt);
+				el_node_key->pvt = NULL;
 				ast_free(el_node_key);
 				ast_mutex_unlock(&el_db_lock);
 				ast_mutex_unlock(&el_nodelist_lock);
@@ -3493,6 +3497,7 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 
 			if (!chan) {
 				ao2_cleanup(el_node_key->pvt);
+				el_node_key->pvt = NULL;
 				ast_free(el_node_key);
 				ast_mutex_unlock(&el_db_lock);
 				ast_mutex_unlock(&el_nodelist_lock);
@@ -3534,6 +3539,8 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 
 	ast_log(LOG_ERROR, "Failed to add new call, Callsign %s, IP Address %s, Name %s.\n", el_node_key->call, el_node_key->ip,
 		el_node_key->name);
+	ao2_cleanup(el_node_key->pvt);
+	el_node_key->pvt = NULL;
 	ast_free(el_node_key);
 	ast_mutex_unlock(&el_nodelist_lock);
 	ast_mutex_unlock(&el_db_lock);
@@ -3960,7 +3967,7 @@ static void *el_reader(void *data)
 								node->isdoubling = 1;
 								ast_mutex_unlock(&el_nodelist_lock);
 								ast_channel_unref(ast);
-								ao2_ref(pvt, -1);
+								ao2_cleanup(pvt);
 								continue;
 							}
 						}
@@ -3974,7 +3981,7 @@ static void *el_reader(void *data)
 							node->istimedout = 1;
 							ast_mutex_unlock(&el_nodelist_lock);
 							ast_channel_unref(ast);
-							ao2_ref(pvt, -1);
+							ao2_cleanup(pvt);
 							continue;
 						}
 
@@ -4048,7 +4055,7 @@ static void *el_reader(void *data)
 						}
 
 						ast_channel_unref(ast);
-						ao2_ref(pvt, -1);
+						ao2_cleanup(pvt);
 					} else {
 						instp->rx_bad_packets++;
 					}

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -186,8 +186,8 @@ do not use 127.0.0.1
 #include "asterisk/cli.h"
 #include "asterisk/format_cache.h"
 
-#define MAX_RXKEY_TIME 320	   /* ms */
-#define KEEPALIVE_TIME 10000   /* ms = 10 seconds heartbeat */
+#define MAX_RXKEY_TIME 320	 /* ms */
+#define KEEPALIVE_TIME 10000 /* ms = 10 seconds heartbeat */
 #define AUTH_RETRY_MS 5000
 #define AUTH_ABANDONED_MS 15000
 #define BLOCKING_FACTOR 4

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -1985,6 +1985,7 @@ static void process_unkey_timers(const void *nodep, const VISIT which, void *clo
 		if (pvt->rxkey <= 0) {
 			/* The timer has expired, queue up an unkey for the channel */
 			struct ast_channel *chan;
+
 			chan = pvt->owner ? ast_channel_ref(pvt->owner) : NULL;
 			if (chan) {
 				struct pending_ctrl item = {
@@ -2172,10 +2173,13 @@ static int find_delete(const struct el_node *key, struct el_instance *instp)
 	int found = 0;
 	struct el_node **found_key;
 	struct el_node *node;
+
 	ast_mutex_lock(&el_nodelist_lock);
+
 	found_key = (struct el_node **) tfind(key, &el_node_list, compare_ip);
 	if (found_key) {
 		node = *found_key;
+
 		if (instp) {
 			if (instp->current_talker == node) {
 				ast_debug(3, "Current talker %s is disconnecting, clearing current talker.\n", node->call);
@@ -2186,6 +2190,7 @@ static int find_delete(const struct el_node *key, struct el_instance *instp)
 				instp->current_talker_last_time = (struct timeval) { 0 };
 			}
 		}
+
 		ast_debug(3, "Removing from current node list Callsign %s, IP Address %s.\n", node->call, node->ip);
 		found = 1;
 		node->pvt->hangup = 1;
@@ -2194,6 +2199,7 @@ static int find_delete(const struct el_node *key, struct el_instance *instp)
 		node->pvt = NULL;
 		ast_free(node);
 	}
+
 	ast_mutex_unlock(&el_nodelist_lock);
 	return found;
 }
@@ -2250,10 +2256,12 @@ static void process_cmd(char *buf, int buf_len, const char *fromip, struct el_in
 	if (strncmp(fromip, "127.0.0.1", EL_IP_SIZE) != 0) {
 		return;
 	}
+
 	ptr = strchr(buf, (int) '\r');
 	if (ptr) {
 		*ptr = '\0';
 	}
+
 	ptr = strchr(buf, (int) '\n');
 	if (ptr) {
 		*ptr = '\0';
@@ -2279,6 +2287,7 @@ static void process_cmd(char *buf, int buf_len, const char *fromip, struct el_in
 				ast_debug(3, "Recording into %s started.\n", instp->fdr_file);
 			}
 		}
+
 		return;
 	}
 
@@ -2306,6 +2315,7 @@ static void process_cmd(char *buf, int buf_len, const char *fromip, struct el_in
 			pack_length = rtcp_make_bye(pack, sizeof(pack), "bye");
 			n = 20;
 		}
+
 		memset(&sin, 0, sizeof(sin));
 		sin.sin_family = AF_INET;
 		sin.sin_port = htons(instp->ctrl_port);
@@ -2327,8 +2337,10 @@ static void process_cmd(char *buf, int buf_len, const char *fromip, struct el_in
 			}
 			ast_debug(3, "Connect request sent to %s.\n", arg1);
 		}
+
 		return;
 	}
+
 	instp->rx_bad_packets++;
 }
 
@@ -2903,6 +2915,7 @@ static int sendcmd(const char *server, const struct el_instance *instp)
 	}
 
 	buf[0] = '\0';
+
 	while (1) {
 		rc = read(sd, buf, LOGINSIZE);
 		if (rc > 0) {
@@ -2912,6 +2925,7 @@ static int sendcmd(const char *server, const struct el_instance *instp)
 			break;
 		}
 	}
+
 	close(sd);
 
 	if (strncmp(buf, "OK", 2)) {
@@ -2985,6 +2999,7 @@ static int el_net_read(int sock, unsigned char *buf1, int buf1len, int compresse
 			}
 			return n;
 		}
+
 		memset(buf1, 0, buf1len);
 		memset(buf, 0, sizeof(buf));
 		n = recv(sock, buf, sizeof(buf) - 1, 0);
@@ -3098,7 +3113,6 @@ static int do_el_directory(const char *hostname)
 	}
 
 	host = ast_gethostbyname(hostname, &ah);
-
 	if (!host) {
 		ast_log(LOG_ERROR, "Unable to resolve name for directory server %s.\n", hostname);
 		inflateEnd(&z);
@@ -3224,7 +3238,6 @@ static int do_el_directory(const char *hostname)
 		}
 
 		str_len = strlen(str);
-
 		if (str[str_len - 1] == '\n') {
 			str[str_len - 1] = 0;
 		}
@@ -3393,6 +3406,7 @@ static void *el_register(void *data)
 		time(&now);
 		el_login_sleeptime -= (now - then);
 		then = now;
+
 		if (el_login_sleeptime < 0) {
 			el_login_sleeptime = 0;
 		}
@@ -3450,7 +3464,6 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 	time_t now;
 
 	el_node_key = ast_calloc(1, sizeof(struct el_node));
-
 	if (!el_node_key) {
 		return -1;
 	}
@@ -3504,8 +3517,8 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 			ao2_ref(pvt, +1);
 			el_node_key->pvt = pvt;
 			ast_copy_string(el_node_key->pvt->ip, instp->el_node_test.ip, EL_IP_SIZE);
-			chan = el_new(el_node_key->pvt, AST_STATE_RINGING, el_node_key->nodenum, NULL, NULL);
 
+			chan = el_new(el_node_key->pvt, AST_STATE_RINGING, el_node_key->nodenum, NULL, NULL);
 			if (!chan) {
 				ao2_cleanup(el_node_key->pvt);
 				el_node_key->pvt = NULL;
@@ -3677,7 +3690,6 @@ static void *el_reader(void *data)
 					if (sscanf(gps_data, N_FMT(llu) " %*u " N_FMT(f) N_FMT(c) N_FMT(f) N_FMT(c), &u_mono, &lat, &latc, &lon, &lonc) == 5) {
 						now_mono = time_monotonic();
 						was_mono = (time_t) u_mono;
-
 						if ((was_mono + GPS_VALID_SECS) >= now_mono) {
 							mylat = floor(lat / 100.0);
 							mylat += (lat - (mylat * 100)) / 60.0;
@@ -3728,8 +3740,8 @@ static void *el_reader(void *data)
 
 				sin_aprs.sin_family = AF_INET;
 				sin_aprs.sin_port = htons(5199);
-				ahp = ast_gethostbyname(EL_APRS_SERVER, &ah);
 
+				ahp = ast_gethostbyname(EL_APRS_SERVER, &ah);
 				if (!ahp) {
 					ast_log(LOG_WARNING, "Unable to resolve echolink APRS server IP address %s.\n", EL_APRS_SERVER);
 					memset(&sin_aprs, 0, sizeof(sin_aprs));

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -3505,7 +3505,7 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *p, const char *
 		ast_debug(1, "New Call - Callsign %s, IP Address %s, Node %i, Name %s.\n", el_node_key->call, el_node_key->ip,
 			el_node_key->nodenum, el_node_key->name);
 
-		if (p == NULL) { 
+		if (p == NULL) {
 			/* A new inbound call */
 			struct ast_frame fr = {
 				.frametype = AST_FRAME_CONTROL,
@@ -3546,7 +3546,7 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *p, const char *
 			el_node_key->pvt = p;
 			ast_mutex_unlock(&instp->lock);
 
-		} else { 
+		} else {
 			/* A new outbound call*/
 			ao2_ref(p, 1);
 			el_node_key->pvt = p; /* Assign the passed in reference for an outbound call */

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -187,7 +187,7 @@ do not use 127.0.0.1
 #include "asterisk/format_cache.h"
 
 #define MAX_RXKEY_TIME 320	   /* ms */
-#define KEEPALIVE_TIME 50 * 10 /* 50 * 10 * 20ms iax2 = 10,000ms = 10 seconds heartbeat */
+#define KEEPALIVE_TIME 10000   /* ms = 10 seconds heartbeat */
 #define AUTH_RETRY_MS 5000
 #define AUTH_ABANDONED_MS 15000
 #define BLOCKING_FACTOR 4
@@ -2309,16 +2309,13 @@ static struct ast_frame *el_xread(struct ast_channel *ast)
 
 /*!
  * \brief Asterisk write function.
- * This routine handles echolink to asterisk and asterisk to echolink.
+ * This routine handles asterisk to echolink.
  * \param ast			Pointer to Asterisk channel.
  * \param frame			Pointer to Asterisk frame to process.
  * \retval 0			Successful.
  */
 static int el_xwrite(struct ast_channel *ast, struct ast_frame *frame)
 {
-	int bye_length;
-	unsigned char bye[50];
-	unsigned short i;
 	struct sockaddr_in sin;
 	struct el_pvt *p = ast_channel_tech_pvt(ast);
 	struct el_instance *instp = p->instp;
@@ -2333,9 +2330,11 @@ static int el_xwrite(struct ast_channel *ast, struct ast_frame *frame)
 		ast_queue_frame(ast, &fr3);
 		p->last_firstheard = 1;
 	}
+
 	if (frame->frametype != AST_FRAME_VOICE) {
 		return 0;
 	}
+
 	if (p->hangup) {
 		ast_softhangup(ast, AST_SOFTHANGUP_DEV);
 		p->hangup = 0;
@@ -2357,6 +2356,7 @@ static int el_xwrite(struct ast_channel *ast, struct ast_frame *frame)
 
 		instp->tx_ctrl_packets++;
 	}
+
 	/* Asterisk to Echolink */
 	if (ast_format_cap_iscompatible_format(ast_channel_nativeformats(ast), frame->subclass.format) == AST_FORMAT_CMP_NOT_EQUAL) {
 		struct ast_str *cap_buf = ast_str_alloca(AST_FORMAT_CAP_NAMES_LEN);
@@ -2365,9 +2365,11 @@ static int el_xwrite(struct ast_channel *ast, struct ast_frame *frame)
 			ast_format_get_name(ast_channel_readformat(ast)), ast_format_get_name(ast_channel_writeformat(ast)));
 		return 0;
 	}
+
 	if (p->txkey || p->txindex) {
 		memcpy(instp->audio_all.data + (GSM_FRAME_SIZE * p->txindex++), frame->data.ptr, GSM_FRAME_SIZE);
 	}
+
 	if (p->txindex >= BLOCKING_FACTOR) {
 		ast_mutex_lock(&instp->lock);
 		strcpy(instp->el_node_test.ip, p->ip);
@@ -2378,34 +2380,6 @@ static int el_xwrite(struct ast_channel *ast, struct ast_frame *frame)
 		p->txindex = 0;
 	}
 
-	if (p->keepalive--) {
-		return 0;
-	}
-	p->keepalive = KEEPALIVE_TIME;
-
-	/* Echolink: send heartbeats and drop dead stations */
-	ast_mutex_lock(&instp->lock);
-	instp->el_node_test.ip[0] = '\0';
-	ast_mutex_lock(&el_nodelist_lock);
-	twalk(el_node_list, send_heartbeat);
-	ast_mutex_unlock(&el_nodelist_lock);
-	if (instp->el_node_test.ip[0] != '\0') {
-		if (find_delete(&instp->el_node_test)) {
-			bye_length = rtcp_make_bye(bye, sizeof(bye), "rtcp timeout");
-			memset(&sin, 0, sizeof(sin));
-			sin.sin_family = AF_INET;
-			sin.sin_addr.s_addr = inet_addr(instp->el_node_test.ip);
-			sin.sin_port = htons(instp->ctrl_port);
-			/* send 20 bye packets to insure that they receive this disconnect */
-			for (i = 0; i < 20; i++) {
-				sendto(instp->ctrl_sock, bye, bye_length, 0, (struct sockaddr *) &sin, sizeof(sin));
-				instp->tx_ctrl_packets++;
-			}
-			ast_verb(4, "Callsign %s RTCP timeout, removing connection.\n", instp->el_node_test.call);
-		}
-		instp->el_node_test.ip[0] = '\0';
-	}
-	ast_mutex_unlock(&instp->lock);
 	return 0;
 }
 
@@ -2435,9 +2409,11 @@ static struct ast_channel *el_new(struct el_pvt *pvt, int state, unsigned int no
 	ast_channel_set_rawwriteformat(tmp, ast_format_gsm);
 	ast_channel_set_writeformat(tmp, ast_format_gsm);
 	ast_channel_set_readformat(tmp, ast_format_gsm);
+
 	if (state == AST_STATE_RING) {
 		ast_channel_rings_set(tmp, 1);
 	}
+
 	ast_channel_tech_pvt_set(tmp, pvt);
 	ast_channel_context_set(tmp, pvt->instp->context);
 	ast_channel_exten_set(tmp, pvt->instp->astnode);
@@ -2450,14 +2426,17 @@ static struct ast_channel *el_new(struct el_pvt *pvt, int state, unsigned int no
 		snprintf(tmpstr, sizeof(tmpstr), "3%06u", nodenum);
 		ast_set_callerid(tmp, tmpstr, NULL, NULL);
 	}
+
 	pvt->u = ast_module_user_add(tmp);
 	pvt->nodenum = nodenum;
+
 	if (state != AST_STATE_DOWN) {
 		if (ast_pbx_start(tmp)) {
 			ast_log(LOG_WARNING, "Unable to start PBX on %s.\n", ast_channel_name(tmp));
 			ast_hangup(tmp);
 		}
 	}
+
 	pvt->owner = tmp;
 	return tmp;
 }
@@ -2505,7 +2484,6 @@ static struct ast_channel *el_request(const char *type, struct ast_format_cap *c
 	}
 
 	p = el_alloc(str);
-
 	if (p) {
 		tmp = el_new(p, AST_STATE_DOWN, nodenum, assignedids, requestor);
 		if (!tmp) {
@@ -2534,7 +2512,9 @@ static int el_do_dbdump(int fd, int argc, const char *const *argv)
 	if (argc > 2) {
 		c = tolower(*argv[2]);
 	}
+
 	ast_mutex_lock(&el_db_lock);
+
 	if (c == 'i') {
 		twalk_r(el_db_ipaddr, print_nodes, &fd);
 	} else if (c == 'c') {
@@ -2542,6 +2522,7 @@ static int el_do_dbdump(int fd, int argc, const char *const *argv)
 	} else {
 		twalk_r(el_db_nodenum, print_nodes, &fd);
 	}
+
 	ast_mutex_unlock(&el_db_lock);
 	return RESULT_SUCCESS;
 }
@@ -2566,6 +2547,7 @@ static int el_do_dbget(int fd, int argc, const char *const *argv)
 
 	c = tolower(*argv[2]);
 	ast_mutex_lock(&el_db_lock);
+
 	if (c == 'i') {
 		/* Lookup node data by IP address */
 		mynode = el_db_find_ipaddr(argv[3]);
@@ -2580,6 +2562,7 @@ static int el_do_dbget(int fd, int argc, const char *const *argv)
 			mynode = &found_node;
 		}
 	}
+
 	/* Report failure to find node */
 	if (!mynode) {
 		ast_cli(fd, "Error: Entry for %s not found!\n", argv[3]);
@@ -2680,6 +2663,7 @@ static char *handle_cli_dbdump(struct ast_cli_entry *e, int cmd, struct ast_cli_
 	case CLI_GENERATE:
 		return NULL;
 	}
+
 	return res2cli(el_do_dbdump(a->fd, a->argc, a->argv));
 }
 
@@ -2700,6 +2684,7 @@ static char *handle_cli_dbget(struct ast_cli_entry *e, int cmd, struct ast_cli_a
 	case CLI_GENERATE:
 		return NULL;
 	}
+
 	return res2cli(el_do_dbget(a->fd, a->argc, a->argv));
 }
 
@@ -2720,6 +2705,7 @@ static char *handle_cli_show_nodes(struct ast_cli_entry *e, int cmd, struct ast_
 	case CLI_GENERATE:
 		return NULL;
 	}
+
 	return res2cli(el_do_show_nodes(a->fd, a->argc, a->argv));
 }
 
@@ -2740,6 +2726,7 @@ static char *handle_cli_show_stats(struct ast_cli_entry *e, int cmd, struct ast_
 	case CLI_GENERATE:
 		return NULL;
 	}
+
 	return res2cli(el_do_show_stats(a->fd, a->argc, a->argv));
 }
 
@@ -2775,12 +2762,15 @@ static int writen(int fd, const char *buffer, int nbytes)
 
 	while (nleft > 0) {
 		nwritten = write(fd, local_ptr, nleft);
+
 		if (nwritten < 0) {
 			return nwritten;
 		}
+
 		nleft -= nwritten;
 		local_ptr += nwritten;
 	}
+
 	return (nbytes - nleft);
 }
 
@@ -2889,12 +2879,13 @@ static void el_db_delete_all_nodes(void)
 	struct eldb *node;
 
 	ast_mutex_lock(&el_db_lock);
+
 	while (el_db_callsign) {
 		node = *(struct eldb **) el_db_callsign;
 		el_db_delete_entries(node);
 	}
-	ast_mutex_unlock(&el_db_lock);
 
+	ast_mutex_unlock(&el_db_lock);
 	ast_assert((!el_db_nodenum && !el_db_callsign && !el_db_ipaddr));
 }
 
@@ -2908,11 +2899,13 @@ static void el_db_delete_call(const char *call)
 
 	ast_debug(5, "Directory - Attempt to delete: Call=%s.\n", call);
 	ast_mutex_lock(&el_db_lock);
+
 	mynode = el_db_find_callsign(call);
 	if (mynode) {
 		ast_debug(5, "Directory - Deleted: Node=%s, Call=%s, IP=%s.\n", mynode->nodenum, mynode->callsign, mynode->ipaddr);
 		el_db_delete_entries(mynode);
 	}
+
 	ast_mutex_unlock(&el_db_lock);
 }
 
@@ -2951,19 +2944,24 @@ static int el_net_read(int sock, unsigned char *buf1, int buf1len, int compresse
 		z->next_out = buf1;
 		z->avail_out = buf1len;
 		r = inflate(z, Z_NO_FLUSH);
+
 		if ((r != Z_OK) && (r != Z_STREAM_END)) {
 			if (z->msg) {
 				ast_log(LOG_ERROR, "Unable to inflate (Zlib): %s.\n", z->msg);
 			} else {
 				ast_log(LOG_ERROR, "Unable to inflate (Zlib).\n");
 			}
+
 			return -1;
 		}
+
 		r = buf1len - z->avail_out;
+
 		if ((!n) || r) {
 			break;
 		}
 	}
+
 	return (buf1len - z->avail_out);
 }
 
@@ -2987,23 +2985,29 @@ static int el_net_get_line(int s, char *str, int max, int compressed, struct z_s
 		if (el_net_get_index >= el_net_get_nread) {
 			el_net_get_index = 0;
 			el_net_get_nread = el_net_read(s, buf, sizeof(buf), compressed, z);
+
 			if ((el_net_get_nread) < 1) {
 				return el_net_get_nread;
 			}
 		}
+
 		if (buf[el_net_get_index] > 126) {
 			buf[el_net_get_index] = ' ';
 		}
+
 		c = buf[el_net_get_index++];
 		str[nstr++] = c & 0x7f;
 		str[nstr] = 0;
+
 		if (c < ' ') {
 			break;
 		}
+
 		if (nstr >= max) {
 			break;
 		}
 	}
+
 	return nstr;
 }
 
@@ -3030,45 +3034,57 @@ static int do_el_directory(const char *hostname)
 	el_net_get_index = 0;
 	el_net_get_nread = 0;
 	memset(&z, 0, sizeof(z));
+
 	if (inflateInit(&z) != Z_OK) {
 		if (z.msg) {
 			ast_log(LOG_ERROR, "Unable to initialize Zlib: %s.\n", z.msg);
 		} else {
 			ast_log(LOG_ERROR, "Unable to initialize Zlib.\n");
 		}
+
 		return -1;
 	}
+
 	host = ast_gethostbyname(hostname, &ah);
+
 	if (!host) {
 		ast_log(LOG_ERROR, "Unable to resolve name for directory server %s.\n", hostname);
 		inflateEnd(&z);
 		return -1;
 	}
+
 	memset(&dirserver, 0, sizeof(dirserver)); /* Clear struct */
 	dirserver.sin_family = AF_INET;			  /* Internet/IP */
 	dirserver.sin_addr.s_addr = *(unsigned long *) host->h_addr_list[0];
 	dirserver.sin_port = htons(EL_DIRECTORY_PORT); /* server port */
+
 	sock = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
 	if (sock < 0) {
 		ast_log(LOG_ERROR, "Unable to obtain a socket for directory server %s.\n", hostname);
 		inflateEnd(&z);
 		return -1;
 	}
+
 	/* Establish connection */
 	if (connect(sock, (struct sockaddr *) &dirserver, sizeof(dirserver)) < 0) {
 		ast_log(LOG_ERROR, "Unable to connect to directory server %s.\n", hostname);
 		goto cleanup;
 	}
+
 	snprintf(str, sizeof(str), "F%s\r", snapshot_id);
+
 	if (send(sock, str, strlen(str), 0) < 0) {
 		ast_log(LOG_ERROR, "Unable to send to directory server %s.\n", hostname);
 		goto cleanup;
 	}
+
 	ast_debug(4, "Sending: %s to %s.\n", str, hostname);
+
 	if (recv(sock, str, 4, 0) != 4) {
 		ast_log(LOG_ERROR, "Error in directory download (header) on %s.\n", hostname);
 		goto cleanup;
 	}
+
 	dir_compressed = 1;
 	dir_partial = 0;
 	/* Determine if the response is full, partial or the stream is compressed.
@@ -3083,6 +3099,7 @@ static int do_el_directory(const char *hostname)
 		dir_partial = 1;
 		dir_compressed = 0;
 	}
+
 	if (dir_compressed) {
 		if (el_net_get_line(sock, str, sizeof(str) - 1, dir_compressed, &z) < 1) {
 			ast_log(LOG_ERROR, "Error in directory download (header) on %s.\n", hostname);
@@ -3097,22 +3114,26 @@ static int do_el_directory(const char *hostname)
 			goto cleanup;
 		}
 	}
+
 	/* read the header line with the line count and possibly the snapshot id */
 	if (el_net_get_line(sock, str, sizeof(str) - 1, dir_compressed, &z) < 1) {
 		ast_log(LOG_ERROR, "Error in directory download (header) on %s.\n", hostname);
 		goto cleanup;
 	}
+
 	if (dir_compressed) {
 		if (sscanf(str, N_FMT(d) ":" S_FMT(SNAPSHOT_SZ), &rep_lines, snapshot_id) < 2) {
 			ast_log(LOG_ERROR, "Error in parsing header on %s.\n", hostname);
 			goto cleanup;
 		}
+
 	} else {
 		if (sscanf(str, N_FMT(d), &rep_lines) < 1) {
 			ast_log(LOG_ERROR, "Error in parsing header on %s.\n", hostname);
 			goto cleanup;
 		}
 	}
+
 	delmode = 0;
 	/* if the returned directory is not partial - we should
 	 * delete all existing directory messages
@@ -3131,77 +3152,99 @@ static int do_el_directory(const char *hostname)
 		if (el_net_get_line(sock, str, sizeof(str) - 1, dir_compressed, &z) < 1) {
 			break;
 		}
+
 		if (*str <= ' ') {
 			break;
 		}
+
 		/* see if we are at the end of the current list */
 		if (!strncmp(str, "+++", 3)) {
 			if (delmode) {
 				break;
 			}
+
 			if (!dir_partial) {
 				break;
 			}
+
 			delmode = 1;
 			continue;
 		}
+
 		str_len = strlen(str);
+
 		if (str[str_len - 1] == '\n') {
 			str[str_len - 1] = 0;
 		}
+
 		ast_copy_string(call, str, sizeof(call));
+
 		if (dir_partial) {
 			el_db_delete_call(call);
 			if (delmode) {
 				continue;
 			}
 		}
+
 		/* read the location / status line (we will not use this line) */
 		if (el_net_get_line(sock, str, sizeof(str) - 1, dir_compressed, &z) < 1) {
 			ast_log(LOG_ERROR, "Error in directory download on %s.\n", hostname);
 			el_db_delete_all_nodes();
 			goto cleanup;
 		}
+
 		/* read the node number line */
 		if (el_net_get_line(sock, str, sizeof(str) - 1, dir_compressed, &z) < 1) {
 			ast_log(LOG_ERROR, "Error in directory download on %s.\n", hostname);
 			el_db_delete_all_nodes();
 			goto cleanup;
 		}
+
 		str_len = strlen(str);
+
 		if (str[str_len - 1] == '\n') {
 			str[str_len - 1] = 0;
 		}
+
 		ast_copy_string(nodenum, str, sizeof(nodenum));
+
 		/* read the ip address line */
 		if (el_net_get_line(sock, str, sizeof(str) - 1, dir_compressed, &z) < 1) {
 			ast_log(LOG_ERROR, "Error in directory download on %s.\n", hostname);
 			el_db_delete_all_nodes();
 			goto cleanup;
 		}
+
 		str_len = strlen(str);
+
 		if (str[str_len - 1] == '\n') {
 			str[str_len - 1] = 0;
 		}
+
 		ast_copy_string(ipaddr, str, sizeof(ipaddr));
+
 		/* every 10 records, sleep for a short time */
 		if (!(n % 10)) {
 			usleep(2000); /* To get to dry land */
 		}
+
 		/* add this entry to our table */
 		ast_mutex_lock(&el_db_lock);
 		el_db_put(nodenum, ipaddr, call);
 		ast_mutex_unlock(&el_db_lock);
 		n++;
 	}
+
 	close(sock);
 	inflateEnd(&z);
 	pp = (dir_partial) ? "partial" : "full";
 	cc = (dir_compressed) ? "compressed" : "un-compressed";
 	ast_verb(4, "Directory completed downloading(%s,%s), %d records.\n", pp, cc, n);
+
 	if (dir_compressed) {
 		ast_debug(4, "Got snapshot_id: %s\n", snapshot_id);
 	}
+
 	return dir_compressed;
 
 cleanup:
@@ -3232,24 +3275,31 @@ static void *el_directory(void *data)
 	time_t then, now;
 	curdir = 0;
 	time(&then);
+
 	while (run_forever) {
 		time(&now);
 		el_sleeptime -= (now - then);
 		then = now;
+
 		if (el_sleeptime < 0) {
 			el_sleeptime = 0;
 		}
+
 		if (el_sleeptime) {
 			usleep(200000);
 			continue;
 		}
+
 		if (!instances[0]->elservers[curdir][0]) {
 			if (++curdir >= EL_MAX_SERVERS) {
 				curdir = 0;
 			}
+
 			continue;
 		}
+
 		ast_debug(2, "Trying to do directory download Echolink server %s.\n", instances[0]->elservers[curdir]);
+
 		rc = do_el_directory(instances[0]->elservers[curdir]);
 		if (rc < 0) {
 			if (++curdir >= EL_MAX_SERVERS) {
@@ -3258,12 +3308,14 @@ static void *el_directory(void *data)
 			el_sleeptime = 20;
 			continue;
 		}
+
 		if (rc == 1) {
 			el_sleeptime = 240;
 		} else if (rc == 0) {
 			el_sleeptime = 1800;
 		}
 	}
+
 	ast_debug(1, "Echolink directory thread exited.\n");
 	return NULL;
 }
@@ -3284,6 +3336,7 @@ static void *el_register(void *data)
 
 	time(&then);
 	ast_debug(1, "Echolink registration thread started on %s.\n", instp->name);
+
 	while (run_forever) {
 		time(&now);
 		el_login_sleeptime -= (now - then);
@@ -3291,10 +3344,12 @@ static void *el_register(void *data)
 		if (el_login_sleeptime < 0) {
 			el_login_sleeptime = 0;
 		}
+
 		if (el_login_sleeptime) {
 			usleep(200000);
 			continue;
 		}
+
 		if (i >= EL_MAX_SERVERS) {
 			i = 0;
 		}
@@ -3303,6 +3358,7 @@ static void *el_register(void *data)
 			if (instp->elservers[i][0] != '\0') {
 				break;
 			}
+
 			i++;
 		} while (i < EL_MAX_SERVERS);
 
@@ -3310,12 +3366,14 @@ static void *el_register(void *data)
 			ast_debug(2, "Trying to register with Echolink server %s.\n", instp->elservers[i]);
 			rc = sendcmd(instp->elservers[i++], instp);
 		}
+
 		if (rc == 0) {
 			el_login_sleeptime = 360;
 		} else {
 			el_login_sleeptime = 20;
 		}
 	}
+
 	/* Send a de-register message, but what is the point, Echolink deactivates this node within 6 minutes */
 	ast_debug(1, "Echolink registration thread exited.\n");
 	return NULL;
@@ -3340,14 +3398,17 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 	time_t now;
 
 	el_node_key = ast_calloc(1, sizeof(struct el_node));
+
 	if (!el_node_key) {
 		return -1;
 	}
+
 	ast_copy_string(el_node_key->call, call, EL_CALL_SIZE);
 	ast_copy_string(el_node_key->ip, instp->el_node_test.ip, EL_IP_SIZE);
 	ast_copy_string(el_node_key->name, name, EL_NAME_SIZE);
 
 	ast_mutex_lock(&el_db_lock);
+
 	mynode = el_db_find_ipaddr(el_node_key->ip);
 	if (!mynode) {
 		ast_log(LOG_ERROR, "Cannot find database entry for IP address %s, Callsign %s.\n", el_node_key->ip, call);
@@ -3355,14 +3416,17 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 		ast_mutex_unlock(&el_db_lock);
 		return 1;
 	}
+
 	ast_copy_string(nodestr, mynode->nodenum, sizeof(nodestr));
 	el_node_key->nodenum = atoi(nodestr);
 	el_node_key->countdown = instp->rtcptimeout;
 	el_node_key->seqnum = 1;
 	el_node_key->instp = instp;
+
 	if (tsearch(el_node_key, &el_node_list, compare_ip)) {
 		ast_debug(1, "New Call - Callsign %s, IP Address %s, Node %i, Name %s.\n", el_node_key->call, el_node_key->ip,
 			el_node_key->nodenum, el_node_key->name);
+
 		if (pvt == NULL) { /* if a new inbound call */
 			struct ast_frame fr = {
 				.frametype = AST_FRAME_CONTROL,
@@ -3377,9 +3441,11 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 				ast_mutex_unlock(&el_db_lock);
 				return -1;
 			}
+
 			el_node_key->pvt = pvt;
 			ast_copy_string(el_node_key->pvt->ip, instp->el_node_test.ip, EL_IP_SIZE);
 			chan = el_new(el_node_key->pvt, AST_STATE_RINGING, el_node_key->nodenum, NULL, NULL);
+
 			if (!chan) {
 				el_destroy(el_node_key->pvt);
 				ast_free(el_node_key);
@@ -3457,6 +3523,7 @@ static void *el_reader(void *data)
 	uint32_t time_difference;
 	struct timeval start_time;
 	int elap;
+	int heartbeat_timer;
 
 	time(&instp->starttime);
 	instp->aprstime = instp->starttime + EL_APRS_START_DELAY;
@@ -3470,12 +3537,15 @@ static void *el_reader(void *data)
 	fds[1].events = POLLIN;
 
 	start_time = tvnow();
+	heartbeat_timer = KEEPALIVE_TIME;
 
 	while (run_forever) {
 		/* Send APRS information every EL_APRS_INTERVAL */
 		time(&now);
+
 		if (instp->aprstime <= now) {
 			instp->aprstime = now + EL_APRS_INTERVAL;
+
 			if (sin_aprs.sin_port) { /* a zero port indicates that we never resolved the host name */
 				char aprsstr[512], aprscall[256], gps_data[100], latc, lonc;
 				unsigned char sdes_packet[256];
@@ -3492,6 +3562,7 @@ static void *el_reader(void *data)
 				twalk_r(el_node_list, count_users, &count);
 				ast_mutex_unlock(&el_nodelist_lock);
 				tm = gmtime(&now);
+
 				if (!count.outbound) { /* if no outbound users */
 					snprintf(instp->login_display, EL_NAME_SIZE + EL_CALL_SIZE, "%s [%d/%d]", instp->myqth, count.inbound, instp->maxstns);
 					snprintf(instp->aprs_display, EL_APRS_SIZE, " On @ %02d%02d [%d/%d]", tm->tm_hour, tm->tm_min, count.inbound,
@@ -3500,24 +3571,30 @@ static void *el_reader(void *data)
 					snprintf(instp->login_display, EL_NAME_SIZE + EL_CALL_SIZE, "In Conference %s", instp->lastcall);
 					snprintf(instp->aprs_display, EL_APRS_SIZE, "=N%s @ %02d%02d", instp->lastcall, tm->tm_hour, tm->tm_min);
 				}
+
 				mylat = instp->lat;
 				mylon = instp->lon;
+
 				if (ast_custom_function_find("GPS_READ") && !ast_func_read(NULL, "GPS_READ()", gps_data, sizeof(gps_data))) {
 					/* gps_data format monotonic time, epoch, latitude, longitude, elevation */
 					if (sscanf(gps_data, N_FMT(llu) " %*u " N_FMT(f) N_FMT(c) N_FMT(f) N_FMT(c), &u_mono, &lat, &latc, &lon, &lonc) == 5) {
 						now_mono = time_monotonic();
 						was_mono = (time_t) u_mono;
+
 						if ((was_mono + GPS_VALID_SECS) >= now_mono) {
 							mylat = floor(lat / 100.0);
 							mylat += (lat - (mylat * 100)) / 60.0;
 							mylon = floor(lon / 100.0);
 							mylon += (lon - (mylon * 100)) / 60.0;
+
 							if (latc == 'S') {
 								mylat = -mylat;
 							}
+
 							if (lonc == 'W') {
 								mylon = -mylon;
 							}
+
 							from_GPS = 1;
 						}
 					}
@@ -3547,12 +3624,15 @@ static void *el_reader(void *data)
 				sdes_length = rtcp_make_el_sdes(sdes_packet, sizeof(sdes_packet), aprscall, aprsstr);
 				sendto(instp->ctrl_sock, sdes_packet, sdes_length, 0, (struct sockaddr *) &sin_aprs, sizeof(sin_aprs));
 				instp->tx_ctrl_packets++;
+
 			} else { /* we were unable to resolve the APRS host name - attempt to resolve it now */
 				struct hostent *ahp;
 				struct ast_hostent ah;
+
 				sin_aprs.sin_family = AF_INET;
 				sin_aprs.sin_port = htons(5199);
 				ahp = ast_gethostbyname(EL_APRS_SERVER, &ah);
+
 				if (!ahp) {
 					ast_log(LOG_WARNING, "Unable to resolve echolink APRS server IP address %s.\n", EL_APRS_SERVER);
 					memset(&sin_aprs, 0, sizeof(sin_aprs));
@@ -3560,6 +3640,7 @@ static void *el_reader(void *data)
 					memcpy(&sin_aprs.sin_addr.s_addr, ahp->h_addr, sizeof(in_addr_t));
 				}
 			}
+
 			el_sleeptime = 0;
 			el_login_sleeptime = 0;
 		}
@@ -3568,6 +3649,7 @@ static void *el_reader(void *data)
 		 * poll for activity
 		 */
 		i = ast_poll(fds, 2, 50);
+
 		if (i == 0) {
 			/* Time out, update the timers */
 			elap = time_elapsed(&start_time);
@@ -3577,6 +3659,7 @@ static void *el_reader(void *data)
 			ast_mutex_lock(&instp->lock);
 			continue;
 		}
+
 		if (i < 0) {
 			ast_log(LOG_ERROR, "Fatal error, poll returned %d: %s\n", i, strerror(errno));
 			run_forever = 0;
@@ -3589,7 +3672,40 @@ static void *el_reader(void *data)
 		twalk_r(el_node_list, process_timers, &elap);
 		ast_mutex_unlock(&el_nodelist_lock);
 
-		ast_mutex_lock(&instp->lock);
+		/* Echolink: send heartbeats and drop dead stations */
+		update_timer(&heartbeat_timer, elap, 0);
+
+		if (!heartbeat_timer) {
+			heartbeat_timer = KEEPALIVE_TIME;
+			ast_mutex_lock(&instp->lock);
+			instp->el_node_test.ip[0] = '\0';
+			ast_mutex_lock(&el_nodelist_lock);
+			twalk(el_node_list, send_heartbeat);
+			ast_mutex_unlock(&el_nodelist_lock);
+
+			if (instp->el_node_test.ip[0] != '\0') {
+				if (find_delete(&instp->el_node_test)) {
+					int bye_length;
+
+					bye_length = rtcp_make_bye(bye, sizeof(bye), "rtcp timeout");
+					memset(&sin, 0, sizeof(sin));
+					sin.sin_family = AF_INET;
+					sin.sin_addr.s_addr = inet_addr(instp->el_node_test.ip);
+					sin.sin_port = htons(instp->ctrl_port);
+
+					/* send 20 bye packets to insure that they receive this disconnect */
+					for (i = 0; i < 20; i++) {
+						sendto(instp->ctrl_sock, bye, bye_length, 0, (struct sockaddr *) &sin, sizeof(sin));
+						instp->tx_ctrl_packets++;
+					}
+
+					ast_verb(4, "Callsign %s RTCP timeout, removing connection.\n", instp->el_node_test.call);
+				}
+
+				instp->el_node_test.ip[0] = '\0';
+			}
+		}
+
 		/*
 		 * process the control socket
 		 */
@@ -4133,6 +4249,7 @@ static int store_config(struct ast_config *cfg, char *ctg)
 		ast_log(LOG_ERROR, "Unable to load config %s.\n", rpt_config);
 		return -1;
 	}
+
 	val = ast_variable_retrieve(rpt_cfg, instp->astnode, "totime");
 	if (!val) {
 		instp->timeout_time = 180000;
@@ -4148,31 +4265,38 @@ static int store_config(struct ast_config *cfg, char *ctg)
 		ast_log(LOG_ERROR, "Your Echolink call or password is not correct.\n");
 		return -1;
 	}
+
 	if ((instp->elservers[0][0] == '\0') || (instp->elservers[1][0] == '\0') || (instp->elservers[2][0] == '\0')) {
 		ast_log(LOG_ERROR, "One of the Echolink servers missing.\n");
 		return -1;
 	}
+
 	/* start up the socket listeners */
 	if ((instp->audio_sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) == -1) {
 		ast_log(LOG_WARNING, "Unable to create new socket for echolink audio connection.\n");
 		return -1;
 	}
+
 	if ((instp->ctrl_sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) == -1) {
 		ast_log(LOG_WARNING, "Unable to create new socket for echolink control connection.\n");
 		close(instp->audio_sock);
 		instp->audio_sock = -1;
 		return -1;
 	}
+
 	/* audio channel */
 	memset(&si_me, 0, sizeof(si_me));
 	si_me.sin_family = AF_INET;
+
 	if (strcmp(instp->ipaddr, "0.0.0.0") == 0) {
 		si_me.sin_addr.s_addr = htonl(INADDR_ANY);
 	} else {
 		si_me.sin_addr.s_addr = inet_addr(instp->ipaddr);
 	}
+
 	instp->audio_port = atoi(instp->port);
 	si_me.sin_port = htons(instp->audio_port);
+
 	if (bind(instp->audio_sock, &si_me, sizeof(si_me)) == -1) {
 		ast_log(LOG_WARNING, "Unable to bind port for echolink audio connection\n");
 		close(instp->ctrl_sock);
@@ -4181,9 +4305,11 @@ static int store_config(struct ast_config *cfg, char *ctg)
 		instp->audio_sock = -1;
 		return -1;
 	}
+
 	/* control channel */
 	instp->ctrl_port = instp->audio_port + 1;
 	si_me.sin_port = htons(instp->ctrl_port);
+
 	if (bind(instp->ctrl_sock, &si_me, sizeof(si_me)) == -1) {
 		ast_log(LOG_WARNING, "Unable to bind port for echolink control connection\n");
 		close(instp->ctrl_sock);
@@ -4192,6 +4318,7 @@ static int store_config(struct ast_config *cfg, char *ctg)
 		instp->audio_sock = -1;
 		return -1;
 	}
+
 	fcntl(instp->audio_sock, F_SETFL, O_NONBLOCK);
 	fcntl(instp->ctrl_sock, F_SETFL, O_NONBLOCK);
 	/* APRS channel */
@@ -4199,6 +4326,7 @@ static int store_config(struct ast_config *cfg, char *ctg)
 	sin_aprs.sin_family = AF_INET;
 	sin_aprs.sin_port = htons(5199);
 	ahp = ast_gethostbyname(EL_APRS_SERVER, &ah);
+
 	if (!ahp) {
 		/* We could not resolve the host name.  This will be attempted again
 		 * when we need to send an APRS packet
@@ -4208,6 +4336,7 @@ static int store_config(struct ast_config *cfg, char *ctg)
 	} else {
 		memcpy(&sin_aprs.sin_addr.s_addr, ahp->h_addr, sizeof(in_addr_t));
 	}
+
 	/* start the registration thread */
 	ast_pthread_create(&el_register_thread, NULL, el_register, instp);
 	ast_pthread_create(&instp->el_reader_thread, NULL, el_reader, instp);
@@ -4231,16 +4360,19 @@ static int unload_module(void)
 	int n;
 
 	run_forever = 0;
+
 	if (el_node_list) {
 		ast_mutex_lock(&el_nodelist_lock);
 		tdestroy(el_node_list, free_node);
 		ast_mutex_unlock(&el_nodelist_lock);
 	}
+
 	if (el_db_callsign) {
 		el_db_delete_all_nodes();
 	}
 
 	ast_debug(1, "We have %d Echolink instance%s.\n", ninstances, ESS(ninstances));
+
 	for (n = 0; n < ninstances; n++) {
 		ast_debug(2, "Closing Echolink instance %d.\n", n);
 		if (instances[n]->audio_sock != -1) {
@@ -4275,6 +4407,7 @@ static int unload_module(void)
 	for (n = 0; n < ninstances; n++) {
 		ast_free(instances[n]);
 	}
+
 	return 0;
 }
 
@@ -4292,12 +4425,14 @@ static int load_module(void)
 	if (!(el_tech.capabilities = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT))) {
 		return AST_MODULE_LOAD_DECLINE;
 	}
+
 	ast_format_cap_append(el_tech.capabilities, ast_format_gsm, 0);
 
 	while ((ctg = ast_category_browse(cfg, ctg)) != NULL) {
 		if (ctg == NULL) {
 			continue;
 		}
+
 		if (store_config(cfg, ctg) < 0) {
 			return AST_MODULE_LOAD_DECLINE;
 		}
@@ -4305,6 +4440,7 @@ static int load_module(void)
 	ast_config_destroy(cfg);
 	cfg = NULL;
 	ast_verb(4, "Total of %d Echolink instances found.\n", ninstances);
+
 	if (ninstances < 1) {
 		ast_log(LOG_ERROR, "Cannot run echolink with no instances.\n");
 		return AST_MODULE_LOAD_DECLINE;

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -462,20 +462,12 @@ struct el_instance {
 };
 
 /*!
- * \brief Echolink receive queue struct from asterisk.
- */
-struct el_rxqast {
-	struct el_rxqast *qe_forw;
-	struct el_rxqast *qe_back;
-	char buf[GSM_FRAME_SIZE];
-};
-
-/*!
  * \brief Echolink private information.
  * This is stored in the asterisk channel private technology for reference.
  */
 struct el_pvt {
 	struct el_instance *instp;
+	struct ast_channel *owner;
 	char app[16];
 	char stream[80];
 	char ip[EL_IP_SIZE];
@@ -487,7 +479,6 @@ struct el_pvt {
 	int rxkey;						/* Receive keyed timer */
 	int keepalive;
 	int txindex;
-	struct el_rxqast rxqast;
 	struct ast_dsp *dsp;
 	struct ast_module_user *u;
 	struct ast_trans_pvt *xpath;
@@ -1373,7 +1364,7 @@ static int el_call(struct ast_channel *ast, const char *dest, int timeout)
 	do_new_call(instp, p, "OUTBOUND", "OUTBOUND");
 	process_cmd(buf, sizeof(buf), "127.0.0.1", instp);
 	ast_mutex_unlock(&instp->lock);
-
+	p->owner = ast;
 	ast_setstate(ast, AST_STATE_RINGING);
 
 	return 0;
@@ -1385,16 +1376,6 @@ static int el_call(struct ast_channel *ast, const char *dest, int timeout)
  */
 static void el_destroy(struct el_pvt *pvt)
 {
-	struct el_rxqast *qpast;
-
-	ast_mutex_lock(&pvt->lock);
-	while (pvt->rxqast.qe_forw != &pvt->rxqast) {
-		qpast = pvt->rxqast.qe_forw;
-		remque(qpast);
-		ast_free(qpast);
-	}
-	ast_mutex_unlock(&pvt->lock);
-
 	if (pvt->dsp) {
 		ast_dsp_free(pvt->dsp);
 	}
@@ -1405,6 +1386,7 @@ static void el_destroy(struct el_pvt *pvt)
 		ast_free(pvt->linkstr);
 	}
 	pvt->linkstr = NULL;
+	pvt->owner = NULL;
 	ast_mutex_lock(&el_nodelist_lock);
 	twalk(el_node_list, send_info);
 	ast_mutex_unlock(&el_nodelist_lock);
@@ -1439,8 +1421,6 @@ static struct el_pvt *el_alloc(const char *data)
 	pvt = ast_calloc(1, sizeof(struct el_pvt));
 	if (pvt) {
 		snprintf(pvt->stream, sizeof(pvt->stream), "%s-%lu", data, instances[n]->seqno++);
-		pvt->rxqast.qe_forw = &pvt->rxqast;
-		pvt->rxqast.qe_back = &pvt->rxqast;
 
 		pvt->keepalive = KEEPALIVE_TIME;
 		pvt->instp = instances[n];
@@ -2248,10 +2228,6 @@ static int el_xwrite(struct ast_channel *ast, struct ast_frame *frame)
 	struct sockaddr_in sin;
 	struct el_pvt *p = ast_channel_tech_pvt(ast);
 	struct el_instance *instp = p->instp;
-	struct ast_frame fr, *f1, *f2;
-	struct el_rxqast *qpast;
-	int n, x;
-	char buf[GSM_FRAME_SIZE + AST_FRIENDLY_OFFSET];
 
 	if (!p->last_firstheard && p->firstheard) {
 		struct ast_frame fr3 = {
@@ -2287,70 +2263,7 @@ static int el_xwrite(struct ast_channel *ast, struct ast_frame *frame)
 
 		instp->tx_ctrl_packets++;
 	}
-
-	/* Echolink to Asterisk */
-	if (p->rxqast.qe_forw != &p->rxqast) {
-		for (n = 0, qpast = p->rxqast.qe_forw; qpast != &p->rxqast; qpast = qpast->qe_forw) {
-			n++;
-		}
-		if (n > QUEUE_OVERLOAD_THRESHOLD_AST) {
-			ast_mutex_lock(&p->lock);
-			while (p->rxqast.qe_forw != &p->rxqast) {
-				qpast = p->rxqast.qe_forw;
-				remque((struct qelem *) qpast);
-				ast_free(qpast);
-			}
-			ast_mutex_unlock(&p->lock);
-			if (p->rxkey) {
-				p->rxkey = 1;
-			}
-		} else {
-			if (!p->rxkey) {
-				struct ast_frame wf = {
-					.frametype = AST_FRAME_CONTROL,
-					.subclass.integer = AST_CONTROL_RADIO_KEY,
-					.src = __PRETTY_FUNCTION__,
-				};
-
-				ast_queue_frame(ast, &wf);
-			}
-			p->rxkey = MAX_RXKEY_TIME;
-			ast_mutex_lock(&p->lock);
-			qpast = p->rxqast.qe_forw;
-			remque((struct qelem *) qpast);
-			ast_mutex_unlock(&p->lock);
-			memcpy(buf + AST_FRIENDLY_OFFSET, qpast->buf, GSM_FRAME_SIZE);
-			ast_free(qpast);
-
-			memset(&fr, 0, sizeof(fr));
-			fr.datalen = GSM_FRAME_SIZE;
-			fr.samples = GSM_SAMPLES;
-			fr.frametype = AST_FRAME_VOICE;
-			fr.subclass.format = ast_format_gsm;
-			fr.data.ptr = buf + AST_FRIENDLY_OFFSET;
-			fr.offset = AST_FRIENDLY_OFFSET;
-			fr.src = __PRETTY_FUNCTION__;
-
-			x = 0;
-			if (p->dsp) {
-				f2 = ast_translate(p->xpath, &fr, 0);
-				f1 = ast_dsp_process(NULL, p->dsp, f2);
-				if ((f1->frametype == AST_FRAME_DTMF_END) || (f1->frametype == AST_FRAME_DTMF_BEGIN)) {
-					if ((f1->subclass.integer != 'm') && (f1->subclass.integer != 'u')) {
-						if (f1->frametype == AST_FRAME_DTMF_END) {
-							ast_verb(4, "Echolink %s Got DTMF character %c from IP address %s.\n", p->stream, f1->subclass.integer, p->ip);
-						}
-						ast_queue_frame(ast, f1);
-						x = 1;
-					}
-				}
-				ast_frfree(f1);
-			}
-			if (!x) {
-				ast_queue_frame(ast, &fr);
-			}
-		}
-	}
+	ast_mutex_lock(&p->lock);
 	if (p->rxkey == 1) {
 		struct ast_frame wf = {
 			.frametype = AST_FRAME_CONTROL,
@@ -2363,7 +2276,7 @@ static int el_xwrite(struct ast_channel *ast, struct ast_frame *frame)
 	if (p->rxkey) {
 		p->rxkey--;
 	}
-
+	ast_mutex_unlock(&p->lock);
 	/* Asterisk to Echolink */
 	if (ast_format_cap_iscompatible_format(ast_channel_nativeformats(ast), frame->subclass.format) == AST_FORMAT_CMP_NOT_EQUAL) {
 		struct ast_str *cap_buf = ast_str_alloca(AST_FORMAT_CAP_NAMES_LEN);
@@ -3387,6 +3300,7 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 				ast_mutex_unlock(&el_db_lock);
 				return -1;
 			}
+			pvt->owner = chan;
 			ast_queue_frame(chan, &fr);
 			el_node_key->rx_ctrl_packets++;
 			ast_mutex_lock(&instp->lock);
@@ -3434,7 +3348,6 @@ static void *el_reader(void *data)
 	unsigned char bye[40];
 	struct sockaddr_in sin, sin1;
 	int i, j, x;
-	struct el_rxqast *qpast;
 	socklen_t fromlen;
 	ssize_t recvlen;
 	time_t now;
@@ -3738,9 +3651,13 @@ static void *el_reader(void *data)
 				} else {
 					ast_mutex_lock(&el_nodelist_lock);
 					found_key = (struct el_node **) tfind(&instp->el_node_test, &el_node_list, compare_ip);
-					ast_mutex_unlock(&el_nodelist_lock);
 					if (found_key) {
+						struct el_pvt *pvt;
+						struct ast_channel *ast;
+
 						node = *found_key;
+						pvt = node->pvt;
+						ast = pvt->owner;
 						node->pvt->firstheard = 1;
 						node->countdown = instp->rtcptimeout;
 						node->rx_audio_packets++;
@@ -3784,17 +3701,55 @@ static void *el_reader(void *data)
 						if (recvlen == sizeof(struct gsmVoice_t)) {
 							if (gsmPacket->version == 3 && gsmPacket->payt == 3) {
 								/* break them up for Asterisk */
+								char inbuf[GSM_FRAME_SIZE + AST_FRIENDLY_OFFSET];
 								for (i = 0; i < BLOCKING_FACTOR; i++) {
-									qpast = ast_malloc(sizeof(struct el_rxqast));
-									if (qpast) {
-										memcpy(qpast->buf, gsmPacket->data + (GSM_FRAME_SIZE * i), GSM_FRAME_SIZE);
-										ast_mutex_lock(&node->pvt->lock);
-										insque((struct qelem *) qpast, (struct qelem *) node->pvt->rxqast.qe_back);
-										ast_mutex_unlock(&node->pvt->lock);
+									/* Echolink to Asterisk */
+									struct ast_frame *f1, *f2;
+									struct ast_frame fr = {
+										.datalen = GSM_FRAME_SIZE,
+										.samples = GSM_SAMPLES,
+										.frametype = AST_FRAME_VOICE,
+										.subclass.format = ast_format_gsm,
+										.data.ptr = inbuf + AST_FRIENDLY_OFFSET,
+										.offset = AST_FRIENDLY_OFFSET,
+										.src = __PRETTY_FUNCTION__,
+									};
+									ast_mutex_lock(&pvt->lock);
+									if (!pvt->rxkey) {
+										struct ast_frame wf = {
+											.frametype = AST_FRAME_CONTROL,
+											.subclass.integer = AST_CONTROL_RADIO_KEY,
+											.src = __PRETTY_FUNCTION__,
+										};
+										if (ast) {
+											ast_queue_frame(ast, &wf);
+										}
+									}
+									pvt->rxkey = MAX_RXKEY_TIME;
+									ast_mutex_unlock(&pvt->lock);
+									memcpy(inbuf + AST_FRIENDLY_OFFSET, gsmPacket->data + (GSM_FRAME_SIZE * i), GSM_FRAME_SIZE);
+									x = 0;
+									if (pvt->dsp) {
+										f2 = ast_translate(pvt->xpath, &fr, 0);
+										f1 = ast_dsp_process(NULL, pvt->dsp, f2);
+										if ((f1->frametype == AST_FRAME_DTMF_END) || (f1->frametype == AST_FRAME_DTMF_BEGIN)) {
+											if ((f1->subclass.integer != 'm') && (f1->subclass.integer != 'u')) {
+												if (f1->frametype == AST_FRAME_DTMF_END) {
+													ast_verb(4, "Echolink %s Got DTMF character %c from IP address %s.\n",
+														pvt->stream, f1->subclass.integer, pvt->ip);
+												}
+												if (ast) {
+													ast_queue_frame(ast, f1);
+													x = 1;
+												}
+											}
+										}
+										ast_frfree(f2); /* We own f2, f1 could be f2 or a control frame that should not be freed */
+									}
+									if (!x && ast) {
+										ast_queue_frame(ast, &fr);
 									}
 								}
-							} else {
-								instp->rx_bad_packets++;
 							}
 						} else {
 							instp->rx_bad_packets++;
@@ -3802,6 +3757,7 @@ static void *el_reader(void *data)
 					} else {
 						instp->rx_bad_packets++;
 					}
+					ast_mutex_unlock(&el_nodelist_lock);
 				}
 			}
 		}

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -2226,6 +2226,7 @@ static void process_cmd(char *buf, int buf_len, const char *fromip, struct el_in
 	int pack_length;
 	unsigned short i, n;
 	struct el_node key;
+	int conn;
 
 	/*
 	 * see if this is a text packet
@@ -2304,18 +2305,12 @@ static void process_cmd(char *buf, int buf_len, const char *fromip, struct el_in
 	strtok_r(NULL, delim, &saveptr);
 	strtok_r(NULL, delim, &saveptr);
 
-	if ((strcmp(cmd, "o.conip") == 0) || (strcmp(cmd, "o.dconip") == 0)) {
+	conn = strcmp(cmd, "o.conip");
+
+	if (conn == 0 || strcmp(cmd, "o.dconip") == 0) {
 		if (!arg1) {
 			instp->rx_bad_packets++;
 			return;
-		}
-
-		if (strcmp(cmd, "o.conip") == 0) {
-			n = 1;
-			pack_length = rtcp_make_sdes(pack, sizeof(pack), instp->mycall, instp->myname, instp->astnode);
-		} else {
-			pack_length = rtcp_make_bye(pack, sizeof(pack), "bye");
-			n = 20;
 		}
 
 		memset(&sin, 0, sizeof(sin));
@@ -2323,21 +2318,26 @@ static void process_cmd(char *buf, int buf_len, const char *fromip, struct el_in
 		sin.sin_port = htons(instp->ctrl_port);
 		sin.sin_addr.s_addr = inet_addr(arg1);
 
-		if (strcmp(cmd, "o.dconip") == 0) {
+		if (conn == 0) {
+			n = 1;
+			pack_length = rtcp_make_sdes(pack, sizeof(pack), instp->mycall, instp->myname, instp->astnode);
+			for (i = 0; i < n; i++) {
+				sendto(instp->ctrl_sock, pack, pack_length, 0, (struct sockaddr *) &sin, sizeof(sin));
+			}
+			ast_debug(3, "Connect request sent to %s.\n", arg1);
+
+		} else { /* It's a disconnect */
+			pack_length = rtcp_make_bye(pack, sizeof(pack), "bye");
+			n = 20;
 			ast_copy_string(key.ip, arg1, sizeof(key.ip));
 			if (find_delete(&key, NULL)) {
-				for (i = 0; i < 20; i++) {
+				for (i = 0; i < n; i++) {
 					sendto(instp->ctrl_sock, pack, pack_length, 0, (struct sockaddr *) &sin, sizeof(sin));
 				}
 				ast_debug(1, "Disconnect request sent to %s.\n", key.ip);
 			} else {
 				ast_debug(1, "Did not find IP Address %s to request disconnect.\n", key.ip);
 			}
-		} else {
-			for (i = 0; i < n; i++) {
-				sendto(instp->ctrl_sock, pack, pack_length, 0, (struct sockaddr *) &sin, sizeof(sin));
-			}
-			ast_debug(3, "Connect request sent to %s.\n", arg1);
 		}
 
 		return;

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -1374,7 +1374,7 @@ static int el_call(struct ast_channel *ast, const char *dest, int timeout)
 
 	/* make the call */
 	ast_mutex_lock(&instp->lock);
-	strcpy(instp->el_node_test.ip, ipaddr);
+	strcpy(p->el_node_test.ip, ipaddr);
 	do_new_call(instp, p, "OUTBOUND", "OUTBOUND");
 	process_cmd(buf, sizeof(buf), "127.0.0.1", instp);
 	ast_mutex_unlock(&instp->lock);
@@ -2121,7 +2121,7 @@ static void send_text(const void *nodep, const VISIT which, const int depth)
 	struct el_node *node = *(struct el_node **) nodep;
 
 	if ((which == leaf) || (which == postorder)) {
-		if (strncmp(node->ip, node->instp->el_node_test.ip, sizeof(node->ip))) {
+		if (strncmp(node->ip, node->pvt->el_node_test.ip, sizeof(node->ip))) {
 			memset(&sin, 0, sizeof(sin));
 			sin.sin_family = AF_INET;
 			sin.sin_port = htons(node->instp->audio_port);
@@ -3469,7 +3469,7 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 	}
 
 	ast_copy_string(el_node_key->call, call, EL_CALL_SIZE);
-	ast_copy_string(el_node_key->ip, instp->el_node_test.ip, EL_IP_SIZE);
+	ast_copy_string(el_node_key->ip, pvt->el_node_test.ip, EL_IP_SIZE);
 	ast_copy_string(el_node_key->name, name, EL_NAME_SIZE);
 
 	ast_mutex_lock(&el_db_lock);
@@ -3515,7 +3515,7 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 			}
 
 			el_node_key->pvt = pvt;
-			ast_copy_string(el_node_key->pvt->ip, instp->el_node_test.ip, EL_IP_SIZE);
+			ast_copy_string(el_node_key->pvt->ip, pvt->el_node_test.ip, EL_IP_SIZE);
 
 			chan = el_new(el_node_key->pvt, AST_STATE_RINGING, el_node_key->nodenum, NULL, NULL);
 			if (!chan) {
@@ -3541,7 +3541,7 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 		} else {
 			ao2_ref(el_node_key->pvt, -1);
 			el_node_key->pvt = pvt;
-			ast_copy_string(el_node_key->pvt->ip, instp->el_node_test.ip, EL_IP_SIZE);
+			ast_copy_string(el_node_key->pvt->ip, pvt->el_node_test.ip, EL_IP_SIZE);
 			el_node_key->outbound = 1;
 			el_node_key->rx_ctrl_packets++;
 			ast_mutex_lock(&instp->lock);
@@ -3769,9 +3769,21 @@ static void *el_reader(void *data)
 			instp->el_node_test.ip[0] = '\0';
 
 			ast_mutex_lock(&el_nodelist_lock);
+			/* If twalk finds a dead node, it puts the IP address in the instp->el_node_test.ip
+			 * field and we disconnect that node after the walk.  This is done to avoid disconnecting
+			 * nodes while we are walking the tree, which can cause deadlocks if we have to acquire
+			 * the node list lock to disconnect a node while we are walking the tree.
+			 */
 			twalk(el_node_list, send_heartbeat);
 			ast_mutex_unlock(&el_nodelist_lock);
 
+			/* If twalk finds multiple dead nodes, the last dead node will be in instp->el_node_test.ip field
+			 * and disconnected.  If there are multiple dead nodes, it will take multiple heartbeat loops to find
+			 * them and kill them off.
+			 */
+
+			/*! \todo Find all dead nodes in one pass and cleanup the process?
+			 */
 			if (instp->el_node_test.ip[0] != '\0') {
 				if (find_delete(&instp->el_node_test, instp)) {
 					int bye_length;

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -1484,20 +1484,26 @@ static int el_hangup(struct ast_channel *ast)
 	sin.sin_family = AF_INET;
 	sin.sin_addr.s_addr = inet_addr(pvt->ip);
 	sin.sin_port = htons(instp->ctrl_port);
+
 	/* send 20 bye packets to insure that they receive this disconnect */
 	for (i = 0; i < 20; i++) {
 		sendto(instp->ctrl_sock, bye, n, 0, (struct sockaddr *) &sin, sizeof(sin));
 		instp->tx_ctrl_packets++;
 	}
+
 	time(&now);
+
 	if (instp->starttime < (now - EL_APRS_START_DELAY)) {
 		instp->aprstime = now;
 	}
+
 	ast_debug(1, "Hanging up (%s).\n", ast_channel_name(ast));
+
 	if (!ast_channel_tech_pvt(ast)) {
 		ast_log(LOG_WARNING, "Asked to hangup channel not connected.\n");
 		return 0;
 	}
+
 	el_destroy(pvt);
 	ast_channel_tech_pvt_set(ast, NULL);
 	ast_setstate(ast, AST_STATE_DOWN);
@@ -4057,15 +4063,12 @@ static void *el_reader(void *data)
 
 		if (!heartbeat_timer) {
 			heartbeat_timer = KEEPALIVE_TIME;
-			ast_mutex_lock(&instp->lock);
 			instp->el_node_test.ip[0] = '\0';
-			ast_mutex_unlock(&instp->lock);
 
 			ast_mutex_lock(&el_nodelist_lock);
 			twalk(el_node_list, send_heartbeat);
 			ast_mutex_unlock(&el_nodelist_lock);
 
-			ast_mutex_lock(&instp->lock);
 			if (instp->el_node_test.ip[0] != '\0') {
 				if (find_delete(&instp->el_node_test)) {
 					int bye_length;
@@ -4087,7 +4090,6 @@ static void *el_reader(void *data)
 
 				instp->el_node_test.ip[0] = '\0';
 			}
-			ast_mutex_unlock(&instp->lock);
 		}
 	}
 

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -1508,7 +1508,7 @@ static int el_hangup(struct ast_channel *ast)
 	}
 
 	ast_channel_tech_pvt_set(ast, NULL);
-	ao2_cleanup(pvt);
+	ao2_ref(pvt, -1);
 	ast_setstate(ast, AST_STATE_DOWN);
 	return 0;
 }
@@ -2002,7 +2002,7 @@ static void process_unkey_timers(const void *nodep, const VISIT which, void *clo
 			pvt->rxkey = 0;
 		}
 
-		ao2_cleanup(pvt);
+		ao2_ref(pvt, -1);
 	}
 }
 
@@ -2195,7 +2195,7 @@ static int find_delete(const struct el_node *key, struct el_instance *instp)
 		found = 1;
 		node->pvt->hangup = 1;
 		tdelete(node, &el_node_list, compare_ip);
-		ao2_cleanup(node->pvt);
+		ao2_ref(node->pvt, -1);
 		node->pvt = NULL;
 		ast_free(node);
 	}
@@ -2553,7 +2553,7 @@ static struct ast_channel *el_request(const char *type, struct ast_format_cap *c
 	if (p) {
 		tmp = el_new(p, AST_STATE_DOWN, nodenum, assignedids, requestor);
 		if (!tmp) {
-			ao2_cleanup(p);
+			ao2_ref(p, -1);
 		}
 	}
 
@@ -3477,7 +3477,7 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 	mynode = el_db_find_ipaddr(el_node_key->ip);
 	if (!mynode) {
 		ast_log(LOG_ERROR, "Cannot find database entry for IP address %s, Callsign %s.\n", el_node_key->ip, call);
-		ao2_cleanup(el_node_key->pvt);
+		ao2_ref(el_node_key->pvt, -1);
 		el_node_key->pvt = NULL;
 		ast_free(el_node_key);
 		ast_mutex_unlock(&el_db_lock);
@@ -3506,25 +3506,24 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 			pvt = el_alloc(instp->name);
 			if (!pvt) {
 				ast_log(LOG_ERROR, "Cannot alloc el channel %s.\n", instp->name);
-				ao2_cleanup(el_node_key->pvt);
+				ao2_ref(el_node_key->pvt, -1);
 				el_node_key->pvt = NULL;
 				ast_free(el_node_key);
-				ast_mutex_unlock(&el_db_lock);
 				ast_mutex_unlock(&el_nodelist_lock);
+				ast_mutex_unlock(&el_db_lock);
 				return -1;
 			}
 
-			ao2_ref(pvt, +1);
 			el_node_key->pvt = pvt;
 			ast_copy_string(el_node_key->pvt->ip, instp->el_node_test.ip, EL_IP_SIZE);
 
 			chan = el_new(el_node_key->pvt, AST_STATE_RINGING, el_node_key->nodenum, NULL, NULL);
 			if (!chan) {
-				ao2_cleanup(el_node_key->pvt);
+				ao2_ref(el_node_key->pvt, -1);
 				el_node_key->pvt = NULL;
 				ast_free(el_node_key);
-				ast_mutex_unlock(&el_db_lock);
 				ast_mutex_unlock(&el_nodelist_lock);
+				ast_mutex_unlock(&el_db_lock);
 				return -1;
 			}
 
@@ -3540,7 +3539,7 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 			ast_mutex_unlock(&instp->lock);
 
 		} else {
-			ao2_ref(pvt, +1);
+			ao2_ref(el_node_key->pvt, -1);
 			el_node_key->pvt = pvt;
 			ast_copy_string(el_node_key->pvt->ip, instp->el_node_test.ip, EL_IP_SIZE);
 			el_node_key->outbound = 1;
@@ -3556,14 +3555,15 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 			ast_mutex_unlock(&instp->lock);
 		}
 
-		ast_mutex_unlock(&el_db_lock);
 		ast_mutex_unlock(&el_nodelist_lock);
+		ast_mutex_unlock(&el_db_lock);
+
 		return 0;
 	}
 
 	ast_log(LOG_ERROR, "Failed to add new call, Callsign %s, IP Address %s, Name %s.\n", el_node_key->call, el_node_key->ip,
 		el_node_key->name);
-	ao2_cleanup(el_node_key->pvt);
+	ao2_ref(el_node_key->pvt, -1);
 	el_node_key->pvt = NULL;
 	ast_free(el_node_key);
 	ast_mutex_unlock(&el_nodelist_lock);
@@ -3989,6 +3989,7 @@ static void *el_reader(void *data)
 						node = *found_key;
 						pvt = node->pvt;
 						ao2_ref(pvt, +1);
+
 						if (pvt->owner) {
 							ast = ast_channel_ref(pvt->owner);
 						}
@@ -4023,8 +4024,12 @@ static void *el_reader(void *data)
 								}
 								node->isdoubling = 1;
 								ast_mutex_unlock(&el_nodelist_lock);
-								ast_channel_unref(ast);
-								ao2_cleanup(pvt);
+
+								if (ast) {
+									ast_channel_unref(ast);
+								}
+
+								ao2_ref(pvt, -1);
 								continue;
 							}
 						}
@@ -4037,8 +4042,12 @@ static void *el_reader(void *data)
 							}
 							node->istimedout = 1;
 							ast_mutex_unlock(&el_nodelist_lock);
-							ast_channel_unref(ast);
-							ao2_cleanup(pvt);
+
+							if (ast) {
+								ast_channel_unref(ast);
+							}
+
+							ao2_ref(pvt, -1);
 							continue;
 						}
 
@@ -4049,6 +4058,7 @@ static void *el_reader(void *data)
 							if (gsmPacket->version == 3 && gsmPacket->payt == 3) {
 								/* break them up for Asterisk */
 								char inbuf[GSM_FRAME_SIZE + AST_FRIENDLY_OFFSET];
+
 								for (i = 0; i < BLOCKING_FACTOR; i++) {
 									/* Echolink to Asterisk */
 									struct ast_frame *f1, *f2;
@@ -4111,8 +4121,11 @@ static void *el_reader(void *data)
 							instp->rx_bad_packets++;
 						}
 
-						ast_channel_unref(ast);
-						ao2_cleanup(pvt);
+						if (ast) {
+							ast_channel_unref(ast);
+						}
+
+						ao2_ref(pvt, -1);
 					} else {
 						instp->rx_bad_packets++;
 					}

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -3527,9 +3527,9 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *p, const char *
 				return -1;
 			}
 
-			ast_copy_string(el_node_key->pvt->ip, node_lookup->ip, EL_IP_SIZE);
+			ast_copy_string(p->ip, node_lookup->ip, EL_IP_SIZE);
 
-			chan = el_new(el_node_key->pvt, AST_STATE_RINGING, el_node_key->nodenum, NULL, NULL);
+			chan = el_new(p, AST_STATE_RINGING, el_node_key->nodenum, NULL, NULL);
 			if (!chan) {
 				ao2_ref(p, -1);
 				ast_free(el_node_key);

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -186,7 +186,7 @@ do not use 127.0.0.1
 #include "asterisk/cli.h"
 #include "asterisk/format_cache.h"
 
-#define MAX_RXKEY_TIME 4
+#define MAX_RXKEY_TIME 80	   /* ms */
 #define KEEPALIVE_TIME 50 * 10 /* 50 * 10 * 20ms iax2 = 10,000ms = 10 seconds heartbeat */
 #define AUTH_RETRY_MS 5000
 #define AUTH_ABANDONED_MS 15000
@@ -1873,6 +1873,37 @@ static void lookup_node_nodenum(const void *nodep, const VISIT which, void *clos
 }
 
 /*!
+ * \brief Update timers for all nodes
+ * \param nodep		Pointer to el_node struct.
+ * \param which		Enum for VISIT used by twalk.
+ * \param time		Points to decriment time.
+ */
+static void process_timers(const void *nodep, const VISIT which, void *time)
+{
+	const struct el_node *node;
+	struct el_pvt *pvt;
+	int *decr_time = time;
+
+	if ((which == leaf) || (which == postorder)) {
+		node = *(struct el_node **) nodep;
+		pvt = node->pvt;
+		if (pvt->rxkey) {
+			pvt->rxkey -= *decr_time;
+			if (pvt->rxkey <= 0) {
+				struct ast_frame wf = {
+					.frametype = AST_FRAME_CONTROL,
+					.subclass.integer = AST_CONTROL_RADIO_UNKEY,
+					.src = __PRETTY_FUNCTION__,
+				};
+
+				ast_queue_frame(pvt->owner, &wf);
+				pvt->rxkey = 0;
+			}
+		}
+	}
+}
+
+/*!
  * \brief Lookup node number by callsign for a connected node.
  * \param nodep		Pointer to el_node struct.
  * \param which		Enum for VISIT used by twalk.
@@ -3473,6 +3504,9 @@ static void *el_reader(void *data)
 			run_forever = 0;
 			break;
 		}
+
+		twalk_r(el_node_list, process_timers, &i);
+
 		ast_mutex_lock(&instp->lock);
 		/*
 		 * process the control socket
@@ -3661,20 +3695,6 @@ static void *el_reader(void *data)
 						}
 
 						node->last_packet_time = current_packet_time;
-
-						if (pvt->rxkey == 1) {
-							struct ast_frame wf = {
-								.frametype = AST_FRAME_CONTROL,
-								.subclass.integer = AST_CONTROL_RADIO_UNKEY,
-								.src = __PRETTY_FUNCTION__,
-							};
-
-							ast_queue_frame(ast, &wf);
-						}
-
-						if (pvt->rxkey) {
-							pvt->rxkey--;
-						}
 
 						/*
 						 * see if we have a new talker

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -185,6 +185,7 @@ do not use 127.0.0.1
 #include "asterisk/translate.h"
 #include "asterisk/cli.h"
 #include "asterisk/format_cache.h"
+#include "asterisk/vector.h"
 
 #define MAX_RXKEY_TIME 320	 /* ms */
 #define KEEPALIVE_TIME 10000 /* ms = 10 seconds heartbeat */
@@ -496,8 +497,20 @@ struct eldb {
 	char ipaddr[ELDB_IPADDRLEN];
 };
 
+struct pending_ctrl {
+	struct ast_channel *chan;			 /* should be ref'd */
+	enum ast_control_frame_type control; /* e.g., AST_CONTROL_RADIO_UNKEY */
+};
+
+struct unkey_walk_closure {
+	int elap;
+	struct pending_vector *pend;
+};
+
 AST_MUTEX_DEFINE_STATIC(el_db_lock);
 AST_MUTEX_DEFINE_STATIC(el_nodelist_lock);
+
+AST_VECTOR(pending_vector, struct pending_ctrl);
 
 struct el_instance *instances[EL_MAX_INSTANCES];
 int ninstances = 0;
@@ -1939,29 +1952,40 @@ static void update_timer(int *timer_ptr, int elap, int end_val)
  * \param which		Enum for VISIT used by twalk.
  * \param time		Points to decriment time.
  */
-static void process_unkey_timers(const void *nodep, const VISIT which, void *time)
+static void process_unkey_timers(const void *nodep, const VISIT which, void *closure)
 {
+	struct unkey_walk_closure *cl = closure;
 	const struct el_node *node;
 	struct el_pvt *pvt;
-	int elap = *(int *) time;
 
 	if ((which == leaf) || (which == postorder)) {
 		node = *(struct el_node **) nodep;
 		pvt = node->pvt;
-		if (pvt->rxkey) {
-			update_timer(&pvt->rxkey, elap, 0);
-			if (pvt->rxkey <= 0) {
-				struct ast_frame wf = {
-					.frametype = AST_FRAME_CONTROL,
-					.subclass.integer = AST_CONTROL_RADIO_UNKEY,
-					.src = __PRETTY_FUNCTION__,
+
+		if (!pvt || !pvt->rxkey) {
+			return;
+		}
+
+		update_timer(&pvt->rxkey, cl->elap, 0);
+
+		if (pvt->rxkey <= 0) {
+			/* The timer has expired, queue up an unkey for the channel */
+			struct ast_channel *chan;
+
+			chan = pvt->owner ? ast_channel_ref(pvt->owner) : NULL;
+			if (chan) {
+				struct pending_ctrl item = {
+					.chan = chan,
+					.control = AST_CONTROL_RADIO_UNKEY,
 				};
-				ast_debug(1, "I'm unkeying");
-				if (pvt->owner) {
-					ast_queue_frame(pvt->owner, &wf);
+
+				if (AST_VECTOR_APPEND(cl->pend, item)) {
+					ast_log(LOG_ERROR, "Unable to append pending control item.\n");
+					ast_channel_unref(chan);
 				}
-				pvt->rxkey = 0;
 			}
+
+			pvt->rxkey = 0;
 		}
 	}
 }
@@ -2293,6 +2317,7 @@ static struct ast_frame *el_xread(struct ast_channel *ast)
 		ast_softhangup(ast, AST_SOFTHANGUP_DEV);
 		p->hangup = 0;
 	}
+
 	if (!p->last_firstheard && p->firstheard) {
 		struct ast_frame fr = {
 			.frametype = AST_FRAME_CONTROL,
@@ -2303,6 +2328,7 @@ static struct ast_frame *el_xread(struct ast_channel *ast)
 		ast_queue_frame(ast, &fr);
 		p->last_firstheard = 1;
 	}
+
 	return &ast_null_frame;
 }
 
@@ -2373,6 +2399,7 @@ static int el_xwrite(struct ast_channel *ast, struct ast_frame *frame)
 		ast_mutex_lock(&instp->lock);
 		strcpy(instp->el_node_test.ip, p->ip);
 		ast_mutex_unlock(&instp->lock);
+
 		ast_mutex_lock(&el_nodelist_lock);
 		twalk(el_node_list, send_audio_only_one);
 		ast_mutex_unlock(&el_nodelist_lock);
@@ -2545,11 +2572,11 @@ static int el_do_dbget(int fd, int argc, const char *const *argv)
 	}
 
 	c = tolower(*argv[2]);
-	ast_mutex_lock(&el_db_lock);
-
 	if (c == 'i') {
 		/* Lookup node data by IP address */
+		ast_mutex_lock(&el_db_lock);
 		mynode = el_db_find_ipaddr(argv[3]);
+		ast_mutex_unlock(&el_db_lock);
 	} else if (c == 'c') {
 		/* Lookup node data by callsign */
 		if (lookup_node_by_callsign(argv[3], &found_node)) {
@@ -2565,12 +2592,10 @@ static int el_do_dbget(int fd, int argc, const char *const *argv)
 	/* Report failure to find node */
 	if (!mynode) {
 		ast_cli(fd, "Error: Entry for %s not found!\n", argv[3]);
-		ast_mutex_unlock(&el_db_lock);
 		return RESULT_FAILURE;
 	}
 
 	ast_cli(fd, "%s|%s|%s\n", mynode->nodenum, mynode->callsign, mynode->ipaddr);
-	ast_mutex_unlock(&el_db_lock);
 	return RESULT_SUCCESS;
 }
 
@@ -3422,7 +3447,10 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 	el_node_key->seqnum = 1;
 	el_node_key->instp = instp;
 
+	ast_mutex_lock(&el_nodelist_lock);
+
 	if (tsearch(el_node_key, &el_node_list, compare_ip)) {
+		ast_mutex_unlock(&el_nodelist_lock);
 		ast_debug(1, "New Call - Callsign %s, IP Address %s, Node %i, Name %s.\n", el_node_key->call, el_node_key->ip,
 			el_node_key->nodenum, el_node_key->name);
 
@@ -3464,6 +3492,7 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 			ast_mutex_unlock(&instp->lock);
 
 		} else {
+			ast_mutex_unlock(&el_nodelist_lock);
 			el_node_key->pvt = pvt;
 			ast_copy_string(el_node_key->pvt->ip, instp->el_node_test.ip, EL_IP_SIZE);
 			el_node_key->outbound = 1;
@@ -3492,10 +3521,32 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 
 static void update_unkey_timers(int elap)
 {
-	/* Time out, update the timers */
+	size_t i;
+	struct pending_vector pending_messages;
+	struct unkey_walk_closure closure = {
+		.elap = elap,
+		.pend = &pending_messages,
+	};
+
+	AST_VECTOR_INIT(&pending_messages, 16);
+	/* Unkey timeout, update the timers */
 	ast_mutex_lock(&el_nodelist_lock);
-	twalk_r(el_node_list, process_unkey_timers, &elap);
+	twalk_r(el_node_list, process_unkey_timers, &closure);
 	ast_mutex_unlock(&el_nodelist_lock);
+	/* queue messages outside of lock to prevent potential channel deadlock */
+	for (i = 0; i < AST_VECTOR_SIZE(&pending_messages); ++i) {
+		struct pending_ctrl item = AST_VECTOR_GET(&pending_messages, i);
+		struct ast_frame f = {
+			.frametype = AST_FRAME_CONTROL,
+			.subclass.integer = item.control,
+			.src = __PRETTY_FUNCTION__,
+		};
+
+		ast_queue_frame(item.chan, &f);
+		ast_channel_unref(item.chan);
+	}
+
+	AST_VECTOR_FREE(&pending_messages);
 }
 
 /*!
@@ -3672,7 +3723,7 @@ static void *el_reader(void *data)
 			break;
 		}
 
-		/* update the timers */
+		/* update the node timers */
 		update_unkey_timers(elap);
 
 		/* Echolink: send heartbeats and drop dead stations */
@@ -3683,10 +3734,12 @@ static void *el_reader(void *data)
 			ast_mutex_lock(&instp->lock);
 			instp->el_node_test.ip[0] = '\0';
 			ast_mutex_unlock(&instp->lock);
+
 			ast_mutex_lock(&el_nodelist_lock);
 			twalk(el_node_list, send_heartbeat);
 			ast_mutex_unlock(&el_nodelist_lock);
 
+			ast_mutex_lock(&instp->lock);
 			if (instp->el_node_test.ip[0] != '\0') {
 				if (find_delete(&instp->el_node_test)) {
 					int bye_length;
@@ -3708,6 +3761,7 @@ static void *el_reader(void *data)
 
 				instp->el_node_test.ip[0] = '\0';
 			}
+			ast_mutex_unlock(&instp->lock);
 		}
 
 		/*
@@ -3741,7 +3795,6 @@ static void *el_reader(void *data)
 						}
 						ast_mutex_lock(&el_nodelist_lock);
 						found_key = (struct el_node **) tfind(&instp->el_node_test, &el_node_list, compare_ip);
-						ast_mutex_unlock(&el_nodelist_lock);
 						if (found_key) {
 							node = *found_key;
 							node->pvt->firstheard = 1;
@@ -3757,7 +3810,9 @@ static void *el_reader(void *data)
 								ast_copy_string(node->name, name, EL_NAME_SIZE);
 							}
 							node->rx_ctrl_packets++;
+							ast_mutex_unlock(&el_nodelist_lock);
 						} else {   /* otherwise its a new request */
+							ast_mutex_unlock(&el_nodelist_lock);
 							i = 0; /* default authorized */
 							if (instp->ndenylist) {
 								for (x = 0; x < instp->ndenylist; x++) {
@@ -3878,6 +3933,7 @@ static void *el_reader(void *data)
 					process_cmd(buf, recvlen, instp->el_node_test.ip, instp);
 				} else {
 					ast_mutex_lock(&el_nodelist_lock);
+
 					found_key = (struct el_node **) tfind(&instp->el_node_test, &el_node_list, compare_ip);
 					if (found_key) {
 						struct el_pvt *pvt;
@@ -3915,6 +3971,7 @@ static void *el_reader(void *data)
 									send_text_one(node, "You are doubling.");
 								}
 								node->isdoubling = 1;
+								ast_mutex_unlock(&el_nodelist_lock);
 								continue;
 							}
 						}
@@ -3926,8 +3983,12 @@ static void *el_reader(void *data)
 								send_text_one(node, "You have timed out.");
 							}
 							node->istimedout = 1;
+							ast_mutex_unlock(&el_nodelist_lock);
 							continue;
 						}
+
+						ast_mutex_unlock(&el_nodelist_lock);
+
 						/* queue the gsm packets */
 						if (recvlen == sizeof(struct gsmVoice_t)) {
 							if (gsmPacket->version == 3 && gsmPacket->payt == 3) {
@@ -3952,7 +4013,7 @@ static void *el_reader(void *data)
 											.subclass.integer = AST_CONTROL_RADIO_KEY,
 											.src = __PRETTY_FUNCTION__,
 										};
-										ast_debug(1, "I'm keying up");
+
 										if (ast) {
 											ast_queue_frame(ast, &wf);
 										}
@@ -3998,12 +4059,11 @@ static void *el_reader(void *data)
 					} else {
 						instp->rx_bad_packets++;
 					}
-
-					ast_mutex_unlock(&el_nodelist_lock);
 				}
 			}
 		}
 		/* check current talker (see if they have stopped talking) */
+		ast_mutex_lock(&instp->lock);
 		if (instp->current_talker) {
 			if (ast_tvdiff_ms(ast_tvnow(), instp->current_talker_last_time) > AUDIO_TIMEOUT) {
 				ast_debug(3, "Station %s stopped talking.\n", instp->current_talker->call);
@@ -4014,7 +4074,6 @@ static void *el_reader(void *data)
 				instp->current_talker_last_time = (struct timeval) { 0 };
 			}
 		}
-		ast_mutex_lock(&instp->lock);
 	}
 
 	ast_mutex_unlock(&instp->lock);

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -1939,7 +1939,7 @@ static void update_timer(int *timer_ptr, int elap, int end_val)
  * \param which		Enum for VISIT used by twalk.
  * \param time		Points to decriment time.
  */
-static void process_timers(const void *nodep, const VISIT which, void *time)
+static void process_unkey_timers(const void *nodep, const VISIT which, void *time)
 {
 	const struct el_node *node;
 	struct el_pvt *pvt;
@@ -1950,7 +1950,6 @@ static void process_timers(const void *nodep, const VISIT which, void *time)
 		pvt = node->pvt;
 		if (pvt->rxkey) {
 			update_timer(&pvt->rxkey, elap, 0);
-			// pvt->rxkey -= *decr_time;
 			if (pvt->rxkey <= 0) {
 				struct ast_frame wf = {
 					.frametype = AST_FRAME_CONTROL,
@@ -2429,6 +2428,7 @@ static struct ast_channel *el_new(struct el_pvt *pvt, int state, unsigned int no
 
 	pvt->u = ast_module_user_add(tmp);
 	pvt->nodenum = nodenum;
+	pvt->owner = tmp;
 
 	if (state != AST_STATE_DOWN) {
 		if (ast_pbx_start(tmp)) {
@@ -2437,7 +2437,6 @@ static struct ast_channel *el_new(struct el_pvt *pvt, int state, unsigned int no
 		}
 	}
 
-	pvt->owner = tmp;
 	return tmp;
 }
 
@@ -3491,6 +3490,14 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 	return -1;
 }
 
+static void update_unkey_timers(int elap)
+{
+	/* Time out, update the timers */
+	ast_mutex_lock(&el_nodelist_lock);
+	twalk_r(el_node_list, process_unkey_timers, &elap);
+	ast_mutex_unlock(&el_nodelist_lock);
+}
+
 /*!
  * \brief This routine watches the UDP ports for activity.
  * It runs in its own thread and processes RTP / RTCP packets as they arrive.
@@ -3644,18 +3651,17 @@ static void *el_reader(void *data)
 			el_sleeptime = 0;
 			el_login_sleeptime = 0;
 		}
+
 		ast_mutex_unlock(&instp->lock);
 		/*
 		 * poll for activity
 		 */
 		i = ast_poll(fds, 2, 50);
+		elap = time_elapsed(&start_time);
 
 		if (i == 0) {
 			/* Time out, update the timers */
-			elap = time_elapsed(&start_time);
-			ast_mutex_lock(&el_nodelist_lock);
-			twalk_r(el_node_list, process_timers, &elap);
-			ast_mutex_unlock(&el_nodelist_lock);
+			update_unkey_timers(elap);
 			ast_mutex_lock(&instp->lock);
 			continue;
 		}
@@ -3667,10 +3673,7 @@ static void *el_reader(void *data)
 		}
 
 		/* update the timers */
-		elap = time_elapsed(&start_time);
-		ast_mutex_lock(&el_nodelist_lock);
-		twalk_r(el_node_list, process_timers, &elap);
-		ast_mutex_unlock(&el_nodelist_lock);
+		update_unkey_timers(elap);
 
 		/* Echolink: send heartbeats and drop dead stations */
 		update_timer(&heartbeat_timer, elap, 0);

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -3682,6 +3682,7 @@ static void *el_reader(void *data)
 			heartbeat_timer = KEEPALIVE_TIME;
 			ast_mutex_lock(&instp->lock);
 			instp->el_node_test.ip[0] = '\0';
+			ast_mutex_unlock(&instp->lock);
 			ast_mutex_lock(&el_nodelist_lock);
 			twalk(el_node_list, send_heartbeat);
 			ast_mutex_unlock(&el_nodelist_lock);
@@ -4013,7 +4014,9 @@ static void *el_reader(void *data)
 				instp->current_talker_last_time = (struct timeval) { 0 };
 			}
 		}
+		ast_mutex_lock(&instp->lock);
 	}
+
 	ast_mutex_unlock(&instp->lock);
 	ast_debug(1, "Echolink read thread exited.\n");
 	return NULL;

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -2262,20 +2262,6 @@ static int el_xwrite(struct ast_channel *ast, struct ast_frame *frame)
 
 		instp->tx_ctrl_packets++;
 	}
-	ast_mutex_lock(&p->lock);
-	if (p->rxkey == 1) {
-		struct ast_frame wf = {
-			.frametype = AST_FRAME_CONTROL,
-			.subclass.integer = AST_CONTROL_RADIO_UNKEY,
-			.src = __PRETTY_FUNCTION__,
-		};
-
-		ast_queue_frame(ast, &wf);
-	}
-	if (p->rxkey) {
-		p->rxkey--;
-	}
-	ast_mutex_unlock(&p->lock);
 	/* Asterisk to Echolink */
 	if (ast_format_cap_iscompatible_format(ast_channel_nativeformats(ast), frame->subclass.format) == AST_FORMAT_CMP_NOT_EQUAL) {
 		struct ast_str *cap_buf = ast_str_alloca(AST_FORMAT_CAP_NAMES_LEN);
@@ -3669,10 +3655,27 @@ static void *el_reader(void *data)
 						node->rx_audio_packets++;
 						/* compute inter-arrival jitter */
 						time_difference = ast_tvdiff_ms(current_packet_time, node->last_packet_time);
+
 						if (time_difference < 2000) {
 							node->jitter = (time_difference + node->jitter) / 2;
 						}
+
 						node->last_packet_time = current_packet_time;
+
+						if (pvt->rxkey == 1) {
+							struct ast_frame wf = {
+								.frametype = AST_FRAME_CONTROL,
+								.subclass.integer = AST_CONTROL_RADIO_UNKEY,
+								.src = __PRETTY_FUNCTION__,
+							};
+
+							ast_queue_frame(ast, &wf);
+						}
+
+						if (pvt->rxkey) {
+							pvt->rxkey--;
+						}
+
 						/*
 						 * see if we have a new talker
 						 */
@@ -3720,38 +3723,44 @@ static void *el_reader(void *data)
 										.offset = AST_FRIENDLY_OFFSET,
 										.src = __PRETTY_FUNCTION__,
 									};
-									ast_mutex_lock(&pvt->lock);
+
 									if (!pvt->rxkey) {
 										struct ast_frame wf = {
 											.frametype = AST_FRAME_CONTROL,
 											.subclass.integer = AST_CONTROL_RADIO_KEY,
 											.src = __PRETTY_FUNCTION__,
 										};
+
 										if (ast) {
 											ast_queue_frame(ast, &wf);
 										}
 									}
+
 									pvt->rxkey = MAX_RXKEY_TIME;
-									ast_mutex_unlock(&pvt->lock);
 									memcpy(inbuf + AST_FRIENDLY_OFFSET, gsmPacket->data + (GSM_FRAME_SIZE * i), GSM_FRAME_SIZE);
 									x = 0;
+
 									if (pvt->dsp) {
 										f2 = ast_translate(pvt->xpath, &fr, 0);
 										f1 = ast_dsp_process(NULL, pvt->dsp, f2);
+
 										if ((f1->frametype == AST_FRAME_DTMF_END) || (f1->frametype == AST_FRAME_DTMF_BEGIN)) {
 											if ((f1->subclass.integer != 'm') && (f1->subclass.integer != 'u')) {
 												if (f1->frametype == AST_FRAME_DTMF_END) {
 													ast_verb(4, "Echolink %s Got DTMF character %c from IP address %s.\n",
 														pvt->stream, f1->subclass.integer, pvt->ip);
 												}
+
 												if (ast) {
 													ast_queue_frame(ast, f1);
 													x = 1;
 												}
 											}
 										}
+
 										ast_frfree(f2); /* We own f2, f1 could be f2 or a control frame that should not be freed */
 									}
+
 									if (!x && ast) {
 										ast_queue_frame(ast, &fr);
 									}
@@ -3760,9 +3769,11 @@ static void *el_reader(void *data)
 						} else {
 							instp->rx_bad_packets++;
 						}
+
 					} else {
 						instp->rx_bad_packets++;
 					}
+
 					ast_mutex_unlock(&el_nodelist_lock);
 				}
 			}

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -3507,7 +3507,7 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *p, const char *
 
 	ast_mutex_lock(&el_nodelist_lock);
 
-	if (tfind(el_node_key, &el_node_list, compare_ip)) {
+	if (tsearch(el_node_key, &el_node_list, compare_ip)) {
 		ast_debug(1, "New Call - Callsign %s, IP Address %s, Node %i, Name %s.\n", el_node_key->call, el_node_key->ip,
 			el_node_key->nodenum, el_node_key->name);
 
@@ -3522,7 +3522,7 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *p, const char *
 			p = el_alloc(instp->name);
 			if (!p) {
 				ast_log(LOG_ERROR, "Cannot alloc el channel %s.\n", instp->name);
-				ast_free(el_node_key);
+				find_delete(el_node_key, instp);
 				ast_mutex_unlock(&el_nodelist_lock);
 				ast_mutex_unlock(&el_db_lock);
 				return -1;
@@ -3533,7 +3533,7 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *p, const char *
 			chan = el_new(p, AST_STATE_RINGING, el_node_key->nodenum, NULL, NULL);
 			if (!chan) {
 				ao2_ref(p, -1);
-				ast_free(el_node_key);
+				find_delete(el_node_key, instp);
 				ast_mutex_unlock(&el_nodelist_lock);
 				ast_mutex_unlock(&el_db_lock);
 				return -1;
@@ -3572,7 +3572,6 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *p, const char *
 
 		ast_mutex_unlock(&el_nodelist_lock);
 		ast_mutex_unlock(&el_db_lock);
-		tsearch(el_node_key, &el_node_list, compare_ip); /* Add the node to the list  after everything is "happy" */
 		return 0;
 	}
 

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -3322,15 +3322,16 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 			}
 			ast_mutex_unlock(&instp->lock);
 		}
-	} else {
-		ast_log(LOG_ERROR, "Failed to add new call, Callsign %s, IP Address %s, Name %s.\n", el_node_key->call, el_node_key->ip,
-			el_node_key->name);
-		ast_free(el_node_key);
+
 		ast_mutex_unlock(&el_db_lock);
-		return -1;
+		return 0;
 	}
+
+	ast_log(LOG_ERROR, "Failed to add new call, Callsign %s, IP Address %s, Name %s.\n", el_node_key->call, el_node_key->ip,
+		el_node_key->name);
+	ast_free(el_node_key);
 	ast_mutex_unlock(&el_db_lock);
-	return 0;
+	return -1;
 }
 
 /*!

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -1388,6 +1388,7 @@ static int el_call(struct ast_channel *ast, const char *dest, int timeout)
  */
 static void el_destroy(struct el_pvt *pvt)
 {
+	ast_mutex_lock(&pvt->lock);
 	if (pvt->dsp) {
 		ast_dsp_free(pvt->dsp);
 	}
@@ -1399,6 +1400,8 @@ static void el_destroy(struct el_pvt *pvt)
 	}
 	pvt->linkstr = NULL;
 	pvt->owner = NULL;
+	ast_mutex_unlock(&pvt->lock);
+
 	ast_mutex_lock(&el_nodelist_lock);
 	twalk(el_node_list, send_info);
 	ast_mutex_unlock(&el_nodelist_lock);
@@ -1432,6 +1435,7 @@ static struct el_pvt *el_alloc(const char *data)
 
 	pvt = ast_calloc(1, sizeof(struct el_pvt));
 	if (pvt) {
+		ast_mutex_init(&pvt->lock);
 		snprintf(pvt->stream, sizeof(pvt->stream), "%s-%lu", data, instances[n]->seqno++);
 
 		pvt->keepalive = KEEPALIVE_TIME;
@@ -2454,9 +2458,11 @@ static struct ast_channel *el_new(struct el_pvt *pvt, int state, unsigned int no
 		ast_set_callerid(tmp, tmpstr, NULL, NULL);
 	}
 
+	ast_mutex_lock(&pvt->lock);
 	pvt->u = ast_module_user_add(tmp);
 	pvt->nodenum = nodenum;
 	pvt->owner = tmp;
+	ast_mutex_unlock(&pvt->lock);
 
 	if (state != AST_STATE_DOWN) {
 		if (ast_pbx_start(tmp)) {

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -3841,9 +3841,9 @@ static void *el_reader(void *data)
 									pvt->rxkey = MAX_RXKEY_TIME;
 									memcpy(inbuf + AST_FRIENDLY_OFFSET, gsmPacket->data + (GSM_FRAME_SIZE * i), GSM_FRAME_SIZE);
 									x = 0;
+									f2 = ast_translate(pvt->xpath, &fr, 0);
 
 									if (pvt->dsp) {
-										f2 = ast_translate(pvt->xpath, &fr, 0);
 										f1 = ast_dsp_process(NULL, pvt->dsp, f2);
 
 										if ((f1->frametype == AST_FRAME_DTMF_END) || (f1->frametype == AST_FRAME_DTMF_BEGIN)) {
@@ -3855,16 +3855,19 @@ static void *el_reader(void *data)
 
 												if (ast) {
 													ast_queue_frame(ast, f1);
+													ast_frfree(f1);
 													x = 1;
 												}
 											}
 										}
-
-										ast_frfree(f2); /* We own f2, f1 could be f2 or a control frame that should not be freed */
 									}
 
-									if (!x && ast) {
-										ast_queue_frame(ast, &fr);
+									if (!x) {
+										if (ast) {
+											ast_queue_frame(ast, f2);
+										}
+
+										ast_frfree(f2);
 									}
 								}
 							}

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -417,8 +417,9 @@ struct el_instance {
 	char port[EL_IP_SIZE];
 	char astnode[EL_NAME_SIZE];
 	char context[EL_NAME_SIZE];
-	/* missed 10 heartbeats, you're out */
-	short rtcptimeout;
+	short rtcptimeout; /*!< rtcptimeout: Maximum number of missed heartbeat intervals before considering
+						* the Echolink connection as timed out. Used to detect and handle lost connections.
+						*/
 	float lat;
 	float lon;
 	float freq;

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -186,7 +186,7 @@ do not use 127.0.0.1
 #include "asterisk/cli.h"
 #include "asterisk/format_cache.h"
 
-#define MAX_RXKEY_TIME 80	   /* ms */
+#define MAX_RXKEY_TIME 320	   /* ms */
 #define KEEPALIVE_TIME 50 * 10 /* 50 * 10 * 20ms iax2 = 10,000ms = 10 seconds heartbeat */
 #define AUTH_RETRY_MS 5000
 #define AUTH_ABANDONED_MS 15000
@@ -1871,6 +1871,67 @@ static void lookup_node_nodenum(const void *nodep, const VISIT which, void *clos
 		}
 	}
 }
+/*!
+ * \brief get current time in timeval
+ * \return timeval structure
+ */
+static struct timeval tvnow(void)
+{
+	struct timeval t;
+	struct timespec ts;
+
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	t = ast_tv(ts.tv_sec, ts.tv_nsec / 1000);
+
+	return t;
+}
+
+/*!
+ * \brief calculate elapsed time in milliseconds
+ * \param start Pointer to timeval structure of the start time. This will be updated to the current time minus any residual milliseconds.
+ * \return elapsed time in milliseconds
+ */
+static int time_elapsed(struct timeval *start)
+{
+	int elap;
+	struct timeval now, elap_tv_us;
+
+	now = tvnow();
+	elap_tv_us = ast_tvsub(now, *start);
+	elap = (elap_tv_us.tv_sec * 1000) + (elap_tv_us.tv_usec / 1000);
+
+	if (elap > 0) {
+		struct timeval elap_tv_ms, residualtime;
+
+		elap_tv_ms = ast_tv(elap_tv_us.tv_sec, (elap_tv_us.tv_usec / 1000) * 1000);
+		residualtime = ast_tvsub(elap_tv_us, elap_tv_ms);
+		*start = ast_tvsub(now, residualtime);
+	}
+
+	return elap;
+}
+
+/*!
+ * \brief update a count down timer
+ * \param timer_ptr Pointer to the timer value.
+ * \param elap Elapsed time in milliseconds.
+ * \param end_val The value at which the timer ends.
+ */
+static void update_timer(int *timer_ptr, int elap, int end_val)
+{
+	if (!timer_ptr || !*timer_ptr) {
+		/* if the timer value = 0 or we have a null pointer, do not update */
+		return;
+	}
+
+	if (*timer_ptr > end_val) {
+		*timer_ptr -= elap;
+	}
+
+	if (*timer_ptr < end_val) {
+		*timer_ptr = end_val;
+	}
+}
 
 /*!
  * \brief Update timers for all nodes
@@ -1882,21 +1943,24 @@ static void process_timers(const void *nodep, const VISIT which, void *time)
 {
 	const struct el_node *node;
 	struct el_pvt *pvt;
-	int *decr_time = time;
+	int elap = *(int *) time;
 
 	if ((which == leaf) || (which == postorder)) {
 		node = *(struct el_node **) nodep;
 		pvt = node->pvt;
 		if (pvt->rxkey) {
-			pvt->rxkey -= *decr_time;
+			update_timer(&pvt->rxkey, elap, 0);
+			// pvt->rxkey -= *decr_time;
 			if (pvt->rxkey <= 0) {
 				struct ast_frame wf = {
 					.frametype = AST_FRAME_CONTROL,
 					.subclass.integer = AST_CONTROL_RADIO_UNKEY,
 					.src = __PRETTY_FUNCTION__,
 				};
-
-				ast_queue_frame(pvt->owner, &wf);
+				ast_debug(1, "I'm unkeying");
+				if (pvt->owner) {
+					ast_queue_frame(pvt->owner, &wf);
+				}
 				pvt->rxkey = 0;
 			}
 		}
@@ -2394,6 +2458,7 @@ static struct ast_channel *el_new(struct el_pvt *pvt, int state, unsigned int no
 			ast_hangup(tmp);
 		}
 	}
+	pvt->owner = tmp;
 	return tmp;
 }
 
@@ -2428,7 +2493,9 @@ static struct ast_channel *el_request(const char *type, struct ast_format_cap *c
 	if (!str) {
 		return NULL;
 	}
+
 	nodenum = 0;
+
 	cp = strchr(str, '/');
 	if (cp) {
 		*cp++ = 0;
@@ -2436,14 +2503,16 @@ static struct ast_channel *el_request(const char *type, struct ast_format_cap *c
 			nodenum = atoi(cp);
 		}
 	}
+
 	p = el_alloc(str);
+
 	if (p) {
 		tmp = el_new(p, AST_STATE_DOWN, nodenum, assignedids, requestor);
 		if (!tmp) {
 			el_destroy(p);
 		}
 	}
-	p->owner = tmp;
+
 	return tmp;
 }
 
@@ -3386,6 +3455,8 @@ static void *el_reader(void *data)
 	struct timeval current_packet_time;
 	struct gsmVoice_t *gsmPacket;
 	uint32_t time_difference;
+	struct timeval start_time;
+	int elap;
 
 	time(&instp->starttime);
 	instp->aprstime = instp->starttime + EL_APRS_START_DELAY;
@@ -3397,6 +3468,8 @@ static void *el_reader(void *data)
 	fds[0].events = POLLIN;
 	fds[1].fd = instp->audio_sock;
 	fds[1].events = POLLIN;
+
+	start_time = tvnow();
 
 	while (run_forever) {
 		/* Send APRS information every EL_APRS_INTERVAL */
@@ -3496,6 +3569,11 @@ static void *el_reader(void *data)
 		 */
 		i = ast_poll(fds, 2, 50);
 		if (i == 0) {
+			/* Time out, update the timers */
+			elap = time_elapsed(&start_time);
+			ast_mutex_lock(&el_nodelist_lock);
+			twalk_r(el_node_list, process_timers, &elap);
+			ast_mutex_unlock(&el_nodelist_lock);
 			ast_mutex_lock(&instp->lock);
 			continue;
 		}
@@ -3505,7 +3583,11 @@ static void *el_reader(void *data)
 			break;
 		}
 
-		twalk_r(el_node_list, process_timers, &i);
+		/* update the timers */
+		elap = time_elapsed(&start_time);
+		ast_mutex_lock(&el_nodelist_lock);
+		twalk_r(el_node_list, process_timers, &elap);
+		ast_mutex_unlock(&el_nodelist_lock);
 
 		ast_mutex_lock(&instp->lock);
 		/*
@@ -3684,7 +3766,7 @@ static void *el_reader(void *data)
 						node = *found_key;
 						pvt = node->pvt;
 						ast = pvt->owner;
-						node->pvt->firstheard = 1;
+						pvt->firstheard = 1;
 						node->countdown = instp->rtcptimeout;
 						node->rx_audio_packets++;
 						/* compute inter-arrival jitter */
@@ -3750,7 +3832,7 @@ static void *el_reader(void *data)
 											.subclass.integer = AST_CONTROL_RADIO_KEY,
 											.src = __PRETTY_FUNCTION__,
 										};
-
+										ast_debug(1, "I'm keying up");
 										if (ast) {
 											ast_queue_frame(ast, &wf);
 										}

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -357,7 +357,7 @@ struct el_node {
 	char name[EL_NAME_SIZE];
 	char outbound;
 	unsigned int nodenum;
-	short countdown;
+	short heartbeat_countdown;
 	uint16_t seqnum;
 	float jitter;
 	struct el_instance *instp;
@@ -485,7 +485,7 @@ struct el_pvt {
 	unsigned int nodenum;
 	struct ast_str *linkstr;
 	struct gsmVoice_t audio;
-	struct el_node el_node_test;
+	struct el_node node_lookup;
 	ast_mutex_t lock;
 };
 
@@ -534,14 +534,14 @@ static char *rpt_config = "rpt.conf";
 
 static struct ast_channel *el_request(const char *type, struct ast_format_cap *cap, const struct ast_assigned_ids *assignedids,
 	const struct ast_channel *requestor, const char *data, int *cause);
-static int el_call(struct ast_channel *ast, const char *dest, int timeout);
-static int el_hangup(struct ast_channel *ast);
-static struct ast_frame *el_xread(struct ast_channel *ast);
-static int el_xwrite(struct ast_channel *ast, struct ast_frame *frame);
-static int el_indicate(struct ast_channel *ast, int cond, const void *data, size_t datalen);
-static int el_digit_begin(struct ast_channel *c, char digit);
-static int el_digit_end(struct ast_channel *c, char digit, unsigned int duratiion);
-static int el_text(struct ast_channel *c, const char *text);
+static int el_call(struct ast_channel *chan, const char *dest, int timeout);
+static int el_hangup(struct ast_channel *chan);
+static struct ast_frame *el_xread(struct ast_channel *chan);
+static int el_xwrite(struct ast_channel *chan, struct ast_frame *frame);
+static int el_indicate(struct ast_channel *chan, int cond, const void *data, size_t datalen);
+static int el_digit_begin(struct ast_channel *chan, char digit);
+static int el_digit_end(struct ast_channel *chan, char digit, unsigned int duratiion);
+static int el_text(struct ast_channel *chan, const char *text);
 static int el_queryoption(struct ast_channel *chan, int option, void *data, int *datalen);
 
 static void send_info(const void *nodep, const VISIT which, const int depth);
@@ -1307,28 +1307,28 @@ static int is_rtcp_sdes(const unsigned char *pkt, int len)
 
 /*!
  * \brief Echolink call.
- * \param ast			Pointer to Asterisk channel.
+ * \param chan			Pointer to Asterisk channel.
  * \param dest			Pointer to Destination (echolink node number - format 'el0/009999').
  * \param timeout		Timeout.
  * \retval -1 			if not successful.
  * \retval 0 			if successful.
  */
-static int el_call(struct ast_channel *ast, const char *dest, int timeout)
+static int el_call(struct ast_channel *chan, const char *dest, int timeout)
 {
-	struct el_pvt *p = ast_channel_tech_pvt(ast);
+	struct el_pvt *p = ast_channel_tech_pvt(chan);
 	struct el_instance *instp = p->instp;
 	struct eldb *foundnode;
 	char ipaddr[EL_IP_SIZE];
 	char buf[100];
 	char *str, *cp;
 
-	if ((ast_channel_state(ast) != AST_STATE_DOWN) && (ast_channel_state(ast) != AST_STATE_RESERVED)) {
-		ast_log(LOG_WARNING, "el_call called on %s, neither down nor reserved.\n", ast_channel_name(ast));
+	if ((ast_channel_state(chan) != AST_STATE_DOWN) && (ast_channel_state(chan) != AST_STATE_RESERVED)) {
+		ast_log(LOG_WARNING, "el_call called on %s, neither down nor reserved.\n", ast_channel_name(chan));
 		return -1;
 	}
 	/* Make sure we have a destination */
 	if (!*dest) {
-		ast_log(LOG_WARNING, "Call on %s failed - no destination.\n", ast_channel_name(ast));
+		ast_log(LOG_WARNING, "Call on %s failed - no destination.\n", ast_channel_name(chan));
 		return -1;
 	}
 	/* When we call, it just works, really, there's no destination...  Just
@@ -1364,64 +1364,67 @@ static int el_call(struct ast_channel *ast, const char *dest, int timeout)
 	ast_free(str);
 
 	if (!foundnode) {
-		ast_verb(3, "Call for node %s on %s, failed. Node not found in database.\n", dest, ast_channel_name(ast));
+		ast_verb(3, "Call for node %s on %s, failed. Node not found in database.\n", dest, ast_channel_name(chan));
 		return -1;
 	}
 
 	snprintf(buf, sizeof(buf), "o.conip %s", ipaddr);
 
-	ast_debug(1, "Calling %s/%s on %s.\n", dest, ipaddr, ast_channel_name(ast));
+	ast_debug(1, "Calling %s/%s on %s.\n", dest, ipaddr, ast_channel_name(chan));
 
 	/* make the call */
 	ast_mutex_lock(&instp->lock);
-	strcpy(p->el_node_test.ip, ipaddr);
+	strcpy(p->node_lookup.ip, ipaddr);
 	do_new_call(instp, p, "OUTBOUND", "OUTBOUND");
 	process_cmd(buf, sizeof(buf), "127.0.0.1", instp);
 	ast_mutex_unlock(&instp->lock);
-	ast_setstate(ast, AST_STATE_RINGING);
+	ast_setstate(chan, AST_STATE_RINGING);
 
 	return 0;
 }
 
 /*!
  * \brief Destroy and free an echolink instance.
- * \param pvt		Pointer to el_pvt struct to release.
+ * \param obj Pointer to el_pvt struct to release.
  */
 static void el_destroy(void *obj)
 {
-	struct el_pvt *pvt = obj;
+	struct el_pvt *p = obj;
 
-	if (pvt->dsp) {
-		ast_dsp_free(pvt->dsp);
+	if (p->dsp) {
+		ast_dsp_free(p->dsp);
 	}
-	if (pvt->xpath) {
-		ast_translator_free_path(pvt->xpath);
+
+	if (p->xpath) {
+		ast_translator_free_path(p->xpath);
 	}
-	if (pvt->linkstr) {
-		ast_free(pvt->linkstr);
+
+	if (p->linkstr) {
+		ast_free(p->linkstr);
 	}
-	pvt->linkstr = NULL;
-	ast_mutex_lock(&pvt->lock);
-	pvt->owner = NULL;
-	ast_mutex_unlock(&pvt->lock);
+
+	ast_mutex_lock(&p->lock);
+	p->linkstr = NULL;
+	p->owner = NULL;
+	ast_mutex_unlock(&p->lock);
 
 	ast_mutex_lock(&el_nodelist_lock);
 	twalk(el_node_list, send_info);
 	ast_mutex_unlock(&el_nodelist_lock);
 
-	if (pvt->u) {
-		ast_module_user_remove(pvt->u);
+	if (p->u) {
+		ast_module_user_remove(p->u);
 	}
 }
 
 /*!
  * \brief Allocate and initialize an echolink private structure.
  * \param data			Pointer to echolink instance name to initialize.
- * \retval 				el_pvt structure.
+ * \retval 				ao2 el_pvt structure.
  */
 static struct el_pvt *el_alloc(const char *data)
 {
-	struct el_pvt *pvt;
+	struct el_pvt *p;
 	int n;
 
 	if (ast_strlen_zero(data)) {
@@ -1438,58 +1441,62 @@ static struct el_pvt *el_alloc(const char *data)
 		return NULL;
 	}
 
-	pvt = ao2_alloc(sizeof(struct el_pvt), el_destroy);
-	if (pvt) {
-		snprintf(pvt->stream, sizeof(pvt->stream), "%s-%lu", data, instances[n]->seqno++);
+	p = ao2_alloc(sizeof(struct el_pvt), el_destroy);
+	if (p) {
+		snprintf(p->stream, sizeof(p->stream), "%s-%lu", data, instances[n]->seqno++);
 
-		pvt->keepalive = KEEPALIVE_TIME;
-		pvt->instp = instances[n];
-		pvt->dsp = ast_dsp_new();
-		if (!pvt->dsp) {
+		p->keepalive = KEEPALIVE_TIME;
+		p->instp = instances[n];
+		p->dsp = ast_dsp_new();
+
+		if (!p->dsp) {
 			ast_log(LOG_ERROR, "Cannot get DSP!\n");
-			ao2_cleanup(pvt);
+			ao2_cleanup(p);
 			return NULL;
 		}
-		pvt->hangup = 0;
-		ast_dsp_set_features(pvt->dsp, DSP_FEATURE_DIGIT_DETECT);
-		ast_dsp_set_digitmode(pvt->dsp, DSP_DIGITMODE_DTMF | DSP_DIGITMODE_MUTECONF | DSP_DIGITMODE_RELAXDTMF);
-		pvt->xpath = ast_translator_build_path(ast_format_slin, ast_format_gsm);
-		if (!pvt->xpath) {
+
+		p->hangup = 0;
+		ast_dsp_set_features(p->dsp, DSP_FEATURE_DIGIT_DETECT);
+		ast_dsp_set_digitmode(p->dsp, DSP_DIGITMODE_DTMF | DSP_DIGITMODE_MUTECONF | DSP_DIGITMODE_RELAXDTMF);
+
+		p->xpath = ast_translator_build_path(ast_format_slin, ast_format_gsm);
+
+		if (!p->xpath) {
 			ast_log(LOG_ERROR, "Cannot get translator!\n");
-			ao2_cleanup(pvt);
+			ast_dsp_free(p->dsp);
+			ao2_cleanup(p);
 			return NULL;
 		}
-		ast_mutex_init(&pvt->lock);
+
+		ast_mutex_init(&p->lock);
 	}
-	return pvt;
+	return p;
 }
 
 /*!
  * \brief Asterisk hangup function.
- * \param ast			Asterisk channel.
+ * \param chan			Asterisk channel.
  * \retval 0			Always returns 0.
  */
-static int el_hangup(struct ast_channel *ast)
+static int el_hangup(struct ast_channel *chan)
 {
-	struct el_pvt *pvt = ast_channel_tech_pvt(ast);
-	struct el_instance *instp = pvt->instp;
+	struct el_pvt *p = ast_channel_tech_pvt(chan);
+	struct el_instance *instp = p->instp;
 	int i, n;
 	unsigned char bye[50];
 	struct sockaddr_in sin;
 	time_t now;
 
-	ast_debug(1, "Sent bye to IP address %s.\n", pvt->ip);
-	ast_mutex_lock(&instp->lock);
-	strcpy(instp->el_node_test.ip, pvt->ip);
-	find_delete(&instp->el_node_test, instp);
-	ast_softhangup(ast, AST_SOFTHANGUP_DEV);
-	pvt->hangup = 0;
-	ast_mutex_unlock(&instp->lock);
+	ast_debug(1, "Sent bye to IP address %s.\n", p->ip);
+	strcpy(p->node_lookup.ip, p->ip);
+	find_delete(&p->node_lookup, instp);
+	ast_softhangup(chan, AST_SOFTHANGUP_DEV);
+	p->hangup = 0;
 	n = rtcp_make_bye(bye, sizeof(bye), "disconnected");
 
 	memset(&sin, 0, sizeof(sin));
 	sin.sin_family = AF_INET;
-	sin.sin_addr.s_addr = inet_addr(pvt->ip);
+	sin.sin_addr.s_addr = inet_addr(p->ip);
 	sin.sin_port = htons(instp->ctrl_port);
 
 	/* send 20 bye packets to insure that they receive this disconnect */
@@ -1504,17 +1511,17 @@ static int el_hangup(struct ast_channel *ast)
 		instp->aprstime = now;
 	}
 
-	ast_debug(1, "Hanging up (%s).\n", ast_channel_name(ast));
+	ast_debug(1, "Hanging up (%s).\n", ast_channel_name(chan));
 
-	if (!ast_channel_tech_pvt(ast)) {
+	if (!ast_channel_tech_pvt(chan)) {
 		ast_log(LOG_WARNING, "Asked to hangup channel not connected.\n");
 		return 0;
 	}
 
-	ast_channel_tech_pvt_set(ast, NULL);
-	ast_mutex_destroy(&pvt->lock);
-	ao2_ref(pvt, -1);
-	ast_setstate(ast, AST_STATE_DOWN);
+	ast_channel_tech_pvt_set(chan, NULL);
+	ast_mutex_destroy(&p->lock);
+	ao2_ref(p, -1);
+	ast_setstate(chan, AST_STATE_DOWN);
 
 	return 0;
 }
@@ -1522,23 +1529,23 @@ static int el_hangup(struct ast_channel *ast)
 /*!
  * \brief Asterisk indicate function.
  * This is used to indicate tx key / unkey.
- * \param ast			Pointer to Asterisk channel.
+ * \param chan			Pointer to Asterisk channel.
  * \param cond			Condition.
  * \param data			Pointer to data.
  * \param datalen		Pointer to data length.
  * \retval 0			If successful.
  * \retval -1			For hangup.
  */
-static int el_indicate(struct ast_channel *ast, int cond, const void *data, size_t datalen)
+static int el_indicate(struct ast_channel *chan, int cond, const void *data, size_t datalen)
 {
-	struct el_pvt *pvt = ast_channel_tech_pvt(ast);
+	struct el_pvt *p = ast_channel_tech_pvt(chan);
 
 	switch (cond) {
 	case AST_CONTROL_RADIO_KEY:
-		pvt->txkey = 1;
+		p->txkey = 1;
 		break;
 	case AST_CONTROL_RADIO_UNKEY:
-		pvt->txkey = 0;
+		p->txkey = 0;
 		break;
 	case AST_CONTROL_HANGUP:
 		return -1;
@@ -1551,23 +1558,23 @@ static int el_indicate(struct ast_channel *ast, int cond, const void *data, size
 
 /*!
  * \brief Asterisk digit begin function.
- * \param ast			Pointer to Asterisk channel.
+ * \param chan			Pointer to Asterisk channel.
  * \param digit			Digit processed.
  * \retval -1
  */
-static int el_digit_begin(struct ast_channel *ast, char digit)
+static int el_digit_begin(struct ast_channel *chan, char digit)
 {
 	return -1;
 }
 
 /*!
  * \brief Asterisk digit end function.
- * \param ast			Pointer to Asterisk channel.
+ * \param chan			Pointer to Asterisk channel.
  * \param digit			Digit processed.
  * \param duration		Duration of the digit.
  * \retval -1
  */
-static int el_digit_end(struct ast_channel *ast, char digit, unsigned int duration)
+static int el_digit_end(struct ast_channel *chan, char digit, unsigned int duration)
 {
 	return -1;
 }
@@ -1658,16 +1665,16 @@ static int mycompar(const void *a, const void *b)
 
 /*!
  * \brief Asterisk text function.
- * \param ast			Pointer to Asterisk channel.
+ * \param chan			Pointer to Asterisk channel.
  * \param text			Pointer to text message to process.
  * \retval 0			If successful.
  * \retval -1			If unsuccessful.
  */
-static int el_text(struct ast_channel *ast, const char *text)
+static int el_text(struct ast_channel *chan, const char *text)
 {
 #define MAXLINKSTRS 250
 
-	struct el_pvt *pvt = ast_channel_tech_pvt(ast);
+	struct el_pvt *p = ast_channel_tech_pvt(chan);
 	const char *delim = " ";
 	char *cmd, *arg1, *arg4;
 	char *ptr, *saveptr, *cp;
@@ -1675,20 +1682,20 @@ static int el_text(struct ast_channel *ast, const char *text)
 	int i, j, k, x;
 
 	/* see if we are receiving a link text message */
-	if (pvt->instp && (text[0] == 'L')) {
+	if (p->instp && (text[0] == 'L')) {
 		if (strlen(text) < 3) {
-			if (pvt->linkstr) {
-				ast_free(pvt->linkstr);
-				pvt->linkstr = NULL;
+			if (p->linkstr) {
+				ast_free(p->linkstr);
+				p->linkstr = NULL;
 				ast_mutex_lock(&el_nodelist_lock);
 				twalk(el_node_list, send_info);
 				ast_mutex_unlock(&el_nodelist_lock);
 			}
 			return 0;
 		}
-		if (pvt->linkstr) {
-			ast_free(pvt->linkstr);
-			pvt->linkstr = NULL;
+		if (p->linkstr) {
+			ast_free(p->linkstr);
+			p->linkstr = NULL;
 		}
 		cp = ast_strdup(text + 2);
 		if (!cp) {
@@ -1753,7 +1760,7 @@ static int el_text(struct ast_channel *ast, const char *text)
 			}
 			ast_str_append(&pkt, 0, "\r");
 
-			pvt->linkstr = pkt;
+			p->linkstr = pkt;
 		}
 		ast_free(cp);
 		ast_mutex_lock(&el_nodelist_lock);
@@ -1783,12 +1790,12 @@ static int el_text(struct ast_channel *ast, const char *text)
 	arg4 = strtok_r(NULL, delim, &saveptr);
 
 	if (!strcasecmp(cmd, "D")) {
-		snprintf(str, sizeof(str), "3%06u", pvt->nodenum);
+		snprintf(str, sizeof(str), "3%06u", p->nodenum);
 		/* if not for this one, we can't go any farther */
 		if (strcmp(arg1, str)) {
 			return 0;
 		}
-		ast_senddigit(ast, *arg4, 0);
+		ast_senddigit(chan, *arg4, 0);
 		return 0;
 	}
 	return 0;
@@ -1821,7 +1828,7 @@ static void send_audio_only_one(const void *nodep, const VISIT which, const int 
 	struct sockaddr_in sin;
 
 	if ((which == leaf) || (which == postorder)) {
-		if (strncmp(node->ip, p->el_node_test.ip, EL_IP_SIZE) == 0) {
+		if (strncmp(node->ip, p->node_lookup.ip, EL_IP_SIZE) == 0) {
 			memset(&sin, 0, sizeof(sin));
 			sin.sin_family = AF_INET;
 			sin.sin_port = htons(instp->audio_port);
@@ -1905,7 +1912,7 @@ static void lookup_node_nodenum(const void *nodep, const VISIT which, void *clos
 	}
 }
 /*!
- * \brief get current time in timeval
+ * \brief get current clock time monotonic in timeval format
  * \return timeval structure
  */
 static struct timeval tvnow(void)
@@ -1947,8 +1954,8 @@ static int time_elapsed(struct timeval *start)
 /*!
  * \brief update a count down timer
  * \param timer_ptr Pointer to the timer value.
- * \param elap Elapsed time in milliseconds.
- * \param end_val The value at which the timer ends.
+ * \param elap      Elapsed time in milliseconds.
+ * \param end_val   The value at which the timer ends.
  */
 static void update_timer(int *timer_ptr, int elap, int end_val)
 {
@@ -1976,24 +1983,24 @@ static void process_unkey_timers(const void *nodep, const VISIT which, void *clo
 {
 	struct unkey_walk_closure *cl = closure;
 	const struct el_node *node;
-	struct el_pvt *pvt;
+	struct el_pvt *p;
 
 	if ((which == leaf) || (which == postorder)) {
 		node = *(struct el_node **) nodep;
-		pvt = node->pvt;
+		p = node->pvt;
 
-		if (!pvt || !pvt->rxkey) {
+		if (!p || !p->rxkey) {
 			return;
 		}
 
-		ao2_ref(pvt, +1);
-		update_timer(&pvt->rxkey, cl->elap, 0);
+		ao2_ref(p, +1);
+		update_timer(&p->rxkey, cl->elap, 0);
 
-		if (pvt->rxkey <= 0) {
+		if (p->rxkey <= 0) {
 			/* The timer has expired, queue up an unkey for the channel */
 			struct ast_channel *chan;
 
-			chan = pvt->owner ? ast_channel_ref(pvt->owner) : NULL;
+			chan = p->owner ? ast_channel_ref(p->owner) : NULL;
 			if (chan) {
 				struct pending_ctrl item = {
 					.chan = chan,
@@ -2006,10 +2013,10 @@ static void process_unkey_timers(const void *nodep, const VISIT which, void *clo
 				}
 			}
 
-			pvt->rxkey = 0;
+			p->rxkey = 0;
 		}
 
-		ao2_ref(pvt, -1);
+		ao2_ref(p, -1);
 	}
 }
 
@@ -2090,16 +2097,17 @@ static void send_heartbeat(const void *nodep, const VISIT which, const int depth
 	int sdes_length;
 
 	if ((which == leaf) || (which == postorder)) {
-		if (node->countdown >= 0) {
-			node->countdown--;
+		if (node->heartbeat_countdown >= 0) {
+			node->heartbeat_countdown--;
 		}
 
-		if (node->countdown < 0) {
+		if (node->heartbeat_countdown < 0) {
 			ast_copy_string(instp->el_node_test.ip, node->ip, EL_IP_SIZE);
 			ast_copy_string(instp->el_node_test.call, node->call, EL_CALL_SIZE);
 			ast_log(LOG_WARNING, "Countdown for Callsign %s, IP Address %s is negative.\n", instp->el_node_test.call,
 				instp->el_node_test.ip);
 		}
+
 		memset(sdes_packet, 0, sizeof(sdes_packet));
 		sdes_length = rtcp_make_sdes(sdes_packet, sizeof(sdes_packet), instp->mycall, instp->myname, instp->astnode);
 
@@ -2126,7 +2134,7 @@ static void send_text(const void *nodep, const VISIT which, const int depth)
 	struct el_node *node = *(struct el_node **) nodep;
 
 	if ((which == leaf) || (which == postorder)) {
-		if (strncmp(node->ip, node->pvt->el_node_test.ip, sizeof(node->ip))) {
+		if (strncmp(node->ip, node->pvt->node_lookup.ip, sizeof(node->ip))) {
 			memset(&sin, 0, sizeof(sin));
 			sin.sin_family = AF_INET;
 			sin.sin_port = htons(node->instp->audio_port);
@@ -2202,7 +2210,8 @@ static int find_delete(const struct el_node *key, struct el_instance *instp)
 		found = 1;
 		node->pvt->hangup = 1;
 		tdelete(node, &el_node_list, compare_ip);
-		node->pvt = NULL; /* We've dereferenced the node pvt, by setting it to null.  Hangup will clean up the reference */
+		ao2_ref(node->pvt, -1);
+		node->pvt = NULL;
 		ast_free(node);
 	}
 
@@ -2323,11 +2332,8 @@ static void process_cmd(char *buf, int buf_len, const char *fromip, struct el_in
 		sin.sin_addr.s_addr = inet_addr(arg1);
 
 		if (conn == 0) {
-			n = 1;
 			pack_length = rtcp_make_sdes(pack, sizeof(pack), instp->mycall, instp->myname, instp->astnode);
-			for (i = 0; i < n; i++) {
-				sendto(instp->ctrl_sock, pack, pack_length, 0, (struct sockaddr *) &sin, sizeof(sin));
-			}
+			sendto(instp->ctrl_sock, pack, pack_length, 0, (struct sockaddr *) &sin, sizeof(sin));
 			ast_debug(3, "Connect request sent to %s.\n", arg1);
 
 		} else { /* It's a disconnect */
@@ -2352,15 +2358,15 @@ static void process_cmd(char *buf, int buf_len, const char *fromip, struct el_in
 
 /*!
  * \brief Asterisk read function.
- * \param ast			Pointer to Asterisk channel.
- * \retval 				Asterisk frame.
+ * \param chan			Pointer to Asterisk channel.
+ * \retval				Asterisk frame.
  */
-static struct ast_frame *el_xread(struct ast_channel *ast)
+static struct ast_frame *el_xread(struct ast_channel *chan)
 {
-	struct el_pvt *p = ast_channel_tech_pvt(ast);
+	struct el_pvt *p = ast_channel_tech_pvt(chan);
 
 	if (p->hangup) {
-		ast_softhangup(ast, AST_SOFTHANGUP_DEV);
+		ast_softhangup(chan, AST_SOFTHANGUP_DEV);
 		p->hangup = 0;
 	}
 
@@ -2371,7 +2377,7 @@ static struct ast_frame *el_xread(struct ast_channel *ast)
 			.src = __PRETTY_FUNCTION__,
 		};
 
-		ast_queue_frame(ast, &fr);
+		ast_queue_frame(chan, &fr);
 		p->last_firstheard = 1;
 	}
 
@@ -2381,14 +2387,14 @@ static struct ast_frame *el_xread(struct ast_channel *ast)
 /*!
  * \brief Asterisk write function.
  * This routine handles asterisk to echolink.
- * \param ast			Pointer to Asterisk channel.
+ * \param chan			Pointer to Asterisk channel.
  * \param frame			Pointer to Asterisk frame to process.
  * \retval 0			Successful.
  */
-static int el_xwrite(struct ast_channel *ast, struct ast_frame *frame)
+static int el_xwrite(struct ast_channel *chan, struct ast_frame *frame)
 {
 	struct sockaddr_in sin;
-	struct el_pvt *p = ast_channel_tech_pvt(ast);
+	struct el_pvt *p = ast_channel_tech_pvt(chan);
 	struct el_instance *instp = p->instp;
 
 	if (!p->last_firstheard && p->firstheard) {
@@ -2398,7 +2404,7 @@ static int el_xwrite(struct ast_channel *ast, struct ast_frame *frame)
 			.src = __PRETTY_FUNCTION__,
 		};
 
-		ast_queue_frame(ast, &fr3);
+		ast_queue_frame(chan, &fr3);
 		p->last_firstheard = 1;
 	}
 
@@ -2407,7 +2413,7 @@ static int el_xwrite(struct ast_channel *ast, struct ast_frame *frame)
 	}
 
 	if (p->hangup) {
-		ast_softhangup(ast, AST_SOFTHANGUP_DEV);
+		ast_softhangup(chan, AST_SOFTHANGUP_DEV);
 		p->hangup = 0;
 	}
 
@@ -2429,11 +2435,11 @@ static int el_xwrite(struct ast_channel *ast, struct ast_frame *frame)
 	}
 
 	/* Asterisk to Echolink */
-	if (ast_format_cap_iscompatible_format(ast_channel_nativeformats(ast), frame->subclass.format) == AST_FORMAT_CMP_NOT_EQUAL) {
+	if (ast_format_cap_iscompatible_format(ast_channel_nativeformats(chan), frame->subclass.format) == AST_FORMAT_CMP_NOT_EQUAL) {
 		struct ast_str *cap_buf = ast_str_alloca(AST_FORMAT_CAP_NAMES_LEN);
 		ast_log(LOG_WARNING, "Asked to transmit frame type %s, while native formats is %s (read/write = (%s/%s)).\n",
-			ast_format_get_name(frame->subclass.format), ast_format_cap_get_names(ast_channel_nativeformats(ast), &cap_buf),
-			ast_format_get_name(ast_channel_readformat(ast)), ast_format_get_name(ast_channel_writeformat(ast)));
+			ast_format_get_name(frame->subclass.format), ast_format_cap_get_names(ast_channel_nativeformats(chan), &cap_buf),
+			ast_format_get_name(ast_channel_readformat(chan)), ast_format_get_name(ast_channel_writeformat(chan)));
 		return 0;
 	}
 
@@ -2442,7 +2448,7 @@ static int el_xwrite(struct ast_channel *ast, struct ast_frame *frame)
 	}
 
 	if (p->txindex >= BLOCKING_FACTOR) {
-		strcpy(p->el_node_test.ip, p->ip);
+		strcpy(p->node_lookup.ip, p->ip);
 
 		ast_mutex_lock(&el_nodelist_lock);
 		twalk(el_node_list, send_audio_only_one);
@@ -2455,61 +2461,61 @@ static int el_xwrite(struct ast_channel *ast, struct ast_frame *frame)
 
 /*!
  * \brief Start a new Echolink call.
- * \param pvt			Pointer to echolink private.
+ * \param p				Pointer to echolink private.
  * \param state			State.
  * \param nodenum		Node number to call.
  * \param assignedids	Pointer to unique ID string assigned to the channel.
  * \param requestor		Pointer to Asterisk channel.
  * \return 				Asterisk channel.
  */
-static struct ast_channel *el_new(struct el_pvt *pvt, int state, unsigned int nodenum, const struct ast_assigned_ids *assignedids,
+static struct ast_channel *el_new(struct el_pvt *p, int state, unsigned int nodenum, const struct ast_assigned_ids *assignedids,
 	const struct ast_channel *requestor)
 {
-	struct ast_channel *tmp;
+	struct ast_channel *chan;
 
-	tmp = ast_channel_alloc(1, state, 0, 0, "", pvt->instp->astnode, pvt->instp->context, assignedids, requestor, 0, "echolink/%s", pvt->stream);
-	if (!tmp) {
+	chan = ast_channel_alloc(1, state, 0, 0, "", p->instp->astnode, p->instp->context, assignedids, requestor, 0, "echolink/%s", p->stream);
+	if (!chan) {
 		ast_log(LOG_WARNING, "Unable to allocate channel structure.\n");
 		return NULL;
 	}
 
-	ast_channel_tech_set(tmp, &el_tech);
-	ast_channel_nativeformats_set(tmp, el_tech.capabilities);
-	ast_channel_set_rawreadformat(tmp, ast_format_gsm);
-	ast_channel_set_rawwriteformat(tmp, ast_format_gsm);
-	ast_channel_set_writeformat(tmp, ast_format_gsm);
-	ast_channel_set_readformat(tmp, ast_format_gsm);
+	ast_channel_tech_set(chan, &el_tech);
+	ast_channel_nativeformats_set(chan, el_tech.capabilities);
+	ast_channel_set_rawreadformat(chan, ast_format_gsm);
+	ast_channel_set_rawwriteformat(chan, ast_format_gsm);
+	ast_channel_set_writeformat(chan, ast_format_gsm);
+	ast_channel_set_readformat(chan, ast_format_gsm);
 
 	if (state == AST_STATE_RING) {
-		ast_channel_rings_set(tmp, 1);
+		ast_channel_rings_set(chan, 1);
 	}
 
-	ast_channel_context_set(tmp, pvt->instp->context);
-	ast_channel_exten_set(tmp, pvt->instp->astnode);
-	ast_channel_language_set(tmp, "");
+	ast_channel_context_set(chan, p->instp->context);
+	ast_channel_exten_set(chan, p->instp->astnode);
+	ast_channel_language_set(chan, "");
 
-	pvt->u = ast_module_user_add(tmp);
-	pvt->nodenum = nodenum;
-	pvt->owner = tmp;
+	p->u = ast_module_user_add(chan);
+	p->nodenum = nodenum;
+	p->owner = chan;
 
-	ast_channel_tech_pvt_set(tmp, pvt);
-	ast_channel_unlock(tmp);
+	ast_channel_tech_pvt_set(chan, p);
+	ast_channel_unlock(chan);
 
 	if (nodenum > 0) {
 		char tmpstr[30];
 
 		snprintf(tmpstr, sizeof(tmpstr), "3%06u", nodenum);
-		ast_set_callerid(tmp, tmpstr, NULL, NULL);
+		ast_set_callerid(chan, tmpstr, NULL, NULL);
 	}
 
 	if (state != AST_STATE_DOWN) {
-		if (ast_pbx_start(tmp)) {
-			ast_log(LOG_WARNING, "Unable to start PBX on %s.\n", ast_channel_name(tmp));
-			ast_hangup(tmp);
+		if (ast_pbx_start(chan)) {
+			ast_log(LOG_WARNING, "Unable to start PBX on %s.\n", ast_channel_name(chan));
+			ast_hangup(chan);
 		}
 	}
 
-	return tmp;
+	return chan;
 }
 
 /*!
@@ -2530,7 +2536,7 @@ static struct ast_channel *el_request(const char *type, struct ast_format_cap *c
 {
 	int nodenum;
 	struct el_pvt *p;
-	struct ast_channel *tmp = NULL;
+	struct ast_channel *chan = NULL;
 	char *str, *cp;
 
 	if (!(ast_format_cap_iscompatible(cap, el_tech.capabilities))) {
@@ -2556,13 +2562,13 @@ static struct ast_channel *el_request(const char *type, struct ast_format_cap *c
 
 	p = el_alloc(str);
 	if (p) {
-		tmp = el_new(p, AST_STATE_DOWN, nodenum, assignedids, requestor);
-		if (!tmp) {
+		chan = el_new(p, AST_STATE_DOWN, nodenum, assignedids, requestor);
+		if (!chan) {
 			ao2_ref(p, -1);
 		}
 	}
 
-	return tmp;
+	return chan;
 }
 
 /*!
@@ -3460,7 +3466,7 @@ static void *el_register(void *data)
  * \retval 0 			if successful.
  * \retval -1			if memory allocation error.
  */
-static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char *call, const char *name)
+static int do_new_call(struct el_instance *instp, struct el_pvt *p, const char *call, const char *name)
 {
 	struct el_node *el_node_key;
 	struct ast_channel *chan;
@@ -3474,7 +3480,7 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 	}
 
 	ast_copy_string(el_node_key->call, call, EL_CALL_SIZE);
-	ast_copy_string(el_node_key->ip, pvt->el_node_test.ip, EL_IP_SIZE);
+	ast_copy_string(el_node_key->ip, p->node_lookup.ip, EL_IP_SIZE);
 	ast_copy_string(el_node_key->name, name, EL_NAME_SIZE);
 
 	ast_mutex_lock(&el_db_lock);
@@ -3489,7 +3495,7 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 
 	ast_copy_string(nodestr, mynode->nodenum, sizeof(nodestr));
 	el_node_key->nodenum = atoi(nodestr);
-	el_node_key->countdown = instp->rtcptimeout;
+	el_node_key->heartbeat_countdown = instp->rtcptimeout;
 	el_node_key->seqnum = 1;
 	el_node_key->instp = instp;
 
@@ -3499,15 +3505,16 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 		ast_debug(1, "New Call - Callsign %s, IP Address %s, Node %i, Name %s.\n", el_node_key->call, el_node_key->ip,
 			el_node_key->nodenum, el_node_key->name);
 
-		if (pvt == NULL) { /* if a new inbound call */
+		if (p == NULL) { 
+			/* A new inbound call */
 			struct ast_frame fr = {
 				.frametype = AST_FRAME_CONTROL,
 				.subclass.integer = AST_CONTROL_ANSWER,
 				.src = __PRETTY_FUNCTION__,
 			};
 
-			pvt = el_alloc(instp->name);
-			if (!pvt) {
+			p = el_alloc(instp->name);
+			if (!p) {
 				ast_log(LOG_ERROR, "Cannot alloc el channel %s.\n", instp->name);
 				ast_free(el_node_key);
 				ast_mutex_unlock(&el_nodelist_lock);
@@ -3515,13 +3522,11 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 				return -1;
 			}
 
-			el_node_key->pvt = pvt; /* Assign the allocated reference for an inbound call */
-			ast_copy_string(el_node_key->pvt->ip, pvt->el_node_test.ip, EL_IP_SIZE);
+			ast_copy_string(el_node_key->pvt->ip, p->node_lookup.ip, EL_IP_SIZE);
 
 			chan = el_new(el_node_key->pvt, AST_STATE_RINGING, el_node_key->nodenum, NULL, NULL);
 			if (!chan) {
-				ao2_ref(el_node_key->pvt, -1);
-				el_node_key->pvt = NULL;
+				ao2_ref(p, -1);
 				ast_free(el_node_key);
 				ast_mutex_unlock(&el_nodelist_lock);
 				ast_mutex_unlock(&el_db_lock);
@@ -3537,11 +3542,15 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 				instp->aprstime = now;
 			}
 
+			ao2_ref(p, 1);
+			el_node_key->pvt = p;
 			ast_mutex_unlock(&instp->lock);
 
-		} else {
-			el_node_key->pvt = pvt; /* Assign the passed in reference for an outbound call */
-			ast_copy_string(el_node_key->pvt->ip, pvt->el_node_test.ip, EL_IP_SIZE);
+		} else { 
+			/* A new outbound call*/
+			ao2_ref(p, 1);
+			el_node_key->pvt = p; /* Assign the passed in reference for an outbound call */
+			ast_copy_string(el_node_key->pvt->ip, p->node_lookup.ip, EL_IP_SIZE);
 			el_node_key->outbound = 1;
 			el_node_key->rx_ctrl_packets++;
 			ast_mutex_lock(&instp->lock);
@@ -3563,8 +3572,6 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 
 	ast_log(LOG_ERROR, "Failed to add new call, Callsign %s, IP Address %s, Name %s.\n", el_node_key->call, el_node_key->ip,
 		el_node_key->name);
-	ao2_ref(el_node_key->pvt, -1);
-	el_node_key->pvt = NULL;
 	ast_free(el_node_key);
 	ast_mutex_unlock(&el_nodelist_lock);
 	ast_mutex_unlock(&el_db_lock);
@@ -3833,32 +3840,36 @@ static void *el_reader(void *data)
 			recvlen = recvfrom(instp->ctrl_sock, buf, sizeof(buf) - 1, 0, (struct sockaddr *) &sin, &fromlen);
 			if (recvlen > 0) {
 				buf[recvlen] = '\0';
-				ast_copy_string(instp->el_node_test.ip, ast_inet_ntoa(sin.sin_addr), EL_IP_SIZE);
 				if (is_rtcp_sdes((unsigned char *) buf, recvlen)) {
 					call_name[0] = '\0';
 					items.nitems = 1;
 					items.item[0].r_item = 2;
 					items.item[0].r_text = NULL;
 					parse_sdes((unsigned char *) buf, &items);
+
 					if (items.item[0].r_text != NULL) {
 						copy_sdes_item(items.item[0].r_text, call_name, sizeof(call_name));
 					}
+
 					if (call_name[0] != '\0') {
 						call = call_name;
 						nameptr = strchr(call_name, ' ');
 						name = "UNKNOWN";
+
 						if (nameptr) {
 							*nameptr = '\0';
 							name = nameptr + 1;
 							name = ast_strip(name);
 						}
+
 						ast_mutex_lock(&el_nodelist_lock);
+						ast_copy_string(instp->el_node_test.ip, ast_inet_ntoa(sin.sin_addr), EL_IP_SIZE);
+
 						found_key = (struct el_node **) tfind(&instp->el_node_test, &el_node_list, compare_ip);
 						if (found_key) {
 							node = *found_key;
 							node->pvt->firstheard = 1;
-
-							node->countdown = instp->rtcptimeout;
+							node->heartbeat_countdown = instp->rtcptimeout;
 							/* different callsigns behind a NAT router, running -L, -R, ... */
 							if (strncmp((*found_key)->call, call, EL_CALL_SIZE - 1) != 0) {
 								ast_verb(4, "Call changed from %s to %s.\n", node->call, call);
@@ -3995,21 +4006,21 @@ static void *el_reader(void *data)
 
 					found_key = (struct el_node **) tfind(&instp->el_node_test, &el_node_list, compare_ip);
 					if (found_key) {
-						struct el_pvt *pvt;
-						struct ast_channel *ast = NULL;
+						struct el_pvt *p;
+						struct ast_channel *chan = NULL;
 
 						node = *found_key;
-						pvt = node->pvt;
-						ao2_ref(pvt, +1);
+						p = node->pvt;
+						ao2_ref(p, +1);
 
-						ast_mutex_lock(&pvt->lock);
-						if (pvt->owner) {
-							ast = ast_channel_ref(pvt->owner);
+						ast_mutex_lock(&p->lock);
+						if (p->owner) {
+							chan = ast_channel_ref(p->owner);
 						}
-						ast_mutex_unlock(&pvt->lock);
+						ast_mutex_unlock(&p->lock);
 
-						pvt->firstheard = 1;
-						node->countdown = instp->rtcptimeout;
+						p->firstheard = 1;
+						node->heartbeat_countdown = instp->rtcptimeout;
 						node->rx_audio_packets++;
 						/* compute inter-arrival jitter */
 						time_difference = ast_tvdiff_ms(current_packet_time, node->last_packet_time);
@@ -4039,11 +4050,11 @@ static void *el_reader(void *data)
 								node->isdoubling = 1;
 								ast_mutex_unlock(&el_nodelist_lock);
 
-								if (ast) {
-									ast_channel_unref(ast);
+								if (chan) {
+									ast_channel_unref(chan);
 								}
 
-								ao2_ref(pvt, -1);
+								ao2_ref(p, -1);
 								continue;
 							}
 						}
@@ -4057,11 +4068,11 @@ static void *el_reader(void *data)
 							node->istimedout = 1;
 							ast_mutex_unlock(&el_nodelist_lock);
 
-							if (ast) {
-								ast_channel_unref(ast);
+							if (chan) {
+								ast_channel_unref(chan);
 							}
 
-							ao2_ref(pvt, -1);
+							ao2_ref(p, -1);
 							continue;
 						}
 
@@ -4086,35 +4097,35 @@ static void *el_reader(void *data)
 										.src = __PRETTY_FUNCTION__,
 									};
 
-									if (!pvt->rxkey) {
+									if (!p->rxkey) {
 										struct ast_frame wf = {
 											.frametype = AST_FRAME_CONTROL,
 											.subclass.integer = AST_CONTROL_RADIO_KEY,
 											.src = __PRETTY_FUNCTION__,
 										};
 
-										if (ast) {
-											ast_queue_frame(ast, &wf);
+										if (chan) {
+											ast_queue_frame(chan, &wf);
 										}
 									}
 
-									pvt->rxkey = MAX_RXKEY_TIME;
+									p->rxkey = MAX_RXKEY_TIME;
 									memcpy(inbuf + AST_FRIENDLY_OFFSET, gsmPacket->data + (GSM_FRAME_SIZE * i), GSM_FRAME_SIZE);
 									x = 0;
-									f2 = ast_translate(pvt->xpath, &fr, 0);
+									f2 = ast_translate(p->xpath, &fr, 0);
 
-									if (pvt->dsp) {
-										f1 = ast_dsp_process(NULL, pvt->dsp, f2);
+									if (p->dsp) {
+										f1 = ast_dsp_process(NULL, p->dsp, f2);
 
 										if ((f1->frametype == AST_FRAME_DTMF_END) || (f1->frametype == AST_FRAME_DTMF_BEGIN)) {
 											if ((f1->subclass.integer != 'm') && (f1->subclass.integer != 'u')) {
 												if (f1->frametype == AST_FRAME_DTMF_END) {
 													ast_verb(4, "Echolink %s Got DTMF character %c from IP address %s.\n",
-														pvt->stream, f1->subclass.integer, pvt->ip);
+														p->stream, f1->subclass.integer, p->ip);
 												}
 
-												if (ast) {
-													ast_queue_frame(ast, f1);
+												if (chan) {
+													ast_queue_frame(chan, f1);
 													ast_frfree(f1);
 													x = 1;
 												}
@@ -4123,8 +4134,8 @@ static void *el_reader(void *data)
 									}
 
 									if (!x) {
-										if (ast) {
-											ast_queue_frame(ast, f2);
+										if (chan) {
+											ast_queue_frame(chan, f2);
 										}
 
 										ast_frfree(f2);
@@ -4135,11 +4146,11 @@ static void *el_reader(void *data)
 							instp->rx_bad_packets++;
 						}
 
-						if (ast) {
-							ast_channel_unref(ast);
+						if (chan) {
+							ast_channel_unref(chan);
 						}
 
-						ao2_ref(pvt, -1);
+						ao2_ref(p, -1);
 					} else {
 						instp->rx_bad_packets++;
 					}

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -1971,8 +1971,9 @@ static void process_unkey_timers(const void *nodep, const VISIT which, void *clo
 		if (pvt->rxkey <= 0) {
 			/* The timer has expired, queue up an unkey for the channel */
 			struct ast_channel *chan;
-
+			ast_mutex_lock(&pvt->lock);
 			chan = pvt->owner ? ast_channel_ref(pvt->owner) : NULL;
+			ast_mutex_unlock(&pvt->lock);
 			if (chan) {
 				struct pending_ctrl item = {
 					.chan = chan,
@@ -3901,11 +3902,17 @@ static void *el_reader(void *data)
 					found_key = (struct el_node **) tfind(&instp->el_node_test, &el_node_list, compare_ip);
 					if (found_key) {
 						struct el_pvt *pvt;
-						struct ast_channel *ast;
+						struct ast_channel *ast = NULL;
 
 						node = *found_key;
 						pvt = node->pvt;
-						ast = pvt->owner;
+
+						ast_mutex_lock(&pvt->lock);
+						if (pvt->owner) {
+							ast = ast_channel_ref(pvt->owner);
+						}
+						ast_mutex_unlock(&pvt->lock);
+
 						pvt->firstheard = 1;
 						node->countdown = instp->rtcptimeout;
 						node->rx_audio_packets++;
@@ -4019,7 +4026,7 @@ static void *el_reader(void *data)
 						} else {
 							instp->rx_bad_packets++;
 						}
-
+						ast_channel_unref(ast);
 					} else {
 						instp->rx_bad_packets++;
 					}

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -3450,7 +3450,6 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 	ast_mutex_lock(&el_nodelist_lock);
 
 	if (tsearch(el_node_key, &el_node_list, compare_ip)) {
-		ast_mutex_unlock(&el_nodelist_lock);
 		ast_debug(1, "New Call - Callsign %s, IP Address %s, Node %i, Name %s.\n", el_node_key->call, el_node_key->ip,
 			el_node_key->nodenum, el_node_key->name);
 
@@ -3466,6 +3465,7 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 				ast_log(LOG_ERROR, "Cannot alloc el channel %s.\n", instp->name);
 				ast_free(el_node_key);
 				ast_mutex_unlock(&el_db_lock);
+				ast_mutex_unlock(&el_nodelist_lock);
 				return -1;
 			}
 
@@ -3477,6 +3477,7 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 				el_destroy(el_node_key->pvt);
 				ast_free(el_node_key);
 				ast_mutex_unlock(&el_db_lock);
+				ast_mutex_unlock(&el_nodelist_lock);
 				return -1;
 			}
 
@@ -3492,7 +3493,6 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 			ast_mutex_unlock(&instp->lock);
 
 		} else {
-			ast_mutex_unlock(&el_nodelist_lock);
 			el_node_key->pvt = pvt;
 			ast_copy_string(el_node_key->pvt->ip, instp->el_node_test.ip, EL_IP_SIZE);
 			el_node_key->outbound = 1;
@@ -3509,12 +3509,14 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 		}
 
 		ast_mutex_unlock(&el_db_lock);
+		ast_mutex_unlock(&el_nodelist_lock);
 		return 0;
 	}
 
 	ast_log(LOG_ERROR, "Failed to add new call, Callsign %s, IP Address %s, Name %s.\n", el_node_key->call, el_node_key->ip,
 		el_node_key->name);
 	ast_free(el_node_key);
+	ast_mutex_unlock(&el_nodelist_lock);
 	ast_mutex_unlock(&el_db_lock);
 	return -1;
 }
@@ -3725,44 +3727,6 @@ static void *el_reader(void *data)
 
 		/* update the node timers */
 		update_unkey_timers(elap);
-
-		/* Echolink: send heartbeats and drop dead stations */
-		update_timer(&heartbeat_timer, elap, 0);
-
-		if (!heartbeat_timer) {
-			heartbeat_timer = KEEPALIVE_TIME;
-			ast_mutex_lock(&instp->lock);
-			instp->el_node_test.ip[0] = '\0';
-			ast_mutex_unlock(&instp->lock);
-
-			ast_mutex_lock(&el_nodelist_lock);
-			twalk(el_node_list, send_heartbeat);
-			ast_mutex_unlock(&el_nodelist_lock);
-
-			ast_mutex_lock(&instp->lock);
-			if (instp->el_node_test.ip[0] != '\0') {
-				if (find_delete(&instp->el_node_test)) {
-					int bye_length;
-
-					bye_length = rtcp_make_bye(bye, sizeof(bye), "rtcp timeout");
-					memset(&sin, 0, sizeof(sin));
-					sin.sin_family = AF_INET;
-					sin.sin_addr.s_addr = inet_addr(instp->el_node_test.ip);
-					sin.sin_port = htons(instp->ctrl_port);
-
-					/* send 20 bye packets to insure that they receive this disconnect */
-					for (i = 0; i < 20; i++) {
-						sendto(instp->ctrl_sock, bye, bye_length, 0, (struct sockaddr *) &sin, sizeof(sin));
-						instp->tx_ctrl_packets++;
-					}
-
-					ast_verb(4, "Callsign %s RTCP timeout, removing connection.\n", instp->el_node_test.call);
-				}
-
-				instp->el_node_test.ip[0] = '\0';
-			}
-			ast_mutex_unlock(&instp->lock);
-		}
 
 		/*
 		 * process the control socket
@@ -4073,6 +4037,44 @@ static void *el_reader(void *data)
 				instp->current_talker_start_time = (struct timeval) { 0 };
 				instp->current_talker_last_time = (struct timeval) { 0 };
 			}
+		}
+
+		/* Echolink: send heartbeats and drop dead stations */
+		update_timer(&heartbeat_timer, elap, 0);
+
+		if (!heartbeat_timer) {
+			heartbeat_timer = KEEPALIVE_TIME;
+			ast_mutex_lock(&instp->lock);
+			instp->el_node_test.ip[0] = '\0';
+			ast_mutex_unlock(&instp->lock);
+
+			ast_mutex_lock(&el_nodelist_lock);
+			twalk(el_node_list, send_heartbeat);
+			ast_mutex_unlock(&el_nodelist_lock);
+
+			ast_mutex_lock(&instp->lock);
+			if (instp->el_node_test.ip[0] != '\0') {
+				if (find_delete(&instp->el_node_test)) {
+					int bye_length;
+
+					bye_length = rtcp_make_bye(bye, sizeof(bye), "rtcp timeout");
+					memset(&sin, 0, sizeof(sin));
+					sin.sin_family = AF_INET;
+					sin.sin_addr.s_addr = inet_addr(instp->el_node_test.ip);
+					sin.sin_port = htons(instp->ctrl_port);
+
+					/* send 20 bye packets to insure that they receive this disconnect */
+					for (i = 0; i < 20; i++) {
+						sendto(instp->ctrl_sock, bye, bye_length, 0, (struct sockaddr *) &sin, sizeof(sin));
+						instp->tx_ctrl_packets++;
+					}
+
+					ast_verb(4, "Callsign %s RTCP timeout, removing connection.\n", instp->el_node_test.call);
+				}
+
+				instp->el_node_test.ip[0] = '\0';
+			}
+			ast_mutex_unlock(&instp->lock);
 		}
 	}
 
@@ -4426,6 +4428,10 @@ static int unload_module(void)
 
 	run_forever = 0;
 
+	/* Wait for all threads to exit */
+	pthread_join(el_directory_thread, NULL);
+	pthread_join(el_register_thread, NULL);
+
 	if (el_node_list) {
 		ast_mutex_lock(&el_nodelist_lock);
 		tdestroy(el_node_list, free_node);
@@ -4458,10 +4464,6 @@ static int unload_module(void)
 			ast_free(instances[n]->permitlist[0]);
 		}
 	}
-
-	/* Wait for all threads to exit */
-	pthread_join(el_directory_thread, NULL);
-	pthread_join(el_register_thread, NULL);
 
 	ast_cli_unregister_multiple(el_cli, sizeof(el_cli) / sizeof(struct ast_cli_entry));
 	/* First, take us out of the channel loop */

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -1386,9 +1386,10 @@ static int el_call(struct ast_channel *ast, const char *dest, int timeout)
  * \brief Destroy and free an echolink instance.
  * \param pvt		Pointer to el_pvt struct to release.
  */
-static void el_destroy(struct el_pvt *pvt)
+static void el_destroy(void *obj)
 {
-	ast_mutex_lock(&pvt->lock);
+	struct el_pvt *pvt = obj;
+
 	if (pvt->dsp) {
 		ast_dsp_free(pvt->dsp);
 	}
@@ -1400,12 +1401,15 @@ static void el_destroy(struct el_pvt *pvt)
 	}
 	pvt->linkstr = NULL;
 	pvt->owner = NULL;
-	ast_mutex_unlock(&pvt->lock);
 
 	ast_mutex_lock(&el_nodelist_lock);
 	twalk(el_node_list, send_info);
 	ast_mutex_unlock(&el_nodelist_lock);
-	ast_module_user_remove(pvt->u);
+
+	if (pvt->u) {
+		ast_module_user_remove(pvt->u);
+	}
+
 	ast_free(pvt);
 }
 
@@ -1433,9 +1437,8 @@ static struct el_pvt *el_alloc(const char *data)
 		return NULL;
 	}
 
-	pvt = ast_calloc(1, sizeof(struct el_pvt));
+	pvt = ao2_alloc(sizeof(struct el_pvt), el_destroy);
 	if (pvt) {
-		ast_mutex_init(&pvt->lock);
 		snprintf(pvt->stream, sizeof(pvt->stream), "%s-%lu", data, instances[n]->seqno++);
 
 		pvt->keepalive = KEEPALIVE_TIME;
@@ -1504,8 +1507,8 @@ static int el_hangup(struct ast_channel *ast)
 		return 0;
 	}
 
-	el_destroy(pvt);
 	ast_channel_tech_pvt_set(ast, NULL);
+	ao2_cleanup(pvt);
 	ast_setstate(ast, AST_STATE_DOWN);
 	return 0;
 }
@@ -1976,14 +1979,13 @@ static void process_unkey_timers(const void *nodep, const VISIT which, void *clo
 			return;
 		}
 
+		ao2_ref(pvt, +1);
 		update_timer(&pvt->rxkey, cl->elap, 0);
 
 		if (pvt->rxkey <= 0) {
 			/* The timer has expired, queue up an unkey for the channel */
 			struct ast_channel *chan;
-			ast_mutex_lock(&pvt->lock);
 			chan = pvt->owner ? ast_channel_ref(pvt->owner) : NULL;
-			ast_mutex_unlock(&pvt->lock);
 			if (chan) {
 				struct pending_ctrl item = {
 					.chan = chan,
@@ -1998,6 +2000,8 @@ static void process_unkey_timers(const void *nodep, const VISIT which, void *clo
 
 			pvt->rxkey = 0;
 		}
+
+		ao2_ref(pvt, -1);
 	}
 }
 
@@ -2175,6 +2179,8 @@ static int find_delete(const struct el_node *key)
 		found = 1;
 		node->pvt->hangup = 1;
 		tdelete(node, &el_node_list, compare_ip);
+		ao2_cleanup(node->pvt);
+		node->pvt = NULL;
 		ast_free(node);
 	}
 	ast_mutex_unlock(&el_nodelist_lock);
@@ -2464,11 +2470,9 @@ static struct ast_channel *el_new(struct el_pvt *pvt, int state, unsigned int no
 		ast_set_callerid(tmp, tmpstr, NULL, NULL);
 	}
 
-	ast_mutex_lock(&pvt->lock);
 	pvt->u = ast_module_user_add(tmp);
 	pvt->nodenum = nodenum;
 	pvt->owner = tmp;
-	ast_mutex_unlock(&pvt->lock);
 
 	if (state != AST_STATE_DOWN) {
 		if (ast_pbx_start(tmp)) {
@@ -2526,7 +2530,7 @@ static struct ast_channel *el_request(const char *type, struct ast_format_cap *c
 	if (p) {
 		tmp = el_new(p, AST_STATE_DOWN, nodenum, assignedids, requestor);
 		if (!tmp) {
-			el_destroy(p);
+			ao2_cleanup(p);
 		}
 	}
 
@@ -3482,12 +3486,13 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 				return -1;
 			}
 
+			ao2_ref(pvt, +1);
 			el_node_key->pvt = pvt;
 			ast_copy_string(el_node_key->pvt->ip, instp->el_node_test.ip, EL_IP_SIZE);
 			chan = el_new(el_node_key->pvt, AST_STATE_RINGING, el_node_key->nodenum, NULL, NULL);
 
 			if (!chan) {
-				el_destroy(el_node_key->pvt);
+				ao2_cleanup(el_node_key->pvt);
 				ast_free(el_node_key);
 				ast_mutex_unlock(&el_db_lock);
 				ast_mutex_unlock(&el_nodelist_lock);
@@ -3506,6 +3511,7 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 			ast_mutex_unlock(&instp->lock);
 
 		} else {
+			ao2_ref(pvt, +1);
 			el_node_key->pvt = pvt;
 			ast_copy_string(el_node_key->pvt->ip, instp->el_node_test.ip, EL_IP_SIZE);
 			el_node_key->outbound = 1;
@@ -3918,12 +3924,10 @@ static void *el_reader(void *data)
 
 						node = *found_key;
 						pvt = node->pvt;
-
-						ast_mutex_lock(&pvt->lock);
+						ao2_ref(pvt, +1);
 						if (pvt->owner) {
 							ast = ast_channel_ref(pvt->owner);
 						}
-						ast_mutex_unlock(&pvt->lock);
 
 						pvt->firstheard = 1;
 						node->countdown = instp->rtcptimeout;
@@ -3955,6 +3959,8 @@ static void *el_reader(void *data)
 								}
 								node->isdoubling = 1;
 								ast_mutex_unlock(&el_nodelist_lock);
+								ast_channel_unref(ast);
+								ao2_ref(pvt, -1);
 								continue;
 							}
 						}
@@ -3967,6 +3973,8 @@ static void *el_reader(void *data)
 							}
 							node->istimedout = 1;
 							ast_mutex_unlock(&el_nodelist_lock);
+							ast_channel_unref(ast);
+							ao2_ref(pvt, -1);
 							continue;
 						}
 
@@ -4038,7 +4046,9 @@ static void *el_reader(void *data)
 						} else {
 							instp->rx_bad_packets++;
 						}
+
 						ast_channel_unref(ast);
+						ao2_ref(pvt, -1);
 					} else {
 						instp->rx_bad_packets++;
 					}

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -440,7 +440,6 @@ struct el_instance {
 	uint16_t audio_port;
 	uint16_t ctrl_port;
 	unsigned long seqno;
-	struct el_node el_node_test;
 	struct el_pending pending[MAXPENDING];
 	time_t aprstime;
 	time_t starttime;
@@ -485,7 +484,6 @@ struct el_pvt {
 	unsigned int nodenum;
 	struct ast_str *linkstr;
 	struct gsmVoice_t audio;
-	struct el_node node_lookup;
 	ast_mutex_t lock;
 };
 
@@ -545,9 +543,9 @@ static int el_text(struct ast_channel *chan, const char *text);
 static int el_queryoption(struct ast_channel *chan, int option, void *data, int *datalen);
 
 static void send_info(const void *nodep, const VISIT which, const int depth);
-static void process_cmd(char *buf, int buf_len, const char *fromip, struct el_instance *instp);
+static void process_cmd(char *buf, int buf_len, const char *fromip, struct el_instance *instp, struct el_node *node_lookup);
 static int find_delete(const struct el_node *key, struct el_instance *instp);
-static int do_new_call(struct el_instance *instp, struct el_pvt *p, const char *call, const char *name);
+static int do_new_call(struct el_instance *instp, struct el_pvt *p, const char *call, const char *name, struct el_node *node_lookup);
 static void lookup_node_nodenum(const void *nodep, const VISIT which, void *closure);
 static void lookup_node_callsign(const void *nodep, const VISIT which, void *closure);
 
@@ -1318,6 +1316,7 @@ static int el_call(struct ast_channel *chan, const char *dest, int timeout)
 	struct el_pvt *p = ast_channel_tech_pvt(chan);
 	struct el_instance *instp = p->instp;
 	struct eldb *foundnode;
+	struct el_node node_lookup;
 	char ipaddr[EL_IP_SIZE];
 	char buf[100];
 	char *str, *cp;
@@ -1374,9 +1373,9 @@ static int el_call(struct ast_channel *chan, const char *dest, int timeout)
 
 	/* make the call */
 	ast_mutex_lock(&instp->lock);
-	strcpy(p->node_lookup.ip, ipaddr);
-	do_new_call(instp, p, "OUTBOUND", "OUTBOUND");
-	process_cmd(buf, sizeof(buf), "127.0.0.1", instp);
+	strcpy(node_lookup.ip, ipaddr);
+	do_new_call(instp, p, "OUTBOUND", "OUTBOUND", &node_lookup);
+	process_cmd(buf, sizeof(buf), "127.0.0.1", instp, &node_lookup);
 	ast_mutex_unlock(&instp->lock);
 	ast_setstate(chan, AST_STATE_RINGING);
 
@@ -1485,11 +1484,12 @@ static int el_hangup(struct ast_channel *chan)
 	int i, n;
 	unsigned char bye[50];
 	struct sockaddr_in sin;
+	struct el_node node_lookup;
 	time_t now;
 
 	ast_debug(1, "Sent bye to IP address %s.\n", p->ip);
-	strcpy(p->node_lookup.ip, p->ip);
-	find_delete(&p->node_lookup, instp);
+	strcpy(node_lookup.ip, p->ip);
+	find_delete(&node_lookup, instp);
 	ast_softhangup(chan, AST_SOFTHANGUP_DEV);
 	p->hangup = 0;
 	n = rtcp_make_bye(bye, sizeof(bye), "disconnected");
@@ -1820,15 +1820,16 @@ static int compare_ip(const void *pa, const void *pb)
  * \param which		Enum for VISIT used by twalk.
  * \param depth		Level of the node in the tree.
  */
-static void send_audio_only_one(const void *nodep, const VISIT which, const int depth)
+static void send_audio_only_one(const void *nodep, const VISIT which, void *closure)
 {
 	struct el_node *node = *(struct el_node **) nodep;
 	struct el_instance *instp = node->instp;
 	struct el_pvt *p = node->pvt;
 	struct sockaddr_in sin;
+	struct el_node *node_lookup = closure;
 
 	if ((which == leaf) || (which == postorder)) {
-		if (strncmp(node->ip, p->node_lookup.ip, EL_IP_SIZE) == 0) {
+		if (strncmp(node->ip, node_lookup->ip, EL_IP_SIZE) == 0) {
 			memset(&sin, 0, sizeof(sin));
 			sin.sin_family = AF_INET;
 			sin.sin_port = htons(instp->audio_port);
@@ -2086,13 +2087,14 @@ static void send_info(const void *nodep, const VISIT which, const int depth)
  * \brief Send a heartbeat packet to connected nodes.
  * \param nodep		Pointer to eldb struct.
  * \param which		Enum for VISIT used by twalk.
- * \param depth		Level of the node in the tree.
+ * \param closure	Pointer to el_node struct for lookup.
  */
-static void send_heartbeat(const void *nodep, const VISIT which, const int depth)
+static void send_heartbeat(const void *nodep, const VISIT which, void *closure)
 {
 	struct el_node *node = *(struct el_node **) nodep;
 	struct el_instance *instp = node->instp;
 	struct sockaddr_in sin;
+	struct el_node *node_lookup = closure;
 	unsigned char sdes_packet[256];
 	int sdes_length;
 
@@ -2102,10 +2104,9 @@ static void send_heartbeat(const void *nodep, const VISIT which, const int depth
 		}
 
 		if (node->heartbeat_countdown < 0) {
-			ast_copy_string(instp->el_node_test.ip, node->ip, EL_IP_SIZE);
-			ast_copy_string(instp->el_node_test.call, node->call, EL_CALL_SIZE);
-			ast_log(LOG_WARNING, "Countdown for Callsign %s, IP Address %s is negative.\n", instp->el_node_test.call,
-				instp->el_node_test.ip);
+			ast_copy_string(node_lookup->ip, node->ip, EL_IP_SIZE);
+			ast_copy_string(node_lookup->call, node->call, EL_CALL_SIZE);
+			ast_log(LOG_WARNING, "Countdown for Callsign %s, IP Address %s is negative.\n", node_lookup->call, node_lookup->ip);
 		}
 
 		memset(sdes_packet, 0, sizeof(sdes_packet));
@@ -2126,15 +2127,16 @@ static void send_heartbeat(const void *nodep, const VISIT which, const int depth
  * \brief Send text message to connected nodes except sender.
  * \param nodep		Pointer to el_node struct.
  * \param which		Enum for VISIT used by twalk.
- * \param depth		Level of the node in the tree.
+ * \param closure	Pointer to el_node struct for lookup.
  */
-static void send_text(const void *nodep, const VISIT which, const int depth)
+static void send_text(const void *nodep, const VISIT which, void *closure)
 {
 	struct sockaddr_in sin;
 	struct el_node *node = *(struct el_node **) nodep;
+	struct el_node *node_lookup = closure;
 
 	if ((which == leaf) || (which == postorder)) {
-		if (strncmp(node->ip, node->pvt->node_lookup.ip, sizeof(node->ip))) {
+		if (strncmp(node->ip, node_lookup->ip, sizeof(node->ip))) {
 			memset(&sin, 0, sizeof(sin));
 			sin.sin_family = AF_INET;
 			sin.sin_port = htons(node->instp->audio_port);
@@ -2225,11 +2227,12 @@ static int find_delete(const struct el_node *key, struct el_instance *instp)
  *	o.conip <IPaddress>    (request a connect)
  *	o.dconip <IPaddress>   (request a disconnect)
  *	o.rec                  (turn on/off recording)
- * \param buf			Pointer to buffer with command data.
- * \param fromip		Pointer to ip address that sent the command.
- * \param instp			Pointer to Echolink instance.
+ * \param buf			   Pointer to buffer with command data.
+ * \param fromip		   Pointer to ip address that sent the command.
+ * \param instp			   Pointer to Echolink instance.
+ * \param node_lookup	   Pointer to Echolink node struct for lookup.
  */
-static void process_cmd(char *buf, int buf_len, const char *fromip, struct el_instance *instp)
+static void process_cmd(char *buf, int buf_len, const char *fromip, struct el_instance *instp, struct el_node *node_lookup)
 {
 	char *cmd, *arg1;
 	const char *delim = " ";
@@ -2252,7 +2255,7 @@ static void process_cmd(char *buf, int buf_len, const char *fromip, struct el_in
 			instp->text_packet = buf;
 			instp->text_packet_len = buf_len;
 			ast_mutex_lock(&el_nodelist_lock);
-			twalk(el_node_list, send_text);
+			twalk_r(el_node_list, send_text, node_lookup);
 			ast_mutex_unlock(&el_nodelist_lock);
 			instp->text_packet = NULL;
 			instp->text_packet_len = 0;
@@ -2448,10 +2451,11 @@ static int el_xwrite(struct ast_channel *chan, struct ast_frame *frame)
 	}
 
 	if (p->txindex >= BLOCKING_FACTOR) {
-		strcpy(p->node_lookup.ip, p->ip);
+		struct el_node node_lookup;
 
+		strcpy(node_lookup.ip, p->ip);
 		ast_mutex_lock(&el_nodelist_lock);
-		twalk(el_node_list, send_audio_only_one);
+		twalk_r(el_node_list, send_audio_only_one, &node_lookup);
 		ast_mutex_unlock(&el_nodelist_lock);
 		p->txindex = 0;
 	}
@@ -3462,11 +3466,12 @@ static void *el_register(void *data)
  * \param pvt			Pointer to echolink private data.
  * \param call			Pointer to callsign.
  * \param name			Pointer to name associated with the callsign.
+ * \param node_lookup	Pointer to el_node struct with the ip address to use for this call.
  * \retval 1 			if not successful.
  * \retval 0 			if successful.
  * \retval -1			if memory allocation error.
  */
-static int do_new_call(struct el_instance *instp, struct el_pvt *p, const char *call, const char *name)
+static int do_new_call(struct el_instance *instp, struct el_pvt *p, const char *call, const char *name, struct el_node *node_lookup)
 {
 	struct el_node *el_node_key;
 	struct ast_channel *chan;
@@ -3480,7 +3485,7 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *p, const char *
 	}
 
 	ast_copy_string(el_node_key->call, call, EL_CALL_SIZE);
-	ast_copy_string(el_node_key->ip, p->node_lookup.ip, EL_IP_SIZE);
+	ast_copy_string(el_node_key->ip, node_lookup->ip, EL_IP_SIZE);
 	ast_copy_string(el_node_key->name, name, EL_NAME_SIZE);
 
 	ast_mutex_lock(&el_db_lock);
@@ -3522,7 +3527,7 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *p, const char *
 				return -1;
 			}
 
-			ast_copy_string(el_node_key->pvt->ip, p->node_lookup.ip, EL_IP_SIZE);
+			ast_copy_string(el_node_key->pvt->ip, node_lookup->ip, EL_IP_SIZE);
 
 			chan = el_new(el_node_key->pvt, AST_STATE_RINGING, el_node_key->nodenum, NULL, NULL);
 			if (!chan) {
@@ -3550,7 +3555,7 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *p, const char *
 			/* A new outbound call*/
 			ao2_ref(p, 1);
 			el_node_key->pvt = p; /* Assign the passed in reference for an outbound call */
-			ast_copy_string(el_node_key->pvt->ip, p->node_lookup.ip, EL_IP_SIZE);
+			ast_copy_string(el_node_key->pvt->ip, node_lookup->ip, EL_IP_SIZE);
 			el_node_key->outbound = 1;
 			el_node_key->rx_ctrl_packets++;
 			ast_mutex_lock(&instp->lock);
@@ -3772,33 +3777,35 @@ static void *el_reader(void *data)
 		update_timer(&heartbeat_timer, elap, 0);
 
 		if (heartbeat_timer <= 0) {
+			struct el_node node_lookup;
+
 			heartbeat_timer = KEEPALIVE_TIME;
-			instp->el_node_test.ip[0] = '\0';
+			node_lookup.ip[0] = '\0';
 
 			ast_mutex_lock(&el_nodelist_lock);
-			/* If twalk finds a dead node, it puts the IP address in the instp->el_node_test.ip
+			/* If twalk finds a dead node, it puts the IP address in the node_lookup.ip
 			 * field and we disconnect that node after the walk.  This is done to avoid disconnecting
 			 * nodes while we are walking the tree, which can cause deadlocks if we have to acquire
 			 * the node list lock to disconnect a node while we are walking the tree.
 			 */
-			twalk(el_node_list, send_heartbeat);
+			twalk_r(el_node_list, send_heartbeat, &node_lookup);
 			ast_mutex_unlock(&el_nodelist_lock);
 
-			/* If twalk finds multiple dead nodes, the last dead node will be in instp->el_node_test.ip field
+			/* If twalk finds multiple dead nodes, the last dead node will be in node_lookup.ip field
 			 * and disconnected.  If there are multiple dead nodes, it will take multiple heartbeat loops to find
 			 * them and kill them off.
 			 */
 
 			/*! \todo Find all dead nodes in one pass and cleanup the process?
 			 */
-			if (instp->el_node_test.ip[0] != '\0') {
-				if (find_delete(&instp->el_node_test, instp)) {
+			if (node_lookup.ip[0] != '\0') {
+				if (find_delete(&node_lookup, instp)) {
 					int bye_length;
 
 					bye_length = rtcp_make_bye(bye, sizeof(bye), "rtcp timeout");
 					memset(&sin, 0, sizeof(sin));
 					sin.sin_family = AF_INET;
-					sin.sin_addr.s_addr = inet_addr(instp->el_node_test.ip);
+					sin.sin_addr.s_addr = inet_addr(node_lookup.ip);
 					sin.sin_port = htons(instp->ctrl_port);
 
 					/* send 20 bye packets to insure that they receive this disconnect */
@@ -3807,10 +3814,8 @@ static void *el_reader(void *data)
 						instp->tx_ctrl_packets++;
 					}
 
-					ast_verb(4, "Callsign %s RTCP timeout, removing connection.\n", instp->el_node_test.call);
+					ast_verb(4, "Callsign %s RTCP timeout, removing connection.\n", node_lookup.call);
 				}
-
-				instp->el_node_test.ip[0] = '\0';
 			}
 		}
 
@@ -3834,6 +3839,8 @@ static void *el_reader(void *data)
 		 * process the control socket
 		 */
 		if (fds[0].revents) { /* if a ctrl packet */
+			struct el_node node_lookup;
+
 			fds[0].revents = 0;
 			instp->rx_ctrl_packets++;
 			fromlen = sizeof(struct sockaddr_in);
@@ -3863,9 +3870,9 @@ static void *el_reader(void *data)
 						}
 
 						ast_mutex_lock(&el_nodelist_lock);
-						ast_copy_string(instp->el_node_test.ip, ast_inet_ntoa(sin.sin_addr), EL_IP_SIZE);
+						ast_copy_string(node_lookup.ip, ast_inet_ntoa(sin.sin_addr), EL_IP_SIZE);
 
-						found_key = (struct el_node **) tfind(&instp->el_node_test, &el_node_list, compare_ip);
+						found_key = (struct el_node **) tfind(&node_lookup, &el_node_list, compare_ip);
 						if (found_key) {
 							node = *found_key;
 							node->pvt->firstheard = 1;
@@ -3906,7 +3913,7 @@ static void *el_reader(void *data)
 								}
 							}
 							if (!i) { /* if authorized */
-								i = do_new_call(instp, NULL, call, name);
+								i = do_new_call(instp, NULL, call, name, &node_lookup);
 								if (i < 0) {
 									/* we failed to create a new call - error reported by do_new_call */
 									i = 0;
@@ -3915,7 +3922,7 @@ static void *el_reader(void *data)
 							if (i) { /* if not authorized or do_new_call failed*/
 								/* first, see if we have one that is ours and not abandoned */
 								for (x = 0; x < MAXPENDING; x++) {
-									if (strcmp(instp->pending[x].fromip, instp->el_node_test.ip)) {
+									if (strcmp(instp->pending[x].fromip, node_lookup.ip)) {
 										continue;
 									}
 									if (ast_tvdiff_ms(ast_tvnow(), instp->pending[x].reqtime) < AUTH_ABANDONED_MS) {
@@ -3925,11 +3932,11 @@ static void *el_reader(void *data)
 								if (x < MAXPENDING) {
 									/* if its time, send un-auth */
 									if (ast_tvdiff_ms(ast_tvnow(), instp->pending[x].reqtime) >= AUTH_RETRY_MS) {
-										ast_debug(1, "Sent bye to IP address %s.\n", instp->el_node_test.ip);
+										ast_debug(1, "Sent bye to IP address %s.\n", node_lookup.ip);
 										j = rtcp_make_bye(bye, sizeof(bye), "UN-AUTHORIZED");
 										memset(&sin1, 0, sizeof(sin1));
 										sin1.sin_family = AF_INET;
-										sin1.sin_addr.s_addr = inet_addr(instp->el_node_test.ip);
+										sin1.sin_addr.s_addr = inet_addr(node_lookup.ip);
 										sin1.sin_port = htons(instp->ctrl_port);
 										for (i = 0; i < 20; i++) {
 											sendto(instp->ctrl_sock, bye, j, 0, (struct sockaddr *) &sin1, sizeof(sin1));
@@ -3951,7 +3958,7 @@ static void *el_reader(void *data)
 										}
 									}
 									if (x < MAXPENDING) { /* we found one */
-										strcpy(instp->pending[x].fromip, instp->el_node_test.ip);
+										strcpy(instp->pending[x].fromip, node_lookup.ip);
 										instp->pending[x].reqtime = ast_tvnow();
 										time(&now);
 										if (instp->starttime < (now - EL_APRS_START_DELAY)) {
@@ -3962,7 +3969,7 @@ static void *el_reader(void *data)
 										}
 									} else {
 										ast_log(LOG_ERROR, "Cannot find open pending echolink request slot for IP Address %s.\n",
-											instp->el_node_test.ip);
+											node_lookup.ip);
 									}
 								}
 							}
@@ -3975,9 +3982,8 @@ static void *el_reader(void *data)
 					}
 				} else {
 					if (is_rtcp_bye((unsigned char *) buf, recvlen)) {
-						if (find_delete(&instp->el_node_test, instp)) {
-							ast_verb(4, "Disconnect from IP address %s, Callsign %s.\n", instp->el_node_test.ip,
-								instp->el_node_test.call);
+						if (find_delete(&node_lookup, instp)) {
+							ast_verb(4, "Disconnect from IP address %s, Callsign %s.\n", node_lookup.ip, node_lookup.call);
 						}
 					} else {
 						instp->rx_bad_packets++;
@@ -3989,6 +3995,8 @@ static void *el_reader(void *data)
 		 *process the audio socket
 		 */
 		if (fds[1].revents) { /* if an audio packet */
+			struct el_node node_lookup;
+
 			fds[1].revents = 0;
 			instp->rx_audio_packets++;
 			current_packet_time = ast_tvnow();
@@ -3996,15 +4004,15 @@ static void *el_reader(void *data)
 			recvlen = recvfrom(instp->audio_sock, buf, sizeof(buf) - 1, 0, (struct sockaddr *) &sin, &fromlen);
 			if (recvlen > 0) {
 				buf[recvlen] = '\0';
-				ast_copy_string(instp->el_node_test.ip, ast_inet_ntoa(sin.sin_addr), EL_IP_SIZE);
+				ast_copy_string(node_lookup.ip, ast_inet_ntoa(sin.sin_addr), EL_IP_SIZE);
 				gsmPacket = (struct gsmVoice_t *) &buf;
 				/* packets that start with 0x6f are text packets */
 				if (buf[0] == 0x6f) {
-					process_cmd(buf, recvlen, instp->el_node_test.ip, instp);
+					process_cmd(buf, recvlen, node_lookup.ip, instp, &node_lookup);
 				} else {
 					ast_mutex_lock(&el_nodelist_lock);
 
-					found_key = (struct el_node **) tfind(&instp->el_node_test, &el_node_list, compare_ip);
+					found_key = (struct el_node **) tfind(&node_lookup, &el_node_list, compare_ip);
 					if (found_key) {
 						struct el_pvt *p;
 						struct ast_channel *chan = NULL;

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -1401,7 +1401,9 @@ static void el_destroy(void *obj)
 		ast_free(pvt->linkstr);
 	}
 	pvt->linkstr = NULL;
+	ast_mutex_lock(&pvt->lock);
 	pvt->owner = NULL;
+	ast_mutex_unlock(&pvt->lock);
 
 	ast_mutex_lock(&el_nodelist_lock);
 	twalk(el_node_list, send_info);
@@ -1457,6 +1459,7 @@ static struct el_pvt *el_alloc(const char *data)
 			ao2_cleanup(pvt);
 			return NULL;
 		}
+		ast_mutex_init(&pvt->lock);
 	}
 	return pvt;
 }
@@ -1509,8 +1512,10 @@ static int el_hangup(struct ast_channel *ast)
 	}
 
 	ast_channel_tech_pvt_set(ast, NULL);
+	ast_mutex_destroy(&pvt->lock);
 	ao2_ref(pvt, -1);
 	ast_setstate(ast, AST_STATE_DOWN);
+
 	return 0;
 }
 
@@ -2197,8 +2202,7 @@ static int find_delete(const struct el_node *key, struct el_instance *instp)
 		found = 1;
 		node->pvt->hangup = 1;
 		tdelete(node, &el_node_list, compare_ip);
-		ao2_ref(node->pvt, -1);
-		node->pvt = NULL;
+		node->pvt = NULL; /* We've dereferenced the node pvt, by setting it to null.  Hangup will clean up the reference */
 		ast_free(node);
 	}
 
@@ -2480,10 +2484,15 @@ static struct ast_channel *el_new(struct el_pvt *pvt, int state, unsigned int no
 		ast_channel_rings_set(tmp, 1);
 	}
 
-	ast_channel_tech_pvt_set(tmp, pvt);
 	ast_channel_context_set(tmp, pvt->instp->context);
 	ast_channel_exten_set(tmp, pvt->instp->astnode);
 	ast_channel_language_set(tmp, "");
+
+	pvt->u = ast_module_user_add(tmp);
+	pvt->nodenum = nodenum;
+	pvt->owner = tmp;
+
+	ast_channel_tech_pvt_set(tmp, pvt);
 	ast_channel_unlock(tmp);
 
 	if (nodenum > 0) {
@@ -2492,10 +2501,6 @@ static struct ast_channel *el_new(struct el_pvt *pvt, int state, unsigned int no
 		snprintf(tmpstr, sizeof(tmpstr), "3%06u", nodenum);
 		ast_set_callerid(tmp, tmpstr, NULL, NULL);
 	}
-
-	pvt->u = ast_module_user_add(tmp);
-	pvt->nodenum = nodenum;
-	pvt->owner = tmp;
 
 	if (state != AST_STATE_DOWN) {
 		if (ast_pbx_start(tmp)) {
@@ -3477,8 +3482,6 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 	mynode = el_db_find_ipaddr(el_node_key->ip);
 	if (!mynode) {
 		ast_log(LOG_ERROR, "Cannot find database entry for IP address %s, Callsign %s.\n", el_node_key->ip, call);
-		ao2_ref(el_node_key->pvt, -1);
-		el_node_key->pvt = NULL;
 		ast_free(el_node_key);
 		ast_mutex_unlock(&el_db_lock);
 		return 1;
@@ -3506,15 +3509,13 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 			pvt = el_alloc(instp->name);
 			if (!pvt) {
 				ast_log(LOG_ERROR, "Cannot alloc el channel %s.\n", instp->name);
-				ao2_ref(el_node_key->pvt, -1);
-				el_node_key->pvt = NULL;
 				ast_free(el_node_key);
 				ast_mutex_unlock(&el_nodelist_lock);
 				ast_mutex_unlock(&el_db_lock);
 				return -1;
 			}
 
-			el_node_key->pvt = pvt;
+			el_node_key->pvt = pvt; /* Assign the allocated reference for an inbound call */
 			ast_copy_string(el_node_key->pvt->ip, pvt->el_node_test.ip, EL_IP_SIZE);
 
 			chan = el_new(el_node_key->pvt, AST_STATE_RINGING, el_node_key->nodenum, NULL, NULL);
@@ -3539,8 +3540,7 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 			ast_mutex_unlock(&instp->lock);
 
 		} else {
-			ao2_ref(el_node_key->pvt, -1);
-			el_node_key->pvt = pvt;
+			el_node_key->pvt = pvt; /* Assign the passed in reference for an outbound call */
 			ast_copy_string(el_node_key->pvt->ip, pvt->el_node_test.ip, EL_IP_SIZE);
 			el_node_key->outbound = 1;
 			el_node_key->rx_ctrl_packets++;
@@ -4002,9 +4002,11 @@ static void *el_reader(void *data)
 						pvt = node->pvt;
 						ao2_ref(pvt, +1);
 
+						ast_mutex_lock(&pvt->lock);
 						if (pvt->owner) {
 							ast = ast_channel_ref(pvt->owner);
 						}
+						ast_mutex_unlock(&pvt->lock);
 
 						pvt->firstheard = 1;
 						node->countdown = instp->rtcptimeout;
@@ -4526,6 +4528,7 @@ static int unload_module(void)
 		}
 		if (instances[n]->el_reader_thread) {
 			pthread_join(instances[n]->el_reader_thread, NULL);
+			ast_mutex_destroy(&instances[n]->lock);
 		}
 		if (instances[n]->denylist[0]) {
 			ast_free(instances[n]->denylist[0]);
@@ -4555,6 +4558,8 @@ static int unload_module(void)
 		ast_free(instances[n]);
 	}
 
+	ast_mutex_destroy(&el_nodelist_lock);
+	ast_mutex_destroy(&el_db_lock);
 	return 0;
 }
 

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -3571,7 +3571,7 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *pvt, const char
 	return -1;
 }
 
-static void update_unkey_timers(int elap)
+static void update_unkey_timers(const int elap)
 {
 	size_t i;
 	struct pending_vector pending_messages;
@@ -3761,9 +3761,45 @@ static void *el_reader(void *data)
 		i = ast_poll(fds, 2, 50);
 		elap = time_elapsed(&start_time);
 
+		/* Echolink: send heartbeats and drop dead stations */
+		update_timer(&heartbeat_timer, elap, 0);
+
+		if (heartbeat_timer <= 0) {
+			heartbeat_timer = KEEPALIVE_TIME;
+			instp->el_node_test.ip[0] = '\0';
+
+			ast_mutex_lock(&el_nodelist_lock);
+			twalk(el_node_list, send_heartbeat);
+			ast_mutex_unlock(&el_nodelist_lock);
+
+			if (instp->el_node_test.ip[0] != '\0') {
+				if (find_delete(&instp->el_node_test, instp)) {
+					int bye_length;
+
+					bye_length = rtcp_make_bye(bye, sizeof(bye), "rtcp timeout");
+					memset(&sin, 0, sizeof(sin));
+					sin.sin_family = AF_INET;
+					sin.sin_addr.s_addr = inet_addr(instp->el_node_test.ip);
+					sin.sin_port = htons(instp->ctrl_port);
+
+					/* send 20 bye packets to insure that they receive this disconnect */
+					for (i = 0; i < 20; i++) {
+						sendto(instp->ctrl_sock, bye, bye_length, 0, (struct sockaddr *) &sin, sizeof(sin));
+						instp->tx_ctrl_packets++;
+					}
+
+					ast_verb(4, "Callsign %s RTCP timeout, removing connection.\n", instp->el_node_test.call);
+				}
+
+				instp->el_node_test.ip[0] = '\0';
+			}
+		}
+
+		/* update the node timers */
+		update_unkey_timers(elap);
+
 		if (i == 0) {
 			/* Time out, update the timers */
-			update_unkey_timers(elap);
 			ast_mutex_lock(&instp->lock);
 			continue;
 		}
@@ -3774,9 +3810,6 @@ static void *el_reader(void *data)
 			ast_mutex_lock(&instp->lock);
 			break;
 		}
-
-		/* update the node timers */
-		update_unkey_timers(elap);
 
 		/*
 		 * process the control socket
@@ -4096,40 +4129,6 @@ static void *el_reader(void *data)
 				instp->current_talker = NULL;
 				instp->current_talker_start_time = (struct timeval) { 0 };
 				instp->current_talker_last_time = (struct timeval) { 0 };
-			}
-		}
-
-		/* Echolink: send heartbeats and drop dead stations */
-		update_timer(&heartbeat_timer, elap, 0);
-
-		if (!heartbeat_timer) {
-			heartbeat_timer = KEEPALIVE_TIME;
-			instp->el_node_test.ip[0] = '\0';
-
-			ast_mutex_lock(&el_nodelist_lock);
-			twalk(el_node_list, send_heartbeat);
-			ast_mutex_unlock(&el_nodelist_lock);
-
-			if (instp->el_node_test.ip[0] != '\0') {
-				if (find_delete(&instp->el_node_test, instp)) {
-					int bye_length;
-
-					bye_length = rtcp_make_bye(bye, sizeof(bye), "rtcp timeout");
-					memset(&sin, 0, sizeof(sin));
-					sin.sin_family = AF_INET;
-					sin.sin_addr.s_addr = inet_addr(instp->el_node_test.ip);
-					sin.sin_port = htons(instp->ctrl_port);
-
-					/* send 20 bye packets to insure that they receive this disconnect */
-					for (i = 0; i < 20; i++) {
-						sendto(instp->ctrl_sock, bye, bye_length, 0, (struct sockaddr *) &sin, sizeof(sin));
-						instp->tx_ctrl_packets++;
-					}
-
-					ast_verb(4, "Callsign %s RTCP timeout, removing connection.\n", instp->el_node_test.call);
-				}
-
-				instp->el_node_test.ip[0] = '\0';
 			}
 		}
 	}

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -440,7 +440,6 @@ struct el_instance {
 	uint16_t audio_port;
 	uint16_t ctrl_port;
 	unsigned long seqno;
-	struct gsmVoice_t audio_all;
 	struct el_node el_node_test;
 	struct el_pending pending[MAXPENDING];
 	time_t aprstime;
@@ -485,6 +484,8 @@ struct el_pvt {
 	struct ast_trans_pvt *xpath;
 	unsigned int nodenum;
 	struct ast_str *linkstr;
+	struct gsmVoice_t audio;
+	struct el_node el_node_test;
 	ast_mutex_t lock;
 };
 
@@ -1811,26 +1812,27 @@ static void send_audio_only_one(const void *nodep, const VISIT which, const int 
 {
 	struct el_node *node = *(struct el_node **) nodep;
 	struct el_instance *instp = node->instp;
+	struct el_pvt *p = node->pvt;
 	struct sockaddr_in sin;
 
 	if ((which == leaf) || (which == postorder)) {
-		if (strncmp(node->ip, instp->el_node_test.ip, EL_IP_SIZE) == 0) {
+		if (strncmp(node->ip, p->el_node_test.ip, EL_IP_SIZE) == 0) {
 			memset(&sin, 0, sizeof(sin));
 			sin.sin_family = AF_INET;
 			sin.sin_port = htons(instp->audio_port);
 			sin.sin_addr.s_addr = inet_addr(node->ip);
 
-			instp->audio_all.version = 3;
-			instp->audio_all.pad = 0;
-			instp->audio_all.ext = 0;
-			instp->audio_all.csrc = 0;
-			instp->audio_all.marker = 0;
-			instp->audio_all.payt = 3;
-			instp->audio_all.seqnum = htons(node->seqnum++);
-			instp->audio_all.time = htonl(0);
-			instp->audio_all.ssrc = htonl(instp->mynode);
+			p->audio.version = 3;
+			p->audio.pad = 0;
+			p->audio.ext = 0;
+			p->audio.csrc = 0;
+			p->audio.marker = 0;
+			p->audio.payt = 3;
+			p->audio.seqnum = htons(node->seqnum++);
+			p->audio.time = htonl(0);
+			p->audio.ssrc = htonl(instp->mynode);
 
-			sendto(instp->audio_sock, (char *) &instp->audio_all, sizeof(instp->audio_all), 0, (struct sockaddr *) &sin, sizeof(sin));
+			sendto(instp->audio_sock, (char *) &p->audio, sizeof(p->audio), 0, (struct sockaddr *) &sin, sizeof(sin));
 
 			instp->tx_audio_packets++;
 			node->tx_audio_packets++;
@@ -2432,13 +2434,11 @@ static int el_xwrite(struct ast_channel *ast, struct ast_frame *frame)
 	}
 
 	if (p->txkey || p->txindex) {
-		memcpy(instp->audio_all.data + (GSM_FRAME_SIZE * p->txindex++), frame->data.ptr, GSM_FRAME_SIZE);
+		memcpy(p->audio.data + (GSM_FRAME_SIZE * p->txindex++), frame->data.ptr, GSM_FRAME_SIZE);
 	}
 
 	if (p->txindex >= BLOCKING_FACTOR) {
-		ast_mutex_lock(&instp->lock);
-		strcpy(instp->el_node_test.ip, p->ip);
-		ast_mutex_unlock(&instp->lock);
+		strcpy(p->el_node_test.ip, p->ip);
 
 		ast_mutex_lock(&el_nodelist_lock);
 		twalk(el_node_list, send_audio_only_one);

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -545,7 +545,7 @@ static int el_queryoption(struct ast_channel *chan, int option, void *data, int 
 
 static void send_info(const void *nodep, const VISIT which, const int depth);
 static void process_cmd(char *buf, int buf_len, const char *fromip, struct el_instance *instp);
-static int find_delete(const struct el_node *key);
+static int find_delete(const struct el_node *key, struct el_instance *instp);
 static int do_new_call(struct el_instance *instp, struct el_pvt *p, const char *call, const char *name);
 static void lookup_node_nodenum(const void *nodep, const VISIT which, void *closure);
 static void lookup_node_callsign(const void *nodep, const VISIT which, void *closure);
@@ -1477,7 +1477,7 @@ static int el_hangup(struct ast_channel *ast)
 	ast_debug(1, "Sent bye to IP address %s.\n", pvt->ip);
 	ast_mutex_lock(&instp->lock);
 	strcpy(instp->el_node_test.ip, pvt->ip);
-	find_delete(&instp->el_node_test);
+	find_delete(&instp->el_node_test, instp);
 	ast_softhangup(ast, AST_SOFTHANGUP_DEV);
 	pvt->hangup = 0;
 	ast_mutex_unlock(&instp->lock);
@@ -2163,10 +2163,11 @@ static void free_node(void *nodep) {}
 /*!
  * \brief Find and delete a node from our internal node list.
  * \param key			Pointer to Echolink node struct to delete.
+ * \param instp 		Pointer to echolink instance (maybe NULL)
  * \retval 0			If node not found.
  * \retval 1			If node found.
  */
-static int find_delete(const struct el_node *key)
+static int find_delete(const struct el_node *key, struct el_instance *instp)
 {
 	int found = 0;
 	struct el_node **found_key;
@@ -2175,6 +2176,16 @@ static int find_delete(const struct el_node *key)
 	found_key = (struct el_node **) tfind(key, &el_node_list, compare_ip);
 	if (found_key) {
 		node = *found_key;
+		if (instp) {
+			if (instp->current_talker == node) {
+				ast_debug(3, "Current talker %s is disconnecting, clearing current talker.\n", node->call);
+				instp->current_talker->istimedout = 0;
+				instp->current_talker->isdoubling = 0;
+				instp->current_talker = NULL;
+				instp->current_talker_start_time = (struct timeval) { 0 };
+				instp->current_talker_last_time = (struct timeval) { 0 };
+			}
+		}
 		ast_debug(3, "Removing from current node list Callsign %s, IP Address %s.\n", node->call, node->ip);
 		found = 1;
 		node->pvt->hangup = 1;
@@ -2302,7 +2313,7 @@ static void process_cmd(char *buf, int buf_len, const char *fromip, struct el_in
 
 		if (strcmp(cmd, "o.dconip") == 0) {
 			ast_copy_string(key.ip, arg1, sizeof(key.ip));
-			if (find_delete(&key)) {
+			if (find_delete(&key, NULL)) {
 				for (i = 0; i < 20; i++) {
 					sendto(instp->ctrl_sock, pack, pack_length, 0, (struct sockaddr *) &sin, sizeof(sin));
 				}
@@ -3896,7 +3907,7 @@ static void *el_reader(void *data)
 					}
 				} else {
 					if (is_rtcp_bye((unsigned char *) buf, recvlen)) {
-						if (find_delete(&instp->el_node_test)) {
+						if (find_delete(&instp->el_node_test, instp)) {
 							ast_verb(4, "Disconnect from IP address %s, Callsign %s.\n", instp->el_node_test.ip,
 								instp->el_node_test.call);
 						}
@@ -4088,7 +4099,7 @@ static void *el_reader(void *data)
 			ast_mutex_unlock(&el_nodelist_lock);
 
 			if (instp->el_node_test.ip[0] != '\0') {
-				if (find_delete(&instp->el_node_test)) {
+				if (find_delete(&instp->el_node_test, instp)) {
 					int bye_length;
 
 					bye_length = rtcp_make_bye(bye, sizeof(bye), "rtcp timeout");


### PR DESCRIPTION
Use the asterisk audio queue for queuing frames.
Move timer logic out of `el_xwrite()` into `el_reader()` thread addressing mute "problem".
Addresses Echolink part of issue #1036 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified reader-thread processing and timing to use monotonic elapsed time, added per-connection audio buffering, and streamlined lifecycle/teardown handling for clearer resource ownership.

* **Bug Fixes**
  * More reliable key/unkey timing, aggregated pending unkey controls to avoid deadlocks, improved heartbeat/disconnect handling, and clearer node disconnect semantics to reduce missed disconnects and improve session stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->