### PR TITLE
chan_echolink: use read to process audio

### DIFF
--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -491,8 +491,8 @@ struct el_pvt {
 	int rxkey;						/* Receive keyed timer */
 	int keepalive;
 	int txindex;
-	struct ast_timer *timer;		/* Timer for receive audio */	
-	struct el_rxqast rxqast;		/* Received data queue */
+	struct ast_timer *timer; /* Timer for receive audio */	
+	struct el_rxqast rxqast; /* Received data queue */
 	struct ast_dsp *dsp;
 	struct ast_module_user *u;
 	struct ast_trans_pvt *xpath;
@@ -2426,25 +2426,27 @@ static struct ast_frame *el_xread(struct ast_channel *chan)
 		p->last_firstheard = 1;
 	}
 
-	
 	/* Echolink to Asterisk */
+	ast_mutex_lock(&p->lock);
 	if (p->rxqast.qe_forw != &p->rxqast) {
 		for (n = 0, qpast = p->rxqast.qe_forw; qpast != &p->rxqast; qpast = qpast->qe_forw) {
 			n++;
 		}
 		if (n > QUEUE_OVERLOAD_THRESHOLD_AST) {
-			ast_mutex_lock(&p->lock);
 			while (p->rxqast.qe_forw != &p->rxqast) {
 				qpast = p->rxqast.qe_forw;
 				remque((struct qelem *) qpast);
 				ast_free(qpast);
 			}
-			ast_mutex_unlock(&p->lock);
+
 			if (p->rxkey) {
 				p->rxkey = 1;
 			}
+
+			ast_mutex_unlock(&p->lock);
 			return &ast_null_frame;
 		}
+
 		if (!p->rxkey) {
 			struct ast_frame wf = {
 				.frametype = AST_FRAME_CONTROL,
@@ -2454,8 +2456,8 @@ static struct ast_frame *el_xread(struct ast_channel *chan)
 
 			ast_queue_frame(chan, &wf);
 		}
+
 		p->rxkey = MAX_RXKEY_TIME;
-		ast_mutex_lock(&p->lock);
 		qpast = p->rxqast.qe_forw;
 		remque((struct qelem *) qpast);
 		ast_mutex_unlock(&p->lock);
@@ -2490,6 +2492,7 @@ static struct ast_frame *el_xread(struct ast_channel *chan)
 		return ast_frdup(&fr);
 	}
 
+	ast_mutex_unlock(&p->lock);
 	return &ast_null_frame;
 }
 
@@ -4205,9 +4208,9 @@ static void *el_reader(void *data)
 									qpast = ast_malloc(sizeof(struct el_rxqast));
 									if (qpast) {
 										memcpy(qpast->buf, gsmPacket->data + (GSM_FRAME_SIZE * i), GSM_FRAME_SIZE);
-										ast_mutex_lock(&node->pvt->lock);
-										insque((struct qelem *) qpast, (struct qelem *) node->pvt->rxqast.qe_back);
-										ast_mutex_unlock(&node->pvt->lock);
+										ast_mutex_lock(&p->lock);
+										insque((struct qelem *) qpast, (struct qelem *) p->rxqast.qe_back);
+										ast_mutex_unlock(&p->lock);
 									}
 								}
 

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -491,7 +491,7 @@ struct el_pvt {
 	int rxkey;						/* Receive keyed timer */
 	int keepalive;
 	int txindex;
-	struct ast_timer *timer; /* Timer for receive audio */	
+	struct ast_timer *timer; /* Timer for receive audio */
 	struct el_rxqast rxqast; /* Received data queue */
 	struct ast_dsp *dsp;
 	struct ast_module_user *u;

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -2596,7 +2596,7 @@ static struct ast_channel *el_new(struct el_pvt *p, int state, unsigned int node
 		return NULL;
 	}
 
-	if (pipe(p->pipe) == -1) {
+	if (pipe2(p->pipe, O_NONBLOCK) == -1) {
 		ast_log(LOG_ERROR, "Channel %s: Is not able to create a pipe\n", p->app);
 		ast_hangup(chan);
 		return NULL;

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -173,6 +173,7 @@ do not use 127.0.0.1
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/timerfd.h>
 #include <unistd.h>
 #include <math.h>
 
@@ -186,6 +187,7 @@ do not use 127.0.0.1
 #include "asterisk/cli.h"
 #include "asterisk/format_cache.h"
 #include "asterisk/vector.h"
+#include "asterisk/timing.h"
 
 #define MAX_RXKEY_TIME 320	 /* ms */
 #define KEEPALIVE_TIME 10000 /* ms = 10 seconds heartbeat */
@@ -463,6 +465,15 @@ struct el_instance {
 };
 
 /*!
+ * \brief Echolink receive queue struct from asterisk.
+ */
+struct el_rxqast {
+	struct el_rxqast *qe_forw;
+	struct el_rxqast *qe_back;
+	char buf[GSM_FRAME_SIZE];
+};
+
+/*!
  * \brief Echolink private information.
  * This is stored in the asterisk channel private technology for reference.
  */
@@ -480,6 +491,8 @@ struct el_pvt {
 	int rxkey;						/* Receive keyed timer */
 	int keepalive;
 	int txindex;
+	struct ast_timer *timer;		/* Timer for receive audio */	
+	struct el_rxqast rxqast;		/* Received data queue */
 	struct ast_dsp *dsp;
 	struct ast_module_user *u;
 	struct ast_trans_pvt *xpath;
@@ -1395,6 +1408,19 @@ static int el_call(struct ast_channel *chan, const char *dest, int timeout)
 static void el_destroy(void *obj)
 {
 	struct el_pvt *p = obj;
+	struct el_rxqast *qpast;
+
+	ast_mutex_lock(&p->lock);
+	while (p->rxqast.qe_forw != &p->rxqast) {
+		qpast = p->rxqast.qe_forw;
+		remque(qpast);
+		ast_free(qpast);
+	}
+	ast_mutex_unlock(&p->lock);
+
+	if (p->timer) {
+		ast_timer_close(p->timer);
+	}
 
 	if (p->dsp) {
 		ast_dsp_free(p->dsp);
@@ -1448,6 +1474,8 @@ static struct el_pvt *el_alloc(const char *data)
 	if (p) {
 		snprintf(p->stream, sizeof(p->stream), "%s-%lu", data, instances[n]->seqno++);
 
+		p->rxqast.qe_forw = &p->rxqast;
+		p->rxqast.qe_back = &p->rxqast;
 		p->keepalive = KEEPALIVE_TIME;
 		p->instp = instances[n];
 		p->dsp = ast_dsp_new();
@@ -2371,7 +2399,16 @@ static void process_cmd(char *buf, int buf_len, const char *fromip, struct el_in
  */
 static struct ast_frame *el_xread(struct ast_channel *chan)
 {
+	struct el_rxqast *qpast;
 	struct el_pvt *p = ast_channel_tech_pvt(chan);
+	struct ast_frame fr, *f1, *f2;
+	char buf[AST_FRIENDLY_OFFSET + GSM_FRAME_SIZE];
+	int n;
+
+	if ((ast_timer_ack(p->timer, 1) < 0)) {
+		ast_log(LOG_WARNING, "Timer ack failed.\n");
+		return NULL;
+	}
 
 	if (p->hangup) {
 		ast_softhangup(chan, AST_SOFTHANGUP_DEV);
@@ -2387,6 +2424,70 @@ static struct ast_frame *el_xread(struct ast_channel *chan)
 
 		ast_queue_frame(chan, &fr);
 		p->last_firstheard = 1;
+	}
+
+	
+	/* Echolink to Asterisk */
+	if (p->rxqast.qe_forw != &p->rxqast) {
+		for (n = 0, qpast = p->rxqast.qe_forw; qpast != &p->rxqast; qpast = qpast->qe_forw) {
+			n++;
+		}
+		if (n > QUEUE_OVERLOAD_THRESHOLD_AST) {
+			ast_mutex_lock(&p->lock);
+			while (p->rxqast.qe_forw != &p->rxqast) {
+				qpast = p->rxqast.qe_forw;
+				remque((struct qelem *) qpast);
+				ast_free(qpast);
+			}
+			ast_mutex_unlock(&p->lock);
+			if (p->rxkey) {
+				p->rxkey = 1;
+			}
+			return &ast_null_frame;
+		}
+		if (!p->rxkey) {
+			struct ast_frame wf = {
+				.frametype = AST_FRAME_CONTROL,
+				.subclass.integer = AST_CONTROL_RADIO_KEY,
+				.src = __PRETTY_FUNCTION__,
+			};
+
+			ast_queue_frame(chan, &wf);
+		}
+		p->rxkey = MAX_RXKEY_TIME;
+		ast_mutex_lock(&p->lock);
+		qpast = p->rxqast.qe_forw;
+		remque((struct qelem *) qpast);
+		ast_mutex_unlock(&p->lock);
+		memcpy(buf + AST_FRIENDLY_OFFSET, qpast->buf, GSM_FRAME_SIZE);
+		ast_free(qpast);
+
+		memset(&fr, 0, sizeof(fr));
+		fr.datalen = GSM_FRAME_SIZE;
+		fr.samples = GSM_SAMPLES;
+		fr.frametype = AST_FRAME_VOICE;
+		fr.subclass.format = ast_format_gsm;
+		fr.data.ptr = buf + AST_FRIENDLY_OFFSET;
+		fr.offset = AST_FRIENDLY_OFFSET;
+		fr.src = __PRETTY_FUNCTION__;
+
+		if (p->dsp) {
+			f2 = ast_translate(p->xpath, &fr, 0);
+			f1 = ast_dsp_process(NULL, p->dsp, f2);
+			if ((f1->frametype == AST_FRAME_DTMF_END) || (f1->frametype == AST_FRAME_DTMF_BEGIN)) {
+				if ((f1->subclass.integer != 'm') && (f1->subclass.integer != 'u')) {
+					if (f1->frametype == AST_FRAME_DTMF_END) {
+						ast_verb(4, "Echolink %s Got DTMF character %c from IP address %s.\n", p->stream, f1->subclass.integer, p->ip);
+					}
+
+					return f1;
+				}
+			}
+
+			return f2;
+		}
+
+		return ast_frdup(&fr);
 	}
 
 	return &ast_null_frame;
@@ -2488,6 +2589,14 @@ static struct ast_channel *el_new(struct el_pvt *p, int state, unsigned int node
 		return NULL;
 	}
 
+	if (!(p->timer = ast_timer_open())) {
+		ast_log(LOG_ERROR, "Unable to open timer.\n");
+		ast_hangup(chan);
+		return NULL;
+	}
+	ast_timer_set_rate(p->timer, 50); /* Rate in per second - 50/second = 20ms */
+
+	ast_channel_set_fd(chan, 0, ast_timer_fd(p->timer));
 	ast_channel_tech_set(chan, &el_tech);
 	ast_channel_nativeformats_set(chan, el_tech.capabilities);
 	ast_channel_set_rawreadformat(chan, ast_format_gsm);
@@ -4089,65 +4198,21 @@ static void *el_reader(void *data)
 						if (recvlen == sizeof(struct gsmVoice_t)) {
 							if (gsmPacket->version == 3 && gsmPacket->payt == 3) {
 								/* break them up for Asterisk */
-								char inbuf[GSM_FRAME_SIZE + AST_FRIENDLY_OFFSET];
+								struct el_rxqast *qpast;
 
 								for (i = 0; i < BLOCKING_FACTOR; i++) {
 									/* Echolink to Asterisk */
-									struct ast_frame *f1, *f2;
-									struct ast_frame fr = {
-										.datalen = GSM_FRAME_SIZE,
-										.samples = GSM_SAMPLES,
-										.frametype = AST_FRAME_VOICE,
-										.subclass.format = ast_format_gsm,
-										.data.ptr = inbuf + AST_FRIENDLY_OFFSET,
-										.offset = AST_FRIENDLY_OFFSET,
-										.src = __PRETTY_FUNCTION__,
-									};
-
-									if (!p->rxkey) {
-										struct ast_frame wf = {
-											.frametype = AST_FRAME_CONTROL,
-											.subclass.integer = AST_CONTROL_RADIO_KEY,
-											.src = __PRETTY_FUNCTION__,
-										};
-
-										if (chan) {
-											ast_queue_frame(chan, &wf);
-										}
-									}
-
-									p->rxkey = MAX_RXKEY_TIME;
-									memcpy(inbuf + AST_FRIENDLY_OFFSET, gsmPacket->data + (GSM_FRAME_SIZE * i), GSM_FRAME_SIZE);
-									x = 0;
-									f2 = ast_translate(p->xpath, &fr, 0);
-
-									if (p->dsp) {
-										f1 = ast_dsp_process(NULL, p->dsp, f2);
-
-										if ((f1->frametype == AST_FRAME_DTMF_END) || (f1->frametype == AST_FRAME_DTMF_BEGIN)) {
-											if ((f1->subclass.integer != 'm') && (f1->subclass.integer != 'u')) {
-												if (f1->frametype == AST_FRAME_DTMF_END) {
-													ast_verb(4, "Echolink %s Got DTMF character %c from IP address %s.\n",
-														p->stream, f1->subclass.integer, p->ip);
-												}
-
-												if (chan) {
-													ast_queue_frame(chan, f1);
-													ast_frfree(f1);
-													x = 1;
-												}
-											}
-										}
-									}
-
-									if (!x) {
-										if (chan) {
-											ast_queue_frame(chan, f2);
-										}
-
-										ast_frfree(f2);
+									qpast = ast_malloc(sizeof(struct el_rxqast));
+									if (qpast) {
+										memcpy(qpast->buf, gsmPacket->data + (GSM_FRAME_SIZE * i), GSM_FRAME_SIZE);
+										ast_mutex_lock(&node->pvt->lock);
+										insque((struct qelem *) qpast, (struct qelem *) node->pvt->rxqast.qe_back);
+										ast_mutex_unlock(&node->pvt->lock);
 									}
 								}
+
+							} else {
+								instp->rx_bad_packets++;
 							}
 						} else {
 							instp->rx_bad_packets++;

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -2431,20 +2431,19 @@ static struct ast_frame *el_xread(struct ast_channel *chan)
 	if (p->rxqast.qe_forw != &p->rxqast) {
 		for (n = 0, qpast = p->rxqast.qe_forw; qpast != &p->rxqast; qpast = qpast->qe_forw) {
 			n++;
-		}
-		if (n > QUEUE_OVERLOAD_THRESHOLD_AST) {
-			while (p->rxqast.qe_forw != &p->rxqast) {
-				qpast = p->rxqast.qe_forw;
-				remque((struct qelem *) qpast);
-				ast_free(qpast);
-			}
+			if (n > QUEUE_OVERLOAD_THRESHOLD_AST) {
+				while (p->rxqast.qe_forw != &p->rxqast) {
+					qpast = p->rxqast.qe_forw;
+					remque((struct qelem *) qpast);
+					ast_free(qpast);
+				}
+				if (p->rxkey) {
+					p->rxkey = 1;
+				}
 
-			if (p->rxkey) {
-				p->rxkey = 1;
+				ast_mutex_unlock(&p->lock);
+				return &ast_null_frame;
 			}
-
-			ast_mutex_unlock(&p->lock);
-			return &ast_null_frame;
 		}
 
 		if (!p->rxkey) {

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -491,7 +491,7 @@ struct el_pvt {
 	int rxkey;						/* Receive keyed timer */
 	int keepalive;
 	int txindex;
-	int pipe[2];			 /* Timer for receive audio */
+	int pipe[2];			 /* Pipe for receive audio from el_reader to Asterisk */
 	struct el_rxqast rxqast; /* Received data queue */
 	struct ast_dsp *dsp;
 	struct ast_module_user *u;

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -491,7 +491,7 @@ struct el_pvt {
 	int rxkey;						/* Receive keyed timer */
 	int keepalive;
 	int txindex;
-	struct ast_timer *timer; /* Timer for receive audio */
+	int pipe[2];             /* Timer for receive audio */
 	struct el_rxqast rxqast; /* Received data queue */
 	struct ast_dsp *dsp;
 	struct ast_module_user *u;
@@ -1418,8 +1418,12 @@ static void el_destroy(void *obj)
 	}
 	ast_mutex_unlock(&p->lock);
 
-	if (p->timer) {
-		ast_timer_close(p->timer);
+	if (p->pipe[0] != -1) {
+		close(p->pipe[0]);
+	}
+
+	if (p->pipe[1] != -1) {
+		close(p->pipe[1]);
 	}
 
 	if (p->dsp) {
@@ -2403,11 +2407,12 @@ static struct ast_frame *el_xread(struct ast_channel *chan)
 	struct el_pvt *p = ast_channel_tech_pvt(chan);
 	struct ast_frame fr, *f1, *f2;
 	char buf[AST_FRIENDLY_OFFSET + GSM_FRAME_SIZE];
-	int n;
+	char c;
+	int n, bytes;
 
-	if ((ast_timer_ack(p->timer, 1) < 0)) {
-		ast_log(LOG_WARNING, "Timer ack failed.\n");
-		return NULL;
+	bytes = read(p->pipe[0], &c, 1);
+	if (bytes <= 0) {
+		ast_log(LOG_ERROR, "Channel %s: pipe read failed: %s\n", p->app, strerror(errno));
 	}
 
 	if (p->hangup) {
@@ -2591,14 +2596,13 @@ static struct ast_channel *el_new(struct el_pvt *p, int state, unsigned int node
 		return NULL;
 	}
 
-	if (!(p->timer = ast_timer_open())) {
-		ast_log(LOG_ERROR, "Unable to open timer.\n");
+	if (pipe(p->pipe) == -1) {
+		ast_log(LOG_ERROR, "Channel %s: Is not able to create a pipe\n", p->app);
 		ast_hangup(chan);
 		return NULL;
 	}
-	ast_timer_set_rate(p->timer, 50); /* Rate in per second - 50/second = 20ms */
 
-	ast_channel_set_fd(chan, 0, ast_timer_fd(p->timer));
+	ast_channel_set_fd(chan, 0, p->pipe[0]);
 	ast_channel_tech_set(chan, &el_tech);
 	ast_channel_nativeformats_set(chan, el_tech.capabilities);
 	ast_channel_set_rawreadformat(chan, ast_format_gsm);
@@ -4201,6 +4205,8 @@ static void *el_reader(void *data)
 							if (gsmPacket->version == 3 && gsmPacket->payt == 3) {
 								/* break them up for Asterisk */
 								struct el_rxqast *qpast;
+								char c = 0;
+								int res;
 
 								for (i = 0; i < BLOCKING_FACTOR; i++) {
 									/* Echolink to Asterisk */
@@ -4210,6 +4216,11 @@ static void *el_reader(void *data)
 										ast_mutex_lock(&p->lock);
 										insque((struct qelem *) qpast, (struct qelem *) p->rxqast.qe_back);
 										ast_mutex_unlock(&p->lock);
+										res = write(p->pipe[1], &c, 1);
+
+										if (res <= 0) {
+											ast_log(LOG_ERROR, "Channel %s: Write failed: %s\n", p->app, strerror(errno));
+										}
 									}
 								}
 

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -617,6 +617,24 @@ static time_t time_monotonic(void)
 }
 
 /*!
+ * \brief Wake the el channel for frame processing.
+ * \param p		Pointer channel private data.
+ */
+
+static void el_wake_channel(struct el_pvt *p)
+{
+	char c = 0;
+	int res;
+
+	if (p->pipe[1] != -1) {
+		res = write(p->pipe[1], &c, 1);
+		if (res <= 0) {
+			ast_log(LOG_ERROR, "Channel %s: Write failed: %s\n", p->app, strerror(errno));
+		}
+	}
+}
+
+/*!
  * \brief Break up a delimited string into a table of substrings.
  * Uses defines for the delimiters: QUOTECHR and DELIMCHR.
  * \param str		Pointer to string to process (it will be modified).
@@ -2249,6 +2267,7 @@ static int find_delete(const struct el_node *key, struct el_instance *instp)
 		ast_debug(3, "Removing from current node list Callsign %s, IP Address %s.\n", node->call, node->ip);
 		found = 1;
 		node->pvt->hangup = 1;
+		el_wake_channel(node->pvt);
 		tdelete(node, &el_node_list, compare_ip);
 		ao2_ref(node->pvt, -1);
 		node->pvt = NULL;
@@ -2513,17 +2532,6 @@ static int el_xwrite(struct ast_channel *chan, struct ast_frame *frame)
 	struct sockaddr_in sin;
 	struct el_pvt *p = ast_channel_tech_pvt(chan);
 	struct el_instance *instp = p->instp;
-
-	if (!p->last_firstheard && p->firstheard) {
-		struct ast_frame fr3 = {
-			.frametype = AST_FRAME_CONTROL,
-			.subclass.integer = AST_CONTROL_ANSWER,
-			.src = __PRETTY_FUNCTION__,
-		};
-
-		ast_queue_frame(chan, &fr3);
-		p->last_firstheard = 1;
-	}
 
 	if (frame->frametype != AST_FRAME_VOICE) {
 		return 0;
@@ -3991,6 +3999,7 @@ static void *el_reader(void *data)
 						if (found_key) {
 							node = *found_key;
 							node->pvt->firstheard = 1;
+							el_wake_channel(node->pvt);
 							node->heartbeat_countdown = instp->rtcptimeout;
 							/* different callsigns behind a NAT router, running -L, -R, ... */
 							if (strncmp((*found_key)->call, call, EL_CALL_SIZE - 1) != 0) {
@@ -4143,6 +4152,7 @@ static void *el_reader(void *data)
 						ast_mutex_unlock(&p->lock);
 
 						p->firstheard = 1;
+						el_wake_channel(p);
 						node->heartbeat_countdown = instp->rtcptimeout;
 						node->rx_audio_packets++;
 						/* compute inter-arrival jitter */
@@ -4206,8 +4216,6 @@ static void *el_reader(void *data)
 							if (gsmPacket->version == 3 && gsmPacket->payt == 3) {
 								/* break them up for Asterisk */
 								struct el_rxqast *qpast;
-								char c = 0;
-								int res;
 
 								for (i = 0; i < BLOCKING_FACTOR; i++) {
 									/* Echolink to Asterisk */
@@ -4217,11 +4225,7 @@ static void *el_reader(void *data)
 										ast_mutex_lock(&p->lock);
 										insque((struct qelem *) qpast, (struct qelem *) p->rxqast.qe_back);
 										ast_mutex_unlock(&p->lock);
-										res = write(p->pipe[1], &c, 1);
-
-										if (res <= 0) {
-											ast_log(LOG_ERROR, "Channel %s: Write failed: %s\n", p->app, strerror(errno));
-										}
+										el_wake_channel(p);
 									}
 								}
 

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -491,7 +491,7 @@ struct el_pvt {
 	int rxkey;						/* Receive keyed timer */
 	int keepalive;
 	int txindex;
-	int pipe[2];             /* Timer for receive audio */
+	int pipe[2];			 /* Timer for receive audio */
 	struct el_rxqast rxqast; /* Received data queue */
 	struct ast_dsp *dsp;
 	struct ast_module_user *u;

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -1477,7 +1477,8 @@ static struct el_pvt *el_alloc(const char *data)
 	p = ao2_alloc(sizeof(struct el_pvt), el_destroy);
 	if (p) {
 		snprintf(p->stream, sizeof(p->stream), "%s-%lu", data, instances[n]->seqno++);
-
+		p->pipe[0] = -1;
+		p->pipe[1] = -1;
 		p->rxqast.qe_forw = &p->rxqast;
 		p->rxqast.qe_back = &p->rxqast;
 		p->keepalive = KEEPALIVE_TIME;


### PR DESCRIPTION
Use asterisk timer for read fd trigger

This allows multi threaded translation, where the previous update single threaded all DSP and Translation.
This is the suspected cause of choppy inbound audio.
Fixes #1047 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Buffered per-channel receive handling for more stable, timely audio delivery and reduced inline processing.
  * Improved overload protection to drop excess frames and preserve audio continuity.
  * More reliable DTMF detection and translation with better timing for keyed state transitions.
  * Faster, more consistent signaling of answered/first-heard state to the telephony side.

* **Bug Fixes**
  * Channel teardown now fully drains queued audio and closes resources to prevent lingering data and leaks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AllStarLink/app_rpt/pull/1048?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->