### PR TITLE
app_rpt: invalid `rpt_extnodes` file should not be a crasher

### DIFF
--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -536,9 +536,8 @@ int node_lookup(struct rpt *myrpt, char *digitbuf, char *nodedata, size_t nodeda
 			}
 
 			ourcfg = ast_config_load(myrpt->p.extnodefiles[i], config_flags);
-
-			/* if file is not there, try the next one */
-			if (!ourcfg) {
+			if (!ourcfg || (ourcfg == CONFIG_STATUS_FILEINVALID)) {
+				/* if file is not present or not valid, try the next one */
 				continue;
 			}
 


### PR DESCRIPTION
This change prevents asterisk from crashing if the `/var/lib/asterisk/rpt_extnodes` file is not properly formatted (e.g. no `[extnodes]` category)