### PR TITLE
Revert "app_rpt: Allow status ilink,5 to bypass telemmode"

### DIFF
--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -3534,7 +3534,7 @@ void rpt_telemetry(struct rpt *myrpt, enum rpt_tele_mode mode, void *data)
 		break;
 
 	case VARCMD:
-		if (myrpt->telemmode < 2 && strncasecmp((char *) data, "STATUS,", 7)) {
+		if (myrpt->telemmode < 2) {
 			return;
 		}
 


### PR DESCRIPTION
Reverts AllStarLink/app_rpt#985
Fixes #1065 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected telemetry handling logic to consistently apply the same conditions to all command types, including status commands that previously had special exemptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->