### PR TITLE
chan_echolink: missing locks on continue

### DIFF
--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -4188,6 +4188,7 @@ static void *el_reader(void *data)
 								}
 
 								ao2_ref(p, -1);
+								ast_mutex_lock(&instp->lock);
 								continue;
 							}
 						}
@@ -4206,6 +4207,7 @@ static void *el_reader(void *data)
 							}
 
 							ao2_ref(p, -1);
+							ast_mutex_lock(&instp->lock);
 							continue;
 						}
 


### PR DESCRIPTION
`instp->lock` should be locked on `continue`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced thread synchronization in EchoLink channel audio processing to improve stability during concurrent packet handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AllStarLink/app_rpt/pull/1050?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->