### PR TITLE
chan_simpleusb, chan_usbradio: nonblocking pttkick pipe

### DIFF
--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1137,7 +1137,7 @@ static void *hidthread(void *arg)
 		o->had_gpios_in = 0;
 
 		memset(&rfds, 0, sizeof(rfds));
-		rfds[0].fd = o->pttkick[1];
+		rfds[0].fd = o->pttkick[0];
 		rfds[0].events = POLLIN;
 
 		ast_radio_time(&o->lasthidtime);

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -663,7 +663,7 @@ static void kickptt(const struct chan_simpleusb_pvt *o)
 		return;
 	}
 	res = write(o->pttkick[1], &c, 1);
-	if (res <= 0) {
+	if (res <= 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
 		ast_log(LOG_ERROR, "Channel %s: Write failed: %s\n", o->name, strerror(errno));
 	}
 }
@@ -1159,7 +1159,7 @@ static void *hidthread(void *arg)
 				char c;
 
 				int bytes = read(o->pttkick[0], &c, 1);
-				if (bytes <= 0) {
+				if (bytes <= 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
 					ast_log(LOG_ERROR, "Channel %s: pttkick read failed: %s\n", o->name, strerror(errno));
 				}
 			}

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -663,8 +663,10 @@ static void kickptt(const struct chan_simpleusb_pvt *o)
 		return;
 	}
 	res = write(o->pttkick[1], &c, 1);
-	if (res <= 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+	if (res < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
 		ast_log(LOG_ERROR, "Channel %s: Write failed: %s\n", o->name, strerror(errno));
+	} else if (res == 0) {
+		ast_log(LOG_ERROR, "Channel %s: Write returned 0 bytes unexpectedly\n", o->name);
 	}
 }
 
@@ -1159,8 +1161,10 @@ static void *hidthread(void *arg)
 				char c;
 
 				int bytes = read(o->pttkick[0], &c, 1);
-				if (bytes <= 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+				if (bytes < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
 					ast_log(LOG_ERROR, "Channel %s: pttkick read failed: %s\n", o->name, strerror(errno));
+				} else if (bytes == 0) {
+					ast_log(LOG_ERROR, "Channel %s: pttkick pipe closed unexpectedly\n", o->name);
 				}
 			}
 			/* see if we need to process an eeprom read or write */

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1109,10 +1109,11 @@ static void *hidthread(void *arg)
 			close(o->pttkick[1]);
 			o->pttkick[1] = -1;
 		}
-		if (pipe(o->pttkick) == -1) {
+		if (pipe2(o->pttkick, O_NONBLOCK) == -1) {
 			ast_log(LOG_ERROR, "Channel %s: Is not able to create a pipe\n", o->name);
 			pthread_exit(NULL);
 		}
+
 		if ((usb_dev->descriptor.idProduct & 0xfffc) == C108_PRODUCT_ID) {
 			o->devtype = C108_PRODUCT_ID;
 		} else {

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -627,7 +627,7 @@ static void kickptt(const struct chan_usbradio_pvt *o)
 		return;
 	}
 	res = write(o->pttkick[1], &c, 1);
-	if (res <= 0) {
+	if (res <= 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
 		ast_log(LOG_ERROR, "Channel %s: Write failed: %s\n", o->name, strerror(errno));
 	}
 }
@@ -1229,7 +1229,7 @@ static void *hidthread(void *arg)
 				char c;
 
 				int bytes = read(o->pttkick[0], &c, 1);
-				if (bytes <= 0) {
+				if (bytes <= 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
 					ast_log(LOG_ERROR, "Channel %s: pttkick read failed: %s\n", o->name, strerror(errno));
 				}
 			}

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -627,8 +627,10 @@ static void kickptt(const struct chan_usbradio_pvt *o)
 		return;
 	}
 	res = write(o->pttkick[1], &c, 1);
-	if (res <= 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+	if (res < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
 		ast_log(LOG_ERROR, "Channel %s: Write failed: %s\n", o->name, strerror(errno));
+	} else if (res == 0) {
+		ast_log(LOG_ERROR, "Channel %s: Write returned 0 bytes unexpectedly\n", o->name);
 	}
 }
 
@@ -1229,8 +1231,10 @@ static void *hidthread(void *arg)
 				char c;
 
 				int bytes = read(o->pttkick[0], &c, 1);
-				if (bytes <= 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+				if (bytes < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
 					ast_log(LOG_ERROR, "Channel %s: pttkick read failed: %s\n", o->name, strerror(errno));
+				} else if (bytes == 0) {
+					ast_log(LOG_ERROR, "Channel %s: pttkick pipe closed unexpectedly\n", o->name);
 				}
 			}
 			/* see if we need to process an eeprom read or write */

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -1207,7 +1207,7 @@ static void *hidthread(void *arg)
 		o->had_gpios_in = 0;
 
 		memset(&rfds, 0, sizeof(rfds));
-		rfds[0].fd = o->pttkick[1];
+		rfds[0].fd = o->pttkick[0];
 		rfds[0].events = POLLIN;
 
 		ast_radio_time(&o->lasthidtime);

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -1081,7 +1081,7 @@ static void *hidthread(void *arg)
 			close(o->pttkick[1]);
 			o->pttkick[1] = -1;
 		}
-		if (pipe(o->pttkick) == -1) {
+		if (pipe2(o->pttkick, O_NONBLOCK) == -1) {
 			ast_log(LOG_ERROR, "Channel %s: Is not able to create a pipe\n", o->name);
 			pthread_exit(NULL);
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made internal signaling non-blocking to prevent threads from stalling and improve reliability.
  * Reduced spurious error messages by treating transient non-blocking I/O conditions as non-fatal.
  * Fixed event monitoring so signal reads are handled correctly, improving consistent interrupt delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->