### PR TITLE
app_rpt: Protect rxchannel calls causing core dump at shutdown

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2593,7 +2593,7 @@ static void local_dtmf_helper(struct rpt *myrpt, char c_in)
 	}
 
 	chan = ast_channel_ref(myrpt->rxchannel);
-	rpt_manager_trigger(myrpt, "DTMF", tone);
+	rpt_manager_trigger(myrpt, chan, "DTMF", tone);
 	ast_channel_unref(chan);
 	donodelog_fmt(myrpt, "DTMF,MAIN,%c", c);
 	if (c == myrpt->p.endchar) {

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -7896,6 +7896,8 @@ static int stop_repeaters(void)
 
 	for (i = 0; i < nrpts; i++) {
 		struct rpt *myrpt = &rpt_vars[i];
+		struct ast_channel *chan = NULL;
+
 		if (!myrpt) {
 			ast_debug(1, "No RPT at index %d?\n", i);
 			continue;
@@ -7907,16 +7909,22 @@ static int stop_repeaters(void)
 		rpt_mutex_lock(&myrpt->lock);
 
 		if (myrpt->rxchannel) {
-			ast_verb(4, "Hanging up channel %s\n", ast_channel_name(myrpt->rxchannel));
-			ast_channel_lock(myrpt->rxchannel);
-			ast_softhangup(myrpt->rxchannel, AST_SOFTHANGUP_EXPLICIT); /* Hanging up one channel will signal the thread to abort */
-			ast_channel_unlock(myrpt->rxchannel);
+			chan = ast_channel_ref(myrpt->rxchannel);
 			myrpt->rxchannel = NULL; /* If we aborted the repeater but haven't unloaded, this channel handle is not valid anymore
 										in a future call to stop_repeaters() */
 		}
 
 		rpt_mutex_unlock(&myrpt->lock);
+
+		if (chan) {
+			ast_verb(4, "Hanging up channel %s\n", ast_channel_name(chan));
+			ast_channel_lock(chan);
+			ast_softhangup(chan, AST_SOFTHANGUP_EXPLICIT); /* Hanging up one channel will signal the thread to abort */
+			ast_channel_unlock(chan);
+			ast_channel_unref(chan);
+		}
 	}
+
 	return 0;
 }
 

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2592,7 +2592,13 @@ static void local_dtmf_helper(struct rpt *myrpt, char c_in)
 		return;
 	}
 
+	rpt_mutex_lock(&myrpt->lock);
 	chan = ast_channel_ref(myrpt->rxchannel);
+	rpt_mutex_unlock(&myrpt->lock);
+	if (!chan) {
+		return;
+	}
+
 	rpt_manager_trigger(myrpt, chan, "DTMF", tone);
 	ast_channel_unref(chan);
 	donodelog_fmt(myrpt, "DTMF,MAIN,%c", c);

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -757,7 +757,7 @@ void __attribute__((format(gnu_printf, 5, 6))) __donodelog_fmt(struct rpt *myrpt
 }
 
 /*! \brief Routine to process events for rpt_master threads */
-void rpt_event_process(struct rpt *myrpt)
+void rpt_event_process(struct rpt *myrpt, struct ast_channel *chan)
 {
 	char *myval, *argv[5], *cmpvar, *var, *var1, *cmd, c;
 	char buf[1000], valbuf[500], action;
@@ -789,6 +789,7 @@ void rpt_event_process(struct rpt *myrpt)
 		/* start indicating no command to do */
 		cmd = NULL;
 		c = toupper(*argv[1]);
+
 		if (c == 'E') { /* if to merely evaluate the statement */
 			if (!strncasecmp(v->name, "RPT", 3)) {
 				ast_log(LOG_ERROR, "%s is not a valid name for an event variable!!!!\n", v->name);
@@ -799,19 +800,19 @@ void rpt_event_process(struct rpt *myrpt)
 				continue;
 			}
 			/* see if this var exists yet */
-			myval = (char *) pbx_builtin_getvar_helper(myrpt->rxchannel, v->name);
+			myval = (char *) pbx_builtin_getvar_helper(chan, v->name);
 			/* if not, set it to zero, in case of the value being self-referenced */
 			if (!myval) {
-				pbx_builtin_setvar_helper(myrpt->rxchannel, v->name, "0");
+				pbx_builtin_setvar_helper(chan, v->name, "0");
 			}
 			snprintf(valbuf, sizeof(valbuf), "$[ %s ]", argv[2]);
 			buf[0] = 0;
-			pbx_substitute_variables_helper(myrpt->rxchannel, valbuf, buf, sizeof(buf) - 1);
+			pbx_substitute_variables_helper(chan, valbuf, buf, sizeof(buf) - 1);
 			if (pbx_checkcondition(buf)) {
 				cmd = "TRUE";
 			}
 		} else {
-			var = (char *) pbx_builtin_getvar_helper(myrpt->rxchannel, argv[2]);
+			var = (char *) pbx_builtin_getvar_helper(chan, argv[2]);
 			if (!var) {
 				ast_log(LOG_ERROR, "Event variable %s not found\n", argv[2]);
 				continue;
@@ -822,7 +823,7 @@ void rpt_event_process(struct rpt *myrpt)
 				if (ast_asprintf(&cmpvar, "XX_%s", argv[2]) < 0) {
 					return;
 				}
-				var1 = (char *) pbx_builtin_getvar_helper(myrpt->rxchannel, cmpvar);
+				var1 = (char *) pbx_builtin_getvar_helper(chan, cmpvar);
 				var1p = !varp; /* start with it being opposite */
 				if (var1) {
 					/* set to 1 if var is true */
@@ -859,7 +860,7 @@ void rpt_event_process(struct rpt *myrpt)
 			}
 		}
 		if (action == 'V') { /* set a variable */
-			pbx_builtin_setvar_helper(myrpt->rxchannel, v->name, cmd ? "1" : "0");
+			pbx_builtin_setvar_helper(chan, v->name, cmd ? "1" : "0");
 			continue;
 		} else if (action == 'G') { /* set a global variable */
 			pbx_builtin_setvar_helper(NULL, v->name, cmd ? "1" : "0");
@@ -934,7 +935,7 @@ void rpt_event_process(struct rpt *myrpt)
 		if (c == 'E') {
 			continue;
 		}
-		var = (char *) pbx_builtin_getvar_helper(myrpt->rxchannel, argv[2]);
+		var = (char *) pbx_builtin_getvar_helper(chan, argv[2]);
 		if (!var) {
 			continue;
 		}
@@ -943,8 +944,8 @@ void rpt_event_process(struct rpt *myrpt)
 		if (ast_asprintf(&cmpvar, "XX_%s", argv[2]) < 0) {
 			return;
 		}
-		var1 = (char *) pbx_builtin_getvar_helper(myrpt->rxchannel, cmpvar);
-		pbx_builtin_setvar_helper(myrpt->rxchannel, cmpvar, var);
+		var1 = (char *) pbx_builtin_getvar_helper(chan, cmpvar);
+		pbx_builtin_setvar_helper(chan, cmpvar, var);
 		ast_free(cmpvar);
 	}
 	if (option_verbose < 5) {
@@ -952,12 +953,12 @@ void rpt_event_process(struct rpt *myrpt)
 	}
 	i = 0;
 	ast_debug(2, "Node Variable dump for node %s:\n", myrpt->name);
-	ast_channel_lock(myrpt->rxchannel);
-	AST_LIST_TRAVERSE(ast_channel_varshead(myrpt->rxchannel), newvariable, entries) {
+	ast_channel_lock(chan);
+	AST_LIST_TRAVERSE(ast_channel_varshead(chan), newvariable, entries) {
 		i++;
 		ast_debug(2, "   %s=%s\n", ast_var_name(newvariable), ast_var_value(newvariable));
 	}
-	ast_channel_unlock(myrpt->rxchannel);
+	ast_channel_unlock(chan);
 	ast_debug(2, "    -- %d variables\n", i);
 }
 

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2588,11 +2588,12 @@ static void local_dtmf_helper(struct rpt *myrpt, char c_in)
 
 	snprintf(tone, sizeof(tone), "%c", c);
 
+	rpt_mutex_lock(&myrpt->lock);
 	if (!myrpt->rxchannel) {
+		rpt_mutex_unlock(&myrpt->lock);
 		return;
 	}
 
-	rpt_mutex_lock(&myrpt->lock);
 	chan = ast_channel_ref(myrpt->rxchannel);
 	rpt_mutex_unlock(&myrpt->lock);
 	if (!chan) {

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2582,12 +2582,19 @@ static void local_dtmf_helper(struct rpt *myrpt, char c_in)
 {
 	enum rpt_function_response res;
 	char cmd[MAXDTMF + 1] = "", c, tone[10];
+	struct ast_channel *chan;
 
 	c = c_in & 0x7f;
 
 	snprintf(tone, sizeof(tone), "%c", c);
-	rpt_manager_trigger(myrpt, "DTMF", tone);
 
+	if (!myrpt->rxchannel) {
+		return;
+	}
+
+	chan = ast_channel_ref(myrpt->rxchannel);
+	rpt_manager_trigger(myrpt, "DTMF", tone);
+	ast_channel_unref(chan);
 	donodelog_fmt(myrpt, "DTMF,MAIN,%c", c);
 	if (c == myrpt->p.endchar) {
 		/* if in simple mode, kill autopatch */

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -788,8 +788,8 @@ void rpt_event_process(struct rpt *myrpt, struct ast_channel *chan)
 		}
 		/* start indicating no command to do */
 		cmd = NULL;
-		c = toupper(*argv[1]);
 
+		c = toupper(*argv[1]);
 		if (c == 'E') { /* if to merely evaluate the statement */
 			if (!strncasecmp(v->name, "RPT", 3)) {
 				ast_log(LOG_ERROR, "%s is not a valid name for an event variable!!!!\n", v->name);
@@ -2603,6 +2603,7 @@ static void local_dtmf_helper(struct rpt *myrpt, char c_in)
 
 	rpt_manager_trigger(myrpt, chan, "DTMF", tone);
 	ast_channel_unref(chan);
+
 	donodelog_fmt(myrpt, "DTMF,MAIN,%c", c);
 	if (c == myrpt->p.endchar) {
 		/* if in simple mode, kill autopatch */

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -7904,6 +7904,8 @@ static int stop_repeaters(void)
 			continue;
 		}
 		ast_verb(3, "Hanging up repeater %s\n", rpt_vars[i].name);
+		rpt_mutex_lock(&myrpt->lock);
+
 		if (myrpt->rxchannel) {
 			ast_verb(4, "Hanging up channel %s\n", ast_channel_name(myrpt->rxchannel));
 			ast_channel_lock(myrpt->rxchannel);
@@ -7912,6 +7914,8 @@ static int stop_repeaters(void)
 			myrpt->rxchannel = NULL; /* If we aborted the repeater but haven't unloaded, this channel handle is not valid anymore
 										in a future call to stop_repeaters() */
 		}
+
+		rpt_mutex_unlock(&myrpt->lock);
 	}
 	return 0;
 }

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -1164,10 +1164,10 @@ void __donodelog_fmt(struct rpt *myrpt, const char *file, int lineno, const char
  * \brief Process RPT events for a repeater using a caller-owned channel reference.
  *
  * \param myrpt Non-NULL reference to the repeater structure.
- * \param chan Non-NULL channel reference that remains valid for the duration of this call.
+ * \param chan  Non-NULL channel reference that remains valid for the duration of this call.
  */
 void rpt_event_process(struct rpt *myrpt, struct ast_channel *chan);
-void rpt_event_process(struct rpt *myrpt, struct ast_channel *chan);
+
 void *rpt_call(void *this);
 
 /*!

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -1160,7 +1160,7 @@ void donodelog(struct rpt *myrpt, char *str);
 #define donodelog_fmt(myrpt, fmt, ...) __donodelog_fmt(myrpt, __FILE__, __LINE__, __FUNCTION__, fmt, __VA_ARGS__)
 void __donodelog_fmt(struct rpt *myrpt, const char *file, int lineno, const char *func, const char *fmt, ...);
 
-void rpt_event_process(struct rpt *myrpt);
+void rpt_event_process(struct rpt *myrpt, struct ast_channel *chan);
 void *rpt_call(void *this);
 
 /*!

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -1160,6 +1160,13 @@ void donodelog(struct rpt *myrpt, char *str);
 #define donodelog_fmt(myrpt, fmt, ...) __donodelog_fmt(myrpt, __FILE__, __LINE__, __FUNCTION__, fmt, __VA_ARGS__)
 void __donodelog_fmt(struct rpt *myrpt, const char *file, int lineno, const char *func, const char *fmt, ...);
 
+/*!
+ * \brief Process RPT events for a repeater using a caller-owned channel reference.
+ *
+ * \param myrpt Non-NULL reference to the repeater structure.
+ * \param chan Non-NULL channel reference that remains valid for the duration of this call.
+ */
+void rpt_event_process(struct rpt *myrpt, struct ast_channel *chan);
 void rpt_event_process(struct rpt *myrpt, struct ast_channel *chan);
 void *rpt_call(void *this);
 

--- a/apps/app_rpt/rpt_bridging.c
+++ b/apps/app_rpt/rpt_bridging.c
@@ -123,6 +123,7 @@ void rpt_hangup(struct rpt *myrpt, enum rpt_chan_type chantype)
 
 	if (!*chanptr) {
 		ast_log(LOG_WARNING, "No %s channel to hang up\n", rpt_chan_type_str(chantype));
+		rpt_mutex_unlock(&myrpt->lock);
 		return;
 	}
 

--- a/apps/app_rpt/rpt_bridging.c
+++ b/apps/app_rpt/rpt_bridging.c
@@ -118,9 +118,10 @@ static struct ast_channel **rpt_chan_channel(struct rpt *myrpt, struct rpt_link 
 
 void rpt_hangup(struct rpt *myrpt, enum rpt_chan_type chantype)
 {
-	struct ast_channel **chanptr = rpt_chan_channel(myrpt, NULL, chantype);
-	rpt_mutex_lock(&myrpt->lock);
+	struct ast_channel **chanptr;
 
+	rpt_mutex_lock(&myrpt->lock);
+	chanptr = rpt_chan_channel(myrpt, NULL, chantype);
 	if (!*chanptr) {
 		ast_log(LOG_WARNING, "No %s channel to hang up\n", rpt_chan_type_str(chantype));
 		rpt_mutex_unlock(&myrpt->lock);

--- a/apps/app_rpt/rpt_bridging.c
+++ b/apps/app_rpt/rpt_bridging.c
@@ -38,6 +38,7 @@
 
 #include "rpt_bridging.h"
 #include "rpt_call.h"
+#include "rpt_lock.h"
 
 /*!
  *	\brief used to display "words" in debug messages.

--- a/apps/app_rpt/rpt_bridging.c
+++ b/apps/app_rpt/rpt_bridging.c
@@ -118,6 +118,7 @@ static struct ast_channel **rpt_chan_channel(struct rpt *myrpt, struct rpt_link 
 void rpt_hangup(struct rpt *myrpt, enum rpt_chan_type chantype)
 {
 	struct ast_channel **chanptr = rpt_chan_channel(myrpt, NULL, chantype);
+	rpt_mutex_lock(&myrpt->lock);
 
 	if (!*chanptr) {
 		ast_log(LOG_WARNING, "No %s channel to hang up\n", rpt_chan_type_str(chantype));
@@ -150,6 +151,7 @@ void rpt_hangup(struct rpt *myrpt, enum rpt_chan_type chantype)
 	ast_debug(2, "Hanging up channel %s\n", ast_channel_name(*chanptr));
 	ast_hangup(*chanptr);
 	*chanptr = NULL;
+	rpt_mutex_unlock(&myrpt->lock);
 }
 
 static const char *rpt_chan_app(enum rpt_chan_type chantype, enum rpt_chan_flags flags)

--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -1367,7 +1367,13 @@ void rpt_update_boolean(struct rpt *myrpt, char *varname, int newval)
 		return;
 	}
 
+	rpt_mutex_lock(&myrpt->lock);
 	chan = ast_channel_ref(myrpt->rxchannel);
+	rpt_mutex_unlock(&myrpt->lock);
+	if (!chan) {
+		return;
+	}
+
 	pbx_builtin_setvar_helper(chan, varname, buf);
 	rpt_manager_trigger(myrpt, chan, varname, buf);
 	if (newval >= 0) {

--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -1350,6 +1350,7 @@ int rpt_push_alt_macro(struct rpt *myrpt, char *sptr)
 
 void rpt_update_boolean(struct rpt *myrpt, char *varname, int newval)
 {
+	struct ast_channel *chan;
 	char buf[2];
 
 	if (!varname || !*varname) {
@@ -1362,11 +1363,17 @@ void rpt_update_boolean(struct rpt *myrpt, char *varname, int newval)
 		buf[0] = '1';
 	}
 
-	pbx_builtin_setvar_helper(myrpt->rxchannel, varname, buf);
+	if (!myrpt->rxchannel) {
+		return;
+	}
+
+	chan = ast_channel_ref(myrpt->rxchannel);
+	pbx_builtin_setvar_helper(chan, varname, buf);
 	rpt_manager_trigger(myrpt, varname, buf);
 	if (newval >= 0) {
 		rpt_event_process(myrpt);
 	}
+	ast_channel_unref(chan);
 }
 
 int rpt_is_valid_dns_name(const char *dns_name)

--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -1378,7 +1378,7 @@ void rpt_update_boolean(struct rpt *myrpt, char *varname, int newval)
 	pbx_builtin_setvar_helper(chan, varname, buf);
 	rpt_manager_trigger(myrpt, chan, varname, buf);
 	if (newval >= 0) {
-		rpt_event_process(myrpt);
+		rpt_event_process(myrpt, chan);
 	}
 	ast_channel_unref(chan);
 }

--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -1369,7 +1369,7 @@ void rpt_update_boolean(struct rpt *myrpt, char *varname, int newval)
 
 	chan = ast_channel_ref(myrpt->rxchannel);
 	pbx_builtin_setvar_helper(chan, varname, buf);
-	rpt_manager_trigger(myrpt, varname, buf);
+	rpt_manager_trigger(myrpt, chan, varname, buf);
 	if (newval >= 0) {
 		rpt_event_process(myrpt);
 	}

--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -1363,11 +1363,12 @@ void rpt_update_boolean(struct rpt *myrpt, char *varname, int newval)
 		buf[0] = '1';
 	}
 
+	rpt_mutex_lock(&myrpt->lock);
 	if (!myrpt->rxchannel) {
+		rpt_mutex_unlock(&myrpt->lock);
 		return;
 	}
 
-	rpt_mutex_lock(&myrpt->lock);
 	chan = ast_channel_ref(myrpt->rxchannel);
 	rpt_mutex_unlock(&myrpt->lock);
 	if (!chan) {

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -653,7 +653,6 @@ void rpt_update_links(struct rpt *myrpt)
 
 	rpt_mutex_lock(&myrpt->lock);
 	n = __mklinklist(myrpt, NULL, &buf, USE_FORMAT_RPT_ALINK);
-	rpt_mutex_unlock(&myrpt->lock);
 	/* parse em */
 	if (n) {
 		ast_str_set(&obuf, 0, "%d,%s", n, ast_str_buffer(buf));
@@ -666,6 +665,13 @@ void rpt_update_links(struct rpt *myrpt)
 	}
 
 	chan = ast_channel_ref(myrpt->rxchannel);
+	rpt_mutex_unlock(&myrpt->lock);
+	if (!chan) {
+		ast_free(buf);
+		ast_free(obuf);
+		return;
+	}
+
 	pbx_builtin_setvar_helper(chan, "RPT_ALINKS", ast_str_buffer(obuf));
 	rpt_manager_trigger(myrpt, chan, "RPT_ALINKS", ast_str_buffer(obuf));
 	ast_str_set(&obuf, 0, "%d", n);

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -661,6 +661,7 @@ void rpt_update_links(struct rpt *myrpt)
 	if (!myrpt->rxchannel) {
 		ast_free(buf);
 		ast_free(obuf);
+		rpt_mutex_unlock(&myrpt->lock);
 		return;
 	}
 

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -638,6 +638,7 @@ void __kickshort(struct rpt *myrpt)
 void rpt_update_links(struct rpt *myrpt)
 {
 	struct ast_str *buf, *obuf;
+	struct ast_channel *chan;
 	int n;
 
 	buf = ast_str_create(RPT_AST_STR_INIT_SIZE);
@@ -657,12 +658,19 @@ void rpt_update_links(struct rpt *myrpt)
 	if (n) {
 		ast_str_set(&obuf, 0, "%d,%s", n, ast_str_buffer(buf));
 	}
-	pbx_builtin_setvar_helper(myrpt->rxchannel, "RPT_ALINKS", ast_str_buffer(obuf));
+
+	if (!myrpt->rxchannel) {
+		ast_free(buf);
+		ast_free(obuf);
+		return;
+	}
+
+	chan = ast_channel_ref(myrpt->rxchannel);
+	pbx_builtin_setvar_helper(chan, "RPT_ALINKS", ast_str_buffer(obuf));
 	rpt_manager_trigger(myrpt, "RPT_ALINKS", ast_str_buffer(obuf));
 	ast_str_set(&obuf, 0, "%d", n);
-	pbx_builtin_setvar_helper(myrpt->rxchannel, "RPT_NUMALINKS", ast_str_buffer(obuf));
+	pbx_builtin_setvar_helper(chan, "RPT_NUMALINKS", ast_str_buffer(obuf));
 	rpt_manager_trigger(myrpt, "RPT_NUMALINKS", ast_str_buffer(obuf));
-
 	ast_str_reset(buf);
 	rpt_mutex_lock(&myrpt->lock);
 	n = __mklinklist(myrpt, NULL, &buf, USE_FORMAT_RPT_LINK);
@@ -670,12 +678,13 @@ void rpt_update_links(struct rpt *myrpt)
 	if (n) {
 		ast_str_set(&obuf, 0, "%d,%s", n, ast_str_buffer(buf));
 	}
-	pbx_builtin_setvar_helper(myrpt->rxchannel, "RPT_LINKS", ast_str_buffer(obuf));
+	pbx_builtin_setvar_helper(chan, "RPT_LINKS", ast_str_buffer(obuf));
 	rpt_manager_trigger(myrpt, "RPT_LINKS", ast_str_buffer(obuf));
 	ast_str_set(&obuf, 0, "%d", n);
-	pbx_builtin_setvar_helper(myrpt->rxchannel, "RPT_NUMLINKS", ast_str_buffer(obuf));
+	pbx_builtin_setvar_helper(chan, "RPT_NUMLINKS", ast_str_buffer(obuf));
 	rpt_manager_trigger(myrpt, "RPT_NUMLINKS", ast_str_buffer(obuf));
 	rpt_event_process(myrpt);
+	ast_channel_unref(chan);
 
 	ast_free(buf);
 	ast_free(obuf);

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -690,7 +690,7 @@ void rpt_update_links(struct rpt *myrpt)
 	ast_str_set(&obuf, 0, "%d", n);
 	pbx_builtin_setvar_helper(chan, "RPT_NUMLINKS", ast_str_buffer(obuf));
 	rpt_manager_trigger(myrpt, chan, "RPT_NUMLINKS", ast_str_buffer(obuf));
-	rpt_event_process(myrpt);
+	rpt_event_process(myrpt, chan);
 	ast_channel_unref(chan);
 
 	ast_free(buf);

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -667,10 +667,10 @@ void rpt_update_links(struct rpt *myrpt)
 
 	chan = ast_channel_ref(myrpt->rxchannel);
 	pbx_builtin_setvar_helper(chan, "RPT_ALINKS", ast_str_buffer(obuf));
-	rpt_manager_trigger(myrpt, "RPT_ALINKS", ast_str_buffer(obuf));
+	rpt_manager_trigger(myrpt, chan, "RPT_ALINKS", ast_str_buffer(obuf));
 	ast_str_set(&obuf, 0, "%d", n);
 	pbx_builtin_setvar_helper(chan, "RPT_NUMALINKS", ast_str_buffer(obuf));
-	rpt_manager_trigger(myrpt, "RPT_NUMALINKS", ast_str_buffer(obuf));
+	rpt_manager_trigger(myrpt, chan, "RPT_NUMALINKS", ast_str_buffer(obuf));
 	ast_str_reset(buf);
 	rpt_mutex_lock(&myrpt->lock);
 	n = __mklinklist(myrpt, NULL, &buf, USE_FORMAT_RPT_LINK);
@@ -679,10 +679,10 @@ void rpt_update_links(struct rpt *myrpt)
 		ast_str_set(&obuf, 0, "%d,%s", n, ast_str_buffer(buf));
 	}
 	pbx_builtin_setvar_helper(chan, "RPT_LINKS", ast_str_buffer(obuf));
-	rpt_manager_trigger(myrpt, "RPT_LINKS", ast_str_buffer(obuf));
+	rpt_manager_trigger(myrpt, chan, "RPT_LINKS", ast_str_buffer(obuf));
 	ast_str_set(&obuf, 0, "%d", n);
 	pbx_builtin_setvar_helper(chan, "RPT_NUMLINKS", ast_str_buffer(obuf));
-	rpt_manager_trigger(myrpt, "RPT_NUMLINKS", ast_str_buffer(obuf));
+	rpt_manager_trigger(myrpt, chan, "RPT_NUMLINKS", ast_str_buffer(obuf));
 	rpt_event_process(myrpt);
 	ast_channel_unref(chan);
 

--- a/apps/app_rpt/rpt_manager.c
+++ b/apps/app_rpt/rpt_manager.c
@@ -40,7 +40,7 @@ static char *ctime_no_newline(const time_t *clock, char *buf, size_t size)
 	return cp;
 }
 
-void rpt_manager_trigger(struct rpt *myrpt, char *event, char *value)
+void rpt_manager_trigger(struct rpt *myrpt, struct ast_channel *chan, char *event, char *value)
 {
 	char lastkeybuf[32] = "", lasttxkeybuf[32] = "";
 
@@ -53,7 +53,7 @@ void rpt_manager_trigger(struct rpt *myrpt, char *event, char *value)
 		"EventValue: %s\r\n"
 		"LastKeyedTime: %s\r\n"
 		"LastTxKeyedTime: %s\r\n",
-		myrpt->name, ast_channel_name(myrpt->rxchannel), value, lastkeybuf, lasttxkeybuf);
+		myrpt->name, ast_channel_name(chan), value, lastkeybuf, lasttxkeybuf);
 }
 
 /*!\brief callback to display list of locally configured nodes

--- a/apps/app_rpt/rpt_manager.h
+++ b/apps/app_rpt/rpt_manager.h
@@ -1,5 +1,5 @@
 
-void rpt_manager_trigger(struct rpt *myrpt, char *event, char *value);
+void rpt_manager_trigger(struct rpt *myrpt, struct ast_channel *chan, char *event, char *value);
 
 int rpt_manager_load(void);
 int rpt_manager_unload(void);

--- a/apps/app_rpt/rpt_mdc1200.c
+++ b/apps/app_rpt/rpt_mdc1200.c
@@ -82,7 +82,7 @@ void mdc1200_notify(struct rpt *myrpt, char *fromnode, char *data)
 	}
 
 	chan = ast_channel_ref(myrpt->rxchannel);
-	rpt_manager_trigger(myrpt, "MDC-1200", data);
+	rpt_manager_trigger(myrpt, chan, "MDC-1200", data);
 	ast_channel_unref(chan);
 
 	if (!fromnode) {

--- a/apps/app_rpt/rpt_mdc1200.c
+++ b/apps/app_rpt/rpt_mdc1200.c
@@ -77,11 +77,18 @@ void mdc1200_notify(struct rpt *myrpt, char *fromnode, char *data)
 	time_t t;
 	struct ast_channel *chan;
 
+	rpt_mutex_lock(&myrpt->lock);
 	if (!myrpt->rxchannel) {
+		rpt_mutex_unlock(&myrpt->lock);
 		return;
 	}
 
 	chan = ast_channel_ref(myrpt->rxchannel);
+	rpt_mutex_unlock(&myrpt->lock);
+	if (!chan) {
+		return;
+	}
+
 	rpt_manager_trigger(myrpt, chan, "MDC-1200", data);
 	ast_channel_unref(chan);
 

--- a/apps/app_rpt/rpt_mdc1200.c
+++ b/apps/app_rpt/rpt_mdc1200.c
@@ -75,8 +75,15 @@ void mdc1200_notify(struct rpt *myrpt, char *fromnode, char *data)
 	char str[50];
 	struct flock fl;
 	time_t t;
+	struct ast_channel *chan;
 
+	if (!myrpt->rxchannel) {
+		return;
+	}
+
+	chan = ast_channel_ref(myrpt->rxchannel);
 	rpt_manager_trigger(myrpt, "MDC-1200", data);
+	ast_channel_unref(chan);
 
 	if (!fromnode) {
 		ast_verb(4, "Got MDC-1200 data %s from local system (%s)\n", data, myrpt->name);


### PR DESCRIPTION
Resolves coredump / segfault during shutdown / restart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved DTMF handling and related updates by safely handling missing channel context, using stable channel references, and ensuring manager events are triggered only when valid.  
* Strengthened link updates and repeater notifications so they cope with absent/changing channel state, preventing inconsistent manager event data and improving resource lifetime handling.  
* Updated manager event dispatch to consistently use explicit channel context, ensuring the “Channel” field is reliably populated across repeaters (including MDC1200 and other triggers).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->