### PR TITLE
chan_echolink.c: Use 20ms timer to buffer variable inbound gsm frames

### DIFF
--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -2415,7 +2415,7 @@ static struct ast_frame *el_xread(struct ast_channel *chan)
 			ast_log(LOG_WARNING, "Timer ack failed. \n");
 			return NULL;
 		}
-	}       
+	}
 
 	for (n = 0, qpast = p->rxqast.qe_forw; qpast != &p->rxqast; qpast = qpast->qe_forw) {
 		n++;

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -483,11 +483,9 @@ struct el_pvt {
 	char app[16];
 	char stream[80];
 	char ip[EL_IP_SIZE];
-	unsigned int firstsent:1;		/* First packet seen from echolink */
-	unsigned int firstheard:1;		/* First heard from called node */
-	unsigned int answered:1;		/* Indicates the call has been answered */
-	unsigned int txkey:1;			/* Transmit keyed */
-	unsigned int hangup:1;			/* Indicates the channel should hang up */
+	int firstsent;					/* First packet seen from echolink */
+	int firstheard;					/* First heard from called node */
+	int txkey;						/* Transmit keyed */
 	int rxkey;						/* Receive keyed timer */
 	int keepalive;
 	int txindex;
@@ -1543,10 +1541,6 @@ static int el_hangup(struct ast_channel *chan)
 	ast_debug(1, "Sent bye to IP address %s.\n", p->ip);
 	strcpy(node_lookup.ip, p->ip);
 	find_delete(&node_lookup, instp);
-	ast_mutex_lock(&p->lock);
-	p->hangup = 0;
-	ast_mutex_unlock(&p->lock);
-	ast_softhangup(chan, AST_SOFTHANGUP_DEV);
 	n = rtcp_make_bye(bye, sizeof(bye), "disconnected");
 
 	memset(&sin, 0, sizeof(sin));
@@ -2257,7 +2251,6 @@ static int find_delete(const struct el_node *key, struct el_instance *instp)
 	if (found_key) {
 		struct el_node *node = *found_key;
 		struct el_pvt *p = node->pvt;
-		int wake = 0;
 
 		if (instp) {
 			if (instp->current_talker == node) {
@@ -2274,14 +2267,10 @@ static int find_delete(const struct el_node *key, struct el_instance *instp)
 		found = 1;
 
 		ast_mutex_lock(&p->lock);
-		if (!p->hangup) {
-			p->hangup = 1;
-			wake = 1;
+		if (p->owner) {
+			ast_softhangup(p->owner, AST_SOFTHANGUP_DEV);
 		}
 		ast_mutex_unlock(&p->lock);
-		if (wake) {
-			el_wake_channel(p);
-		}
 
 		tdelete(node, &el_node_list, compare_ip);
 		ao2_ref(p, -1);
@@ -2451,32 +2440,6 @@ static struct ast_frame *el_xread(struct ast_channel *chan)
 		return &ast_null_frame;
 	}
 
-	ast_mutex_lock(&p->lock);
-
-	if (p->hangup) {
-		p->hangup = 0;
-		ast_mutex_unlock(&p->lock);
-
-		ast_debug(3, "Channel %s: hangup\n", p->stream);
-		ast_softhangup(chan, AST_SOFTHANGUP_DEV);
-		return &ast_null_frame;
-	}
-
-	if (!p->answered && p->firstheard) {
-		struct ast_frame fr = {
-			.frametype = AST_FRAME_CONTROL,
-			.subclass.integer = AST_CONTROL_ANSWER,
-			.src = __PRETTY_FUNCTION__,
-		};
-
-		p->answered = 1;
-		ast_mutex_unlock(&p->lock);
-
-		ast_debug(3, "Channel %s: answer\n", p->stream);
-		ast_queue_frame(chan, &fr);
-		return &ast_null_frame;
-	}
-
 	for (n = 0, qpast = p->rxqast.qe_forw; qpast != &p->rxqast; qpast = qpast->qe_forw) {
 		n++;
 		if (n > QUEUE_OVERLOAD_THRESHOLD_AST) {
@@ -2487,6 +2450,7 @@ static struct ast_frame *el_xread(struct ast_channel *chan)
 				ast_free(qpast);
 			}
 			if (p->rxkey) {
+				/* rxkey is a timer, set it to "done" */
 				p->rxkey = 1;
 			}
 			break;
@@ -2565,18 +2529,9 @@ static int el_xwrite(struct ast_channel *chan, struct ast_frame *frame)
 	struct sockaddr_in sin;
 	struct el_pvt *p = ast_channel_tech_pvt(chan);
 	struct el_instance *instp = p->instp;
-	int need_hangup = 0;
 
 	if (frame->frametype != AST_FRAME_VOICE) {
 		return 0;
-	}
-
-	ast_mutex_lock(&p->lock);
-	need_hangup = p->hangup;
-	p->hangup = 0;
-	ast_mutex_unlock(&p->lock);
-	if (need_hangup) {
-		ast_softhangup(chan, AST_SOFTHANGUP_DEV);
 	}
 
 	if (!p->firstsent) {
@@ -4035,16 +3990,26 @@ static void *el_reader(void *data)
 						if (found_key) {
 							struct el_node *node = *found_key;
 							struct el_pvt *p = node->pvt;
-							int wake = 0;
 
-							ast_mutex_lock(&p->lock);
-							if (!p->answered && !p->firstheard) {
+							if (!p->firstheard) {
+								struct ast_frame fr = {
+									.frametype = AST_FRAME_CONTROL,
+									.subclass.integer = AST_CONTROL_ANSWER,
+									.src = __PRETTY_FUNCTION__,
+								};
+								struct ast_channel *chan = NULL;
+								ast_mutex_lock(&p->lock);
+								if (p->owner) {
+									chan = ast_channel_ref(p->owner);
+								}
+
 								p->firstheard = 1;
-								wake = 1;
-							}
-							ast_mutex_unlock(&p->lock);
-							if (wake) {
-								el_wake_channel(p);
+								ast_mutex_unlock(&p->lock);
+								if (chan) {
+									ast_queue_frame(chan, &fr);
+									ast_channel_unref(chan);
+								}
+								ast_debug(3, "Channel %s: answer\n", p->stream);
 							}
 
 							node->heartbeat_countdown = instp->rtcptimeout;
@@ -4188,7 +4153,6 @@ static void *el_reader(void *data)
 						struct el_node *node = *found_key;
 						struct el_pvt *p = node->pvt;
 						struct ast_channel *chan = NULL;
-						int wake = 0;
 
 						ao2_ref(p, +1);
 
@@ -4196,13 +4160,18 @@ static void *el_reader(void *data)
 						if (p->owner) {
 							chan = ast_channel_ref(p->owner);
 						}
-						if (!p->answered && !p->firstheard) {
-							p->firstheard = 1;
-							wake = 1;
-						}
 						ast_mutex_unlock(&p->lock);
-						if (wake) {
-							el_wake_channel(p);
+
+						if (!p->firstheard && chan) {
+							struct ast_frame fr = {
+								.frametype = AST_FRAME_CONTROL,
+								.subclass.integer = AST_CONTROL_ANSWER,
+								.src = __PRETTY_FUNCTION__,
+							};
+
+							p->firstheard = 1;
+							ast_debug(3, "Channel %s: answer\n", p->stream);
+							ast_queue_frame(chan, &fr);
 						}
 
 						node->heartbeat_countdown = instp->rtcptimeout;

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -218,7 +218,7 @@ do not use 127.0.0.1
 #define EL_APRS_SERVER "aprs.echolink.org"
 #define EL_APRS_INTERVAL 600
 #define EL_APRS_START_DELAY 10
-#define EL_DELAY 8 /* Number of frames to buffer before starting an rx event */
+#define EL_DELAY (BLOCKING_FACTOR * 1) /* Number of frames to buffer before starting an rx event */
 
 #define EL_QUERY_IPADDR 1
 #define EL_QUERY_CALLSIGN 2
@@ -2410,10 +2410,12 @@ static struct ast_frame *el_xread(struct ast_channel *chan)
 	int n;
 	int need_key;
 
-	if ((ast_timer_ack(p->timer, 1) < 0)) {
-		ast_log(LOG_WARNING, "Timer ack failed. \n");
-		return NULL;
-	}
+	if (ast_timer_get_event(p->timer) == AST_TIMING_EVENT_EXPIRED) {
+		if ((ast_timer_ack(p->timer, 1) < 0)) {
+			ast_log(LOG_WARNING, "Timer ack failed. \n");
+			return NULL;
+		}
+	}       
 
 	for (n = 0, qpast = p->rxqast.qe_forw; qpast != &p->rxqast; qpast = qpast->qe_forw) {
 		n++;
@@ -2569,6 +2571,7 @@ static struct ast_channel *el_new(struct el_pvt *p, int state, unsigned int node
 	const struct ast_channel *requestor)
 {
 	struct ast_channel *chan;
+	int rate;
 
 	chan = ast_channel_alloc(1, state, 0, 0, "", p->instp->astnode, p->instp->context, assignedids, requestor, 0, "echolink/%s", p->stream);
 	if (!chan) {
@@ -2576,19 +2579,23 @@ static struct ast_channel *el_new(struct el_pvt *p, int state, unsigned int node
 		return NULL;
 	}
 
-	if (!(p->timer = ast_timer_open())) {
-		ast_log(LOG_ERROR, "Channel %s: Unable to create timer.\n", p->stream);
-		ast_hangup(chan);
-		return NULL;
-	}
-	ast_timer_set_rate(p->timer, 50);
-	ast_channel_set_fd(chan, 0, ast_timer_fd(p->timer));
 	ast_channel_tech_set(chan, &el_tech);
 	ast_channel_nativeformats_set(chan, el_tech.capabilities);
 	ast_channel_set_rawreadformat(chan, ast_format_gsm);
 	ast_channel_set_rawwriteformat(chan, ast_format_gsm);
 	ast_channel_set_writeformat(chan, ast_format_gsm);
 	ast_channel_set_readformat(chan, ast_format_gsm);
+
+	p->timer = ast_timer_open();
+	if (!p->timer) {
+		ast_log(LOG_ERROR, "Channel %s: Unable to create timer.\n", p->stream);
+		ast_hangup(chan);
+		return NULL;
+	}
+
+	rate = 1000 / ast_format_get_default_ms(ast_format_gsm);
+	ast_timer_set_rate(p->timer, rate);
+	ast_channel_set_fd(chan, 0, ast_timer_fd(p->timer));
 
 	if (state == AST_STATE_RING) {
 		ast_channel_rings_set(chan, 1);

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -345,6 +345,16 @@ struct rtcp_t {
 	} r;
 };
 
+/*! \brief Global jitterbuffer configuration - by default, jb is disabled */
+static struct ast_jb_conf default_jbconf = {
+	.flags = 0,
+	.max_size = 1000,
+	.resync_threshold = 500,
+	.impl = "fixed",
+};
+
+static struct ast_jb_conf global_jbconf;
+
 /* forward definitions */
 struct el_instance;
 struct el_pvt;
@@ -2610,6 +2620,7 @@ static struct ast_channel *el_new(struct el_pvt *p, int state, unsigned int node
 	ast_channel_set_rawwriteformat(chan, ast_format_gsm);
 	ast_channel_set_writeformat(chan, ast_format_gsm);
 	ast_channel_set_readformat(chan, ast_format_gsm);
+	ast_jb_configure(chan, &global_jbconf);
 
 	if (state == AST_STATE_RING) {
 		ast_channel_rings_set(chan, 1);
@@ -3998,6 +4009,7 @@ static void *el_reader(void *data)
 									.src = __PRETTY_FUNCTION__,
 								};
 								struct ast_channel *chan = NULL;
+
 								ast_mutex_lock(&p->lock);
 								if (p->owner) {
 									chan = ast_channel_ref(p->owner);
@@ -4005,6 +4017,7 @@ static void *el_reader(void *data)
 
 								p->firstheard = 1;
 								ast_mutex_unlock(&p->lock);
+
 								if (chan) {
 									ast_queue_frame(chan, &fr);
 									ast_channel_unref(chan);
@@ -4702,6 +4715,9 @@ static int load_module(void)
 	}
 
 	ast_format_cap_append(el_tech.capabilities, ast_format_gsm, 0);
+
+	/* Copy the default jb config over global_jbconf */
+	memcpy(&global_jbconf, &default_jbconf, sizeof(struct ast_jb_conf));
 
 	while ((ctg = ast_category_browse(cfg, ctg)) != NULL) {
 		if (ctg == NULL) {

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -500,6 +500,7 @@ struct el_pvt {
 	int keepalive;
 	int txindex;
 	int pipe[2];			 /* Pipe for receive audio from el_reader to Asterisk */
+	struct ast_timer *timer;
 	struct el_rxqast rxqast; /* Received data queue */
 	struct ast_dsp *dsp;
 	struct ast_module_user *u;
@@ -633,12 +634,13 @@ static void el_wake_channel(struct el_pvt *p)
 	char c = 0;
 	int res;
 
-	if (p->pipe[1] != -1) {
-		res = write(p->pipe[1], &c, 1);
-		if (res <= 0) {
-			ast_log(LOG_ERROR, "Channel %s: Write failed: %s\n", p->stream, strerror(errno));
+	/*	if (p->pipe[1] != -1) {
+			res = write(p->pipe[1], &c, 1);
+			if (res <= 0) {
+				ast_log(LOG_ERROR, "Channel %s: Write failed: %s\n", p->stream, strerror(errno));
+			}
 		}
-	}
+			*/
 }
 
 /*!
@@ -1442,6 +1444,10 @@ static void el_destroy(void *obj)
 		ast_free(qpast);
 	}
 	ast_mutex_unlock(&p->lock);
+
+	if (p->timer) {
+		ast_timer_close(p->timer);
+	}
 
 	if (p->pipe[0] != -1) {
 		close(p->pipe[0]);
@@ -2444,11 +2450,17 @@ static struct ast_frame *el_xread(struct ast_channel *chan)
 	int n, bytes;
 	int need_key;
 
-	bytes = read(p->pipe[0], &c, 1);
-	if (bytes <= 0) {
-		ast_log(LOG_ERROR, "Channel %s: pipe read failed: %s\n", p->stream, strerror(errno));
-		return &ast_null_frame;
+	if ((ast_timer_ack(p->timer, 1) < 0)) {
+		ast_log(LOG_WARNING, "Timrer ack failed. \n");
+		return NULL;
 	}
+
+	/*	bytes = read(p->pipe[0], &c, 1);
+		if (bytes <= 0) {
+			ast_log(LOG_ERROR, "Channel %s: pipe read failed: %s\n", p->stream, strerror(errno));
+			return &ast_null_frame;
+		}
+	*/
 
 	for (n = 0, qpast = p->rxqast.qe_forw; qpast != &p->rxqast; qpast = qpast->qe_forw) {
 		n++;
@@ -2607,13 +2619,21 @@ static struct ast_channel *el_new(struct el_pvt *p, int state, unsigned int node
 		return NULL;
 	}
 
-	if (pipe2(p->pipe, O_NONBLOCK) == -1) {
-		ast_log(LOG_ERROR, "Channel %s: Is not able to create a pipe\n", p->stream);
+	/*	if (pipe2(p->pipe, O_NONBLOCK) == -1) {
+			ast_log(LOG_ERROR, "Channel %s: Is not able to create a pipe\n", p->stream);
+			ast_hangup(chan);
+			return NULL;
+		}
+	*/
+
+	if (!(p->timer = ast_timer_open())) {
+		ast_log(LOG_ERROR, "Channel %s: Unable to create timer.\n", p->stream);
 		ast_hangup(chan);
 		return NULL;
 	}
-
-	ast_channel_set_fd(chan, 0, p->pipe[0]);
+	ast_timer_set_rate(p->timer, 50);
+	//	ast_channel_set_fd(chan, 0, p->pipe[0]);
+	ast_channel_set_fd(chan, 0, ast_timer_fd(p->timer));
 	ast_channel_tech_set(chan, &el_tech);
 	ast_channel_nativeformats_set(chan, el_tech.capabilities);
 	ast_channel_set_rawreadformat(chan, ast_format_gsm);

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -2411,7 +2411,7 @@ static struct ast_frame *el_xread(struct ast_channel *chan)
 	int need_key;
 
 	if ((ast_timer_ack(p->timer, 1) < 0)) {
-		ast_log(LOG_WARNING, "Timrer ack failed. \n");
+		ast_log(LOG_WARNING, "Timer ack failed. \n");
 		return NULL;
 	}
 

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -218,6 +218,7 @@ do not use 127.0.0.1
 #define EL_APRS_SERVER "aprs.echolink.org"
 #define EL_APRS_INTERVAL 600
 #define EL_APRS_START_DELAY 10
+#define EL_DELAY 8 /* Number of frames to buffer before starting an rx event */
 
 #define EL_QUERY_IPADDR 1
 #define EL_QUERY_CALLSIGN 2
@@ -344,16 +345,6 @@ struct rtcp_t {
 		} sdes;
 	} r;
 };
-
-/*! \brief Global jitterbuffer configuration - by default, jb is disabled */
-static struct ast_jb_conf default_jbconf = {
-	.flags = 0,
-	.max_size = 1000,
-	.resync_threshold = 500,
-	.impl = "fixed",
-};
-
-static struct ast_jb_conf global_jbconf;
 
 /* forward definitions */
 struct el_instance;
@@ -499,7 +490,6 @@ struct el_pvt {
 	int rxkey;						/* Receive keyed timer */
 	int keepalive;
 	int txindex;
-	int pipe[2];			 /* Pipe for receive audio from el_reader to Asterisk */
 	struct ast_timer *timer;
 	struct el_rxqast rxqast; /* Received data queue */
 	struct ast_dsp *dsp;
@@ -623,24 +613,6 @@ static time_t time_monotonic(void)
 	clock_gettime(CLOCK_MONOTONIC, &ts);
 
 	return ts.tv_sec;
-}
-
-/*!
- * \brief Wake the el channel for frame processing.
- * \param p		Pointer channel private data.
- */
-static void el_wake_channel(struct el_pvt *p)
-{
-	char c = 0;
-	int res;
-
-	/*	if (p->pipe[1] != -1) {
-			res = write(p->pipe[1], &c, 1);
-			if (res <= 0) {
-				ast_log(LOG_ERROR, "Channel %s: Write failed: %s\n", p->stream, strerror(errno));
-			}
-		}
-			*/
 }
 
 /*!
@@ -1449,14 +1421,6 @@ static void el_destroy(void *obj)
 		ast_timer_close(p->timer);
 	}
 
-	if (p->pipe[0] != -1) {
-		close(p->pipe[0]);
-	}
-
-	if (p->pipe[1] != -1) {
-		close(p->pipe[1]);
-	}
-
 	if (p->dsp) {
 		ast_dsp_free(p->dsp);
 	}
@@ -1508,8 +1472,6 @@ static struct el_pvt *el_alloc(const char *data)
 	p = ao2_alloc(sizeof(struct el_pvt), el_destroy);
 	if (p) {
 		snprintf(p->stream, sizeof(p->stream), "%s-%lu", data, instances[n]->seqno++);
-		p->pipe[0] = -1;
-		p->pipe[1] = -1;
 		p->rxqast.qe_forw = &p->rxqast;
 		p->rxqast.qe_back = &p->rxqast;
 		p->keepalive = KEEPALIVE_TIME;
@@ -1577,7 +1539,6 @@ static int el_hangup(struct ast_channel *chan)
 	}
 
 	ast_debug(1, "Hanging up (%s).\n", ast_channel_name(chan));
-
 	if (!ast_channel_tech_pvt(chan)) {
 		ast_log(LOG_WARNING, "Asked to hangup channel not connected.\n");
 		return 0;
@@ -2446,21 +2407,13 @@ static struct ast_frame *el_xread(struct ast_channel *chan)
 	struct el_pvt *p = ast_channel_tech_pvt(chan);
 	struct ast_frame f_gsm;
 	char buf[AST_FRIENDLY_OFFSET + GSM_FRAME_SIZE];
-	char c;
-	int n, bytes;
+	int n;
 	int need_key;
 
 	if ((ast_timer_ack(p->timer, 1) < 0)) {
 		ast_log(LOG_WARNING, "Timrer ack failed. \n");
 		return NULL;
 	}
-
-	/*	bytes = read(p->pipe[0], &c, 1);
-		if (bytes <= 0) {
-			ast_log(LOG_ERROR, "Channel %s: pipe read failed: %s\n", p->stream, strerror(errno));
-			return &ast_null_frame;
-		}
-	*/
 
 	for (n = 0, qpast = p->rxqast.qe_forw; qpast != &p->rxqast; qpast = qpast->qe_forw) {
 		n++;
@@ -2477,6 +2430,10 @@ static struct ast_frame *el_xread(struct ast_channel *chan)
 			}
 			break;
 		}
+	}
+
+	if (n < EL_DELAY && !p->rxkey) { /* we need a bit of buffer to start sending audio */
+		return &ast_null_frame;
 	}
 
 	qpast = (p->rxqast.qe_forw != &p->rxqast) ? p->rxqast.qe_forw : NULL;
@@ -2619,20 +2576,12 @@ static struct ast_channel *el_new(struct el_pvt *p, int state, unsigned int node
 		return NULL;
 	}
 
-	/*	if (pipe2(p->pipe, O_NONBLOCK) == -1) {
-			ast_log(LOG_ERROR, "Channel %s: Is not able to create a pipe\n", p->stream);
-			ast_hangup(chan);
-			return NULL;
-		}
-	*/
-
 	if (!(p->timer = ast_timer_open())) {
 		ast_log(LOG_ERROR, "Channel %s: Unable to create timer.\n", p->stream);
 		ast_hangup(chan);
 		return NULL;
 	}
 	ast_timer_set_rate(p->timer, 50);
-	//	ast_channel_set_fd(chan, 0, p->pipe[0]);
 	ast_channel_set_fd(chan, 0, ast_timer_fd(p->timer));
 	ast_channel_tech_set(chan, &el_tech);
 	ast_channel_nativeformats_set(chan, el_tech.capabilities);
@@ -2640,7 +2589,6 @@ static struct ast_channel *el_new(struct el_pvt *p, int state, unsigned int node
 	ast_channel_set_rawwriteformat(chan, ast_format_gsm);
 	ast_channel_set_writeformat(chan, ast_format_gsm);
 	ast_channel_set_readformat(chan, ast_format_gsm);
-	ast_jb_configure(chan, &global_jbconf);
 
 	if (state == AST_STATE_RING) {
 		ast_channel_rings_set(chan, 1);
@@ -4281,7 +4229,6 @@ static void *el_reader(void *data)
 										ast_mutex_lock(&p->lock);
 										insque((struct qelem *) qpast, (struct qelem *) p->rxqast.qe_back);
 										ast_mutex_unlock(&p->lock);
-										el_wake_channel(p);
 									}
 								}
 
@@ -4735,9 +4682,6 @@ static int load_module(void)
 	}
 
 	ast_format_cap_append(el_tech.capabilities, ast_format_gsm, 0);
-
-	/* Copy the default jb config over global_jbconf */
-	memcpy(&global_jbconf, &default_jbconf, sizeof(struct ast_jb_conf));
 
 	while ((ctg = ast_category_browse(cfg, ctg)) != NULL) {
 		if (ctg == NULL) {


### PR DESCRIPTION
After relocating the inbound audio from the `.write` function to the `.read` function, inbound frames lost the buffering functionality that previously existed.  This PR restores the buffering functionality.  Additionally, we now have a parameter to add more buffer delay if necessary.
Fixes #1047 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated the Echolink channel driver's internal wake/signaling and resource lifecycle management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AllStarLink/app_rpt/pull/1056?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->