### PR TITLE
app_rpt: Restore ability to flush telemetry when a channel is not allocated

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -337,6 +337,7 @@
 #include "app_rpt/rpt_xcat.h"
 #include "app_rpt/rpt_rig.h"
 #include "app_rpt/rpt_radio.h"
+#include "app_rpt/rpt_telemetry.h"
 
 /*** DOCUMENTATION
 	<application name="Rpt" language="en_US">
@@ -4970,12 +4971,7 @@ static void *rpt(void *this)
 
 	telem = myrpt->tele.next;
 	while (telem != &myrpt->tele) {
-		if (telem->chan) {
-			ast_softhangup(telem->chan, AST_SOFTHANGUP_DEV);
-		} else {
-			telem->killed = 1;
-		}
-
+		rpt_kill_telem(telem);
 		telem = telem->next;
 	}
 	rpt_mutex_unlock(&myrpt->lock);
@@ -5493,23 +5489,21 @@ static void *rpt(void *this)
 			telem = myrpt->tele.next;
 			while (telem != &myrpt->tele) {
 				if (telem->mode == ID && !telem->killed) {
-					telem->killed = 1;
+					rpt_kill_telem(telem);
 					hasid = 1;
-					if (telem->chan) {
-						ast_softhangup(telem->chan, AST_SOFTHANGUP_DEV); /* Whoosh! */
-					}
 				}
+
 				if (telem->mode == TAILMSG && !telem->killed) {
-					telem->killed = 1;
-					if (telem->chan) {
-						ast_softhangup(telem->chan, AST_SOFTHANGUP_DEV); /* Whoosh! */
-					}
+					rpt_kill_telem(telem);
 				}
+
 				if (telem->mode == IDTALKOVER) {
 					hastalkover = 1;
 				}
+
 				telem = telem->next;
 			}
+
 			if (hasid && !hastalkover) {
 				ast_debug(6, "Tracepoint IDTALKOVER\n");
 				rpt_mutex_unlock(&myrpt->lock);
@@ -7738,10 +7732,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 					telem = myrpt->tele.next;
 					while (telem != &myrpt->tele) {
 						if (telem->mode == ACT_TIMEOUT_WARNING && !telem->killed) {
-							if (telem->chan) {
-								ast_softhangup(telem->chan, AST_SOFTHANGUP_DEV); /* Whoosh! */
-							}
-							telem->killed = 1;
+							rpt_kill_telem(telem);
 						}
 						telem = telem->next;
 					}

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4970,7 +4970,12 @@ static void *rpt(void *this)
 
 	telem = myrpt->tele.next;
 	while (telem != &myrpt->tele) {
-		ast_softhangup(telem->chan, AST_SOFTHANGUP_DEV);
+		if (telem->chan) {
+			ast_softhangup(telem->chan, AST_SOFTHANGUP_DEV);
+		} else {
+			telem->killed = 1;
+		}
+
 		telem = telem->next;
 	}
 	rpt_mutex_unlock(&myrpt->lock);
@@ -7733,8 +7738,9 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 					telem = myrpt->tele.next;
 					while (telem != &myrpt->tele) {
 						if (telem->mode == ACT_TIMEOUT_WARNING && !telem->killed) {
-							if (telem->chan)
+							if (telem->chan) {
 								ast_softhangup(telem->chan, AST_SOFTHANGUP_DEV); /* Whoosh! */
+							}
 							telem->killed = 1;
 						}
 						telem = telem->next;

--- a/apps/app_rpt/rpt_cli.c
+++ b/apps/app_rpt/rpt_cli.c
@@ -966,10 +966,7 @@ static int rpt_do_page(int fd, int argc, const char *const *argv)
 			telem = myrpt->tele.next;
 			while (telem != &myrpt->tele) {
 				if (((telem->mode == ID) || (telem->mode == ID1) || (telem->mode == IDTALKOVER)) && (!telem->killed)) {
-					if (telem->chan) {
-						ast_softhangup(telem->chan, AST_SOFTHANGUP_DEV); /* Whoosh! */
-					}
-					telem->killed = 1;
+					rpt_kill_telem(telem);
 					myrpt->deferid = 1;
 				}
 

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -1169,10 +1169,7 @@ enum rpt_function_response function_status(struct rpt *myrpt, char *param, char 
 		telem = myrpt->tele.next;
 		while (telem != &myrpt->tele) {
 			if (((telem->mode == ID) || (telem->mode == ID1)) && (!telem->killed)) {
-				if (telem->chan) {
-					ast_softhangup(telem->chan, AST_SOFTHANGUP_DEV); /* Whoosh! */
-				}
-				telem->killed = 1;
+				rpt_kill_telem(telem);
 			}
 			telem = telem->next;
 		}
@@ -1204,10 +1201,7 @@ enum rpt_function_response function_status(struct rpt *myrpt, char *param, char 
 		telem = myrpt->tele.next;
 		while (telem != &myrpt->tele) {
 			if (((telem->mode == ID) || (telem->mode == ID1)) && (!telem->killed)) {
-				if (telem->chan) {
-					ast_softhangup(telem->chan, AST_SOFTHANGUP_DEV); /* Whoosh! */
-				}
-				telem->killed = 1;
+				rpt_kill_telem(telem);
 			}
 			telem = telem->next;
 		}
@@ -1956,10 +1950,7 @@ enum rpt_function_response function_cop(struct rpt *myrpt, char *param, char *di
 		k = 0;
 		while (telem != &myrpt->tele) {
 			if (((telem->mode == ID) || (telem->mode == ID1) || (telem->mode == IDTALKOVER)) && (!telem->killed)) {
-				if (telem->chan) {
-					ast_softhangup(telem->chan, AST_SOFTHANGUP_DEV); /* Whoosh! */
-				}
-				telem->killed = 1;
+				rpt_kill_telem(telem);
 				myrpt->deferid = 1;
 			}
 			telem = telem->next;

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -624,7 +624,7 @@ void flush_telem(struct rpt *myrpt)
 
 	while (telem != &myrpt->tele) {
 		if (telem->mode != SETREMOTE) {
-			if(telem->chan) {
+			if (telem->chan) {
 				ast_softhangup(telem->chan, AST_SOFTHANGUP_DEV);
 
 				if (myrpt->active_telem == telem) {
@@ -633,7 +633,7 @@ void flush_telem(struct rpt *myrpt)
 				}
 
 			} else {
-					telem->killed = 1;
+				telem->killed = 1;
 			}
 		}
 
@@ -659,7 +659,7 @@ void birdbath(struct rpt *myrpt)
 					/* If we are the active telemetry, we need to clean it up */
 					telem_done(myrpt, telem);
 				}
-	
+
 			} else {
 				telem->killed = 1;
 			}
@@ -1527,8 +1527,8 @@ void *rpt_tele_thread(void *this)
 
 	rpt_mutex_unlock(&myrpt->lock);
 
-	while (!mytele->killed && (mytele->mode != SETREMOTE) && (mytele->mode != UNKEY) && (mytele->mode != LINKUNKEY) && (mytele->mode != LOCUNKEY) &&
-		   (mytele->mode != COMPLETE) && (mytele->mode != REMGO) && (mytele->mode != REMCOMPLETE)) {
+	while (!mytele->killed && (mytele->mode != SETREMOTE) && (mytele->mode != UNKEY) && (mytele->mode != LINKUNKEY) &&
+		   (mytele->mode != LOCUNKEY) && (mytele->mode != COMPLETE) && (mytele->mode != REMGO) && (mytele->mode != REMCOMPLETE)) {
 		rpt_mutex_lock(&myrpt->lock);
 
 		if ((!myrpt->active_telem) && (myrpt->tele.prev == mytele)) {

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -623,12 +623,17 @@ void flush_telem(struct rpt *myrpt)
 	telem = myrpt->tele.next;
 
 	while (telem != &myrpt->tele) {
-		if (telem->mode != SETREMOTE && telem->chan) {
-			ast_softhangup(telem->chan, AST_SOFTHANGUP_DEV);
+		if (telem->mode != SETREMOTE) {
+			if(telem->chan) {
+				ast_softhangup(telem->chan, AST_SOFTHANGUP_DEV);
 
-			if (myrpt->active_telem == telem) {
-				/* If we are the active telemetry, we need to clean it up */
-				telem_done(myrpt, telem);
+				if (myrpt->active_telem == telem) {
+					/* If we are the active telemetry, we need to clean it up */
+					telem_done(myrpt, telem);
+				}
+
+			} else {
+					telem->killed = 1;
 			}
 		}
 
@@ -646,12 +651,17 @@ void birdbath(struct rpt *myrpt)
 	telem = myrpt->tele.next;
 
 	while (telem != &myrpt->tele) {
-		if (telem->mode == PARROT && telem->chan) {
-			ast_softhangup(telem->chan, AST_SOFTHANGUP_DEV);
+		if (telem->mode == PARROT) {
+			if (telem->chan) {
+				ast_softhangup(telem->chan, AST_SOFTHANGUP_DEV);
 
-			if (myrpt->active_telem == telem) {
-				/* If we are the active telemetry, we need to clean it up */
-				telem_done(myrpt, telem);
+				if (myrpt->active_telem == telem) {
+					/* If we are the active telemetry, we need to clean it up */
+					telem_done(myrpt, telem);
+				}
+	
+			} else {
+				telem->killed = 1;
 			}
 		}
 
@@ -674,15 +684,18 @@ void cancel_pfxtone(struct rpt *myrpt)
 
 	telem = myrpt->tele.next;
 	while (telem != &myrpt->tele) {
-		if (telem->mode == PFXTONE && telem->chan) {
-			ast_softhangup(telem->chan, AST_SOFTHANGUP_DEV);
-
-			if (myrpt->active_telem == telem) {
-				/* If we are the active telemetry, we need to clean it up */
-				telem_done(myrpt, telem);
+		if (telem->mode == PFXTONE) {
+			if (telem->chan) {
+				ast_softhangup(telem->chan, AST_SOFTHANGUP_DEV);
+				if (myrpt->active_telem == telem) {
+					/* If we are the active telemetry, we need to clean it up */
+					telem_done(myrpt, telem);
+				}
+			} else {
+				/* We don't have a channel yet */
+				telem->killed = 1;
 			}
 		}
-
 		telem = telem->next;
 	}
 
@@ -1514,7 +1527,7 @@ void *rpt_tele_thread(void *this)
 
 	rpt_mutex_unlock(&myrpt->lock);
 
-	while ((mytele->mode != SETREMOTE) && (mytele->mode != UNKEY) && (mytele->mode != LINKUNKEY) && (mytele->mode != LOCUNKEY) &&
+	while (!mytele->killed && (mytele->mode != SETREMOTE) && (mytele->mode != UNKEY) && (mytele->mode != LINKUNKEY) && (mytele->mode != LOCUNKEY) &&
 		   (mytele->mode != COMPLETE) && (mytele->mode != REMGO) && (mytele->mode != REMCOMPLETE)) {
 		rpt_mutex_lock(&myrpt->lock);
 
@@ -1529,6 +1542,10 @@ void *rpt_tele_thread(void *this)
 	}
 
 	ast_debug(5, "Beginning telemetry, active_telem = %p, mytele = %p\n", myrpt->active_telem, mytele);
+	if (mytele->killed) {
+		rpt_mutex_lock(&myrpt->lock);
+		goto abort;
+	}
 
 	cap = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
 	if (!cap) {

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -624,16 +624,10 @@ void flush_telem(struct rpt *myrpt)
 
 	while (telem != &myrpt->tele) {
 		if (telem->mode != SETREMOTE) {
-			if (telem->chan) {
-				ast_softhangup(telem->chan, AST_SOFTHANGUP_DEV);
-
-				if (myrpt->active_telem == telem) {
-					/* If we are the active telemetry, we need to clean it up */
-					telem_done(myrpt, telem);
-				}
-
-			} else {
-				telem->killed = 1;
+			rpt_kill_telem(telem);
+			if (myrpt->active_telem == telem) {
+				/* If we are the active telemetry, we need to clean it up */
+				telem_done(myrpt, telem);
 			}
 		}
 
@@ -652,16 +646,10 @@ void birdbath(struct rpt *myrpt)
 
 	while (telem != &myrpt->tele) {
 		if (telem->mode == PARROT) {
-			if (telem->chan) {
-				ast_softhangup(telem->chan, AST_SOFTHANGUP_DEV);
-
-				if (myrpt->active_telem == telem) {
-					/* If we are the active telemetry, we need to clean it up */
-					telem_done(myrpt, telem);
-				}
-
-			} else {
-				telem->killed = 1;
+			rpt_kill_telem(telem);
+			if (myrpt->active_telem == telem) {
+				/* If we are the active telemetry, we need to clean it up */
+				telem_done(myrpt, telem);
 			}
 		}
 
@@ -669,6 +657,15 @@ void birdbath(struct rpt *myrpt)
 	}
 
 	rpt_mutex_unlock(&myrpt->lock);
+}
+
+void rpt_kill_telem(struct rpt_tele *telem)
+{
+	if (telem->chan) {
+		ast_softhangup(telem->chan, AST_SOFTHANGUP_DEV); /* Whoosh! */
+	}
+
+	telem->killed = 1;
 }
 
 void cancel_pfxtone(struct rpt *myrpt)
@@ -685,15 +682,10 @@ void cancel_pfxtone(struct rpt *myrpt)
 	telem = myrpt->tele.next;
 	while (telem != &myrpt->tele) {
 		if (telem->mode == PFXTONE) {
-			if (telem->chan) {
-				ast_softhangup(telem->chan, AST_SOFTHANGUP_DEV);
-				if (myrpt->active_telem == telem) {
-					/* If we are the active telemetry, we need to clean it up */
-					telem_done(myrpt, telem);
-				}
-			} else {
-				/* We don't have a channel yet */
-				telem->killed = 1;
+			rpt_kill_telem(telem);
+			if (myrpt->active_telem == telem) {
+				/* If we are the active telemetry, we need to clean it up */
+				telem_done(myrpt, telem);
 			}
 		}
 		telem = telem->next;

--- a/apps/app_rpt/rpt_telemetry.h
+++ b/apps/app_rpt/rpt_telemetry.h
@@ -27,3 +27,9 @@ int rpt_init_telemetry(void);
  * \brief Unregister telemtery functions
  */
 int rpt_cleanup_telemetry(void);
+
+/*!
+ * \brief Kill a telemetry entry
+ * \param telem The telemetry entry to kill
+ */
+void rpt_kill_telem(struct rpt_tele *telem);


### PR DESCRIPTION
The refactored telemetry in PR #865 no longer allocates channels until the telemetry becomes active.  This broke the code which flushes telemetry for various reasons.
The "obvious" sign was PFXTONE not being canceled, specifically if one used `*xxx` in a startup macro.  
Multiple instances of 
```
[2026-06-15 13:50:40.104] DEBUG[220783] app_rpt/rpt_telemetry.c: cancel_pfxfone!!
[2026-06-15 13:50:40.204] DEBUG[220783] app_rpt/rpt_telemetry.c: cancel_pfxfone!!
[2026-06-15 13:50:40.305] DEBUG[220783] app_rpt/rpt_telemetry.c: cancel_pfxfone!!
``` 
Were logged yet the telemetry stayed on the list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

**Bug Fixes**
- Centralized telemetry termination so entries are consistently marked as stopped, even when they don’t have an associated communication channel.
- Updated the telemetry worker behavior to immediately stop processing killed entries, avoiding continued handling and unnecessary channel allocation.
- Improved cleanup paths across status, paging, and connected-node scenarios to use consistent, safer termination handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->