### PR TITLE
app_rpt: Add keyup delay via first_keyup_min_time and first_keyup_inactivity_time parameters

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -3608,7 +3608,7 @@ static inline void rpt_keyed(struct rpt *myrpt, int delay)
 			return;
 		}
 
-		if (delay && myrpt->p.keyupdelay_time > 0 && myrpt->p.keyupdelay_inactivity_time > 0 && myrpt->keyupinactivitytimer <= 0) {
+		if (myrpt->p.keyupdelay_time > 0 && myrpt->p.keyupdelay_inactivity_time > 0 && myrpt->keyupinactivitytimer <= 0) {
 			myrpt->keyupdelaytimer = myrpt->p.keyupdelay_time;
 			ast_debug(6, "[%s] delaying keyed state for %d ms\n", myrpt->name, myrpt->p.keyupdelay_time);
 			return;

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -3608,9 +3608,9 @@ static inline void rpt_keyed(struct rpt *myrpt, int delay)
 			return;
 		}
 
-		if (myrpt->p.keyupdelay_time > 0 && myrpt->p.keyupdelay_inactivity_time > 0 && myrpt->keyupinactivitytimer <= 0) {
-			myrpt->keyupdelaytimer = myrpt->p.keyupdelay_time;
-			ast_debug(6, "[%s] delaying keyed state for %d ms\n", myrpt->name, myrpt->p.keyupdelay_time);
+		if (myrpt->p.first_keyup_min_time > 0 && myrpt->p.first_keyup_inactivity_time > 0 && myrpt->first_keyup_inactivity_timer <= 0) {
+			myrpt->first_keyup_timer = myrpt->p.first_keyup_min_time;
+			ast_debug(6, "[%s] delaying keyed state for %d ms\n", myrpt->name, myrpt->p.first_keyup_min_time);
 			return;
 		}
 	}
@@ -3619,8 +3619,8 @@ static inline void rpt_keyed(struct rpt *myrpt, int delay)
 	myrpt->keyed = 1;
 	time(&myrpt->lastkeyedtime);
 	myrpt->keypost = RPT_KEYPOST_ACTIVE;
-	myrpt->keyupdelaytimer = 0;
-	myrpt->keyupinactivitytimer = myrpt->p.keyupdelay_inactivity_time;
+	myrpt->first_keyup_timer = 0;
+	myrpt->first_keyup_inactivity_timer = myrpt->p.first_keyup_inactivity_time;
 }
 
 static inline int update_timers(struct rpt *myrpt, const int elap, const int totx)
@@ -3677,14 +3677,13 @@ static inline int update_timers(struct rpt *myrpt, const int elap, const int tot
 
 	update_timer(&myrpt->time_out_reset_unkey_interval_timer, elap, 0);
 
-	last_time = myrpt->keyupdelaytimer;
-	update_timer(&myrpt->keyupdelaytimer, elap, 0);
-
-	if (last_time && !myrpt->keyupdelaytimer && !myrpt->keyed) {
+	last_time = myrpt->first_keyup_timer;
+	update_timer(&myrpt->first_keyup_timer, elap, 0);
+	if (last_time && !myrpt->first_keyup_timer && !myrpt->keyed) {
 		rpt_keyed(myrpt, 0);
 	}
 
-	update_timer(&myrpt->keyupinactivitytimer, elap, 0);
+	update_timer(&myrpt->first_keyup_inactivity_timer, elap, 0);
 
 	update_timer(&myrpt->idtimer, elap, 0);
 
@@ -4182,8 +4181,8 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 						if (!strcasecmp(f->data.ptr, myrpt->p.locallist[x])) {
 							myrpt->localoverride = 1;
 							myrpt->keyed = 0;
-							myrpt->keyupdelaytimer = 0;
-							myrpt->keyupinactivitytimer = myrpt->p.keyupdelay_inactivity_time;
+							myrpt->first_keyup_timer = 0;
+							myrpt->first_keyup_inactivity_timer = myrpt->p.first_keyup_inactivity_time;
 							break;
 						}
 					}
@@ -4236,10 +4235,10 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 			was_keyed = myrpt->keyed;
 			myrpt->reallykeyed = 0;
 			myrpt->keyed = 0;
-			myrpt->keyupdelaytimer = 0;
+			myrpt->first_keyup_timer = 0;
 
 			if (was_keyed) {
-				myrpt->keyupinactivitytimer = myrpt->p.keyupdelay_inactivity_time;
+				myrpt->first_keyup_inactivity_timer = myrpt->p.first_keyup_inactivity_time;
 			}
 
 			if ((myrpt->p.duplex > 1) && (!asleep) && myrpt->localoverride) {
@@ -5123,8 +5122,8 @@ static void *rpt(void *this)
 	lastexttx = 0;
 	myrpt->keyed = 0;
 	myrpt->txkeyed = 0;
-	myrpt->keyupdelaytimer = 0;
-	myrpt->keyupinactivitytimer = myrpt->p.keyupdelay_inactivity_time;
+	myrpt->first_keyup_timer = 0;
+	myrpt->first_keyup_inactivity_timer = myrpt->p.first_keyup_inactivity_time;
 	time(&myrpt->lastkeyedtime);
 	myrpt->lastkeyedtime -= RPT_LOCKOUT_SECS;
 	time(&myrpt->lasttxkeyedtime);

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4178,6 +4178,7 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 						if (!strcasecmp(f->data.ptr, myrpt->p.locallist[x])) {
 							myrpt->localoverride = 1;
 							myrpt->keyed = 0;
+							myrpt->keyupdelaytimer = 0;
 							myrpt->keyupinactivitytimer = myrpt->p.keyupdelay_inactivity_time;
 							break;
 						}
@@ -4215,6 +4216,7 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 		/* if RX un-key */
 		if (f->subclass.integer == AST_CONTROL_RADIO_UNKEY) {
 			char asleep;
+			int was_keyed;
 			/* clear rx channel rssi */
 			myrpt->rxrssi = 0;
 			asleep = myrpt->p.s[myrpt->p.sysstate_cur].sleepena & myrpt->sleep;
@@ -4227,16 +4229,26 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 				}
 			}
 			send_link_pl(myrpt, "0");
+			was_keyed = myrpt->keyed;
 			myrpt->reallykeyed = 0;
 			myrpt->keyed = 0;
-			myrpt->keyupinactivitytimer = myrpt->p.keyupdelay_inactivity_time;
 			myrpt->keyupdelaytimer = 0;
+
+			if (was_keyed) {
+				myrpt->keyupinactivitytimer = myrpt->p.keyupdelay_inactivity_time;
+			}
+
 			if ((myrpt->p.duplex > 1) && (!asleep) && myrpt->localoverride) {
 				rpt_telemetry(myrpt, LOCUNKEY, NULL);
 			}
+
 			myrpt->localoverride = 0;
-			time(&myrpt->lastkeyedtime);
-			myrpt->keypost = RPT_KEYPOST_ACTIVE;
+
+			if (was_keyed) {
+				time(&myrpt->lastkeyedtime);
+				myrpt->keypost = RPT_KEYPOST_ACTIVE;
+			}
+
 			myrpt->lastdtmfuser[0] = 0;
 			strcpy(myrpt->lastdtmfuser, myrpt->curdtmfuser);
 			myrpt->curdtmfuser[0] = 0;

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -3595,8 +3595,27 @@ static inline int do_link_post(struct rpt *myrpt)
 	return 0;
 }
 
-static inline void rpt_keyed_set_actual(struct rpt *myrpt)
+/*!
+ * \brief Set the keyed state of the rpt structure with a delay.
+ * \note This function will delay the keyed state for a specified time.
+ * \param myrpt The rpt structure
+ * \param delay Set the delay if not 0, keyup if 0
+ */
+static inline void rpt_keyed(struct rpt *myrpt, int delay)
 {
+	if (delay) {
+		if (myrpt->keyed) {
+			return;
+		}
+
+		if (delay && myrpt->p.keyupdelay_time > 0 && myrpt->p.keyupdelay_inactivity_time > 0 && myrpt->keyupinactivitytimer <= 0) {
+			myrpt->keyupdelaytimer = myrpt->p.keyupdelay_time;
+			ast_debug(6, "[%s] delaying keyed state for %d ms\n", myrpt->name, myrpt->p.keyupdelay_time);
+			return;
+		}
+	}
+
+	/* Set the actual keyed state */
 	myrpt->keyed = 1;
 	time(&myrpt->lastkeyedtime);
 	myrpt->keypost = RPT_KEYPOST_ACTIVE;
@@ -3604,24 +3623,9 @@ static inline void rpt_keyed_set_actual(struct rpt *myrpt)
 	myrpt->keyupinactivitytimer = myrpt->p.keyupdelay_inactivity_time;
 }
 
-static inline void rpt_keyed_set_with_delay(struct rpt *myrpt)
-{
-	if (myrpt->keyed) {
-		return;
-	}
-
-	if (myrpt->p.keyupdelay_time > 0 && myrpt->p.keyupdelay_inactivity_time > 0 && myrpt->keyupinactivitytimer <= 0) {
-		myrpt->keyupdelaytimer = myrpt->p.keyupdelay_time;
-		ast_debug(6, "[%s] delaying keyed state for %d ms\n", myrpt->name, myrpt->p.keyupdelay_time);
-		return;
-	}
-
-	rpt_keyed_set_actual(myrpt);
-}
-
 static inline int update_timers(struct rpt *myrpt, const int elap, const int totx)
 {
-	int i;
+	int last_time;
 
 	update_timer(&myrpt->linkposttimer, elap, 0);
 	if (myrpt->linkposttimer <= 0) {
@@ -3659,9 +3663,9 @@ static inline int update_timers(struct rpt *myrpt, const int elap, const int tot
 		myrpt->totaltxtime += elap;
 	}
 
-	i = myrpt->tailtimer;
+	last_time = myrpt->tailtimer;
 	update_timer(&myrpt->tailtimer, elap, 0);
-	if (i && (myrpt->tailtimer == 0)) {
+	if (last_time && (myrpt->tailtimer == 0)) {
 		myrpt->tailevent = 1;
 	}
 
@@ -3673,11 +3677,11 @@ static inline int update_timers(struct rpt *myrpt, const int elap, const int tot
 
 	update_timer(&myrpt->time_out_reset_unkey_interval_timer, elap, 0);
 
-	i = myrpt->keyupdelaytimer;
+	last_time = myrpt->keyupdelaytimer;
 	update_timer(&myrpt->keyupdelaytimer, elap, 0);
 
-	if (i && !myrpt->keyupdelaytimer && !myrpt->keyed) {
-		rpt_keyed_set_actual(myrpt);
+	if (last_time && !myrpt->keyupdelaytimer && !myrpt->keyed) {
+		rpt_keyed(myrpt, 0);
 	}
 
 	update_timer(&myrpt->keyupinactivitytimer, elap, 0);
@@ -3945,7 +3949,7 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 				if ((!i) && myrpt->lastrxburst) {
 					ast_debug(1, "Node %s now keyed after Rx Burst\n", myrpt->name);
 					myrpt->linkactivitytimer = 0;
-					rpt_keyed_set_with_delay(myrpt);
+					rpt_keyed(myrpt, 1);
 				}
 				myrpt->lastrxburst = i;
 			}
@@ -3959,7 +3963,7 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 				myrpt->dtmfkeyed = 0;
 				myrpt->dtmfkeybuf[0] = 0;
 				myrpt->linkactivitytimer = 0;
-				rpt_keyed_set_with_delay(myrpt);
+				rpt_keyed(myrpt, 1);
 			}
 		}
 #ifdef _MDC_DECODE_H_
@@ -4132,7 +4136,7 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 
 				if ((!myrpt->p.rxburstfreq) && (!myrpt->p.dtmfkey)) {
 					myrpt->linkactivitytimer = 0;
-					rpt_keyed_set_with_delay(myrpt);
+					rpt_keyed(myrpt, 1);
 				}
 			}
 			if (myrpt->p.archivedir) {

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -3595,6 +3595,30 @@ static inline int do_link_post(struct rpt *myrpt)
 	return 0;
 }
 
+static inline void rpt_keyed_set_actual(struct rpt *myrpt)
+{
+	myrpt->keyed = 1;
+	time(&myrpt->lastkeyedtime);
+	myrpt->keypost = RPT_KEYPOST_ACTIVE;
+	myrpt->keyupdelaytimer = 0;
+	myrpt->keyupinactivitytimer = myrpt->p.keyupdelay_inactivity_time;
+}
+
+static inline void rpt_keyed_set_with_delay(struct rpt *myrpt)
+{
+	if (myrpt->keyed) {
+		return;
+	}
+
+	if (myrpt->p.keyupdelay_time > 0 && myrpt->p.keyupdelay_inactivity_time > 0 && myrpt->keyupinactivitytimer <= 0) {
+		myrpt->keyupdelaytimer = myrpt->p.keyupdelay_time;
+		ast_debug(6, "[%s] delaying keyed state for %d ms\n", myrpt->name, myrpt->p.keyupdelay_time);
+		return;
+	}
+
+	rpt_keyed_set_actual(myrpt);
+}
+
 static inline int update_timers(struct rpt *myrpt, const int elap, const int totx)
 {
 	int i;
@@ -3648,6 +3672,15 @@ static inline int update_timers(struct rpt *myrpt, const int elap, const int tot
 	update_timer(&myrpt->remote_time_out_reset_unkey_interval_timer, elap, 0);
 
 	update_timer(&myrpt->time_out_reset_unkey_interval_timer, elap, 0);
+
+	i = myrpt->keyupdelaytimer;
+	update_timer(&myrpt->keyupdelaytimer, elap, 0);
+
+	if (i && !myrpt->keyupdelaytimer && !myrpt->keyed) {
+		rpt_keyed_set_actual(myrpt);
+	}
+
+	update_timer(&myrpt->keyupinactivitytimer, elap, 0);
 
 	update_timer(&myrpt->idtimer, elap, 0);
 
@@ -3912,9 +3945,7 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 				if ((!i) && myrpt->lastrxburst) {
 					ast_debug(1, "Node %s now keyed after Rx Burst\n", myrpt->name);
 					myrpt->linkactivitytimer = 0;
-					myrpt->keyed = 1;
-					time(&myrpt->lastkeyedtime);
-					myrpt->keypost = RPT_KEYPOST_ACTIVE;
+					rpt_keyed_set_with_delay(myrpt);
 				}
 				myrpt->lastrxburst = i;
 			}
@@ -3928,9 +3959,7 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 				myrpt->dtmfkeyed = 0;
 				myrpt->dtmfkeybuf[0] = 0;
 				myrpt->linkactivitytimer = 0;
-				myrpt->keyed = 1;
-				time(&myrpt->lastkeyedtime);
-				myrpt->keypost = RPT_KEYPOST_ACTIVE;
+				rpt_keyed_set_with_delay(myrpt);
 			}
 		}
 #ifdef _MDC_DECODE_H_
@@ -4103,9 +4132,7 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 
 				if ((!myrpt->p.rxburstfreq) && (!myrpt->p.dtmfkey)) {
 					myrpt->linkactivitytimer = 0;
-					myrpt->keyed = 1;
-					time(&myrpt->lastkeyedtime);
-					myrpt->keypost = RPT_KEYPOST_ACTIVE;
+					rpt_keyed_set_with_delay(myrpt);
 				}
 			}
 			if (myrpt->p.archivedir) {
@@ -4151,6 +4178,7 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 						if (!strcasecmp(f->data.ptr, myrpt->p.locallist[x])) {
 							myrpt->localoverride = 1;
 							myrpt->keyed = 0;
+							myrpt->keyupinactivitytimer = myrpt->p.keyupdelay_inactivity_time;
 							break;
 						}
 					}
@@ -4201,6 +4229,8 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 			send_link_pl(myrpt, "0");
 			myrpt->reallykeyed = 0;
 			myrpt->keyed = 0;
+			myrpt->keyupinactivitytimer = myrpt->p.keyupdelay_inactivity_time;
+			myrpt->keyupdelaytimer = 0;
 			if ((myrpt->p.duplex > 1) && (!asleep) && myrpt->localoverride) {
 				rpt_telemetry(myrpt, LOCUNKEY, NULL);
 			}
@@ -5077,6 +5107,8 @@ static void *rpt(void *this)
 	lastexttx = 0;
 	myrpt->keyed = 0;
 	myrpt->txkeyed = 0;
+	myrpt->keyupdelaytimer = 0;
+	myrpt->keyupinactivitytimer = myrpt->p.keyupdelay_inactivity_time;
 	time(&myrpt->lastkeyedtime);
 	myrpt->lastkeyedtime -= RPT_LOCKOUT_SECS;
 	time(&myrpt->lasttxkeyedtime);

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -810,8 +810,8 @@ struct rpt {
 		int totime;
 		int time_out_reset_unkey_interval;
 		int time_out_reset_kerchunk_interval;
-		int keyupdelay_time;
-		int keyupdelay_inactivity_time;
+		int first_keyup_min_time;
+		int first_keyup_inactivity_time;
 		int idtime;
 		int tailmessagetime;
 		int tailsquashedtime;
@@ -995,8 +995,8 @@ struct rpt {
 	rpt_bool mustid:1;
 	rpt_bool tailid:1;
 	int rptinacttimer;
-	int keyupdelaytimer;
-	int keyupinactivitytimer;
+	int first_keyup_timer;
+	int first_keyup_inactivity_timer;
 	int tailevent;
 	int dtmfidx, rem_dtmfidx;
 	int dailytxtime, dailykerchunks, totalkerchunks, dailykeyups, totalkeyups, timeouts;

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -810,6 +810,8 @@ struct rpt {
 		int totime;
 		int time_out_reset_unkey_interval;
 		int time_out_reset_kerchunk_interval;
+		int keyupdelay_time;
+		int keyupdelay_inactivity_time;
 		int idtime;
 		int tailmessagetime;
 		int tailsquashedtime;
@@ -993,6 +995,8 @@ struct rpt {
 	rpt_bool mustid:1;
 	rpt_bool tailid:1;
 	int rptinacttimer;
+	int keyupdelaytimer;
+	int keyupinactivitytimer;
 	int tailevent;
 	int dtmfidx, rem_dtmfidx;
 	int dailytxtime, dailykerchunks, totalkerchunks, dailykeyups, totalkeyups, timeouts;

--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -857,7 +857,8 @@ void load_rpt_vars(int n, int init)
 	RPT_CONFIG_VAR_INT_DEFAULT(simplexphonedelay, "simplexphonedelay", SIMPLEX_PHONE_DELAY);
 	RPT_CONFIG_VAR_INT_MIN_FLOOR(keyupdelay_time, "keyupdelay", 0, 0);
 	RPT_CONFIG_VAR_INT_MIN_FLOOR(keyupdelay_inactivity_time, "keyupdelay_inactivity", 0, 0);
-
+	/* Convert to milliseconds for internal use */
+	rpt_vars[n].p.keyupdelay_inactivity_time = rpt_vars[n].p.keyupdelay_inactivity_time * 1000;
 	/* configure how "L" messages are sent */
 	RPT_CONFIG_VAR_INT_DEFAULT_MIN_MAX(linkpost_max_message_len, "linkpost_max_message_len", 0, 0, 10000);
 	if (rpt_vars[n].p.linkpost_max_message_len && (rpt_vars[n].p.linkpost_max_message_len < 500)) {

--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -855,6 +855,8 @@ void load_rpt_vars(int n, int init)
 	RPT_CONFIG_VAR_INT_DEFAULT(voxrecover_ms, "voxrecover", VOX_RECOVER_MS);
 	RPT_CONFIG_VAR_INT_DEFAULT(simplexpatchdelay, "simplexpatchdelay", SIMPLEX_PATCH_DELAY);
 	RPT_CONFIG_VAR_INT_DEFAULT(simplexphonedelay, "simplexphonedelay", SIMPLEX_PHONE_DELAY);
+	RPT_CONFIG_VAR_INT_DEFAULT(keyupdelay_time, "keyupdelay", 0);
+	RPT_CONFIG_VAR_INT_DEFAULT(keyupdelay_inactivity_time, "keyupdelay_inactivity", 0);
 
 	/* configure how "L" messages are sent */
 	RPT_CONFIG_VAR_INT_DEFAULT_MIN_MAX(linkpost_max_message_len, "linkpost_max_message_len", 0, 0, 10000);

--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -855,8 +855,8 @@ void load_rpt_vars(int n, int init)
 	RPT_CONFIG_VAR_INT_DEFAULT(voxrecover_ms, "voxrecover", VOX_RECOVER_MS);
 	RPT_CONFIG_VAR_INT_DEFAULT(simplexpatchdelay, "simplexpatchdelay", SIMPLEX_PATCH_DELAY);
 	RPT_CONFIG_VAR_INT_DEFAULT(simplexphonedelay, "simplexphonedelay", SIMPLEX_PHONE_DELAY);
-	RPT_CONFIG_VAR_INT_DEFAULT(keyupdelay_time, "keyupdelay", 0);
-	RPT_CONFIG_VAR_INT_DEFAULT(keyupdelay_inactivity_time, "keyupdelay_inactivity", 0);
+	RPT_CONFIG_VAR_INT_MIN_FLOOR(keyupdelay_time, "keyupdelay", 0, 0);
+	RPT_CONFIG_VAR_INT_MIN_FLOOR(keyupdelay_inactivity_time, "keyupdelay_inactivity", 0, 0);
 
 	/* configure how "L" messages are sent */
 	RPT_CONFIG_VAR_INT_DEFAULT_MIN_MAX(linkpost_max_message_len, "linkpost_max_message_len", 0, 0, 10000);

--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -855,10 +855,10 @@ void load_rpt_vars(int n, int init)
 	RPT_CONFIG_VAR_INT_DEFAULT(voxrecover_ms, "voxrecover", VOX_RECOVER_MS);
 	RPT_CONFIG_VAR_INT_DEFAULT(simplexpatchdelay, "simplexpatchdelay", SIMPLEX_PATCH_DELAY);
 	RPT_CONFIG_VAR_INT_DEFAULT(simplexphonedelay, "simplexphonedelay", SIMPLEX_PHONE_DELAY);
-	RPT_CONFIG_VAR_INT_MIN_FLOOR(keyupdelay_time, "keyupdelay", 0, 0);
-	RPT_CONFIG_VAR_INT_MIN_FLOOR(keyupdelay_inactivity_time, "keyupdelay_inactivity", 0, 0);
+	RPT_CONFIG_VAR_INT_DEFAULT_MIN_MAX(first_keyup_min_time, "first_keyup_min_time", 0, 0, 1000);
+	RPT_CONFIG_VAR_INT_MIN_FLOOR(first_keyup_inactivity_time, "first_keyup_inactivity_time", 0, 0);
 	/* Convert to milliseconds for internal use */
-	rpt_vars[n].p.keyupdelay_inactivity_time = rpt_vars[n].p.keyupdelay_inactivity_time * 1000;
+	rpt_vars[n].p.first_keyup_inactivity_time = rpt_vars[n].p.first_keyup_inactivity_time * 1000;
 	/* configure how "L" messages are sent */
 	RPT_CONFIG_VAR_INT_DEFAULT_MIN_MAX(linkpost_max_message_len, "linkpost_max_message_len", 0, 0, 10000);
 	if (rpt_vars[n].p.linkpost_max_message_len && (rpt_vars[n].p.linkpost_max_message_len < 500)) {

--- a/configs/rpt/rpt.conf
+++ b/configs/rpt/rpt.conf
@@ -232,6 +232,10 @@ parrottime = 1000                   ; Set the amount of time in milliseconds
 ; reporting of key up/down changes.
 ;statpost_time = 60                 ; (optional) time (in seconds) (min 30, max 600, default 60)
 
+;keyupdelay = 0                    ; (optional) time in milliseconds to delay setting node keyed
+;                               ; after an RX key event when the node has been inactive.
+;keyupdelay_inactivity = 0         ; (optional) inactivity time in milliseconds before keyup delay applies
+
 ; *** Audio Archiving ***
 ;
 ; The following "archivedir" line can be used to enable a simple log and

--- a/configs/rpt/rpt.conf
+++ b/configs/rpt/rpt.conf
@@ -149,9 +149,19 @@ time_out_reset_unkey_interval = 0   ; The minimum time for no carrier detect aft
 time_out_reset_kerchunk_interval = 250 ; Allows users to reset the time out timer when there is a signal coming in from a link (optional).
 									; A value of 0 disables this feature. Valid only if time_time_out_reset_unkey_interval is non zero. 
 									; Value is in milliseconds. Default is 250ms, minimum is 0ms, maximum is 3000ms
-;keyupdelay_inactivity = 0          ; (optional) local keyup inactivity time in seconds before keyupdelay applies.
-;keyupdelay = 0                     ; (optional) time in milliseconds to delay keyup after a local RX key event. Applies only after 
-;                                   ;  the node has been inactive for keyupdelay_inactivity time.
+;first_keyup_min_time = 200         ; after a period of inactivity, the "first keyup"
+                                    ; time (in ms) that a local RX key event must be
+                                    ; present before the TX will be keyed. This setting
+                                    ; can be used to suppress short noise bursts or
+                                    ; quick keying (kerchunk'ing).
+                                    ; Optional, range 0..1000, default 0.
+
+;first_keyup_inactivity_time = 180  ; the time (in seconds) with no local RX activity
+                                    ; before the longer "first keyup" event is needed
+                                    ; for TX keying.  Longer intervals would allow
+                                    ; quick conversations, shorter intervals would
+                                    ; force key-wait-talk behavior.
+                                    ; Optional, default 0.
 
 idrecording = |iNOTSET              ; id recording or morse string
 ;idtalkover =                       ; Talkover ID (optional) default is none

--- a/configs/rpt/rpt.conf
+++ b/configs/rpt/rpt.conf
@@ -149,6 +149,10 @@ time_out_reset_unkey_interval = 0   ; The minimum time for no carrier detect aft
 time_out_reset_kerchunk_interval = 250 ; Allows users to reset the time out timer when there is a signal coming in from a link (optional).
 									; A value of 0 disables this feature. Valid only if time_time_out_reset_unkey_interval is non zero. 
 									; Value is in milliseconds. Default is 250ms, minimum is 0ms, maximum is 3000ms
+;keyupdelay_inactivity = 0          ; (optional) local keyup inactivity time in seconds before keyupdelay applies.
+;keyupdelay = 0                     ; (optional) time in milliseconds to delay keyup after a local RX key event. Applies only after 
+;                                   ;  the node has been inactive for keyupdelay_inactivity time.
+
 idrecording = |iNOTSET              ; id recording or morse string
 ;idtalkover =                       ; Talkover ID (optional) default is none
 idtime = 540000                     ; id interval time (in ms) (optional) Default 5 minutes (300000 ms)
@@ -231,10 +235,6 @@ parrottime = 1000                   ; Set the amount of time in milliseconds
 ; your nodes reports it's connected links.  This time does not affect the
 ; reporting of key up/down changes.
 ;statpost_time = 60                 ; (optional) time (in seconds) (min 30, max 600, default 60)
-
-;keyupdelay = 0                    ; (optional) time in milliseconds to delay setting node keyed
-;                               ; after an RX key event when the node has been inactive.
-;keyupdelay_inactivity = 0         ; (optional) inactivity time in milliseconds before keyup delay applies
 
 ; *** Audio Archiving ***
 ;


### PR DESCRIPTION
Add two new parameters:
keyupdelay_inactivity: time in ms of inactivity before keyupdelay becomes active.
keyupdelay: time in ms to wait for a "valid" keyup only after `keyupdelay_inactivity` has expired

This delay will prevent/remove/mute audio during the `keyupdelay` time.
Fixes #90 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “first keyup” timing controls to better manage when a repeater begins TX after initial RX key activity.
* **Configuration**
  * New `first_keyup_min_time` sets the minimum delay after inactivity before local RX key events trigger TX keying.
  * New `first_keyup_inactivity_time` sets the inactivity duration (seconds) before the extended “first keyup” behavior applies.
* **Improvements**
  * Key/unkey timing is now handled more consistently across multiple RX key-up sources, with improved timer resets during unkey events and thread startup initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->