### PR TITLE
app_rpt: Prevent channel lock contention using `rpt_sendtext_cb()` rather than `sendtext_cb()`

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4932,17 +4932,6 @@ static inline void voxtostate_to_voxtotimer(struct rpt *myrpt)
 	}
 }
 
-static int sendtext_cb(void *obj, void *arg, int flags)
-{
-	struct rpt_link *link = obj;
-	const char *str = arg;
-
-	if (link->chan) {
-		ast_sendtext(link->chan, str);
-	}
-	return 0;
-}
-
 /* single thread with one file (request) to dial */
 static void *rpt(void *this)
 {
@@ -5239,7 +5228,7 @@ static void *rpt(void *this)
 			rpt_mutex_lock(&myrpt->lock);
 			myrpt->voteremrx = 0; /* no voter remotes keyed */
 			if (myrpt->links) {
-				ao2_callback(myrpt->links, OBJ_MULTIPLE | OBJ_NODATA, sendtext_cb, &tmpstr);
+				ao2_callback(myrpt->links, OBJ_MULTIPLE | OBJ_NODATA, rpt_sendtext_cb, &tmpstr);
 			}
 			rpt_mutex_unlock(&myrpt->lock);
 		}


### PR DESCRIPTION
Addressing this issue:
https://community.allstarlink.org/t/commands-not-working-suddenly-since-asl3-update/24688/3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated GPS text broadcast handling to improve code organization and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->