### PR TITLE
chan_echolink: use untranslated frame for inbound audio.

### DIFF
--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -2510,7 +2510,7 @@ static struct ast_frame *el_xread(struct ast_channel *chan)
 				}
 			}
 
-			return f2;
+			return ast_frdup(&fr);
 		}
 
 		return ast_frdup(&fr);


### PR DESCRIPTION
First step toward fixing choppy rx audio from echolink #1047 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Corrected voice frame handling behavior in EchoLink channels when audio processing is enabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AllStarLink/app_rpt/pull/1054?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->