### PR TITLE
app_rpt: incorrect re-use of static buffer in `ctime_no_newline()`

### DIFF
--- a/apps/app_rpt/rpt_manager.c
+++ b/apps/app_rpt/rpt_manager.c
@@ -18,14 +18,21 @@
 
 extern struct rpt rpt_vars[MAXRPTS];
 
-static char *ctime_no_newline(const time_t *clock)
+static char *ctime_no_newline(const time_t *clock, char *buf, size_t size)
 {
-	static char buf[32];
 	char *cp;
 	size_t len;
 
+	if (!clock || !buf || size == 0) {
+		return NULL;
+	}
+
 	cp = ctime_r(clock, buf);
-	len = strnlen(buf, sizeof(buf));
+	if (!cp) {
+		return NULL;
+	}
+
+	len = strnlen(buf, size);
 	if ((len > 0) && (buf[--len] == '\n')) {
 		buf[len] = '\0';
 	}
@@ -35,14 +42,18 @@ static char *ctime_no_newline(const time_t *clock)
 
 void rpt_manager_trigger(struct rpt *myrpt, char *event, char *value)
 {
+	char lastkeybuf[32] = "", lasttxkeybuf[32] = "";
+
+	ctime_no_newline(&myrpt->lastkeyedtime, lastkeybuf, sizeof(lastkeybuf));
+	ctime_no_newline(&myrpt->lasttxkeyedtime, lasttxkeybuf, sizeof(lasttxkeybuf));
+
 	manager_event(EVENT_FLAG_CALL, event,
 		"Node: %s\r\n"
 		"Channel: %s\r\n"
 		"EventValue: %s\r\n"
 		"LastKeyedTime: %s\r\n"
 		"LastTxKeyedTime: %s\r\n",
-		myrpt->name, ast_channel_name(myrpt->rxchannel), value, ctime_no_newline(&myrpt->lastkeyedtime),
-		ctime_no_newline(&myrpt->lasttxkeyedtime));
+		myrpt->name, ast_channel_name(myrpt->rxchannel), value, lastkeybuf, lasttxkeybuf);
 }
 
 /*!\brief callback to display list of locally configured nodes

--- a/apps/app_rpt/rpt_manager.c
+++ b/apps/app_rpt/rpt_manager.c
@@ -23,7 +23,7 @@ static char *ctime_no_newline(const time_t *clock, char *buf, size_t size)
 	char *cp;
 	size_t len;
 
-	if (!clock || !buf || size == 0) {
+	if (!clock || !buf || size < 27) {
 		return NULL;
 	}
 


### PR DESCRIPTION
`manager_event()` was passed the same pointer for both rx and tx times.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved timestamp formatting by switching to caller-provided buffers, adding input validation, and ensuring safer string-length handling.
* **Bug Fixes**
  * Reduced reliance on shared static buffers by formatting each timestamp separately before emitting event details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->