### PR TITLE
app_rpt: on shutdown, protect NULL `linklist` and `macrobuf`

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -6128,8 +6128,9 @@ static void *rpt_master(void *ignore)
 				thread_hung[i] = rpt_true;
 				ast_log(LOG_WARNING, "RPT thread on %s is hung for %ld seconds.\n", rpt_vars[i].name, current_loop_time);
 			}
-			rv = pthread_kill(rpt_vars[i].rpt_thread, 0); /* Check thread status by sending signal 0 */
-			if (rv) {
+
+			rv = pthread_tryjoin_np(rpt_vars[i].rpt_thread, 0); /* Check thread status by trying to join it */
+			if (rv != EBUSY) {
 				if (rpt_vars[i].deleted == RPT_DELETED_PENDING) {
 					rpt_vars[i].name[0] = 0;
 					if (rpt_vars[i].rpt_thread != AST_PTHREADT_NULL) {

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -1755,8 +1755,14 @@ static int distribute_to_all_links(struct rpt *myrpt, struct rpt_link *mylink, c
 {
 	struct rpt_link *l;
 	struct ao2_iterator l_it;
+
 	/* see if this is one in list */
 	rpt_mutex_lock(&myrpt->lock);
+	if (!myrpt->links) {
+		rpt_mutex_unlock(&myrpt->lock);
+		return -1;
+	}
+
 	RPT_LIST_TRAVERSE(myrpt->links, l, l_it) {
 		if (l->name[0] == '0') {
 			continue;
@@ -3081,24 +3087,28 @@ static inline void dump_rpt(struct rpt *myrpt, const int lasttx, const int laste
 	ast_debug(2, "myrpt->p.parrotmode = %d\n", (int) myrpt->p.parrotmode);
 	ast_debug(2, "myrpt->parrotonce = %d\n", (int) myrpt->parrotonce);
 	ast_debug(2, "myrpt->rpt_newkey =%d\n", myrpt->rpt_newkey);
+
 	rpt_mutex_lock(&myrpt->lock);
-	RPT_LIST_TRAVERSE(myrpt->links, zl, l_it) {
-		ast_debug(2, "*** Link Name: %s ***\n", zl->name);
-		ast_debug(2, "        link->lasttx %d\n", zl->lasttx);
-		ast_debug(2, "        link->lastrx %d\n", zl->lastrx);
-		ast_debug(2, "        link->connected %d\n", zl->connected);
-		ast_debug(2, "        link->hasconnected %d\n", zl->hasconnected);
-		ast_debug(2, "        link->outbound %d\n", zl->outbound);
-		ast_debug(2, "        link->disced %d\n", zl->disced);
-		ast_debug(2, "        link->killme %d\n", zl->killme);
-		ast_debug(2, "        link->disctime %d\n", zl->disctime);
-		ast_debug(2, "        link->retrytimer %d\n", zl->retrytimer);
-		ast_debug(2, "        link->retries = %d\n", zl->retries);
-		ast_debug(2, "        link->reconnects = %d\n", zl->reconnects);
-		ast_debug(2, "        link->link_newkey = %d\n", zl->link_newkey);
+	if (myrpt->links) {
+		RPT_LIST_TRAVERSE(myrpt->links, zl, l_it) {
+			ast_debug(2, "*** Link Name: %s ***\n", zl->name);
+			ast_debug(2, "        link->lasttx %d\n", zl->lasttx);
+			ast_debug(2, "        link->lastrx %d\n", zl->lastrx);
+			ast_debug(2, "        link->connected %d\n", zl->connected);
+			ast_debug(2, "        link->hasconnected %d\n", zl->hasconnected);
+			ast_debug(2, "        link->outbound %d\n", zl->outbound);
+			ast_debug(2, "        link->disced %d\n", zl->disced);
+			ast_debug(2, "        link->killme %d\n", zl->killme);
+			ast_debug(2, "        link->disctime %d\n", zl->disctime);
+			ast_debug(2, "        link->retrytimer %d\n", zl->retrytimer);
+			ast_debug(2, "        link->retries = %d\n", zl->retries);
+			ast_debug(2, "        link->reconnects = %d\n", zl->reconnects);
+			ast_debug(2, "        link->link_newkey = %d\n", zl->link_newkey);
+		}
+		ao2_iterator_destroy(&l_it);
 	}
+
 	rpt_mutex_unlock(&myrpt->lock);
-	ao2_iterator_destroy(&l_it);
 	zt = myrpt->tele.next;
 	if (zt != &myrpt->tele) {
 		ast_debug(2, "*** Telemetry Queue ***\n");

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4367,7 +4367,7 @@ static int remote_hangup_helper(struct rpt *myrpt, struct rpt_link *l)
 
 	if (l->chan && !CHAN_TECH(l->chan, "echolink") && !CHAN_TECH(l->chan, "tlb")) {
 		/* If neither echolink nor tlb */
-		if (l->disced == RPT_LINK_DISCONNECT_NONE) {
+		if (l->disced == RPT_LINK_DISCONNECT_NONE && !ast_shutting_down()) {
 			if (!l->outbound) {
 				if ((l->name[0] <= '0') || (l->name[0] > '9') || l->isremote) {
 					/* Not an allstar link node */
@@ -5740,19 +5740,9 @@ static void *rpt(void *this)
 	rpt_mutex_lock(&myrpt->lock);
 	RPT_LIST_TRAVERSE(myrpt->links, l, l_it) {
 		/* hang-up any running links */
-		l->disced = RPT_LINK_DISCONNECT;
+		l->disced = RPT_LINK_DISCONNECT_SILENT;
 	}
 	ao2_iterator_destroy(&l_it);
-	while (ao2_container_count(myrpt->links) != 0) {
-		/* Wait for the links to close out */
-		rpt_mutex_unlock(&myrpt->lock);
-		usleep(60000);
-		rpt_mutex_lock(&myrpt->lock);
-	}
-	if (myrpt->xlink == 1)
-		myrpt->xlink = 2;
-	ao2_cleanup(myrpt->links);
-	myrpt->links = NULL;
 	rpt_mutex_unlock(&myrpt->lock);
 
 	rpt_hangup(myrpt, RPT_PCHAN);
@@ -5785,6 +5775,24 @@ static void *rpt(void *this)
 		ast_free(myrpt->macrobuf);
 		myrpt->macrobuf = NULL;
 	}
+
+	rpt_mutex_lock(&myrpt->lock);
+	while (ao2_container_count(myrpt->links) != 0) {
+		/* Wait for the links to close out */
+		rpt_mutex_unlock(&myrpt->lock);
+		usleep(60000);
+		rpt_mutex_lock(&myrpt->lock);
+
+	}
+
+	if (myrpt->xlink == 1) {
+		myrpt->xlink = 2;
+	}
+
+	rpt_mutex_unlock(&myrpt->lock);
+
+	ao2_cleanup(myrpt->links);
+	myrpt->links = NULL;
 
 	ast_debug(1, "%s thread now exiting...\n", myrpt->name);
 	return NULL;

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -5764,6 +5764,15 @@ static void *rpt(void *this)
 		close(myrpt->iofd);
 		myrpt->iofd = -1;
 	}
+
+	rpt_mutex_lock(&myrpt->lock);
+	while (ao2_container_count(myrpt->links) != 0) {
+		/* Wait for the links to close out */
+		rpt_mutex_unlock(&myrpt->lock);
+		usleep(60000);
+		rpt_mutex_lock(&myrpt->lock);
+	}
+
 	/* Free dynamically allocated memory */
 #ifdef NATIVE_DSP
 	if (myrpt->dsp) {
@@ -5776,22 +5785,13 @@ static void *rpt(void *this)
 		myrpt->macrobuf = NULL;
 	}
 
-	rpt_mutex_lock(&myrpt->lock);
-	while (ao2_container_count(myrpt->links) != 0) {
-		/* Wait for the links to close out */
-		rpt_mutex_unlock(&myrpt->lock);
-		usleep(60000);
-		rpt_mutex_lock(&myrpt->lock);
-	}
-
 	if (myrpt->xlink == 1) {
 		myrpt->xlink = 2;
 	}
 
-	rpt_mutex_unlock(&myrpt->lock);
-
 	ao2_cleanup(myrpt->links);
 	myrpt->links = NULL;
+	rpt_mutex_unlock(&myrpt->lock);
 
 	ast_debug(1, "%s thread now exiting...\n", myrpt->name);
 	return NULL;

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4216,8 +4216,12 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 				snprintf(str, sizeof(str), "V %s %s", myrpt->name, (char *) f->data.ptr);
 				wf.datalen = strlen(str) + 1;
 				wf.data.ptr = str;
+				rpt_mutex_lock(&myrpt->lock);
 				/* otherwise, send it to all of em */
-				ao2_callback(myrpt->links, OBJ_MULTIPLE | OBJ_NODATA, rxchannel_qwrite_cb, &wf);
+				if (myrpt->links) {
+					ao2_callback(myrpt->links, OBJ_MULTIPLE | OBJ_NODATA, rxchannel_qwrite_cb, &wf);
+				}
+				rpt_mutex_unlock(&myrpt->lock);
 			}
 		}
 	}
@@ -5195,7 +5199,9 @@ static void *rpt(void *this)
 
 			rpt_mutex_lock(&myrpt->lock);
 			myrpt->voteremrx = 0; /* no voter remotes keyed */
-			ao2_callback(myrpt->links, OBJ_MULTIPLE | OBJ_NODATA, sendtext_cb, &tmpstr);
+			if (myrpt->links) {
+				ao2_callback(myrpt->links, OBJ_MULTIPLE | OBJ_NODATA, sendtext_cb, &tmpstr);
+			}
 			rpt_mutex_unlock(&myrpt->lock);
 		}
 		rpt_mutex_lock(&myrpt->lock);
@@ -6134,9 +6140,14 @@ static void *rpt_master(void *ignore)
 				}
 				last_thread_time[i] = rpt_vars[i].lastthreadupdatetime; /* Only log message one time */
 			}
+
 			if (current_loop_time > RPT_THREAD_TIMEOUT && !thread_hung[i]) {
 				thread_hung[i] = rpt_true;
 				ast_log(LOG_WARNING, "RPT thread on %s is hung for %ld seconds.\n", rpt_vars[i].name, current_loop_time);
+			}
+
+			if (!rpt_vars[i].rpt_thread || rpt_vars[i].rpt_thread == AST_PTHREADT_NULL) {
+				continue; /* Thread is not running, nothing to do */
 			}
 
 			rv = pthread_tryjoin_np(rpt_vars[i].rpt_thread, 0); /* Check thread status by trying to join it */

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -5782,7 +5782,6 @@ static void *rpt(void *this)
 		rpt_mutex_unlock(&myrpt->lock);
 		usleep(60000);
 		rpt_mutex_lock(&myrpt->lock);
-
 	}
 
 	if (myrpt->xlink == 1) {

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -6130,47 +6130,47 @@ static void *rpt_master(void *ignore)
 			}
 
 			rv = pthread_tryjoin_np(rpt_vars[i].rpt_thread, 0); /* Check thread status by trying to join it */
-			if (rv != EBUSY) {
-				if (rpt_vars[i].deleted == RPT_DELETED_PENDING) {
-					rpt_vars[i].name[0] = 0;
-					if (rpt_vars[i].rpt_thread != AST_PTHREADT_NULL) {
-						pthread_join(rpt_vars[i].rpt_thread, NULL);
-						rpt_vars[i].rpt_thread = AST_PTHREADT_NULL;
-					}
-					rpt_vars[i].deleted = RPT_DELETED_COMPLETE;
-					continue;
-				}
-				if (ast_shutting_down() || shutting_down) {
-					continue; /* Don't restart thread if we're unloading the module */
-				}
-				if (time(NULL) - rpt_vars[i].lastthreadrestarttime <= 5) {
-					if (rpt_vars[i].threadrestarts >= 5) {
-						/* This is way off-nominal here. The original code just called exit(1) which
-						 * is totally not cool... so this is a little bit saner. */
-						ast_log(LOG_ERROR, "Continual RPT thread restarts, stopping repeaters\n");
-						stop_repeaters();
-						/* Not necessary to set shutting_down to 1, since we're the only thread that uses that, and we're exiting */
-						ast_mutex_unlock(&rpt_master_lock);
-						return NULL; /* The module will have to be unloaded and loaded again to start the repeaters */
-					} else {
-						ast_log(LOG_WARNING, "RPT thread restarted on %s\n", rpt_vars[i].name);
-						rpt_vars[i].threadrestarts++;
-					}
+			if (rv == EBUSY) {
+				continue; /* Thread is still running, nothing to do */
+			}
+			if (rv == 0) {
+				rpt_vars[i].rpt_thread = AST_PTHREADT_NULL;
+			} else {
+				ast_log(LOG_WARNING, "Failed to query %s thread: %s\n", rpt_vars[i].name, strerror(rv));
+				continue;
+			}
+
+			if (rpt_vars[i].deleted == RPT_DELETED_PENDING) {
+				rpt_vars[i].name[0] = 0;
+				rpt_vars[i].deleted = RPT_DELETED_COMPLETE;
+				continue;
+			}
+			if (ast_shutting_down() || shutting_down) {
+				continue; /* Don't restart thread if we're unloading the module */
+			}
+			if (time(NULL) - rpt_vars[i].lastthreadrestarttime <= 5) {
+				if (rpt_vars[i].threadrestarts >= 5) {
+					/* This is way off-nominal here. The original code just called exit(1) which
+					 * is totally not cool... so this is a little bit saner. */
+					ast_log(LOG_ERROR, "Continual RPT thread restarts, stopping repeaters\n");
+					stop_repeaters();
+					/* Not necessary to set shutting_down to 1, since we're the only thread that uses that, and we're exiting */
+					ast_mutex_unlock(&rpt_master_lock);
+					return NULL; /* The module will have to be unloaded and loaded again to start the repeaters */
 				} else {
-					rpt_vars[i].threadrestarts = 0;
+					ast_log(LOG_WARNING, "RPT thread restarted on %s\n", rpt_vars[i].name);
+					rpt_vars[i].threadrestarts++;
 				}
-				rv = pthread_join(rpt_vars[i].rpt_thread, NULL);
-				if (rv) {
-					ast_log(LOG_WARNING, "Failed to join %s thread: %s\n", rpt_vars[i].name, strerror(rv));
-				}
-				rpt_vars[i].lastthreadrestarttime = time(NULL);
-				rpt_vars[i].lastthreadupdatetime = current_time;
-				rv = ast_pthread_create(&rpt_vars[i].rpt_thread, NULL, rpt, &rpt_vars[i]);
-				if (rv) {
-					ast_log(LOG_WARNING, "Failed to create %s thread: %s\n", rpt_vars[i].name, strerror(rv));
-				} else {
-					ast_log(LOG_WARNING, "rpt_thread restarted on node %s\n", rpt_vars[i].name);
-				}
+			} else {
+				rpt_vars[i].threadrestarts = 0;
+			}
+			rpt_vars[i].lastthreadrestarttime = time(NULL);
+			rpt_vars[i].lastthreadupdatetime = current_time;
+			rv = ast_pthread_create(&rpt_vars[i].rpt_thread, NULL, rpt, &rpt_vars[i]);
+			if (rv) {
+				ast_log(LOG_WARNING, "Failed to create %s thread: %s\n", rpt_vars[i].name, strerror(rv));
+			} else {
+				ast_log(LOG_WARNING, "rpt_thread restarted on node %s\n", rpt_vars[i].name);
 			}
 		}
 		for (i = 0; i < nrpts; i++) {

--- a/apps/app_rpt/rpt_cli.c
+++ b/apps/app_rpt/rpt_cli.c
@@ -118,6 +118,12 @@ static int rpt_do_stats(int fd, int argc, const char *const *argv)
 
 			/* Traverse the list of connected nodes */
 			reverse_patch_state = "DOWN";
+
+			if (!myrpt->links) {
+				rpt_mutex_unlock(&myrpt->lock);
+				return RESULT_FAILURE;
+			}
+
 			links_copy = ao2_container_clone(myrpt->links, OBJ_NOLOCK);
 			if (!links_copy) {
 				rpt_mutex_unlock(&myrpt->lock);
@@ -448,6 +454,12 @@ static int rpt_do_xnode(int fd, int argc, const char *const *argv)
 			/* Make a copy of all stat variables while locked */
 			myrpt = &rpt_vars[i];
 			rpt_mutex_lock(&myrpt->lock);
+
+			if (!myrpt->links) {
+				rpt_mutex_unlock(&myrpt->lock);
+				return RESULT_FAILURE;
+			}
+
 			links_copy = ao2_container_clone(myrpt->links, OBJ_NOLOCK);
 			if (!links_copy) {
 				ast_free(lbuf);

--- a/apps/app_rpt/rpt_cli.c
+++ b/apps/app_rpt/rpt_cli.c
@@ -456,6 +456,7 @@ static int rpt_do_xnode(int fd, int argc, const char *const *argv)
 			rpt_mutex_lock(&myrpt->lock);
 
 			if (!myrpt->links) {
+				ast_free(lbuf);
 				rpt_mutex_unlock(&myrpt->lock);
 				return RESULT_FAILURE;
 			}

--- a/apps/app_rpt/rpt_cli.c
+++ b/apps/app_rpt/rpt_cli.c
@@ -105,6 +105,11 @@ static int rpt_do_stats(int fd, int argc, const char *const *argv)
 			/* Make a copy of all stat variables while locked */
 			myrpt = &rpt_vars[i];
 			rpt_mutex_lock(&myrpt->lock);
+			if (!myrpt->links) {
+				rpt_mutex_unlock(&myrpt->lock);
+				return RESULT_FAILURE;
+			}
+
 			uptime = (int) (now - rpt_starttime());
 			dailytxtime = myrpt->dailytxtime;
 			totaltxtime = myrpt->totaltxtime;
@@ -118,12 +123,6 @@ static int rpt_do_stats(int fd, int argc, const char *const *argv)
 
 			/* Traverse the list of connected nodes */
 			reverse_patch_state = "DOWN";
-
-			if (!myrpt->links) {
-				rpt_mutex_unlock(&myrpt->lock);
-				return RESULT_FAILURE;
-			}
-
 			links_copy = ao2_container_clone(myrpt->links, OBJ_NOLOCK);
 			if (!links_copy) {
 				rpt_mutex_unlock(&myrpt->lock);

--- a/apps/app_rpt/rpt_cli.c
+++ b/apps/app_rpt/rpt_cli.c
@@ -369,6 +369,12 @@ static int rpt_do_lstats(int fd, int argc, const char *const *argv)
 
 			/* Make a copy of all stat variables while locked */
 			rpt_mutex_lock(&myrpt->lock);
+			if (!myrpt->links) {
+				ao2_cleanup(links_copy);
+				rpt_mutex_unlock(&myrpt->lock);
+				return RESULT_FAILURE;
+			}
+
 			if (ao2_container_dup(links_copy, myrpt->links, OBJ_NOLOCK)) {
 				ao2_cleanup(links_copy);
 				rpt_mutex_unlock(&myrpt->lock);
@@ -778,6 +784,7 @@ static int rpt_do_restart(int fd, int argc, const char *const *argv)
 		return RESULT_SHOWUSAGE;
 	}
 
+	/* hanging up on the rx channel causes the rpt() thread to restart */
 	for (i = 0; i < nrpts; i++) {
 		if (rpt_vars[i].rxchannel) {
 			ast_softhangup(rpt_vars[i].rxchannel, AST_SOFTHANGUP_DEV);
@@ -800,6 +807,7 @@ static int rpt_do_fun(int fd, int argc, const char *const *argv)
 	for (i = 0; i < nrpts; i++) {
 		if (!strcmp(argv[2], rpt_vars[i].name)) {
 			struct rpt *myrpt = &rpt_vars[i];
+
 			macro_append(myrpt, argv[3]);
 		}
 	}
@@ -824,7 +832,10 @@ static int rpt_do_playback(int fd, int argc, const char *const *argv)
 	for (i = 0; i < nrpts; i++) {
 		if (!strcmp(argv[2], rpt_vars[i].name)) {
 			struct rpt *myrpt = &rpt_vars[i];
-			rpt_telemetry(myrpt, PLAYBACK, (void *) argv[3]);
+
+			if (myrpt->ready) {
+				rpt_telemetry(myrpt, PLAYBACK, (void *) argv[3]);
+			}
 		}
 	}
 
@@ -843,7 +854,10 @@ static int rpt_do_localplay(int fd, int argc, const char *const *argv)
 	for (i = 0; i < nrpts; i++) {
 		if (!strcmp(argv[2], rpt_vars[i].name)) {
 			struct rpt *myrpt = &rpt_vars[i];
-			rpt_telemetry(myrpt, LOCALPLAY, (void *) argv[3]);
+
+			if (myrpt->ready) {
+				rpt_telemetry(myrpt, LOCALPLAY, (void *) argv[3]);
+			}
 		}
 	}
 
@@ -885,8 +899,14 @@ static int rpt_do_sendtext(int fd, int argc, const char *const *argv)
 	for (i = 0; i < nrpts; i++) {
 		if (!strcmp(from, rpt_vars[i].name)) {
 			struct rpt *myrpt = &rpt_vars[i];
+
 			rpt_mutex_lock(&myrpt->lock);
 			/* otherwise, send it to all of em */
+			if (!myrpt->links) {
+				rpt_mutex_unlock(&myrpt->lock);
+				return RESULT_FAILURE;
+			}
+
 			ao2_callback(myrpt->links, OBJ_MULTIPLE | OBJ_NODATA, rpt_sendtext_cb, &str);
 			rpt_mutex_unlock(&myrpt->lock);
 		}
@@ -998,8 +1018,14 @@ int rpt_do_sendall(int fd, int argc, const char *const *argv)
 	for (i = 0; i < nrpts; i++) {
 		if (!strcmp(nodename, rpt_vars[i].name)) {
 			struct rpt *myrpt = &rpt_vars[i];
+
 			rpt_mutex_lock(&myrpt->lock);
 			/* otherwise, send it to all of em */
+			if (!myrpt->links) {
+				rpt_mutex_unlock(&myrpt->lock);
+				return RESULT_FAILURE;
+			}
+
 			ao2_callback(myrpt->links, OBJ_MULTIPLE | OBJ_NODATA, rpt_sendtext_cb, &str);
 			rpt_mutex_unlock(&myrpt->lock);
 		}
@@ -1023,6 +1049,7 @@ static int rpt_do_fun1(int fd, int argc, const char *const *argv)
 	for (i = 0; i < nrpts; i++) {
 		if (!strcmp(argv[2], rpt_vars[i].name)) {
 			struct rpt *myrpt = &rpt_vars[i];
+
 			rpt_push_alt_macro(myrpt, (char *) argv[3]);
 		}
 	}
@@ -1060,6 +1087,12 @@ static int rpt_do_cmd(int fd, int argc, const char *const *argv)
 		ast_cli(fd, "Unknown node number %s.\n", argv[2]);
 		return RESULT_FAILURE;
 	} /* if thisRpt < 0 */
+
+	if (!myrpt->ready) {
+		/* Don't accept comamands for a node that is not ready */
+		ast_cli(fd, "Node %s is not ready.\n", argv[2]);
+		return RESULT_FAILURE;
+	}
 
 	/* Look up the action */
 	thisAction = rpt_function_lookup(argv[3]);

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -158,7 +158,13 @@ enum rpt_function_response function_ilink(struct rpt *myrpt, char *param, char *
 		if ((digitbuf[0] == '0') && (myrpt->lastlinknode[0])) {
 			strcpy(digitbuf, myrpt->lastlinknode);
 		}
+
 		rpt_mutex_lock(&myrpt->lock);
+		if (!myrpt->links) {
+			rpt_mutex_unlock(&myrpt->lock);
+			break;
+		}
+
 		/* try to find this one in queue */
 		l = ao2_find(myrpt->links, digitbuf, 0);
 		if (!l) { /* if not found */
@@ -255,7 +261,7 @@ enum rpt_function_response function_ilink(struct rpt *myrpt, char *param, char *
 			break;
 		}
 		/* if doesn't allow link cmd, or no links active, return */
-		if (!ao2_container_count(myrpt->links)) {
+		if (!myrpt->links || !ao2_container_count(myrpt->links)) {
 			return DC_COMPLETE;
 		}
 		if ((command_source != SOURCE_RPT) && (command_source != SOURCE_PHONE) && (command_source != SOURCE_ALT) &&
@@ -304,6 +310,12 @@ enum rpt_function_response function_ilink(struct rpt *myrpt, char *param, char *
 	case 6: /* All Links Off, including permalinks */
 		rpt_mutex_lock(&myrpt->lock);
 		myrpt->savednodes[0] = 0;
+
+		if (!myrpt->links) {
+			rpt_mutex_unlock(&myrpt->lock);
+			return DC_COMPLETE;
+		}
+
 		/* loop through all links */
 		RPT_LIST_TRAVERSE(myrpt->links, l, l_it) {
 			char c1;
@@ -376,9 +388,13 @@ enum rpt_function_response function_ilink(struct rpt *myrpt, char *param, char *
 		*s2 = 0;
 		snprintf(tmp, MIN(sizeof(tmp), MAX_TEXTMSG_SIZE), "M %s %s %s", myrpt->name, s1 + 1, s2 + 1);
 		rpt_mutex_lock(&myrpt->lock);
-		/* otherwise, send it to all of em */
-		ao2_callback(myrpt->links, OBJ_MULTIPLE | OBJ_NODATA, rpt_sendtext_cb, tmp);
 
+		if (!myrpt->links) {
+			rpt_mutex_unlock(&myrpt->lock);
+			return DC_COMPLETE;
+		}
+
+		ao2_callback(myrpt->links, OBJ_MULTIPLE | OBJ_NODATA, rpt_sendtext_cb, tmp);
 		rpt_mutex_unlock(&myrpt->lock);
 		rpt_telemetry(myrpt, COMPLETE, NULL);
 		return DC_COMPLETE;

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -335,7 +335,7 @@ void send_link_dtmf(struct rpt *myrpt, char c)
 	wf.datalen = strlen(str) + 1;
 	wf.data.ptr = str;
 
-	ast_mutex_lock(&myrpt->lock);
+	rpt_mutex_lock(&myrpt->lock);
 	/* first, see if our dude is there */
 	RPT_LIST_TRAVERSE(myrpt->links, l, l_it) {
 		if (l->name[0] == '0') {

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -212,7 +212,7 @@ void rpt_qwrite(struct rpt_link *l, struct ast_frame *f)
 
 int linkcount(struct rpt *myrpt)
 {
-	return ao2_container_count(myrpt->links);
+	return myrpt->links ? ao2_container_count(myrpt->links) : 0;
 }
 
 void FindBestRssi(struct rpt *myrpt)
@@ -334,6 +334,7 @@ void send_link_dtmf(struct rpt *myrpt, char c)
 	snprintf(str, sizeof(str), "D %s %s %d %c", myrpt->cmdnode, myrpt->name, ++(myrpt->dtmfidx), c);
 	wf.datalen = strlen(str) + 1;
 	wf.data.ptr = str;
+	ast_mutex_lock(&myrpt->lock);
 	/* first, see if our dude is there */
 	RPT_LIST_TRAVERSE(myrpt->links, l, l_it) {
 		if (l->name[0] == '0') {
@@ -350,7 +351,15 @@ void send_link_dtmf(struct rpt *myrpt, char c)
 		}
 	}
 	ao2_iterator_destroy(&l_it);
+
 	/* if not, give it to everyone */
+	rpt_mutex_lock(&myrpt->lock);
+	if (!myrpt->links) {
+		rpt_mutex_unlock(&myrpt->lock);
+		return;
+	}
+
+	rpt_mutex_unlock(&myrpt->lock);
 	ao2_callback(myrpt->links, OBJ_MULTIPLE | OBJ_NODATA, link_qwrite_cb, &wf);
 }
 
@@ -371,8 +380,16 @@ void send_link_keyquery(struct rpt *myrpt)
 	wf.datalen = strlen(str) + 1;
 	wf.data.ptr = str;
 	/* give it to everyone */
+	rpt_mutex_lock(&myrpt->lock);
+	if (!myrpt->links) {
+		rpt_mutex_unlock(&myrpt->lock);
+		return;
+	}
+
+	rpt_mutex_unlock(&myrpt->lock);
 	ao2_callback(myrpt->links, OBJ_MULTIPLE | OBJ_NODATA, link_qwrite_cb, &wf);
 }
+
 void rpt_link_add(struct ao2_container *links, struct rpt_link *l)
 {
 	ast_assert(l != NULL);

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -435,6 +435,10 @@ int __mklinklist(struct rpt *myrpt, struct rpt_link *mylink, struct ast_str **bu
 		return 0;
 	}
 
+	if (!myrpt->links) {
+		return 0;
+	}
+
 	/* go thru all links */
 	RPT_LIST_TRAVERSE(myrpt->links, l, l_it) {
 		if (l->name[0] == '0') {

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -334,6 +334,7 @@ void send_link_dtmf(struct rpt *myrpt, char c)
 	snprintf(str, sizeof(str), "D %s %s %d %c", myrpt->cmdnode, myrpt->name, ++(myrpt->dtmfidx), c);
 	wf.datalen = strlen(str) + 1;
 	wf.data.ptr = str;
+
 	ast_mutex_lock(&myrpt->lock);
 	/* first, see if our dude is there */
 	RPT_LIST_TRAVERSE(myrpt->links, l, l_it) {
@@ -353,14 +354,13 @@ void send_link_dtmf(struct rpt *myrpt, char c)
 	ao2_iterator_destroy(&l_it);
 
 	/* if not, give it to everyone */
-	rpt_mutex_lock(&myrpt->lock);
 	if (!myrpt->links) {
 		rpt_mutex_unlock(&myrpt->lock);
 		return;
 	}
 
-	rpt_mutex_unlock(&myrpt->lock);
 	ao2_callback(myrpt->links, OBJ_MULTIPLE | OBJ_NODATA, link_qwrite_cb, &wf);
+	rpt_mutex_unlock(&myrpt->lock);
 }
 
 void send_link_keyquery(struct rpt *myrpt)

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -336,6 +336,11 @@ void send_link_dtmf(struct rpt *myrpt, char c)
 	wf.data.ptr = str;
 
 	rpt_mutex_lock(&myrpt->lock);
+	if (!myrpt->links) {
+		rpt_mutex_unlock(&myrpt->lock);
+		return;
+	}
+
 	/* first, see if our dude is there */
 	RPT_LIST_TRAVERSE(myrpt->links, l, l_it) {
 		if (l->name[0] == '0') {
@@ -355,11 +360,6 @@ void send_link_dtmf(struct rpt *myrpt, char c)
 	ao2_iterator_destroy(&l_it);
 
 	/* if not, give it to everyone */
-	if (!myrpt->links) {
-		rpt_mutex_unlock(&myrpt->lock);
-		return;
-	}
-
 	ao2_callback(myrpt->links, OBJ_MULTIPLE | OBJ_NODATA, link_qwrite_cb, &wf);
 	rpt_mutex_unlock(&myrpt->lock);
 }

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -348,6 +348,7 @@ void send_link_dtmf(struct rpt *myrpt, char c)
 			}
 			ao2_ref(l, -1);
 			ao2_iterator_destroy(&l_it);
+			rpt_mutex_unlock(&myrpt->lock);
 			return;
 		}
 	}

--- a/apps/app_rpt/rpt_manager.c
+++ b/apps/app_rpt/rpt_manager.c
@@ -208,9 +208,20 @@ static int rpt_manager_do_xstat(struct mansession *ses, const struct message *m)
 				tel_mode = "3";
 			}
 
+			if (!myrpt->links) {
+				ast_free(lbuf);
+				return RESULT_FAILURE;
+			}
+
 			/* Get connected node info */
 			/* Traverse the list of connected nodes */
 			n = __mklinklist(myrpt, NULL, &lbuf, USE_FORMAT_RPT_LINK) + 1;
+
+			if (!myrpt->links) {
+				rpt_mutex_unlock(&myrpt->lock);
+				return RESULT_FAILURE;
+			}
+
 			links_copy = ao2_container_clone(myrpt->links, OBJ_NOLOCK);
 			rpt_mutex_unlock(&myrpt->lock);
 			if (!links_copy) {
@@ -541,6 +552,11 @@ static int rpt_manager_do_stats(struct mansession *s, const struct message *m)
 
 			/* Traverse the list of connected nodes */
 			reverse_patch_state = "DOWN";
+
+			if (!myrpt->links) {
+				rpt_mutex_unlock(&myrpt->lock);
+				return -1;
+			}
 
 			links_copy = ao2_container_clone(myrpt->links, OBJ_NOLOCK);
 			if (!links_copy) {

--- a/apps/app_rpt/rpt_manager.c
+++ b/apps/app_rpt/rpt_manager.c
@@ -150,6 +150,12 @@ static int rpt_manager_do_xstat(struct mansession *ses, const struct message *m)
 			myrpt = &rpt_vars[i];
 			rpt_mutex_lock(&myrpt->lock);
 
+			if (!myrpt->links) {
+				ast_free(lbuf);
+				rpt_mutex_unlock(&myrpt->lock);
+				return RESULT_FAILURE;
+			}
+
 			ast_copy_string(rxchanname, myrpt->rxchanname, sizeof(rxchanname));
 
 			/* Get RPT status states while locked */
@@ -206,12 +212,6 @@ static int rpt_manager_do_xstat(struct mansession *ses, const struct message *m)
 				}
 			} else {
 				tel_mode = "3";
-			}
-
-			if (!myrpt->links) {
-				ast_free(lbuf);
-				rpt_mutex_unlock(&myrpt->lock);
-				return RESULT_FAILURE;
 			}
 
 			/* Get connected node info */
@@ -536,6 +536,13 @@ static int rpt_manager_do_stats(struct mansession *s, const struct message *m)
 			/* ELSE Process as a repeater node */
 			/* Make a copy of all stat variables while locked */
 			rpt_mutex_lock(&myrpt->lock);
+
+			if (!myrpt->links) {
+				rpt_mutex_unlock(&myrpt->lock);
+				ast_free(str);
+				return -1;
+			}
+
 			dailytxtime = myrpt->dailytxtime;
 			totaltxtime = myrpt->totaltxtime;
 			dailykeyups = myrpt->dailykeyups;
@@ -548,12 +555,6 @@ static int rpt_manager_do_stats(struct mansession *s, const struct message *m)
 
 			/* Traverse the list of connected nodes */
 			reverse_patch_state = "DOWN";
-
-			if (!myrpt->links) {
-				rpt_mutex_unlock(&myrpt->lock);
-				ast_free(str);
-				return -1;
-			}
 
 			links_copy = ao2_container_clone(myrpt->links, OBJ_NOLOCK);
 			if (!links_copy) {

--- a/apps/app_rpt/rpt_manager.c
+++ b/apps/app_rpt/rpt_manager.c
@@ -210,17 +210,13 @@ static int rpt_manager_do_xstat(struct mansession *ses, const struct message *m)
 
 			if (!myrpt->links) {
 				ast_free(lbuf);
+				rpt_mutex_unlock(&myrpt->lock);
 				return RESULT_FAILURE;
 			}
 
 			/* Get connected node info */
 			/* Traverse the list of connected nodes */
 			n = __mklinklist(myrpt, NULL, &lbuf, USE_FORMAT_RPT_LINK) + 1;
-
-			if (!myrpt->links) {
-				rpt_mutex_unlock(&myrpt->lock);
-				return RESULT_FAILURE;
-			}
 
 			links_copy = ao2_container_clone(myrpt->links, OBJ_NOLOCK);
 			rpt_mutex_unlock(&myrpt->lock);
@@ -555,6 +551,7 @@ static int rpt_manager_do_stats(struct mansession *s, const struct message *m)
 
 			if (!myrpt->links) {
 				rpt_mutex_unlock(&myrpt->lock);
+				ast_free(str);
 				return -1;
 			}
 

--- a/apps/app_rpt/rpt_mdc1200.c
+++ b/apps/app_rpt/rpt_mdc1200.c
@@ -130,6 +130,11 @@ void mdc1200_send(struct rpt *myrpt, char *data)
 
 	/* otherwise, send it to all of em */
 	rpt_mutex_lock(&myrpt->lock);
+	if (!myrpt->links) {
+		rpt_mutex_unlock(&myrpt->lock);
+		return;
+	}
+
 	RPT_LIST_TRAVERSE(myrpt->links, l, l_it) {
 		/* Dont send to IAXRPT client, unless main channel is Voter */
 		if (((l->name[0] == '0') && !CHAN_TECH(myrpt->rxchannel, "voter")) || (l->phonemode)) {
@@ -139,6 +144,7 @@ void mdc1200_send(struct rpt *myrpt, char *data)
 			rpt_qwrite(l, &wf);
 		}
 	}
+
 	rpt_mutex_unlock(&myrpt->lock);
 	ao2_iterator_destroy(&l_it);
 }

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -2766,6 +2766,10 @@ treataslocal:
 		hastx = 0;
 
 		rpt_mutex_lock(&myrpt->lock);
+		if (!myrpt->links) {
+			goto abort;
+		}
+
 		links_copy = ao2_container_clone(myrpt->links, OBJ_NOLOCK);
 
 		if (!links_copy) {

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -3643,7 +3643,7 @@ void rpt_telemetry(struct rpt *myrpt, enum rpt_tele_mode mode, void *data)
 
 		case REMDISC:
 			mylink = (struct rpt_link *) data;
-			if ((!mylink) || (mylink->name[0] == '0')) {
+			if (!mylink || !myrpt->links || mylink->name[0] == '0') {
 				return;
 			}
 
@@ -3757,6 +3757,11 @@ void rpt_telemetry(struct rpt *myrpt, enum rpt_tele_mode mode, void *data)
 
 		case STATUS:
 			rpt_mutex_lock(&myrpt->lock);
+			if (!myrpt->links) {
+				rpt_mutex_unlock(&myrpt->lock);
+				return;
+			}
+
 			snprintf(mystr, sizeof(mystr), "STATUS,%s,%d", myrpt->name, myrpt->callmode);
 			/* make our own list of links */
 			RPT_LIST_TRAVERSE(myrpt->links, l, l_it) {

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -718,7 +718,11 @@ static void send_tele_link(struct rpt *myrpt, char *cmd)
 	/* give it to everyone */
 	wf.data.ptr = str;
 	wf.datalen = len + 1;
-	ao2_callback(myrpt->links, OBJ_MULTIPLE | OBJ_NODATA, telm_qwrite_cb, &wf);
+	rpt_mutex_lock(&myrpt->lock);
+	if (myrpt->links) {
+		ao2_callback(myrpt->links, OBJ_MULTIPLE | OBJ_NODATA, telm_qwrite_cb, &wf);
+	}
+	rpt_mutex_unlock(&myrpt->lock);
 	ast_free(str);
 
 	rpt_telemetry(myrpt, VARCMD, cmd);

--- a/apps/app_rpt/rpt_utils.c
+++ b/apps/app_rpt/rpt_utils.c
@@ -303,6 +303,11 @@ int macro_append(struct rpt *myrpt, const char *cmd)
 	int res;
 
 	rpt_mutex_lock(&myrpt->lock);
+	if (!myrpt->macrobuf) {
+		rpt_mutex_unlock(&myrpt->lock);
+		return -1;
+	}
+
 	myrpt->macrotimer = MACROTIME;
 	res = ast_str_append(&myrpt->macrobuf, 0, "%s", cmd);
 	rpt_mutex_unlock(&myrpt->lock);


### PR DESCRIPTION
Links were not being removed from the list when shutting down.  This causes a LONG delay before asterisk actually force shuts down without completing the cleanup logic.
Use `pthread_tryjoin_np()` to detect when `rpt()` has exited as `pthread_kill` does not detect zombie threads, which is what happens when a thread dies and has not been joined.  
Add null protection to `myrpt->links` protecting races at shutdown.
Add null protection to `myrpt->macrobuf`

Fixes #1064 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented operations on missing link containers across CLI, manager, telemetry, link, and utility paths to avoid crashes and failed commands.
  * Commands now fail gracefully when a node or system isn't ready (e.g., send, playback, command paths).
  * Suppressed broadcast/hangup actions during module shutdown to avoid shutdown races.

* **Refactor**
  * Improved teardown so links drain cleanly and are cleaned up quietly.
  * Made thread monitoring/restart logic more robust to reliably detect exited threads and skip restarts during shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->