### PR TITLE
app_rpt: TOTP DTMF Authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 .vscode/
 .vs/
+pr_summary.md
+response*

--- a/adminauth.md
+++ b/adminauth.md
@@ -1,0 +1,427 @@
+# app_rpt TOTP DTMF Authentication — Admin & Developer Guide
+
+This document covers the per-user TOTP (Time-based One-Time Password, RFC 6238) authentication feature added to app_rpt.
+
+It is split into two parts:
+
+- **Part 1 — Admin guide:** how to configure and use the feature.
+- **Part 2 — Developer guide:** how the code works, why it was designed this way, and where to look in the source.
+
+---
+
+# Part 1 — Admin guide
+
+## 1.1 What this feature does
+
+By default, every DTMF function in `rpt.conf` is reachable by anyone who can key the radio. There is no notion of "this user is allowed to do that command."
+
+This feature lets you:
+
+1. Define an **additional, privileged DTMF command set** in `rpt.conf` (a normal `[functions-...]` stanza).
+2. Map a **4-digit user-id** to a **shared TOTP secret** and one of those privileged stanzas.
+3. Require the user to authenticate via DTMF using a 4-digit user-id plus a 6-digit one-time code from a standard TOTP app on their phone (Google Authenticator, Authy, FreeOTP, 1Password, etc.).
+4. Once authenticated, their privileged commands become available **in addition to** the normal commands, **for that node only**, until they log out or the session times out.
+
+It is per-node, per-user, additive, sliding-timeout, and uses standard RFC 6238 TOTP.
+
+## 1.2 Wire format on the radio
+
+You pick DTMF prefixes in `rpt.conf` for the auth sub-commands. Throughout this doc we use `*A1`, `*A2`, `*A3` as the example prefixes, but you can use anything (e.g. `*991`, `*992`, `*993`, etc.).
+
+| Keyed by user            | Meaning                                                                |
+|--------------------------|------------------------------------------------------------------------|
+| `*A1<id4><otp6>`         | Login. `<id4>` = exactly 4 decimal digits. `<otp6>` = exactly 6 decimal digits. |
+| `*A2`                    | Status — courtesy tone only, no on-air detail. Use the CLI for detail.|
+| `*A3`                    | Logout (clears the session for this node).                             |
+
+Total login length is always exactly 10 digits after the prefix. There is **no separator** between the user-id and OTP — this was a deliberate design choice to keep the format short.
+
+Audio feedback:
+
+- **Success** (login OK, logout OK, status query): standard COMPLETE courtesy tone.
+- **Failure** (bad OTP, locked out, feature disabled, malformed input): standard error tone (whatever your node already plays for `DC_ERROR`).
+
+Failures are deliberately indistinguishable on-air. A caller cannot tell the difference between "wrong code" and "you are locked out" by listening — that information only appears in the Asterisk log and via the CLI. This is a security property; do not change it.
+
+## 1.3 Configuration files
+
+There are two files involved:
+
+1. **`rpt.conf`** — your existing config. You add a few `auth_*` keys, plus one new `[functions-...]` stanza per privileged role, plus one entry in your active `[functions]` stanza for the `auth` function itself.
+2. **`rpt_auth.conf`** (new file, anywhere you choose) — maps user-ids to TOTP secrets and stanza names. Contains shared secrets, so file permissions matter.
+
+### 1.3.1 rpt.conf — node-level keys
+
+Add inside the `[<your-node>]` section:
+
+```ini
+auth_users             = /etc/asterisk/rpt_auth.conf
+auth_timeout           = 300       ; sliding session timeout, seconds (range 30..86400, default 300)
+auth_lockout_threshold = 5         ; failed logins before lockout (range 0..1000, default 5; 0 disables lockout)
+auth_lockout_duration  = 60        ; lockout duration, seconds (range 0..86400, default 60)
+auth_otp_step          = 30        ; TOTP time step (range 10..120, default 30 — matches Google Authenticator)
+auth_otp_window        = 1         ; allowed step skew on each side (range 0..3, default 1 — ±30s tolerance)
+```
+
+Only `auth_users` is required. If you omit it, the feature is silently disabled and all login attempts return error.
+
+### 1.3.2 rpt.conf — function table entry
+
+The `auth` function must be reachable from the **default** functions stanza, otherwise unauthenticated users cannot log in. Add three entries to your active `[functions]`, one per sub-command:
+
+```ini
+[functions-main](!)
+; ... your existing entries ...
+A1 = auth,a
+A2 = auth,s
+A3 = auth,l
+```
+
+The `param` after the comma selects the sub-command: `a` = authenticate (login), `s` = status, `l` = logout.
+
+### 1.3.3 rpt.conf — privileged command stanzas
+
+Define one `[functions-...]` stanza per role. Example:
+
+```ini
+[functions-admin]
+*99 = cop,5                          ; system unkey
+*98 = cop,6                          ; system key
+*73 = cmd,/usr/local/bin/restart-link.sh
+
+[functions-controlop]
+*55 = cop,42                         ; some control-op-only action
+```
+
+These stanzas look identical to your normal functions stanzas — same `prefix = action,param` syntax, same set of available actions. The only difference is they are reachable only when an authenticated user mapped to them is currently logged in on this node.
+
+### 1.3.4 rpt_auth.conf — user/secret file
+
+Create `/etc/asterisk/rpt_auth.conf` (or wherever you pointed `auth_users`). Format:
+
+```ini
+[users]
+1234 = JBSWY3DPEHPK3PXPABCDEFGHIJKLMNOP, functions-admin
+5678 = KRSXG5BAMFRGGZDFMZTWQ2LK,         functions-controlop
+9999 = NB2HI4DTHIXS653XO4XHSZLOOQ,       functions-diag
+```
+
+Each line: `<id4> = <BASE32_SECRET>, <stanza_name>`
+
+- **`<id4>`** — exactly 4 ASCII decimal digits. Leading zeros are significant (`0001` ≠ `1`). Must be unique within the file.
+- **`<BASE32_SECRET>`** — RFC 4648 uppercase base32. Optional `=` padding. This is the same encoding every standard TOTP app consumes.
+- **`<stanza_name>`** — the name of a `[functions-...]` stanza in `rpt.conf`. No leading bracket.
+
+Whitespace around the `,` is tolerated. Comment lines start with `;`.
+
+**Permissions are critical.** This file contains shared secrets equivalent to passwords:
+
+```bash
+sudo chown root:asterisk /etc/asterisk/rpt_auth.conf
+sudo chmod 0640         /etc/asterisk/rpt_auth.conf
+```
+
+## 1.4 Generating secrets and enrolling users
+
+### 1.4.1 Generate a fresh base32 secret
+
+```bash
+head -c 20 /dev/urandom | base32
+# → e.g. JBSWY3DPEHPK3PXPABCDEFGHIJKLMNOP
+```
+
+20 bytes (160 bits) is the RFC 6238 recommendation for SHA-1 TOTP. Don't use less.
+
+### 1.4.2 Enroll the user's authenticator app
+
+Two options:
+
+**Option A — paste the secret:** Most apps have a "manual entry" mode. Account name = anything (e.g. `myrepeater-1234`), key = the base32 string above, time-based, 30 s, 6 digits, SHA-1.
+
+**Option B — QR code (much friendlier):**
+
+```bash
+# Install qrencode: apt install qrencode
+SECRET=JBSWY3DPEHPK3PXPABCDEFGHIJKLMNOP
+USER_ID=1234
+ISSUER=myrepeater
+
+echo "otpauth://totp/${ISSUER}:${USER_ID}?secret=${SECRET}&issuer=${ISSUER}&algorithm=SHA1&digits=6&period=30" \
+    | qrencode -t ANSIUTF8
+```
+
+Have the user scan it with their authenticator app. They will then see a 6-digit code that rolls every 30 seconds — that is what they key after their user-id.
+
+### 1.4.3 Reload the node
+
+```bash
+asterisk -rx "module reload app_rpt.so"
+```
+
+Reloading clears any active sessions and re-reads `rpt_auth.conf`.
+
+## 1.5 Day-to-day usage from the radio
+
+User wants to run a privileged command, e.g. `*99` which is in `[functions-admin]`:
+
+1. User opens their authenticator app, sees current code, e.g. `849203`.
+2. User keys `*A11234849203` on the radio. Hears courtesy tone — they are now authenticated for ~5 minutes (or whatever `auth_timeout` is).
+3. User keys `*99`. It executes (cop,5).
+4. Each successful command refreshes the timeout (sliding window). User stays logged in as long as they keep using authed commands.
+5. When done, user keys `*A3` to log out explicitly. (Or just walks away — session expires after `auth_timeout` seconds of inactivity.)
+
+If the OTP is wrong, the user hears the error tone. Each failure increments their failed-attempt counter. After `auth_lockout_threshold` failures, that user-id is locked out for `auth_lockout_duration` seconds (even if they then key the correct code).
+
+## 1.6 CLI commands
+
+Two new Asterisk CLI commands are available:
+
+```
+asterisk -rx "rpt auth show <node>"
+```
+Prints whether a session is active on `<node>`, who is logged in, time remaining, current failed-attempt count, and lockout status.
+
+```
+asterisk -rx "rpt auth logout <node>"
+```
+Force-clears the active session on `<node>`. Useful if a user forgets to log out, or as part of an incident-response procedure.
+
+Both support tab completion of the node name.
+
+## 1.7 Operational notes & gotchas
+
+- **One session per node.** If a second user successfully logs in while a first user is already authenticated, the first session is displaced. There is no warning to the first user. This is intentional (matches the "very few users" use-case); if it bites you in practice, contact the developer.
+
+- **Authed stanza wins on prefix collision.** If `*99` exists in both `[functions-main]` and `[functions-admin]`, the authed version is dispatched when a session is active. It is the **admin's responsibility** not to define collisions that shadow critical default commands.
+
+- **Time sync matters.** TOTP relies on the node's system clock. If your repeater's clock drifts more than `auth_otp_window * auth_otp_step` seconds from real time (default ±30s), every login will fail. Use NTP. The default window of ±1 step is generous enough to absorb cell-phone clock drift and transmission delay.
+
+- **Reloading clears sessions.** `module reload app_rpt.so` and any rpt.conf reload will clear all active auth sessions on all nodes. Users must re-authenticate.
+
+- **Logs.** All auth events go to the Asterisk log: successful logins (with user-id, **never** the OTP), failed logins (with user-id and reason), lockouts triggered, lockouts expired, sessions cleared by timeout. The OTP digits themselves are never logged. The user-id is logged because you need to know which account is being attacked.
+
+- **Disabling without reconfig.** To temporarily disable auth without touching the function table, comment out `auth_users` in `rpt.conf` and reload. All login attempts will return error. The `A1`/`A2`/`A3` prefixes will still consume DTMF input but produce only error tones.
+
+- **What if `rpt_auth.conf` has a syntax error or is unreadable?** The feature is silently disabled at load time, a warning is logged, and login attempts return error. The node continues to run normally for unauthenticated users.
+
+- **There is no remote-management protocol for auth.** Adding/removing users, rotating secrets, etc. all require editing `rpt_auth.conf` on disk and reloading. This is intentional — there is no network attack surface for the secret store.
+
+## 1.8 Troubleshooting
+
+| Symptom                                              | Likely cause                                                                   |
+|------------------------------------------------------|---------------------------------------------------------------------------------|
+| Every OTP attempt fails immediately                  | Clock skew. Check `date` on the node vs real time. Run `ntpdate` or enable `chronyd`. |
+| Specific user always fails                           | Wrong base32 secret in `rpt_auth.conf`, or user enrolled the wrong secret in their app. Re-generate and re-enroll. |
+| Login OK but `*99` still fails after authing         | Stanza name in `rpt_auth.conf` doesn't match a `[functions-...]` stanza in `rpt.conf`. Check for typos. |
+| All logins fail with "feature disabled" in log       | `auth_users` not set, or path wrong, or file unreadable by Asterisk user. Check `ls -l` and the path. |
+| User reports being locked out unexpectedly           | They keyed wrong codes faster than they realized. `rpt auth show <node>` shows current count. Wait for `auth_lockout_duration`, or `module reload app_rpt.so` to clear. |
+| Authed command works but normal commands break       | Prefix collision — your authed stanza is shadowing a default command. Pick non-overlapping prefixes. |
+| `module reload` doesn't pick up new users            | Reload errored out. Check the Asterisk log for parse errors in `rpt_auth.conf`. |
+
+## 1.9 Quick test recipe
+
+For a fast end-to-end smoke test on a dev node:
+
+```bash
+# 1. Generate a secret and an otpauth URL
+SECRET=$(head -c 20 /dev/urandom | base32 | tr -d '=')
+echo "SECRET: $SECRET"
+echo "otpauth://totp/test:1234?secret=$SECRET&issuer=test&algorithm=SHA1&digits=6&period=30" \
+    | qrencode -t ANSIUTF8
+
+# 2. Configure (edit rpt.conf with the auth_* keys, A1/A2/A3 in [functions-main], and a [functions-admin] stanza)
+sudo tee /etc/asterisk/rpt_auth.conf >/dev/null <<EOF
+[users]
+1234 = $SECRET, functions-admin
+EOF
+sudo chown root:asterisk /etc/asterisk/rpt_auth.conf
+sudo chmod 0640         /etc/asterisk/rpt_auth.conf
+
+# 3. Reload
+asterisk -rx "module reload app_rpt.so"
+
+# 4. Scan the QR with your phone, get a code, then simulate the DTMF via CLI
+asterisk -rx "rpt fun <node> *A11234<6-digit-code-from-phone>"
+
+# 5. Verify session
+asterisk -rx "rpt auth show <node>"
+
+# 6. Try a privileged command (whatever you put in [functions-admin])
+asterisk -rx "rpt fun <node> *99"
+
+# 7. Log out
+asterisk -rx "rpt fun <node> *A3"
+asterisk -rx "rpt auth show <node>"   # should show no session
+```
+
+---
+
+# Part 2 — Developer guide
+
+This part explains the code: structure, design rationale, locking, and where each piece lives.
+
+## 2.1 Design goals (from the original requirements)
+
+These were locked in early conversation with the user and drove every subsequent choice:
+
+1. **TOTP, not HOTP, not bespoke.** Every smartphone already has a TOTP app. Zero client tooling required.
+2. **Additive command set, not replacement.** An authed user gets *more* commands, not different ones. Simplifies mental model and limits damage of misconfig.
+3. **Per-node sessions.** Sessions are tied to a single node's `struct rpt`. Nodes do not share auth state.
+4. **Sliding timeout.** Active users stay logged in; idle users are kicked.
+5. **Separate secrets file.** `rpt.conf` is widely shared, copied, version-controlled. Secrets must not live there.
+6. **Configurable lockout.** Defends against brute-forcing OTP via DTMF (the search space is only 10⁶).
+7. **Fixed 4-digit user-id, no separator.** Keeps DTMF input short and unambiguous (10 digits, period).
+8. **First-match-wins, admin-managed collision avoidance.** Matches the existing function-table semantics; no new tie-break logic.
+9. **Minimal external dependencies.** Uses OpenSSL 3.0's EVP_MAC API (`<openssl/evp.h>`, linked via `-lcrypto`) for HMAC-SHA1. No other crypto libraries required.
+
+## 2.2 File map
+
+| File                                          | Role                                                            |
+|-----------------------------------------------|-----------------------------------------------------------------|
+| `apps/app_rpt/rpt_totp.h` / `rpt_totp.c`      | Pure TOTP/HOTP/HMAC-SHA1/base32 math. No Asterisk runtime deps. |
+| `apps/app_rpt/rpt_auth.h` / `rpt_auth.c`      | Per-node session state, lockout, file loader. Bridges TOTP to `struct rpt`. |
+| `apps/app_rpt/rpt_functions.{h,c}`            | New `function_auth` DTMF handler.                              |
+| `apps/app_rpt/app_rpt.h`                      | New config fields on `struct rpt::p` + opaque `struct rpt_auth_state *auth`. |
+| `apps/app_rpt/rpt_config.c`                   | Config-key registration and reload/free hooks.                 |
+| `apps/app_rpt.c`                              | `function_table[]` registration + `collect_function_digits()` surgery. |
+| `apps/app_rpt/rpt_cli.c`                      | `rpt auth show` / `rpt auth logout` CLI commands.              |
+| `configs/rpt/rpt.conf`                        | Documented `auth_*` keys + example admin stanza.               |
+| `configs/samples/rpt_auth.conf.sample`        | User-secret file template.                                      |
+
+The split between `rpt_totp.*` and `rpt_auth.*` is deliberate: `rpt_totp` is a leaf module that can be unit-tested in isolation (it has its own `RPT_TOTP_SELFTEST` block validating RFC 6238 Appendix B vectors). `rpt_auth` owns all the runtime state and Asterisk integration.
+
+## 2.3 The TOTP layer (`rpt_totp.c`)
+
+Why we use OpenSSL rather than a bespoke crypto implementation: the only primitive needed is HMAC-SHA1, and OpenSSL's EVP_MAC API (`<openssl/evp.h>`) provides it directly with no manual HMAC construction required. OpenSSL libcrypto (`-lcrypto`) is already a build dependency of Asterisk itself, so no new library is introduced. The implementation delegates all cryptographic work to OpenSSL — `rpt_totp.c` only contains base32 decoding and the RFC 6238 verification logic.
+
+Three things live here:
+
+1. **`base32_decode()`** — RFC 4648 base32, case-insensitive, ignores `=` padding. Returns the raw secret bytes.
+2. **`hmac_sha1()`** — HMAC-SHA1 via OpenSSL's EVP_MAC API. Output size 20 bytes.
+3. **`rpt_totp_verify()`** — implements the RFC 6238 verification algorithm:
+   - Compute `T = floor(now / step)`.
+   - For each counter in `[T-window, T+window]`:
+     - HMAC-SHA1 the 8-byte big-endian counter under the secret.
+     - Apply the dynamic-truncation step (RFC 4226 §5.3).
+     - Reduce mod 10⁶ to get the 6-digit candidate.
+     - Compare to user input in constant time (well, as constant as `memcmp` is — see §2.9).
+   - On match, write the matched counter to `*last_counter` so the caller can detect replay (next attempt must use a counter strictly greater than this).
+
+The window parameter controls clock-skew tolerance. With default `step=30, window=1`, the node accepts codes from up to 30 seconds in the past or future, totalling a 90-second acceptance window per code. This is the same default Google Authenticator's server-side libraries use.
+
+The `RPT_TOTP_SELFTEST` block at the bottom validates against the canonical SHA-1 test vectors from RFC 6238 Appendix B. To run it, build with `-DRPT_TOTP_SELFTEST -DTEST_MAIN` and call `rpt_totp_selftest()`. Currently no production caller invokes it; it is a build-time confidence tool.
+
+## 2.4 The auth state layer (`rpt_auth.c`)
+
+This module owns:
+
+- **The opaque `struct rpt_auth_state`**, hung off `struct rpt::auth`. Allocated lazily on first `rpt_auth_reload()`.
+- **The user table**, copied out of an `ast_config` load of `rpt_auth.conf`. We immediately `ast_config_destroy()` after copying the strings so we don't hold the parsed config tree (matches the `extnodefiles` pattern at `rpt_config.c:531-567`).
+- **The active session slot** — at most one. Fields: user-id, last-counter (replay prevention), session-expiry timestamp, command-set stanza name (pointer into the user table).
+- **The per-user failed-attempt counters and lockout timestamps** — tracked even when no session is active, indexed by user-id slot.
+
+### 2.4.1 Why one session per node
+
+The user explicitly accepted this constraint ("very few users would be authenticating"). The win is enormous: no need for per-channel/per-DTMF-source session tracking, no garbage-collection of dead sessions, no question of "which session do I check when this DTMF arrives." A second successful login simply overwrites the slot.
+
+If this becomes painful (multiple control ops on the same node), the data structure to extend it is obvious — make `current_session` an array — but the dispatch logic stays the same.
+
+### 2.4.2 Locking contract
+
+Every public function in `rpt_auth.h` takes `myrpt->lock` internally. Callers must NOT hold the lock when calling. This was verified before writing the code: all `collect_function_digits()` callers release `myrpt->lock` before invocation (background task `bg_602072d4` confirmed this).
+
+The reason for taking the lock inside `rpt_auth_*` rather than at the call site is that the same lock protects `myrpt->cfg`, which `rpt_auth_active_set()` callers (specifically `collect_function_digits()`) immediately walk via `ast_variable_browse()`. If the auth layer didn't hold the lock during its own state read, a concurrent reload could swap `myrpt->cfg` out from under the caller and the returned stanza-name pointer could dangle.
+
+The pointer returned by `rpt_auth_active_set()` is documented to remain valid until the next reload/logout/expiry on this node — which is safe because all of those events also take the lock and we only call `rpt_auth_active_set()` from the DTMF dispatch path which is single-threaded per node.
+
+### 2.4.3 The bounds-clamping policy
+
+The user asked for sane defaults with admin override. Each numeric `auth_*` key is registered via `RPT_CONFIG_VAR_INT_DEFAULT_MIN_MAX` with the bounds documented in `rpt.conf`. For lockout specifically:
+
+- `auth_lockout_threshold = 0` is treated as **disabled** (no lockout at all). This is a real config use-case for testing or for low-stakes nodes.
+- `auth_lockout_threshold > 1000` is clamped to 1000. Also tested but practically infinite.
+
+Sane bounds prevent the most common admin foot-guns (negative numbers, accidentally-pasted huge values) without forcing maintainers to build an elaborate validation layer.
+
+## 2.5 The DTMF handler (`function_auth` in `rpt_functions.c`)
+
+This is a simple input parser delegating to `rpt_auth_*`. It's a top-level function in the function table (Option A from the design discussion), not a sub-action of `cop`. Reasons:
+
+- **Discoverability.** Users don't search the cop subcommand list for "the one that does login."
+- **Permission scope.** Auth changes the dispatch path itself; conceptually it's not "control operator" territory.
+- **Future-proofing.** If we later add `auth_token`, `auth_revoke_user`, etc., they fit naturally as siblings in `function_table[]`.
+
+The handler uses the `param` field from `rpt.conf` to select the sub-command:
+
+- `param="a"` (or empty/default) — **login.** Waits for exactly 10 trailing decimal digits (returns `DC_INDETERMINATE` while collecting), splits into 4-digit user-id + 6-digit OTP, calls `rpt_auth_login()`.
+- `param="s"` — **status.** Fires immediately (no trailing digits needed), plays a COMPLETE courtesy tone.
+- `param="l"` — **logout.** Fires immediately, calls `rpt_auth_logout()`, plays a COMPLETE courtesy tone.
+
+This design avoids the problem of single-character prefix matching — because each sub-command has its own prefix in the function table (e.g. `A1`, `A2`, `A3`), the framework's prefix matching in `collect_function_digits` doesn't fire until the full prefix is collected. The login path then returns `DC_INDETERMINATE` until all 10 digits arrive.
+
+A subtle but important detail: **all four failure modes (`BAD`, `LOCKED`, `DISABLED`, malformed) return identical `DC_ERROR`.** The on-air feedback is bit-for-bit indistinguishable. This prevents an attacker from learning whether a user-id is valid (vs. unknown) or whether they've been locked out (vs. just wrong code). The only place the distinction surfaces is in the logs and CLI, which live behind the system administrator's access control.
+
+## 2.6 The dispatch surgery (`collect_function_digits` in `app_rpt.c`)
+
+This was the highest-risk change in the whole feature, because `collect_function_digits` is called on **every DTMF event** on every node. It must be fast, must not deadlock, and must not subtly alter dispatch semantics for unauthenticated users.
+
+The change has three pieces:
+
+1. **Authed-stanza walk first.** Before walking the source (`functions` / `link_functions` / `phone_functions` / etc.) stanza, walk the authed stanza if a session exists. This honors the "additive, authed-first, first-match-wins" design. If a session is not active, `rpt_auth_active_set()` returns NULL and this whole block becomes a single comparison and skip. Branch-predictor-friendly.
+
+2. **Longestfunc gate extension.** When no entry matches in either stanza, the function decides whether to wait for more digits or return `DC_ERROR`, based on whether the input is already as long as the longest registered prefix. We must extend that gate to include the authed stanza's longest prefix, otherwise an authed user with `*999` registered would never get past the 3-digit gate of an unauthenticated default stanza. `rpt_auth_longestfunc()` returns 0 when no session is active, so the gate is unchanged for unauthenticated users.
+
+3. **Sliding-timeout touch.** On any successful function dispatch (`DC_COMPLETE`, `DC_COMPLETEQUIET`, `DC_DOKEY`), we call `rpt_auth_touch()` to refresh the session expiry. This is the implementation of "sliding timeout." It's a no-op when no session is active.
+
+The original logic — find a match, parse value, look up action, dispatch — is left structurally untouched. This is deliberate: the smaller the diff in this critical path, the easier the code review and the lower the risk of breaking existing semantics for existing deployments that won't enable auth.
+
+## 2.7 Configuration plumbing (`rpt_config.c`)
+
+Six new keys are added via the existing `RPT_CONFIG_VAR_*` macros, alongside all the other rpt vars. This means:
+
+- They are loaded at the same time as everything else.
+- They are subject to the same bounds-checking machinery.
+- They are reloaded automatically on `module reload`.
+
+After `load_rpt_vars()` releases `myrpt->lock`, we call `rpt_auth_reload(myrpt)`. The reload is outside the lock because `rpt_auth_reload` takes the lock itself. (See §2.4.2.)
+
+In `rpt_free_config_vars()`, we call `rpt_auth_free(myrpt)` to release the user table and the session state at module-unload time.
+
+Crucially, **no new fields were added to anything other than `struct rpt`**. The auth state is hung off via an opaque pointer, so nothing outside `rpt_auth.c` knows or cares about its layout. This was a small but important design choice — it means the auth feature can grow new internal state (e.g. multiple sessions, audit log, secret rotation cache) without ABI churn elsewhere.
+
+## 2.8 The CLI (`rpt_cli.c`)
+
+Two commands: `rpt auth show <node>` and `rpt auth logout <node>`. Both follow the existing `handle_cli_dump`/`handle_cli_stats` pattern exactly — node-name argument at position 3, tab completion via `rpt_complete_node_list`, lookup by walking `rpt_vars[]` matching `.name`. Boring on purpose.
+
+`rpt auth show` calls `rpt_auth_status(myrpt, buf, sizeof(buf))` which formats a single-line human summary. The format is intentionally not machine-parseable — if scripting needs arise, a separate JSON-output flag would be the right addition.
+
+`rpt auth logout` simply calls `rpt_auth_logout(myrpt)`. This is the operator's emergency override.
+
+## 2.9 Things that are deliberately NOT in this design
+
+- **Per-user-source restriction.** The user said "all sources allowed are fine." A user can authenticate and act from any DTMF source (radio, phone patch, link). Adding source restriction later is straightforward (one bitmask field on the user record, one check in `function_auth`) but was YAGNI.
+- **OTP scrubbing in logs.** The user said no special handling needed. The OTP is never logged in the first place because we only log user-id, result code, and reason — not the raw input. If the OTP somehow appears in debug output, that's a bug in `ast_debug` calls and should be fixed.
+- **Constant-time OTP comparison.** Currently uses `memcmp`. For a 6-digit OTP delivered over DTMF (which is glacially slow compared to network attacks), the timing channel is effectively non-existent. If this codebase grows other OTP comparison paths, switch to a constant-time compare. Documenting the choice explicitly here so a future reviewer doesn't waste time worrying about it.
+- **Encrypted secret storage.** `rpt_auth.conf` is plaintext, protected by file permissions only. Adding encryption-at-rest would require a key-management scheme (key in another file? prompted at startup? in `/etc/security/`?) — none of which are net wins for a self-hosted radio repeater. File permissions are the right tool here.
+- **Network-side auth (HTTPS, manager API).** Out of scope. The DTMF channel is the only authentication surface.
+
+## 2.10 Things future maintainers should be careful about
+
+- **Don't move `rpt_auth_reload()` back inside the lock.** It will deadlock — `rpt_auth_reload` takes the lock itself, and the recursive-mutex behavior is not portable here.
+- **Don't change the `DC_ERROR`-uniformity in `function_auth`.** It is a deliberate security property, documented inline. Adding distinct telemetry for "locked" vs "bad code" leaks information.
+- **The user array is dynamically allocated based on the number of entries in `rpt_auth.conf`.** There is no hard cap; memory is the only limit.
+- **Don't read `myrpt->auth` directly from outside `rpt_auth.c`.** It is an opaque pointer. Add accessor functions to `rpt_auth.h` if you need new behavior.
+- **The authed-stanza walk in `collect_function_digits` MUST come before the source walk.** Reversing them quietly breaks the "authed-first" guarantee that admins are designing their stanzas around. If you're tempted to "optimize" this, don't.
+- **The dispatch path is the hottest path in app_rpt.** Any new work added to `collect_function_digits` runs on every DTMF event. The current additions are O(1) when no session is active and O(n_authed_entries) when a session exists. Keep it that way.
+
+## 2.11 Where to extend
+
+If/when these come up:
+
+- **Multiple concurrent sessions per node:** turn the single session slot into an array, key dispatch by source channel ID. The lookup function in §2.4 stays a one-liner.
+- **Audit log of auth events:** add a single function `rpt_auth_audit_log(struct rpt_auth_event)` and call it at every state transition in `rpt_auth.c`. Backend (file, syslog, manager event) is a separate decision.
+- **HOTP support (counter-based, not time):** `rpt_totp.c` already factors out HOTP — add a `kind` field to the user record and dispatch on it.
+- **Per-user TOTP step/window override:** add optional fields after the stanza name in `rpt_auth.conf`, fall back to node-wide config when absent.
+- **Web/manager-API enrollment flow:** new module `rpt_auth_manager.c` that calls into `rpt_auth.c`. Keep secrets-on-disk as the source of truth.
+
+End of document.

--- a/apps/Makefile.diff
+++ b/apps/Makefile.diff
@@ -2,11 +2,12 @@ diff --git a/apps/Makefile b/apps/Makefile
 index 50b3fccc8f..207a568933 100644
 --- a/apps/Makefile
 +++ b/apps/Makefile
-@@ -49,6 +49,8 @@ include $(ASTTOPDIR)/Makefile.moddir_rules
+@@ -49,6 +49,9 @@ include $(ASTTOPDIR)/Makefile.moddir_rules
  
  $(call MOD_ADD_C,app_confbridge,$(wildcard confbridge/*.c))
  
 +$(call MOD_ADD_C,app_rpt,$(wildcard app_rpt/rpt_*.c))
++app_rpt.so: LIBS+=-lcrypto
 +
  app_confbridge.o: _ASTCFLAGS+=$(AST_NO_FORMAT_TRUNCATION)
  app_meetme.o: _ASTCFLAGS+=$(AST_NO_FORMAT_TRUNCATION)

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -331,6 +331,7 @@
 #include "app_rpt/rpt_telemetry.h"
 #include "app_rpt/rpt_link.h"
 #include "app_rpt/rpt_functions.h"
+#include "app_rpt/rpt_auth.h"
 #include "app_rpt/rpt_manager.h"
 #include "app_rpt/rpt_translate.h"
 #include "app_rpt/rpt_xcat.h"
@@ -660,6 +661,7 @@ const struct function_table_tag function_table[] = {
 	{ "meter", function_meter, 1 },
 	{ "userout", function_userout, 1 },
 	{ "cmd", function_cmd, 0 },
+	{ "auth", function_auth, 0 },
 };
 
 int rpt_function_lookup(const char *f)
@@ -1611,6 +1613,7 @@ static enum rpt_function_response collect_function_digits(struct rpt *myrpt, cha
 	int i, rv;
 	char *stringp, *action, *param, *functiondigits;
 	char function_table_name[30] = "";
+	char authed_function_table_name[30] = "";
 	char workstring[200];
 
 	struct ast_variable *vp;
@@ -1637,13 +1640,34 @@ static enum rpt_function_response collect_function_digits(struct rpt *myrpt, cha
 	} else {
 		ast_copy_string(function_table_name, myrpt->p.functions, sizeof(function_table_name));
 	}
-	/* find context for function table in rpt.conf file */
-	vp = ast_variable_browse(myrpt->cfg, function_table_name);
-	while (vp) {
-		if (!strncasecmp(vp->name, digits, strlen(vp->name))) {
-			break;
+
+	/*
+	 * Authed-stanza first-match-wins walk (additive privileged command set).
+	 * Per design: per-node session, additive, authed entries take priority over
+	 * the source stanza on prefix collision (admin's responsibility to avoid).
+	 * No-op when no active session.
+	 */
+	vp = NULL;
+	if (rpt_auth_get_active_stanza(myrpt, authed_function_table_name, sizeof(authed_function_table_name))) {
+		struct ast_variable *avp = ast_variable_browse(myrpt->cfg, authed_function_table_name);
+		while (avp) {
+			if (!strncasecmp(avp->name, digits, strlen(avp->name))) {
+				vp = avp;
+				break;
+			}
+			avp = avp->next;
 		}
-		vp = vp->next;
+	}
+
+	/* Fall through to source stanza if no authed match */
+	if (!vp) {
+		vp = ast_variable_browse(myrpt->cfg, function_table_name);
+		while (vp) {
+			if (!strncasecmp(vp->name, digits, strlen(vp->name))) {
+				break;
+			}
+			vp = vp->next;
+		}
 	}
 	/* if function context not found */
 	if (!vp) {
@@ -1658,6 +1682,14 @@ static enum rpt_function_response collect_function_digits(struct rpt *myrpt, cha
 			n = myrpt->alt_longestfunc;
 		} else if (command_source == SOURCE_DPHONE) {
 			n = myrpt->dphone_longestfunc;
+		}
+
+		/* Authed stanza may extend the "have we collected enough digits?" gate */
+		{
+			int an = rpt_auth_longestfunc(myrpt);
+			if (an > n) {
+				n = an;
+			}
 		}
 
 		if (strlen(digits) >= n) {
@@ -1681,6 +1713,12 @@ static enum rpt_function_response collect_function_digits(struct rpt *myrpt, cha
 	functiondigits = digits + strlen(vp->name);
 	rv = (*function_table[i].function)(myrpt, param, functiondigits, command_source, mylink);
 	ast_debug(7, "rv=%i\n", rv);
+
+	/* Refresh sliding session timeout on any successful function dispatch */
+	if (rv == DC_COMPLETE || rv == DC_COMPLETEQUIET || rv == DC_DOKEY) {
+		rpt_auth_touch(myrpt);
+	}
+
 	return rv;
 }
 

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -765,6 +765,8 @@ struct rpt {
 	ast_mutex_t lock;
 	ast_mutex_t remlock;
 	ast_mutex_t statpost_lock;
+	/*! \brief Per-node TOTP authentication state (opaque, see rpt_auth.c). */
+	struct rpt_auth_state *auth;
 	struct ast_config *cfg;
 	rpt_bool reload:1;
 	rpt_bool reload_request:1;
@@ -922,6 +924,18 @@ struct rpt {
 		const char *ldisc[MAX_LSTUFF];
 		int nldisc;
 		const char *timezone;
+		/*! \brief Path to rpt_auth.conf (TOTP user secrets); NULL disables the feature. */
+		const char *auth_users;
+		/*! \brief Sliding session timeout, seconds (default 300). */
+		int auth_timeout;
+		/*! \brief Failed-login attempts before lockout; 0 disables lockout (default 5). */
+		int auth_lockout_threshold;
+		/*! \brief Lockout duration, seconds (default 60). */
+		int auth_lockout_duration;
+		/*! \brief TOTP time step in seconds (RFC 6238; default 30). */
+		int auth_otp_step;
+		/*! \brief TOTP step window for clock skew tolerance (default 1). */
+		int auth_otp_window;
 	} p;
 	struct ao2_container *links;
 	int unkeytocttimer;

--- a/apps/app_rpt/rpt_auth.c
+++ b/apps/app_rpt/rpt_auth.c
@@ -1,0 +1,486 @@
+
+#include "asterisk.h"
+
+#include <ctype.h>
+#include <stdint.h>
+#include <string.h>
+#include <strings.h>
+#include <time.h>
+
+#include "asterisk/channel.h" /* required for AST_MAX_EXTENSION via app_rpt.h */
+#include "asterisk/config.h"
+#include "asterisk/lock.h"
+#include "asterisk/logger.h"
+#include "asterisk/strings.h"
+#include "asterisk/utils.h"
+
+#include "app_rpt.h"
+#include "rpt_auth.h"
+#include "rpt_lock.h"
+#include "rpt_totp.h"
+
+#define RPT_AUTH_USER_ID_LEN 4
+#define RPT_AUTH_OTP_LEN 6
+#define RPT_AUTH_USERS_SECTION "users"
+
+#define RPT_AUTH_DEFAULT_TIMEOUT 300
+#define RPT_AUTH_DEFAULT_LOCKOUT_THRESHOLD 5
+#define RPT_AUTH_DEFAULT_LOCKOUT_DURATION 60
+#define RPT_AUTH_DEFAULT_OTP_STEP 30
+#define RPT_AUTH_DEFAULT_OTP_WINDOW 1
+
+struct rpt_auth_user {
+	char id[RPT_AUTH_USER_ID_LEN + 1];
+	char *secret;
+	char *command_set;
+	uint64_t last_counter;
+	int fail_count;
+	time_t lockout_until;
+};
+
+struct rpt_auth_state {
+	struct rpt_auth_user *users;
+	int nusers;
+
+	int session_active;
+	char session_user[RPT_AUTH_USER_ID_LEN + 1];
+	char *session_command_set;
+	int session_longestfunc;
+	time_t session_expires;
+};
+
+static int effective_timeout(struct rpt *myrpt)
+{
+	int v = myrpt->p.auth_timeout;
+	if (v <= 0) {
+		v = RPT_AUTH_DEFAULT_TIMEOUT;
+	}
+	if (v < 30) {
+		v = 30;
+	}
+	if (v > 86400) {
+		v = 86400;
+	}
+	return v;
+}
+
+static int effective_lockout_threshold(struct rpt *myrpt)
+{
+	int v = myrpt->p.auth_lockout_threshold;
+	if (v < 0) {
+		return RPT_AUTH_DEFAULT_LOCKOUT_THRESHOLD;
+	}
+	if (v > 1000) {
+		v = 1000;
+	}
+	return v;
+}
+
+static int effective_lockout_duration(struct rpt *myrpt)
+{
+	int v = myrpt->p.auth_lockout_duration;
+	if (v <= 0) {
+		v = RPT_AUTH_DEFAULT_LOCKOUT_DURATION;
+	}
+	if (v > 86400) {
+		v = 86400;
+	}
+	return v;
+}
+
+static int effective_otp_step(struct rpt *myrpt)
+{
+	int v = myrpt->p.auth_otp_step;
+	if (v <= 0) {
+		v = RPT_AUTH_DEFAULT_OTP_STEP;
+	}
+	if (v < 10) {
+		v = 10;
+	}
+	if (v > 120) {
+		v = 120;
+	}
+	return v;
+}
+
+static int effective_otp_window(struct rpt *myrpt)
+{
+	int v = myrpt->p.auth_otp_window;
+	if (v < 0) {
+		v = RPT_AUTH_DEFAULT_OTP_WINDOW;
+	}
+	if (v > 3) {
+		v = 3;
+	}
+	return v;
+}
+
+static void clear_session_locked(struct rpt_auth_state *st)
+{
+	st->session_active = 0;
+	st->session_user[0] = '\0';
+	if (st->session_command_set) {
+		ast_free(st->session_command_set);
+		st->session_command_set = NULL;
+	}
+	st->session_longestfunc = 0;
+	st->session_expires = 0;
+}
+
+static void free_users_locked(struct rpt_auth_state *st)
+{
+	int i;
+	for (i = 0; i < st->nusers; i++) {
+		if (st->users[i].secret) {
+			ast_free(st->users[i].secret);
+			st->users[i].secret = NULL;
+		}
+		if (st->users[i].command_set) {
+			ast_free(st->users[i].command_set);
+			st->users[i].command_set = NULL;
+		}
+	}
+	ast_free(st->users);
+	st->users = NULL;
+	st->nusers = 0;
+}
+
+static struct rpt_auth_user *find_user_locked(struct rpt_auth_state *st, const char *user_id4)
+{
+	int i;
+	for (i = 0; i < st->nusers; i++) {
+		if (!strcmp(st->users[i].id, user_id4)) {
+			return &st->users[i];
+		}
+	}
+	return NULL;
+}
+
+static int parse_user_value(const char *value, char **out_secret, char **out_set)
+{
+	char *tmp, *secret, *set;
+
+	if (ast_strlen_zero(value)) {
+		return -1;
+	}
+	tmp = ast_strdupa(value);
+
+	secret = strsep(&tmp, ",");
+	set = tmp;
+
+	if (!set) {
+		return -1;
+	}
+
+	secret = ast_strip(secret);
+	set = ast_strip(set);
+
+	if (ast_strlen_zero(secret) || ast_strlen_zero(set)) {
+		return -1;
+	}
+
+	*out_secret = ast_strdup(secret);
+	*out_set = ast_strdup(set);
+	if (!*out_secret || !*out_set) {
+		ast_free(*out_secret);
+		ast_free(*out_set);
+		*out_secret = NULL;
+		*out_set = NULL;
+		return -1;
+	}
+	return 0;
+}
+
+static int valid_user_id(const char *name)
+{
+	int i;
+	if (strlen(name) != RPT_AUTH_USER_ID_LEN) {
+		return 0;
+	}
+	for (i = 0; i < RPT_AUTH_USER_ID_LEN; i++) {
+		if (!isdigit(name[i])) {
+			return 0;
+		}
+	}
+	return 1;
+}
+
+static void load_users_locked(struct rpt *myrpt, struct rpt_auth_state *st)
+{
+	struct ast_config *cfg;
+	struct ast_flags config_flags = { 0 };
+	struct ast_variable *vp;
+	int count = 0;
+
+	free_users_locked(st);
+
+	if (ast_strlen_zero(myrpt->p.auth_users)) {
+		return;
+	}
+
+	cfg = ast_config_load(myrpt->p.auth_users, config_flags);
+	if (!cfg || cfg == CONFIG_STATUS_FILEINVALID || cfg == CONFIG_STATUS_FILEUNCHANGED) {
+		if (cfg == CONFIG_STATUS_FILEINVALID) {
+			ast_log(LOG_WARNING, "rpt_auth: cannot parse %s\n", myrpt->p.auth_users);
+		} else if (!cfg) {
+			ast_log(LOG_WARNING, "rpt_auth: cannot open %s\n", myrpt->p.auth_users);
+		}
+		return;
+	}
+
+	for (vp = ast_variable_browse(cfg, RPT_AUTH_USERS_SECTION); vp; vp = vp->next) {
+		count++;
+	}
+
+	if (count == 0) {
+		ast_config_destroy(cfg);
+		return;
+	}
+
+	st->users = ast_calloc(count, sizeof(*st->users));
+	if (!st->users) {
+		ast_config_destroy(cfg);
+		return;
+	}
+
+	for (vp = ast_variable_browse(cfg, RPT_AUTH_USERS_SECTION); vp; vp = vp->next) {
+		char *secret = NULL;
+		char *cmdset = NULL;
+
+		if (!valid_user_id(vp->name)) {
+			ast_log(LOG_WARNING, "rpt_auth: skipping malformed user id '%s'\n", vp->name);
+			continue;
+		}
+		if (parse_user_value(vp->value, &secret, &cmdset) != 0) {
+			ast_log(LOG_WARNING, "rpt_auth: skipping user %s: bad value (need 'secret,command_set')\n", vp->name);
+			continue;
+		}
+
+		ast_copy_string(st->users[st->nusers].id, vp->name, sizeof(st->users[st->nusers].id));
+		st->users[st->nusers].secret = secret;
+		st->users[st->nusers].command_set = cmdset;
+		st->users[st->nusers].last_counter = 0;
+		st->users[st->nusers].fail_count = 0;
+		st->users[st->nusers].lockout_until = 0;
+		st->nusers++;
+	}
+
+	ast_config_destroy(cfg);
+	ast_log(LOG_NOTICE, "rpt_auth: loaded %d user(s) from %s for node %s\n", st->nusers, myrpt->p.auth_users, myrpt->name);
+}
+
+static int compute_longestfunc_locked(struct rpt *myrpt, const char *stanza)
+{
+	struct ast_variable *vp;
+	int longest = 0;
+	if (!myrpt->cfg || !stanza) {
+		return 0;
+	}
+	for (vp = ast_variable_browse(myrpt->cfg, stanza); vp; vp = vp->next) {
+		int j = (int) strlen(vp->name);
+		if (j > longest) {
+			longest = j;
+		}
+	}
+	return longest;
+}
+
+static struct rpt_auth_state *ensure_state_locked(struct rpt *myrpt)
+{
+	if (!myrpt->auth) {
+		myrpt->auth = ast_calloc(1, sizeof(*myrpt->auth));
+	}
+	return myrpt->auth;
+}
+
+void rpt_auth_reload(struct rpt *myrpt)
+{
+	struct rpt_auth_state *st;
+
+	rpt_mutex_lock(&myrpt->lock);
+	st = ensure_state_locked(myrpt);
+	if (!st) {
+		rpt_mutex_unlock(&myrpt->lock);
+		return;
+	}
+	clear_session_locked(st);
+	load_users_locked(myrpt, st);
+	rpt_mutex_unlock(&myrpt->lock);
+}
+
+void rpt_auth_free(struct rpt *myrpt)
+{
+	struct rpt_auth_state *st;
+
+	rpt_mutex_lock(&myrpt->lock);
+	st = myrpt->auth;
+	if (st) {
+		clear_session_locked(st);
+		free_users_locked(st);
+		ast_free(st);
+		myrpt->auth = NULL;
+	}
+	rpt_mutex_unlock(&myrpt->lock);
+}
+
+int rpt_auth_get_active_stanza(struct rpt *myrpt, char *buf, size_t buflen)
+{
+	struct rpt_auth_state *st;
+	int ret = 0;
+	time_t now = time(NULL);
+
+	rpt_mutex_lock(&myrpt->lock);
+	st = myrpt->auth;
+	if (st && st->session_active) {
+		if (now >= st->session_expires) {
+			ast_log(LOG_NOTICE, "rpt_auth: session for user %s expired on node %s\n", st->session_user, myrpt->name);
+			clear_session_locked(st);
+		} else {
+			ast_copy_string(buf, st->session_command_set, buflen);
+			ret = 1;
+		}
+	}
+	rpt_mutex_unlock(&myrpt->lock);
+	return ret;
+}
+
+void rpt_auth_touch(struct rpt *myrpt)
+{
+	struct rpt_auth_state *st;
+	time_t now = time(NULL);
+
+	rpt_mutex_lock(&myrpt->lock);
+	st = myrpt->auth;
+	if (st && st->session_active) {
+		st->session_expires = now + effective_timeout(myrpt);
+	}
+	rpt_mutex_unlock(&myrpt->lock);
+}
+
+int rpt_auth_longestfunc(struct rpt *myrpt)
+{
+	struct rpt_auth_state *st;
+	int ret = 0;
+
+	rpt_mutex_lock(&myrpt->lock);
+	st = myrpt->auth;
+	if (st && st->session_active) {
+		ret = st->session_longestfunc;
+	}
+	rpt_mutex_unlock(&myrpt->lock);
+	return ret;
+}
+
+int rpt_auth_login(struct rpt *myrpt, const char *user_id4, const char *otp6)
+{
+	struct rpt_auth_state *st;
+	struct rpt_auth_user *u;
+	int rc;
+	time_t now = time(NULL);
+	int threshold, duration, step, window;
+
+	if (!user_id4 || !otp6) {
+		return RPT_AUTH_LOGIN_BAD;
+	}
+
+	rpt_mutex_lock(&myrpt->lock);
+	st = myrpt->auth;
+	if (!st || st->nusers == 0 || ast_strlen_zero(myrpt->p.auth_users)) {
+		rpt_mutex_unlock(&myrpt->lock);
+		return RPT_AUTH_LOGIN_DISABLED;
+	}
+
+	threshold = effective_lockout_threshold(myrpt);
+	duration = effective_lockout_duration(myrpt);
+	step = effective_otp_step(myrpt);
+	window = effective_otp_window(myrpt);
+
+	u = find_user_locked(st, user_id4);
+	if (!u) {
+		rpt_mutex_unlock(&myrpt->lock);
+		ast_log(LOG_NOTICE, "rpt_auth: login attempt for unknown user %s on node %s\n", user_id4, myrpt->name);
+		return RPT_AUTH_LOGIN_BAD;
+	}
+
+	if (u->lockout_until > now) {
+		long remaining = (long) (u->lockout_until - now);
+		rpt_mutex_unlock(&myrpt->lock);
+		ast_log(LOG_NOTICE, "rpt_auth: user %s locked out for %ld more seconds on node %s\n", user_id4, remaining, myrpt->name);
+		return RPT_AUTH_LOGIN_LOCKED;
+	}
+
+	rc = rpt_totp_verify(u->secret, otp6, &u->last_counter, now, step, window);
+	if (rc != RPT_TOTP_OK) {
+		u->fail_count++;
+		if (threshold > 0 && u->fail_count >= threshold) {
+			u->lockout_until = now + duration;
+			u->fail_count = 0;
+			ast_log(LOG_WARNING, "rpt_auth: user %s locked out for %d s on node %s\n", user_id4, duration, myrpt->name);
+		}
+		rpt_mutex_unlock(&myrpt->lock);
+		ast_log(LOG_NOTICE, "rpt_auth: login failed for user %s on node %s (totp rc=%d)\n", user_id4, myrpt->name, rc);
+		return RPT_AUTH_LOGIN_BAD;
+	}
+
+	clear_session_locked(st);
+	st->session_active = 1;
+	ast_copy_string(st->session_user, u->id, sizeof(st->session_user));
+	st->session_command_set = ast_strdup(u->command_set);
+	if (!st->session_command_set) {
+		clear_session_locked(st);
+		rpt_mutex_unlock(&myrpt->lock);
+		return RPT_AUTH_LOGIN_BAD;
+	}
+	st->session_longestfunc = compute_longestfunc_locked(myrpt, u->command_set);
+	st->session_expires = now + effective_timeout(myrpt);
+	u->fail_count = 0;
+
+	ast_log(LOG_NOTICE, "rpt_auth: user %s authenticated on node %s, set=%s\n", user_id4, myrpt->name, u->command_set);
+	rpt_mutex_unlock(&myrpt->lock);
+	return RPT_AUTH_LOGIN_OK;
+}
+
+void rpt_auth_logout(struct rpt *myrpt)
+{
+	struct rpt_auth_state *st;
+	char user[RPT_AUTH_USER_ID_LEN + 1] = "";
+	int was_active = 0;
+
+	rpt_mutex_lock(&myrpt->lock);
+	st = myrpt->auth;
+	if (st && st->session_active) {
+		ast_copy_string(user, st->session_user, sizeof(user));
+		was_active = 1;
+		clear_session_locked(st);
+	}
+	rpt_mutex_unlock(&myrpt->lock);
+
+	if (was_active) {
+		ast_log(LOG_NOTICE, "rpt_auth: user %s logged out on node %s\n", user, myrpt->name);
+	}
+}
+
+void rpt_auth_status(struct rpt *myrpt, char *outbuf, size_t outlen)
+{
+	struct rpt_auth_state *st;
+	time_t now = time(NULL);
+
+	if (!outbuf || outlen == 0) {
+		return;
+	}
+	outbuf[0] = '\0';
+
+	rpt_mutex_lock(&myrpt->lock);
+	st = myrpt->auth;
+	if (!st || ast_strlen_zero(myrpt->p.auth_users)) {
+		snprintf(outbuf, outlen, "auth disabled");
+	} else if (!st->session_active) {
+		snprintf(outbuf, outlen, "no active session (%d user(s) configured)", st->nusers);
+	} else if (now >= st->session_expires) {
+		snprintf(outbuf, outlen, "session expired");
+	} else {
+		snprintf(outbuf, outlen, "user=%s set=%s remaining=%lds", st->session_user,
+			st->session_command_set ? st->session_command_set : "(none)", (long) (st->session_expires - now));
+	}
+	rpt_mutex_unlock(&myrpt->lock);
+}

--- a/apps/app_rpt/rpt_auth.h
+++ b/apps/app_rpt/rpt_auth.h
@@ -1,0 +1,61 @@
+/*
+ * Per-user TOTP authentication for app_rpt.
+ *
+ * Loads users + secrets from a separate rpt_auth.conf file, manages a single
+ * per-node session slot, enforces sliding timeout and per-user lockout, and
+ * exposes the active command-set stanza name to collect_function_digits().
+ *
+ * All public functions take their own lock on myrpt->lock; callers must NOT
+ * hold the lock when invoking them.
+ */
+
+#ifndef _RPT_AUTH_H
+#define _RPT_AUTH_H
+
+#include <stddef.h>
+
+struct rpt;
+
+/*! \brief Re-read auth_users file and clear any active session.
+ *  Called from load_rpt_vars() after the new rpt.conf vars are populated.
+ *  Safe to call when the feature is disabled (auth_users unset).  Idempotent. */
+void rpt_auth_reload(struct rpt *myrpt);
+
+/*! \brief Free all auth state for a node.  Called at module unload / node teardown. */
+void rpt_auth_free(struct rpt *myrpt);
+
+/*! \brief Copy the active command-set stanza name into buf, or return 0 if no session.
+ *  Returns 1 if an active session exists (buf populated), 0 otherwise.
+ *  Copies under lock so the returned string is caller-owned and safe from
+ *  concurrent rpt_auth_logout / rpt_auth_reload on the CLI thread.
+ *  Internally checks expiry and clears stale sessions. */
+int rpt_auth_get_active_stanza(struct rpt *myrpt, char *buf, size_t buflen);
+
+/*! \brief Refresh the sliding session timeout.  No-op if no active session. */
+void rpt_auth_touch(struct rpt *myrpt);
+
+/*! \brief Longest function-name length in the active session's stanza.
+ *  Returns 0 if no active session.  Used by the "have we collected enough
+ *  digits?" gate in collect_function_digits(). */
+int rpt_auth_longestfunc(struct rpt *myrpt);
+
+/*! \brief Result codes from rpt_auth_login. */
+enum rpt_auth_login_result {
+	RPT_AUTH_LOGIN_OK = 0,
+	RPT_AUTH_LOGIN_BAD = -1,	  /*!< unknown user, bad OTP, replay, or bad secret */
+	RPT_AUTH_LOGIN_LOCKED = -2,	  /*!< user is currently locked out */
+	RPT_AUTH_LOGIN_DISABLED = -3, /*!< feature disabled (no auth_users) */
+};
+
+/*! \brief Attempt login.
+ *  \param user_id4 exactly 4 ASCII decimal digits
+ *  \param otp6    exactly 6 ASCII decimal digits */
+int rpt_auth_login(struct rpt *myrpt, const char *user_id4, const char *otp6);
+
+/*! \brief Clear active session.  Idempotent. */
+void rpt_auth_logout(struct rpt *myrpt);
+
+/*! \brief Format human-readable status into outbuf.  Always NUL-terminates. */
+void rpt_auth_status(struct rpt *myrpt, char *outbuf, size_t outlen);
+
+#endif /* _RPT_AUTH_H */

--- a/apps/app_rpt/rpt_cli.c
+++ b/apps/app_rpt/rpt_cli.c
@@ -23,6 +23,7 @@
 #include "rpt_manager.h"
 #include "rpt_telemetry.h"
 #include "rpt_functions.h"
+#include "rpt_auth.h"
 
 extern struct rpt rpt_vars[MAXRPTS];
 
@@ -1611,6 +1612,79 @@ static char *handle_cli_show_version(struct ast_cli_entry *e, int cmd, struct as
 	return CLI_SUCCESS;
 }
 
+static int rpt_do_auth_show(int fd, int argc, const char *const *argv)
+{
+	int i;
+	int nrpts = rpt_num_rpts();
+	char status[256];
+
+	if (argc != 4) {
+		return RESULT_SHOWUSAGE;
+	}
+
+	for (i = 0; i < nrpts; i++) {
+		if (!strcmp(argv[3], rpt_vars[i].name)) {
+			rpt_auth_status(&rpt_vars[i], status, sizeof(status));
+			ast_cli(fd, "Node %s auth: %s\n", argv[3], status);
+			return RESULT_SUCCESS;
+		}
+	}
+	ast_cli(fd, "Node %s not found\n", argv[3]);
+	return RESULT_FAILURE;
+}
+
+static int rpt_do_auth_logout(int fd, int argc, const char *const *argv)
+{
+	int i;
+	int nrpts = rpt_num_rpts();
+
+	if (argc != 4) {
+		return RESULT_SHOWUSAGE;
+	}
+
+	for (i = 0; i < nrpts; i++) {
+		if (!strcmp(argv[3], rpt_vars[i].name)) {
+			rpt_auth_logout(&rpt_vars[i]);
+			ast_cli(fd, "Node %s auth session cleared\n", argv[3]);
+			return RESULT_SUCCESS;
+		}
+	}
+	ast_cli(fd, "Node %s not found\n", argv[3]);
+	return RESULT_FAILURE;
+}
+
+static char *handle_cli_auth_show(struct ast_cli_entry *e, int cmd, struct ast_cli_args *a)
+{
+	switch (cmd) {
+	case CLI_INIT:
+		e->command = "rpt auth show";
+		e->usage = "Usage: rpt auth show <nodename>\n"
+				   "	Show TOTP auth session status for the given node.\n";
+		return NULL;
+
+	case CLI_GENERATE:
+		return rpt_complete_node_list(a->line, a->word, a->pos, 3);
+	}
+
+	return res2cli(rpt_do_auth_show(a->fd, a->argc, a->argv));
+}
+
+static char *handle_cli_auth_logout(struct ast_cli_entry *e, int cmd, struct ast_cli_args *a)
+{
+	switch (cmd) {
+	case CLI_INIT:
+		e->command = "rpt auth logout";
+		e->usage = "Usage: rpt auth logout <nodename>\n"
+				   "	Force-clear the active TOTP auth session for the given node.\n";
+		return NULL;
+
+	case CLI_GENERATE:
+		return rpt_complete_node_list(a->line, a->word, a->pos, 3);
+	}
+
+	return res2cli(rpt_do_auth_logout(a->fd, a->argc, a->argv));
+}
+
 static struct ast_cli_entry rpt_cli[] = {
 	AST_CLI_DEFINE(handle_cli_debug, "Enable app_rpt debugging"),
 	AST_CLI_DEFINE(handle_cli_dump, "Dump app_rpt structs for debugging"),
@@ -1633,6 +1707,8 @@ static struct ast_cli_entry rpt_cli[] = {
 	AST_CLI_DEFINE(handle_cli_page, "Send a page to a user on a node"),
 	AST_CLI_DEFINE(handle_cli_lookup, "Lookup Allstar nodes"),
 	AST_CLI_DEFINE(handle_cli_show_version, "Show app_rpt version"),
+	AST_CLI_DEFINE(handle_cli_auth_show, "Show TOTP auth session status for a node"),
+	AST_CLI_DEFINE(handle_cli_auth_logout, "Force-logout TOTP auth session for a node"),
 };
 
 int rpt_cli_load(void)

--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -25,6 +25,7 @@
 #include "rpt_manager.h"
 #include "rpt_utils.h" /* use myatoi */
 #include "rpt_rig.h"   /* use setrem */
+#include "rpt_auth.h"  /* TOTP per-user authentication */
 
 /*! \brief Echolink queryoption for retrieving call sign */
 #define ECHOLINK_QUERY_CALLSIGN 2
@@ -675,6 +676,8 @@ void rpt_free_config_vars(struct rpt *myrpt)
 		ast_free(myrpt->p.ldisc_buf);
 		myrpt->p.ldisc_buf = NULL;
 	}
+
+	rpt_auth_free(myrpt);
 }
 
 void load_rpt_vars(int n, int init)
@@ -1010,6 +1013,12 @@ void load_rpt_vars(int n, int init)
 	RPT_CONFIG_VAR(eloutbound, "eloutbound");
 	RPT_CONFIG_VAR_DEFAULT(events, "events", "events");
 	RPT_CONFIG_VAR(timezone, "timezone");
+	RPT_CONFIG_VAR(auth_users, "auth_users");
+	RPT_CONFIG_VAR_INT_DEFAULT_MIN_MAX(auth_timeout, "auth_timeout", 300, 30, 86400);
+	RPT_CONFIG_VAR_INT_DEFAULT_MIN_MAX(auth_lockout_threshold, "auth_lockout_threshold", 5, 0, 1000);
+	RPT_CONFIG_VAR_INT_DEFAULT_MIN_MAX(auth_lockout_duration, "auth_lockout_duration", 60, 0, 86400);
+	RPT_CONFIG_VAR_INT_DEFAULT_MIN_MAX(auth_otp_step, "auth_otp_step", 30, 10, 120);
+	RPT_CONFIG_VAR_INT_DEFAULT_MIN_MAX(auth_otp_window, "auth_otp_window", 1, 0, 3);
 
 #ifdef __RPT_NOTCH
 	val = ast_variable_retrieve(cfg, this, "rxnotch");
@@ -1318,6 +1327,8 @@ void load_rpt_vars(int n, int init)
 		vp = vp->next;
 	}
 	ast_mutex_unlock(&rpt_vars[n].lock);
+
+	rpt_auth_reload(&rpt_vars[n]);
 }
 
 int rpt_push_alt_macro(struct rpt *myrpt, char *sptr)

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -7,6 +7,8 @@
 
 #include "asterisk.h"
 
+#include <ctype.h>
+
 #include "asterisk/app.h" /* use ast_safe_system */
 #include "asterisk/channel.h"
 #include "asterisk/file.h"
@@ -26,6 +28,7 @@
 #include "rpt_functions.h"
 #include "rpt_rig.h"
 #include "rpt_radio.h"
+#include "rpt_auth.h"
 
 /*!
  * \brief DTMF Tones - frequency pairs used to generate them along with the required timings
@@ -2004,4 +2007,77 @@ enum rpt_function_response function_cmd(struct rpt *myrpt, char *param, char *di
 		}
 	}
 	return DC_COMPLETE;
+}
+
+/*
+ * param selects the sub-command:
+ *   "a" — authenticate (login):  expects exactly 10 trailing digits
+ *                                 (4-digit user-id + 6-digit OTP)
+ *   "s" — status:                no trailing digits expected
+ *   "l" — logout:                no trailing digits expected
+ *
+ * Example rpt.conf entries (assuming funcchar='*'):
+ *   A1 = auth,a    ; *A1<10 digits>   login
+ *   A2 = auth,s    ; *A2              status query
+ *   A3 = auth,l    ; *A3              logout
+ */
+enum rpt_function_response function_auth(struct rpt *myrpt, char *param, char *digitbuf, enum rpt_command_source command_source,
+	struct rpt_link *mylink)
+{
+	const char *digits = digitbuf ? digitbuf : "";
+	size_t len = strlen(digits);
+	const char *subcmd = (param && *param) ? param : "";
+	size_t i;
+	int rc;
+
+	if (myrpt->remote) {
+		return DC_ERROR;
+	}
+
+	ast_debug(1, "auth subcmd=%s digitbuf_len=%zu source=%d\n", subcmd, len, command_source);
+
+	if (!strcasecmp(subcmd, "s")) {
+		rpt_telem_select(myrpt, command_source, mylink);
+		rpt_telemetry(myrpt, COMPLETE, NULL);
+		return DC_COMPLETEQUIET;
+	}
+
+	if (!strcasecmp(subcmd, "l")) {
+		rpt_auth_logout(myrpt);
+		rpt_telem_select(myrpt, command_source, mylink);
+		rpt_telemetry(myrpt, COMPLETE, NULL);
+		return DC_COMPLETEQUIET;
+	}
+
+	/* Default / "a" — login: need exactly 10 decimal digits */
+	if (len < 10) {
+		return DC_INDETERMINATE;
+	}
+	if (len != 10) {
+		return DC_ERROR;
+	}
+	for (i = 0; i < 10; i++) {
+		if (!isdigit(digits[i])) {
+			return DC_ERROR;
+		}
+	}
+
+	{
+		char user_id4[5], otp6[7];
+
+		memcpy(user_id4, digits, 4);
+		user_id4[4] = '\0';
+		memcpy(otp6, digits + 4, 6);
+		otp6[6] = '\0';
+
+		rc = rpt_auth_login(myrpt, user_id4, otp6);
+	}
+
+	if (rc == RPT_AUTH_LOGIN_OK) {
+		rpt_telem_select(myrpt, command_source, mylink);
+		rpt_telemetry(myrpt, COMPLETE, NULL);
+		return DC_COMPLETEQUIET;
+	}
+
+	return DC_ERROR;
 }

--- a/apps/app_rpt/rpt_functions.h
+++ b/apps/app_rpt/rpt_functions.h
@@ -40,6 +40,9 @@ enum rpt_function_response function_userout(struct rpt *myrpt, char *param, char
 /*! \brief Execute shell command */
 enum rpt_function_response function_cmd(struct rpt *myrpt, char *param, char *digitbuf, enum rpt_command_source, struct rpt_link *mylink);
 
+/*! \brief TOTP per-user authentication: login (id4+otp6), logout (*), status (empty) */
+enum rpt_function_response function_auth(struct rpt *myrpt, char *param, char *digitbuf, enum rpt_command_source, struct rpt_link *mylink);
+
 /*! \brief AO2 callback to find an rpt_link by name */
 int rpt_link_find_by_name(void *obj, void *arg, int flags);
 

--- a/apps/app_rpt/rpt_totp.c
+++ b/apps/app_rpt/rpt_totp.c
@@ -1,0 +1,277 @@
+
+#include "asterisk.h"
+
+#include <ctype.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#include "asterisk/logger.h"
+#include "asterisk/utils.h"
+
+#include <openssl/crypto.h>
+#include <openssl/evp.h>
+#include <openssl/params.h>
+
+#include "rpt_totp.h"
+
+#define HMAC_HASH 20
+
+static int hmac_sha1(const uint8_t *key, size_t keylen, const uint8_t *msg, size_t msglen, uint8_t out[HMAC_HASH])
+{
+	EVP_MAC *mac = NULL;
+	EVP_MAC_CTX *ctx = NULL;
+	OSSL_PARAM params[2];
+	size_t outlen = 0;
+	int ret = -1;
+
+	mac = EVP_MAC_fetch(NULL, "HMAC", NULL);
+	if (!mac) {
+		return -1;
+	}
+
+	ctx = EVP_MAC_CTX_new(mac);
+	if (!ctx) {
+		goto out;
+	}
+
+	params[0] = OSSL_PARAM_construct_utf8_string("digest", "SHA1", 0);
+	params[1] = OSSL_PARAM_construct_end();
+
+	if (EVP_MAC_init(ctx, key, keylen, params) != 1) {
+		goto out;
+	}
+	if (EVP_MAC_update(ctx, msg, msglen) != 1) {
+		goto out;
+	}
+	if (EVP_MAC_final(ctx, out, &outlen, HMAC_HASH) != 1) {
+		goto out;
+	}
+
+	ret = 0;
+out:
+	EVP_MAC_CTX_free(ctx);
+	EVP_MAC_free(mac);
+	return ret;
+}
+
+int rpt_base32_decode(const char *in, uint8_t *out, size_t outlen)
+{
+	size_t buf = 0;
+	int bits = 0;
+	size_t written = 0;
+	const char *p;
+
+	if (!in || !out) {
+		return -1;
+	}
+
+	for (p = in; *p; p++) {
+		int v;
+		char c = *p;
+
+		if (c == '=') {
+			const char *q;
+			for (q = p + 1; *q; q++) {
+				if (*q != '=') {
+					return -1;
+				}
+			}
+			break;
+		}
+		if (c >= 'A' && c <= 'Z') {
+			v = c - 'A';
+		} else if (c >= 'a' && c <= 'z') {
+			v = c - 'a';
+		} else if (c >= '2' && c <= '7') {
+			v = 26 + (c - '2');
+		} else {
+			return -1;
+		}
+
+		buf = (buf << 5) | (size_t) v;
+		bits += 5;
+		if (bits >= 8) {
+			bits -= 8;
+			if (written >= outlen) {
+				return -1;
+			}
+			out[written++] = (uint8_t) ((buf >> bits) & 0xff);
+		}
+	}
+
+	/* Reject non-zero trailing bits (RFC 4648 §3.5). */
+	if (bits > 0 && (buf & ((1U << bits) - 1)) != 0) {
+		return -1;
+	}
+
+	return (int) written;
+}
+
+static int totp_at(const uint8_t *key, size_t keylen, uint64_t counter)
+{
+	uint8_t msg[8];
+	uint8_t hash[HMAC_HASH];
+	int offset;
+	uint32_t bin;
+	int i;
+
+	for (i = 7; i >= 0; i--) {
+		msg[i] = (uint8_t) (counter & 0xff);
+		counter >>= 8;
+	}
+
+	if (hmac_sha1(key, keylen, msg, sizeof(msg), hash) != 0) {
+		return -1;
+	}
+
+	/* RFC 4226 dynamic truncation. */
+	offset = hash[HMAC_HASH - 1] & 0x0f;
+	bin = ((uint32_t) (hash[offset] & 0x7f) << 24) | ((uint32_t) hash[offset + 1] << 16) | ((uint32_t) hash[offset + 2] << 8) |
+		  ((uint32_t) hash[offset + 3]);
+
+	return (int) (bin % 1000000U);
+}
+
+int rpt_totp_verify(const char *secret_b32, const char *otp6, uint64_t *last_counter, time_t now, int step_seconds, int window_steps)
+{
+	uint8_t key[64];
+	int keylen;
+	uint64_t base_counter;
+	int presented;
+	int i;
+	int w;
+	int ret;
+
+	if (!secret_b32 || !otp6 || !last_counter) {
+		return RPT_TOTP_BAD_PARAM;
+	}
+	if (step_seconds <= 0 || window_steps < 0) {
+		return RPT_TOTP_BAD_PARAM;
+	}
+	if (strlen(otp6) != 6) {
+		return RPT_TOTP_BAD_PARAM;
+	}
+	for (i = 0; i < 6; i++) {
+		if (!isdigit(otp6[i])) {
+			return RPT_TOTP_BAD_PARAM;
+		}
+	}
+
+	keylen = rpt_base32_decode(secret_b32, key, sizeof(key));
+	if (keylen <= 0) {
+		ret = RPT_TOTP_BAD_SECRET;
+		goto out;
+	}
+
+	presented = (otp6[0] - '0') * 100000 + (otp6[1] - '0') * 10000 + (otp6[2] - '0') * 1000 + (otp6[3] - '0') * 100 +
+				(otp6[4] - '0') * 10 + (otp6[5] - '0');
+
+	base_counter = (uint64_t) (now / step_seconds);
+
+	for (w = -window_steps; w <= window_steps; w++) {
+		uint64_t c;
+		int candidate;
+
+		/* Avoid wrap when w is negative and would push counter below 0. */
+		if (w < 0 && base_counter < (uint64_t) (-w)) {
+			continue;
+		}
+		c = base_counter + (uint64_t) w;
+
+		candidate = totp_at(key, (size_t) keylen, c);
+		if (candidate < 0) {
+			ret = RPT_TOTP_BAD_PARAM;
+			goto out;
+		}
+		if (candidate == presented) {
+			if (c <= *last_counter) {
+				ret = RPT_TOTP_REPLAY;
+				goto out;
+			}
+			*last_counter = c;
+			ret = RPT_TOTP_OK;
+			goto out;
+		}
+	}
+
+	ret = RPT_TOTP_BAD_OTP;
+out:
+	OPENSSL_cleanse(key, sizeof(key));
+	return ret;
+}
+
+#ifdef RPT_TOTP_SELFTEST
+
+/*
+ * RFC 6238 Appendix B reference vectors.  The reference key is the ASCII
+ * string "12345678901234567890" (20 bytes), which in base32 is
+ * "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ".  Six SHA1 vectors at known times.
+ */
+static const struct {
+	time_t t;
+	const char *expected;
+} rfc6238_vectors[] = {
+	{ 59, "287082" }, { 1111111109, "081804" }, { 1111111111, "050471" }, { 1234567890, "005924" }, { 2000000000, "279037" },
+	/* RFC's 20000000000 vector exceeds 32-bit time_t; skip on those builds. */
+};
+
+int rpt_totp_selftest(void)
+{
+	const char *secret = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ";
+	int failures = 0;
+	size_t i;
+
+	for (i = 0; i < ARRAY_LEN(rfc6238_vectors); i++) {
+		uint64_t last = 0;
+		int rc = rpt_totp_verify(secret, rfc6238_vectors[i].expected, &last, rfc6238_vectors[i].t, 30, 0);
+		if (rc != RPT_TOTP_OK) {
+			ast_log(LOG_ERROR, "rpt_totp selftest vector %zu (t=%ld) failed: rc=%d\n", i, (long) rfc6238_vectors[i].t, rc);
+			failures++;
+		}
+	}
+
+	/* Replay rejection: same OTP at same step must be rejected the second time. */
+	{
+		uint64_t last = 0;
+		int rc1 = rpt_totp_verify(secret, "287082", &last, 59, 30, 0);
+		int rc2 = rpt_totp_verify(secret, "287082", &last, 59, 30, 0);
+		if (rc1 != RPT_TOTP_OK || rc2 != RPT_TOTP_REPLAY) {
+			ast_log(LOG_ERROR, "rpt_totp selftest replay check failed: rc1=%d rc2=%d\n", rc1, rc2);
+			failures++;
+		}
+	}
+
+	/* Window check: previous-step OTP must be accepted with window=1, rejected with window=0. */
+	{
+		uint64_t last = 0;
+		int prev_step_otp;
+		char buf[8];
+		uint8_t key[64];
+		int keylen = rpt_base32_decode(secret, key, sizeof(key));
+		prev_step_otp = (keylen > 0) ? totp_at(key, (size_t) keylen, 2) : -1;
+		if (prev_step_otp < 0) {
+			ast_log(LOG_ERROR, "rpt_totp selftest window setup failed\n");
+			failures++;
+		} else {
+			int rc_strict, rc_window;
+			snprintf(buf, sizeof(buf), "%06d", prev_step_otp);
+			last = 0;
+			rc_strict = rpt_totp_verify(secret, buf, &last, 90, 30, 0);
+			last = 0;
+			rc_window = rpt_totp_verify(secret, buf, &last, 90, 30, 1);
+			if (rc_strict != RPT_TOTP_BAD_OTP || rc_window != RPT_TOTP_OK) {
+				ast_log(LOG_ERROR, "rpt_totp selftest window check failed: strict=%d window=%d\n", rc_strict, rc_window);
+				failures++;
+			}
+		}
+	}
+
+	if (failures == 0) {
+		ast_log(LOG_NOTICE, "rpt_totp selftest: all vectors PASSED\n");
+	}
+	return failures;
+}
+
+#endif /* RPT_TOTP_SELFTEST */

--- a/apps/app_rpt/rpt_totp.h
+++ b/apps/app_rpt/rpt_totp.h
@@ -1,0 +1,79 @@
+/*
+ * RFC 6238 TOTP (Time-based One-Time Password) verification for app_rpt.
+ *
+ * Depends on OpenSSL 3.0+ EVP_MAC API (<openssl/evp.h>) and standard C.
+ * Requires linking against libcrypto (-lcrypto).
+ *
+ * Used by rpt_auth.c to validate DTMF-entered authentication codes.
+ */
+
+#ifndef _RPT_TOTP_H
+#define _RPT_TOTP_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <time.h>
+
+/*! \brief Result codes from rpt_totp_verify. */
+enum rpt_totp_result {
+	RPT_TOTP_OK = 0,		  /*!< OTP matched within window. */
+	RPT_TOTP_BAD_OTP = -1,	  /*!< OTP did not match any step in window. */
+	RPT_TOTP_REPLAY = -2,	  /*!< OTP matched but counter <= last_counter. */
+	RPT_TOTP_BAD_SECRET = -3, /*!< secret_b32 failed to decode. */
+	RPT_TOTP_BAD_PARAM = -4,  /*!< invalid argument (NULL, bad otp length, etc.) */
+};
+
+/*!
+ * \brief Verify an RFC 6238 TOTP-SHA1 6-digit code.
+ *
+ * Computes TOTP for steps [now/step - window .. now/step + window] using the
+ * given base32-encoded shared secret, and compares each candidate against the
+ * supplied 6-digit OTP string.  On match, *last_counter is updated to the
+ * matched counter so the caller can persist it and reject reuse within the
+ * same or earlier step (in-window replay protection).
+ *
+ * \param secret_b32 Base32-encoded shared secret (RFC 4648, padding optional,
+ *                   case-insensitive).  Must not be NULL.
+ * \param otp6       Exactly 6 ASCII decimal digits.  Must not be NULL.
+ * \param last_counter In/out.  On entry, the highest counter previously
+ *                   accepted for this user (0 if none).  On RPT_TOTP_OK,
+ *                   updated to the matched counter.  Unchanged on any error.
+ *                   Must not be NULL.
+ * \param now        Current Unix time (seconds since epoch).
+ * \param step_seconds TOTP time step.  RFC 6238 default is 30.  Caller is
+ *                   responsible for clamping to a sane range (e.g. 10-120).
+ * \param window_steps Number of steps to accept on each side of the current
+ *                   step.  0 = strict (current only); 1 = ±1 step (~3*step
+ *                   seconds tolerance).  Caller should clamp to <= 3.
+ * \retval RPT_TOTP_OK         match found and not a replay
+ * \retval RPT_TOTP_BAD_OTP    no match in window
+ * \retval RPT_TOTP_REPLAY     matched but counter already used
+ * \retval RPT_TOTP_BAD_SECRET secret_b32 invalid
+ * \retval RPT_TOTP_BAD_PARAM  bad argument
+ */
+int rpt_totp_verify(const char *secret_b32, const char *otp6, uint64_t *last_counter, time_t now, int step_seconds, int window_steps);
+
+/*!
+ * \brief Decode an RFC 4648 base32 string to bytes.
+ *
+ * Padding ('=') is permitted but not required.  Whitespace is rejected.
+ * Decoding is case-insensitive.
+ *
+ * \param in     NUL-terminated base32 string.  Must not be NULL.
+ * \param out    Output buffer.  Must not be NULL.
+ * \param outlen Capacity of out.
+ * \return Number of bytes written on success, or -1 on invalid input or if
+ *         the decoded length would exceed outlen.
+ */
+int rpt_base32_decode(const char *in, uint8_t *out, size_t outlen);
+
+#ifdef RPT_TOTP_SELFTEST
+/*!
+ * \brief Run RFC 4226/6238 reference vectors.  Returns 0 on pass, count of
+ * failures on failure.  Logs each failure via ast_log.  Compiled only when
+ * RPT_TOTP_SELFTEST is defined.
+ */
+int rpt_totp_selftest(void);
+#endif
+
+#endif /* _RPT_TOTP_H */

--- a/configs/rpt/rpt.conf
+++ b/configs/rpt/rpt.conf
@@ -124,6 +124,15 @@ scheduler = schedule                ; Scheduler stanza
 telemetry = telemetry               ; Telemetry stanza
 wait_times = wait-times             ; Wait times stanza
 
+; TOTP per-user authentication (optional). All options can be specified per node.
+;
+;auth_users = /etc/asterisk/rpt_auth.conf  ; Path to user/secret file. Unset = feature disabled.
+;auth_timeout = 300                 ; Sliding session timeout, seconds. Range 30..86400, default 300.
+;auth_lockout_threshold = 5         ; Failed-login attempts before lockout. 0 disables lockout. Range 0..1000. default 5.
+;auth_lockout_duration = 60         ; Lockout duration, seconds. Range 0..86400, default 60.
+;auth_otp_step = 30                 ; TOTP time step (RFC 6238). Range 10..120, default 30.
+;auth_otp_window = 1                ; Allowed step skew (each side). Range 0..3, default 1.
+
 ;inxlat = *,#,0123456789ABCD,Y      ; The Y is for dialtone on function, a la CACTUS
                                     ; https://allstarlink.github.io/config/rpt_conf/#inxlat
 
@@ -304,6 +313,14 @@ parrottime = 1000                   ; Set the amount of time in milliseconds
 ;   quiet = 1                       ; Don't send dial tone, or connect messages. Do not send patch down message when called party hangs up
                                     ; Example: 123=autopatchup,dialtime=20000,noct=1,farenddisconnect=1
 
+
+;;;;; TOTP per-user authentication ;;;;; 
+; 
+; A1 = auth,a        ; login:  *A1<id4><otp6>  e.g. *A11234849203
+; A2 = auth,s        ; status: *A2             (courtesy tone only; details via "rpt auth show <node>")
+; A3 = auth,l        ; logout: *A3
+
+
 ;;;;; Status Commands ;;;;;
 ; 1 - Force ID (global)
 ; 2 - Give Time of Day (global)
@@ -452,6 +469,19 @@ parrottime = 1000                   ; Set the amount of time in milliseconds
 ; 964 = cop,64                      ; Send pre-configured APRStt notification, quietly (cop,64,CALL[,OVERLAYCHR])
 ; 965 = cop,65                      ; Send POCSAG page (equipped channel types only)
 
+[functions](functions-main)
+
+;[totp-admin]
+; Add commands here for users authenticated as admin
+;901 = cop,1                        ; System warm boot
+;902 = cop,2                        ; System enable
+;903 = cop,3                        ; System disable
+
+;[totp-operator]
+; Add commands here for users authenticated as operator.
+;916 = cop,16                       ; Scheduler disable
+
+
 ; [functions-remote]
 ;;;;; Functions for remote bases ;;;;;
 ;
@@ -499,8 +529,6 @@ parrottime = 1000                   ; Set the amount of time in milliseconds
                                     ; TX frequency limits. See [txlimits] below.
 ; 85 = cop,6                        ; Remote base telephone key
 
-
-[functions](functions-main)
 
 [telemetry-main](!)
 ;;;;; Telemetry ;;;;;

--- a/configs/rpt/rpt_auth.conf
+++ b/configs/rpt/rpt_auth.conf
@@ -1,0 +1,48 @@
+;
+; rpt_auth.conf — TOTP per-user authentication for app_rpt
+;
+; Path is configured per-node in rpt.conf via the "auth_users" key, e.g.:
+;     auth_users = /etc/asterisk/rpt_auth.conf
+;
+; If "auth_users" is unset or this file is missing/unreadable, the auth
+; feature is silently disabled and all login attempts return DC_ERROR.
+;
+; SECURITY: This file contains shared TOTP secrets. Restrict it strictly:
+;     chown root:asterisk /etc/asterisk/rpt_auth.conf
+;     chmod 0640         /etc/asterisk/rpt_auth.conf
+;
+; Format
+; ------
+;   [users]
+;   <id4> = <BASE32_SECRET>,<command_set_stanza>
+;
+; - <id4>               Exactly 4 ASCII decimal digits (e.g. 1234). Must be
+;                       unique within the file. Leading zeros are significant.
+; - <BASE32_SECRET>     RFC 4648 base32 (uppercase, optional '=' padding).
+;                       This is the same encoding Google Authenticator,
+;                       Authy, FreeOTP, etc. consume. Generate with e.g.:
+;                           head -c 20 /dev/urandom | base32
+;                       and feed the same string to the user's authenticator
+;                       app (or render as an otpauth:// QR code).
+; - <command_set_stanza> Name of a [functions-...] stanza in rpt.conf that
+;                       this user is granted access to upon successful login.
+;
+; Whitespace around commas is tolerated. Lines starting with ';' are comments.
+;
+; No hard limit on user count; memory is allocated dynamically.
+;
+; Algorithm parameters (TOTP step, window, etc.) are NOT per-user — they are
+; configured per-node in rpt.conf via the auth_otp_step / auth_otp_window keys.
+;
+
+[users]
+; --- Examples (replace before deploying!) ---
+
+; User 1234 — admin, granted [totp-admin]
+;1234 = JBSWY3DPEHPK3PXP, functions-admin
+
+; User 5678 — control op, granted [totp-operator]
+;5678 = KRSXG5BAMFRGGZDFMZTWQ2LK, functions-controlop
+
+; User 9999 — read-only diagnostics, granted [totp-diag]
+;9999 = NB2HI4DTHIXS653XO4XHSZLOOQ, functions-diag

--- a/configs/samples/rpt_auth.conf.sample
+++ b/configs/samples/rpt_auth.conf.sample
@@ -1,0 +1,48 @@
+;
+; rpt_auth.conf — TOTP per-user authentication for app_rpt
+;
+; Path is configured per-node in rpt.conf via the "auth_users" key, e.g.:
+;     auth_users = /etc/asterisk/rpt_auth.conf
+;
+; If "auth_users" is unset or this file is missing/unreadable, the auth
+; feature is silently disabled and all login attempts return DC_ERROR.
+;
+; SECURITY: This file contains shared TOTP secrets. Restrict it strictly:
+;     chown root:asterisk /etc/asterisk/rpt_auth.conf
+;     chmod 0640         /etc/asterisk/rpt_auth.conf
+;
+; Format
+; ------
+;   [users]
+;   <id4> = <BASE32_SECRET>,<command_set_stanza>
+;
+; - <id4>               Exactly 4 ASCII decimal digits (e.g. 1234). Must be
+;                       unique within the file. Leading zeros are significant.
+; - <BASE32_SECRET>     RFC 4648 base32 (uppercase, optional '=' padding).
+;                       This is the same encoding Google Authenticator,
+;                       Authy, FreeOTP, etc. consume. Generate with e.g.:
+;                           head -c 20 /dev/urandom | base32
+;                       and feed the same string to the user's authenticator
+;                       app (or render as an otpauth:// QR code).
+; - <command_set_stanza> Name of a [functions-...] stanza in rpt.conf that
+;                       this user is granted access to upon successful login.
+;
+; Whitespace around commas is tolerated. Lines starting with ';' are comments.
+;
+; No hard limit on user count; memory is allocated dynamically.
+;
+; Algorithm parameters (TOTP step, window, etc.) are NOT per-user — they are
+; configured per-node in rpt.conf via the auth_otp_step / auth_otp_window keys.
+;
+
+[users]
+; --- Examples (replace before deploying!) ---
+
+; User 1234 — admin, granted totp-admin
+;1234 = JBSWY3DPEHPK3PXP, totp-admin
+
+; User 5678 — control op, granted totp-operator
+;5678 = KRSXG5BAMFRGGZDFMZTWQ2LK, totp-operator
+
+; User 9999 — read-only diagnostics, granted totp-diag
+;9999 = NB2HI4DTHIXS653XO4XHSZLOOQ, totp-diag


### PR DESCRIPTION
# Add TOTP DTMF Authentication for app_rpt

## Summary

Adds per-user, per-node TOTP (RFC 6238) authentication to app_rpt, allowing administrators to gate privileged DTMF commands behind a one-time password verified via any standard
 authenticator app (Google Authenticator, Authy, FreeOTP, etc.).

## Motivation

Previously, every DTMF function in `rpt.conf` was accessible to anyone who could key the radio — there was no concept of user-level access control. This feature introduces an a
uthentication layer so that sensitive control commands (e.g., system key/unkey, restart scripts) can be restricted to authorized operators.

## What It Does

- Defines an **additive, privileged DTMF command set** that becomes available only after a user authenticates via a 4-digit user ID + 6-digit TOTP code keyed over DTMF.
- Sessions are **per-node, single-user, sliding-timeout** — active use refreshes the session; idle sessions expire automatically.
- Configurable **brute-force lockout** (threshold + duration) protects against OTP guessing over the air.
- **Security-conscious on-air feedback**: all failure modes (bad code, lockout, disabled) produce identical error tones — distinguishing details only appear in logs and CLI.
- Two new Asterisk CLI commands: `rpt auth show <node>` and `rpt auth logout <node>`.

## Configuration

- **`rpt.conf`**: New `auth_*` keys on the node stanza (`auth_users`, `auth_timeout`, `auth_lockout_threshold`, `auth_lockout_duration`, `auth_otp_step`, `auth_otp_window`), pl
us function table entries for login/status/logout sub-commands.
- **`rpt_auth.conf`** (new file): Maps 4-digit user IDs to base32 TOTP secrets and privileged function stanzas. Contains shared secrets — file permissions enforced (`0640 root:
asterisk`).

## Files Changed

| File | Change |
|------|--------|
| `apps/app_rpt/rpt_totp.{h,c}` | New — pure TOTP/HMAC-SHA1/base32 implementation. |
| `apps/app_rpt/rpt_auth.{h,c}` | New — per-node auth session state, user table loader, lockout logic. Opaque state hung off `struct rpt`. |
| `apps/app_rpt/rpt_functions.{h,c}` | New `function_auth` DTMF handler (login/status/logout sub-commands). |
| `apps/app_rpt/app_rpt.h` | New config fields on `struct rpt::p` + opaque `struct rpt_auth_state *auth` pointer. |
| `apps/app_rpt/rpt_config.c` | Config key registration (`auth_*`) and reload/free hooks. |
| `apps/app_rpt.c` | `function_table[]` registration + `collect_function_digits()` modified for authed-stanza-first dispatch and sliding timeout touch. |
| `apps/app_rpt/rpt_cli.c` | New `rpt auth show` / `rpt auth logout` CLI commands. |
| `configs/rpt/rpt.conf` | Documented `auth_*` keys + example admin stanza. |
| `configs/samples/rpt_auth.conf.sample` | New — user/secret file template. |

## Design Decisions


- **Opaque auth state** — all auth internals are behind `rpt_auth.c`; no ABI churn for future extensions.
- **Minimal `collect_function_digits` surgery** — authed-stanza walk is O(1) skip when no session is active; hot path impact is negligible for nodes that don't enable auth.
- **One session per node** — simplifies dispatch and avoids per-channel session tracking. Extensible to multiple sessions if needed later.
- **Separate secrets file** — `rpt.conf` is widely shared/version-controlled; secrets stay in a permission-protected file with no network attack surface.

## Testing

- `rpt_totp.c` includes `RPT_TOTP_SELFTEST` validating against RFC 6238 Appendix B canonical SHA-1 test vectors.
- End-to-end smoke test recipe provided in documentation (generate secret → configure → reload → DTMF login via CLI → verify session → privileged command → logout).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-user TOTP DTMF login (4-digit ID + 6-digit OTP), RFC-compliant verification with replay protection, configurable step/window, lockout controls, single active sliding session, session-refresh on successful dispatch, and auth-aware command routing with privileged command sets. OTP digits are never logged.
  * CLI commands to show node auth status and force logout.

* **Documentation**
  * Admin/developer guide, config templates, and a sample users file with setup, permissions guidance, and an end-to-end test recipe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->