### PR TITLE
app_rpt: refactor: replace unsafe string functions with snprintf() or ast_copy_string()

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -1407,7 +1407,7 @@ void *rpt_call(void *this)
 	 */
 
 	if (myrpt->patchexten[0]) {
-		strcpy(myrpt->exten, myrpt->patchexten);
+		snprintf(myrpt->exten, sizeof(myrpt->exten), "%s", myrpt->patchexten);
 		myrpt->callmode = CALLMODE_CONNECTING;
 	}
 	while ((myrpt->callmode == CALLMODE_DIALING) || (myrpt->callmode == CALLMODE_FAILED)) {
@@ -2035,7 +2035,7 @@ static void handle_link_data(struct rpt *myrpt, struct rpt_link *mylink, char *s
 			return;
 		}
 		if (dest[0] == '0') {
-			strcpy(dest, myrpt->name);
+			snprintf(dest, sizeof(dest), "%s", myrpt->name);
 		}
 		/* if not for me, redistribute to all links */
 		if (strcmp(dest, myrpt->name)) {
@@ -2109,7 +2109,7 @@ static void handle_link_data(struct rpt *myrpt, struct rpt_link *mylink, char *s
 		}
 	}
 	if (dest[0] == '0') {
-		strcpy(dest, myrpt->name);
+		snprintf(dest, sizeof(dest), "%s", myrpt->name);
 	}
 
 	/* if not for me, redistribute to all links */
@@ -4208,7 +4208,7 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 			time(&myrpt->lastkeyedtime);
 			myrpt->keypost = RPT_KEYPOST_ACTIVE;
 			myrpt->lastdtmfuser[0] = 0;
-			strcpy(myrpt->lastdtmfuser, myrpt->curdtmfuser);
+			snprintf(myrpt->lastdtmfuser, sizeof(myrpt->lastdtmfuser), "%s", myrpt->curdtmfuser);
 			myrpt->curdtmfuser[0] = 0;
 			if (myrpt->monstream && (myrpt->p.duplex < 2)) {
 				ast_closestream(myrpt->monstream);
@@ -5242,7 +5242,8 @@ static void *rpt(void *this)
 				if (l->voterlink)
 					myrpt->voteremrx = 1;
 				if ((l->name[0] > '0') && (l->name[0] <= '9'))		/* Ignore '0' nodes */
-					strcpy(myrpt->lastnodewhichkeyedusup, l->name); /* Note the node which is doing the key up */
+					snprintf(myrpt->lastnodewhichkeyedusup, sizeof(myrpt->lastnodewhichkeyedusup), "%s",
+						l->name); /* Note the node which is doing the key up */
 			}
 		}
 		ao2_iterator_destroy(&l_it);
@@ -6749,7 +6750,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 			if (!strcmp(myadr, s2)) { /* if we have it.. */
 				char tmp2[512];
 
-				strcpy(tmp2, tmp);
+				snprintf(tmp2, sizeof(tmp2), "%s", tmp);
 				if (options && callstr)
 					snprintf(tmp2, sizeof(tmp2), "0%s%s", callstr, tmp);
 				mypfx = ast_variable_retrieve(cfg, "proxy", "nodeprefix");

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -1407,7 +1407,7 @@ void *rpt_call(void *this)
 	 */
 
 	if (myrpt->patchexten[0]) {
-		snprintf(myrpt->exten, sizeof(myrpt->exten), "%s", myrpt->patchexten);
+		ast_copy_string(myrpt->exten, myrpt->patchexten, sizeof(myrpt->exten));
 		myrpt->callmode = CALLMODE_CONNECTING;
 	}
 	while ((myrpt->callmode == CALLMODE_DIALING) || (myrpt->callmode == CALLMODE_FAILED)) {
@@ -2035,7 +2035,7 @@ static void handle_link_data(struct rpt *myrpt, struct rpt_link *mylink, char *s
 			return;
 		}
 		if (dest[0] == '0') {
-			snprintf(dest, sizeof(dest), "%s", myrpt->name);
+			ast_copy_string(dest, myrpt->name, sizeof(dest));
 		}
 		/* if not for me, redistribute to all links */
 		if (strcmp(dest, myrpt->name)) {
@@ -2109,7 +2109,7 @@ static void handle_link_data(struct rpt *myrpt, struct rpt_link *mylink, char *s
 		}
 	}
 	if (dest[0] == '0') {
-		snprintf(dest, sizeof(dest), "%s", myrpt->name);
+		ast_copy_string(dest, myrpt->name, sizeof(dest));
 	}
 
 	/* if not for me, redistribute to all links */
@@ -4208,7 +4208,7 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 			time(&myrpt->lastkeyedtime);
 			myrpt->keypost = RPT_KEYPOST_ACTIVE;
 			myrpt->lastdtmfuser[0] = 0;
-			snprintf(myrpt->lastdtmfuser, sizeof(myrpt->lastdtmfuser), "%s", myrpt->curdtmfuser);
+			ast_copy_string(myrpt->lastdtmfuser, myrpt->curdtmfuser, sizeof(myrpt->lastdtmfuser));
 			myrpt->curdtmfuser[0] = 0;
 			if (myrpt->monstream && (myrpt->p.duplex < 2)) {
 				ast_closestream(myrpt->monstream);
@@ -5242,8 +5242,7 @@ static void *rpt(void *this)
 				if (l->voterlink)
 					myrpt->voteremrx = 1;
 				if ((l->name[0] > '0') && (l->name[0] <= '9'))		/* Ignore '0' nodes */
-					snprintf(myrpt->lastnodewhichkeyedusup, sizeof(myrpt->lastnodewhichkeyedusup), "%s",
-						l->name); /* Note the node which is doing the key up */
+					ast_copy_string(myrpt->lastnodewhichkeyedusup, l->name, sizeof(myrpt->lastnodewhichkeyedusup));
 			}
 		}
 		ao2_iterator_destroy(&l_it);
@@ -6750,7 +6749,7 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 			if (!strcmp(myadr, s2)) { /* if we have it.. */
 				char tmp2[512];
 
-				snprintf(tmp2, sizeof(tmp2), "%s", tmp);
+				ast_copy_string(tmp2, tmp, sizeof(tmp2));
 				if (options && callstr)
 					snprintf(tmp2, sizeof(tmp2), "0%s%s", callstr, tmp);
 				mypfx = ast_variable_retrieve(cfg, "proxy", "nodeprefix");

--- a/apps/app_rpt/rpt_channel.c
+++ b/apps/app_rpt/rpt_channel.c
@@ -164,7 +164,7 @@ int saynode(struct rpt *myrpt, struct ast_channel *mychannel, char *name)
 	if (myrpt->p.eannmode < 2) {
 		return res;
 	}
-	sprintf(str, "%d", atoi(name + 1));
+	snprintf(str, sizeof(str), "%d", atoi(name + 1));
 	if (elink_query_callsign(str, fname, sizeof(fname))) {
 		return res;
 	}

--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -480,7 +480,7 @@ int node_lookup(struct rpt *myrpt, char *digitbuf, char *nodedata, size_t nodeda
 	val = ast_variable_retrieve(myrpt->cfg, myrpt->p.nodes, digitbuf);
 	if (val) {
 		if (nodedata && nodedatalength) {
-			snprintf(nodedata, nodedatalength, "%s", val);
+			ast_copy_string(nodedata, val, nodedatalength);
 			ast_debug(4, "Resolved by internal: node %s to %s\n", digitbuf, nodedata);
 		}
 		return 0;
@@ -490,7 +490,7 @@ int node_lookup(struct rpt *myrpt, char *digitbuf, char *nodedata, size_t nodeda
 		while (vp) {
 			if (ast_extension_match(vp->name, digitbuf)) {
 				if (nodedata && nodedatalength) {
-					snprintf(nodedata, nodedatalength, "%s", vp->value);
+					ast_copy_string(nodedata, vp->value, nodedatalength);
 					ast_debug(4, "Resolved by internal/wild: node %s to %s\n", digitbuf, nodedata);
 				}
 				return 0;

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -159,7 +159,7 @@ enum rpt_function_response function_ilink(struct rpt *myrpt, char *param, char *
 			break;
 		}
 		if ((digitbuf[0] == '0') && (myrpt->lastlinknode[0])) {
-			strcpy(digitbuf, myrpt->lastlinknode);
+			snprintf(digitbuf, sizeof(digitbuf), "%s", myrpt->lastlinknode);
 		}
 
 		rpt_mutex_lock(&myrpt->lock);
@@ -336,7 +336,7 @@ enum rpt_function_response function_ilink(struct rpt *myrpt, char *param, char *
 			}
 
 			/* Make a string of disconnected nodes for possible restoration */
-			sprintf(tmp, "%c%c%.290s", c1, (l->perma) ? 'P' : 'T', l->name);
+			snprintf(tmp, sizeof(tmp), "%c%c%.290s", c1, (l->perma) ? 'P' : 'T', l->name);
 			if (strlen(tmp) + strlen(myrpt->savednodes) + 1 < MAXNODESTR) {
 				if (myrpt->savednodes[0])
 					strcat(myrpt->savednodes, ",");
@@ -1901,10 +1901,10 @@ enum rpt_function_response function_cop(struct rpt *myrpt, char *param, char *di
 		/* go thru all the specs */
 		for (i = 1; i < argc; i++) {
 			if (sscanf(argv[i], "%*[Gg]%*[Pp]%*[Ii]%*[oO]" N_FMT(d) "%*[=:]" N_FMT(d), &j, &k) == 2) {
-				sprintf(string, "GPIO %d %d", j, k);
+				snprintf(string, sizeof(string), "GPIO %d %d", j, k);
 				ast_sendtext(myrpt->rxchannel, string);
 			} else if (sscanf(argv[i], "%*2[pP]" N_FMT(d) "=" N_FMT(d), &j, &k) == 2) {
-				sprintf(string, "PP %d %d", j, k);
+				snprintf(string, sizeof(string), "PP %d %d", j, k);
 				ast_sendtext(myrpt->rxchannel, string);
 			} else {
 				ast_log(LOG_WARNING, "Invalid command COP %s, %s", argv[0], argv[i]);
@@ -1941,9 +1941,9 @@ enum rpt_function_response function_cop(struct rpt *myrpt, char *param, char *di
 			break;
 		}
 		if (argc > 5) {
-			sprintf(string, "PAGE %s %s %s %s %s", argv[1], argv[2], argv[3], argv[4], argv[5]);
+			snprintf(string, sizeof(string), "PAGE %s %s %s %s %s", argv[1], argv[2], argv[3], argv[4], argv[5]);
 		} else {
-			sprintf(string, "PAGE %s %s %s", argv[1], argv[2], argv[3]);
+			snprintf(string, sizeof(string), "PAGE %s %s %s", argv[1], argv[2], argv[3]);
 		}
 		rpt_mutex_lock(&myrpt->lock);
 		telem = myrpt->tele.next;

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -159,7 +159,7 @@ enum rpt_function_response function_ilink(struct rpt *myrpt, char *param, char *
 			break;
 		}
 		if ((digitbuf[0] == '0') && (myrpt->lastlinknode[0])) {
-			snprintf(digitbuf, sizeof(digitbuf), "%s", myrpt->lastlinknode);
+			ast_copy_string(digitbuf, myrpt->lastlinknode, sizeof(digitbuf));
 		}
 
 		rpt_mutex_lock(&myrpt->lock);

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -1933,6 +1933,7 @@ enum rpt_function_response function_cop(struct rpt *myrpt, char *param, char *di
 		}
 		return DC_COMPLETE;
 	case 65: /* send POCSAG page */
+	{
 		int written;
 
 		if (argc < 3) {
@@ -1968,6 +1969,7 @@ enum rpt_function_response function_cop(struct rpt *myrpt, char *param, char *di
 		gettimeofday(&myrpt->paging, NULL);
 		ast_sendtext(myrpt->rxchannel, string);
 		return DC_COMPLETE;
+	}
 	}
 	return DC_INDETERMINATE;
 }

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -293,7 +293,7 @@ enum rpt_function_response function_ilink(struct rpt *myrpt, char *param, char *
 			return DC_ERROR;
 		}
 		rpt_mutex_lock(&myrpt->lock);
-		strcpy(myrpt->lastlinknode, digitbuf);
+		ast_copy_string(myrpt->lastlinknode, digitbuf, sizeof(myrpt->lastlinknode));
 		ast_copy_string(myrpt->cmdnode, digitbuf, sizeof(myrpt->cmdnode));
 		rpt_mutex_unlock(&myrpt->lock);
 		rpt_telem_select(myrpt, command_source, mylink);

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -1933,6 +1933,8 @@ enum rpt_function_response function_cop(struct rpt *myrpt, char *param, char *di
 		}
 		return DC_COMPLETE;
 	case 65: /* send POCSAG page */
+		int written;
+
 		if (argc < 3) {
 			break;
 		}
@@ -1940,11 +1942,18 @@ enum rpt_function_response function_cop(struct rpt *myrpt, char *param, char *di
 			/* ignore if not a USB channel */
 			break;
 		}
+
 		if (argc > 5) {
-			snprintf(string, sizeof(string), "PAGE %s %s %s %s %s", argv[1], argv[2], argv[3], argv[4], argv[5]);
+			written = snprintf(string, sizeof(string), "PAGE %s %s %s %s %s", argv[1], argv[2], argv[3], argv[4], argv[5]);
 		} else {
-			snprintf(string, sizeof(string), "PAGE %s %s %s", argv[1], argv[2], argv[3]);
+			written = snprintf(string, sizeof(string), "PAGE %s %s %s", argv[1], argv[2], argv[3]);
 		}
+
+		if (written < 0 || written >= sizeof(string)) {
+			ast_log(LOG_WARNING, "app_rpt: POCSAG PAGE message too long, command rejected\n");
+			return DC_ERROR;
+		}
+
 		rpt_mutex_lock(&myrpt->lock);
 		telem = myrpt->tele.next;
 		k = 0;

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -290,7 +290,7 @@ void rssi_send(struct rpt *myrpt)
 	};
 	char str[200];
 
-	sprintf(str, "R %i", myrpt->rxrssi);
+	snprintf(str, sizeof(str), "R %i", myrpt->rxrssi);
 	wf.datalen = strlen(str) + 1;
 	wf.data.ptr = str;
 	/* otherwise, send it to all of em */
@@ -718,7 +718,7 @@ void *rpt_link_connect(void *data)
 		if (!strchr(s1, ':') && strchr(s1, '/') && strncasecmp(s1, "local/", 6) && strncasecmp(s1, "echolink/", 9)) {
 			sy = strchr(s1, '/');
 			*sy = 0;
-			sprintf(sx, "%s:4569/%s", s1, sy + 1);
+			snprintf(sx, sizeof(sx), "%s:4569/%s", s1, sy + 1);
 			s1 = sx;
 		}
 		strsep(&s, ",");

--- a/apps/app_rpt/rpt_mdc1200.c
+++ b/apps/app_rpt/rpt_mdc1200.c
@@ -124,7 +124,7 @@ void mdc1200_send(struct rpt *myrpt, char *data)
 		return;
 	}
 
-	sprintf(str, "I %s %s", myrpt->name, data);
+	snprintf(str, sizeof(str), "I %s %s", myrpt->name, data);
 	wf.data.ptr = str;
 	wf.datalen = strlen(str) + 1; /* Isuani, 20141001 */
 

--- a/apps/app_rpt/rpt_rig.c
+++ b/apps/app_rpt/rpt_rig.c
@@ -2472,8 +2472,9 @@ int setrem(struct rpt *myrpt)
 				strcat(myfreq, "0");
 			}
 			snprintf(str, sizeof(str), "J Remote Frequency\n%s FM\n%s Offset\n", (cp) ? myfreq : myrpt->freq, offsets[(int) myrpt->offset]);
-			snprintf(str + strlen(str), sizeof(str) - strlen(str), "%s Power\nTX PL %s\nRX PL %s\n",
-				powerlevels[(int) myrpt->powerlevel], (myrpt->txplon) ? myrpt->txpl : "Off", (myrpt->rxplon) ? myrpt->rxpl : "Off");
+			i = strlen(str);
+			snprintf(str + i, sizeof(str) - i, "%s Power\nTX PL %s\nRX PL %s\n", powerlevels[(int) myrpt->powerlevel],
+				(myrpt->txplon) ? myrpt->txpl : "Off", (myrpt->rxplon) ? myrpt->rxpl : "Off");
 		} else {
 			snprintf(str, sizeof(str), "J Remote Frequency %s %s\n%s Power\n", myrpt->freq, modes[(int) myrpt->remmode],
 				powerlevels[(int) myrpt->powerlevel]);

--- a/apps/app_rpt/rpt_rig.c
+++ b/apps/app_rpt/rpt_rig.c
@@ -489,7 +489,7 @@ int setkenwood(struct rpt *myrpt)
 		}
 	}
 
-	sprintf(offset, "%06d000", mysplit);
+	snprintf(offset, sizeof(offset), "%06d000", mysplit);
 	strcpy(freq, "000000");
 	ast_copy_string(freq, decimals, strlen(freq) - 1);
 
@@ -503,18 +503,18 @@ int setkenwood(struct rpt *myrpt)
 		step = 1;
 	}
 
-	sprintf(txstr, "VW %c,%05d%s,%d,%d,0,%d,%d,,%02d,,%02d,%s\r", band, atoi(mhz), freq, step, offsets[(int) myrpt->offset],
-		(myrpt->txplon != 0), myrxpl, kenwood_pltocode(myrpt->txpl), kenwood_pltocode(myrpt->rxpl), offset);
+	snprintf(txstr, sizeof(txstr), "VW %c,%05d%s,%d,%d,0,%d,%d,,%02d,,%02d,%s\r", band, atoi(mhz), freq, step,
+		offsets[(int) myrpt->offset], (myrpt->txplon != 0), myrxpl, kenwood_pltocode(myrpt->txpl), kenwood_pltocode(myrpt->rxpl), offset);
 	if (sendrxkenwood(myrpt, txstr, rxstr, "VW") < 0) {
 		return -1;
 	}
 
-	sprintf(txstr, "RBN %c\r", band2);
+	snprintf(txstr, sizeof(txstr), "RBN %c\r", band2);
 	if (sendrxkenwood(myrpt, txstr, rxstr, "RBN") < 0) {
 		return -1;
 	}
 
-	sprintf(txstr, "PC %c,%d\r", band1, powers[(int) myrpt->powerlevel]);
+	snprintf(txstr, sizeof(txstr), "PC %c,%d\r", band1, powers[(int) myrpt->powerlevel]);
 	if (sendrxkenwood(myrpt, txstr, rxstr, "PC") < 0) {
 		return -1;
 	}
@@ -551,7 +551,7 @@ int set_tmd700(struct rpt *myrpt)
 		}
 	}
 
-	sprintf(offset, "%06d000", mysplit);
+	snprintf(offset, sizeof(offset), "%06d000", mysplit);
 	strcpy(freq, "000000");
 	ast_copy_string(freq, decimals, strlen(freq) - 1);
 
@@ -565,8 +565,8 @@ int set_tmd700(struct rpt *myrpt)
 		myrxpl = 0;
 	}
 
-	sprintf(txstr, "VW %d,%05d%s,%d,%d,0,%d,%d,0,%02d,0010,%02d,%s,0\r", band, atoi(mhz), freq, step, offsets[(int) myrpt->offset],
-		(myrpt->txplon != 0), myrxpl, kenwood_pltocode(myrpt->txpl), kenwood_pltocode(myrpt->rxpl), offset);
+	snprintf(txstr, sizeof(txstr), "VW %d,%05d%s,%d,%d,0,%d,%d,0,%02d,0010,%02d,%s,0\r", band, atoi(mhz), freq, step,
+		offsets[(int) myrpt->offset], (myrpt->txplon != 0), myrxpl, kenwood_pltocode(myrpt->txpl), kenwood_pltocode(myrpt->rxpl), offset);
 	if (sendrxkenwood(myrpt, txstr, rxstr, "VW") < 0) {
 		return -1;
 	}
@@ -575,19 +575,19 @@ int set_tmd700(struct rpt *myrpt)
 		return -1;
 	}
 
-	sprintf(txstr, "RBN\r");
+	snprintf(txstr, sizeof(txstr), "RBN\r");
 	if (sendrxkenwood(myrpt, txstr, rxstr, "RBN") < 0) {
 		return -1;
 	}
 
-	sprintf(txstr, "RBN %d\r", band);
+	snprintf(txstr, sizeof(txstr), "RBN %d\r", band);
 	if (strncmp(rxstr, txstr, 5)) {
 		if (sendrxkenwood(myrpt, txstr, rxstr, "RBN") < 0) {
 			return -1;
 		}
 	}
 
-	sprintf(txstr, "PC 0,%d\r", powers[(int) myrpt->powerlevel]);
+	snprintf(txstr, sizeof(txstr), "PC 0,%d\r", powers[(int) myrpt->powerlevel]);
 	if (sendrxkenwood(myrpt, txstr, rxstr, "PC") < 0) {
 		return -1;
 	}
@@ -619,8 +619,8 @@ int set_tm271(struct rpt *myrpt)
 		step = 1;
 	}
 
-	sprintf(txstr, "VF %04d%s,%d,%d,0,%d,0,0,%02d,00,000,%05d000,0,0\r", atoi(mhz), freq, step, offsets[(int) myrpt->offset],
-		(myrpt->txplon != 0), tm271_pltocode(myrpt->txpl), mysplit);
+	snprintf(txstr, sizeof(txstr), "VF %04d%s,%d,%d,0,%d,0,0,%02d,00,000,%05d000,0,0\r", atoi(mhz), freq, step,
+		offsets[(int) myrpt->offset], (myrpt->txplon != 0), tm271_pltocode(myrpt->txpl), mysplit);
 	if (sendrxkenwood(myrpt, "VM 0\r", rxstr, "VM") < 0) {
 		return -1;
 	}
@@ -629,7 +629,7 @@ int set_tm271(struct rpt *myrpt)
 		return -1;
 	}
 
-	sprintf(txstr, "PC %d\r", powers[(int) myrpt->powerlevel]);
+	snprintf(txstr, sizeof(txstr), "PC %d\r", powers[(int) myrpt->powerlevel]);
 	if (sendrxkenwood(myrpt, txstr, rxstr, "PC") < 0) {
 		return -1;
 	}
@@ -1595,7 +1595,7 @@ static int set_freq_ft950(struct rpt *myrpt, char *newfreq)
 	m = atoi(mhz);
 	d = atoi(decimals);
 
-	sprintf(cmdstr, "FA%d%06d;", m, d * 10);
+	snprintf(cmdstr, sizeof(cmdstr), "FA%d%06d;", m, d * 10);
 	return serial_remote_io(myrpt, (unsigned char *) cmdstr, strlen(cmdstr), NULL, 0, 0);
 }
 
@@ -1686,7 +1686,7 @@ static int set_ctcss_freq_ft950(struct rpt *myrpt, char *txtone, char *rxtone)
 		return -1;
 	}
 
-	sprintf(cmdstr, "CN0%02d;", c);
+	snprintf(cmdstr, sizeof(cmdstr), "CN0%02d;", c);
 
 	return serial_remote_io(myrpt, (unsigned char *) cmdstr, strlen(cmdstr), NULL, 0, 0);
 }
@@ -2471,11 +2471,12 @@ int setrem(struct rpt *myrpt)
 			if (myfreq[0] && (myfreq[strlen(myfreq) - 1] == '.')) {
 				strcat(myfreq, "0");
 			}
-			sprintf(str, "J Remote Frequency\n%s FM\n%s Offset\n", (cp) ? myfreq : myrpt->freq, offsets[(int) myrpt->offset]);
-			sprintf(str + strlen(str), "%s Power\nTX PL %s\nRX PL %s\n", powerlevels[(int) myrpt->powerlevel],
-				(myrpt->txplon) ? myrpt->txpl : "Off", (myrpt->rxplon) ? myrpt->rxpl : "Off");
+			snprintf(str, sizeof(str), "J Remote Frequency\n%s FM\n%s Offset\n", (cp) ? myfreq : myrpt->freq, offsets[(int) myrpt->offset]);
+			snprintf(str + strlen(str), sizeof(str) - strlen(str), "%s Power\nTX PL %s\nRX PL %s\n",
+				powerlevels[(int) myrpt->powerlevel], (myrpt->txplon) ? myrpt->txpl : "Off", (myrpt->rxplon) ? myrpt->rxpl : "Off");
 		} else {
-			sprintf(str, "J Remote Frequency %s %s\n%s Power\n", myrpt->freq, modes[(int) myrpt->remmode], powerlevels[(int) myrpt->powerlevel]);
+			snprintf(str, sizeof(str), "J Remote Frequency %s %s\n%s Power\n", myrpt->freq, modes[(int) myrpt->remmode],
+				powerlevels[(int) myrpt->powerlevel]);
 		}
 
 		ast_sendtext(myrpt->remote_webtransceiver, str);
@@ -2801,7 +2802,7 @@ int channel_steer(struct rpt *myrpt, char *data)
 		myrpt->nowchan = strtod(data, NULL);
 		if (!strcmp(myrpt->remoterig, REMOTE_RIG_PPP16)) {
 			char string[16];
-			sprintf(string, "SETCHAN %d ", myrpt->nowchan);
+			snprintf(string, sizeof(string), "SETCHAN %d ", myrpt->nowchan);
 			send_usb_txt(myrpt, string);
 		} else {
 			if (get_mem_set(myrpt, data)) {
@@ -2826,7 +2827,7 @@ int channel_revert(struct rpt *myrpt)
 	if (myrpt->nowchan != myrpt->waschan) {
 		char data[8];
 		ast_debug(1, "reverting.\n");
-		sprintf(data, "%02d", myrpt->waschan);
+		snprintf(data, sizeof(data), "%02d", myrpt->waschan);
 		myrpt->nowchan = myrpt->waschan;
 		channel_steer(myrpt, data);
 		res = 1;

--- a/apps/app_rpt/rpt_rig.c
+++ b/apps/app_rpt/rpt_rig.c
@@ -2460,7 +2460,7 @@ int setrem(struct rpt *myrpt)
 	if (myrpt->remote && myrpt->remote_webtransceiver) {
 		if (myrpt->remmode == REM_MODE_FM) {
 			char myfreq[MAXREMSTR], *cp;
-			strcpy(myfreq, myrpt->freq);
+			ast_copy_string(myfreq, myrpt->freq, sizeof(myfreq));
 			cp = strchr(myfreq, '.');
 			for (i = strlen(myfreq) - 1; i >= 0; i--) {
 				if (myfreq[i] != '0') {

--- a/apps/app_rpt/rpt_serial.c
+++ b/apps/app_rpt/rpt_serial.c
@@ -773,7 +773,7 @@ int setrtx(struct rpt *myrpt)
 	}
 
 	if (!res) {
-		sprintf(rigstr, "SETFREQ %s %f %s %s %c", myrpt->freq, txfreq, (myrpt->rxplon) ? myrpt->rxpl : "0.0",
+		snprintf(rigstr, sizeof(rigstr), "SETFREQ %s %f %s %s %c", myrpt->freq, txfreq, (myrpt->rxplon) ? myrpt->rxpl : "0.0",
 			(myrpt->txplon) ? myrpt->txpl : "0.0", pwr);
 		send_usb_txt(myrpt, rigstr);
 		rpt_telemetry(myrpt, COMPLETE, NULL);
@@ -823,9 +823,10 @@ int setxpmr(struct rpt *myrpt, int dotx)
 			return -1;
 		}
 
-		sprintf(rigstr, "SETFREQ 0.0 0.0 %s %s L", (myrpt->rxplon) ? myrpt->rxpl : "0.0", (myrpt->txplon) ? myrpt->txpl : "0.0");
+		snprintf(rigstr, sizeof(rigstr), "SETFREQ 0.0 0.0 %s %s L", (myrpt->rxplon) ? myrpt->rxpl : "0.0",
+			(myrpt->txplon) ? myrpt->txpl : "0.0");
 	} else {
-		sprintf(rigstr, "SETFREQ 0.0 0.0 %s 0.0 L", (myrpt->rxplon) ? myrpt->rxpl : "0.0");
+		snprintf(rigstr, sizeof(rigstr), "SETFREQ 0.0 0.0 %s 0.0 L", (myrpt->rxplon) ? myrpt->rxpl : "0.0");
 	}
 
 	send_usb_txt(myrpt, rigstr);

--- a/apps/app_rpt/rpt_serial.c
+++ b/apps/app_rpt/rpt_serial.c
@@ -517,7 +517,7 @@ int serial_remote_io(struct rpt *myrpt, unsigned char *txbuf, int txbytes, unsig
 			j = serial_rxready(myrpt->iofd, 1000);
 			if (j < 1) {
 #ifdef FAKE_SERIAL_RESPONSE
-				strcpy((char *) rxbuf, (char *) txbuf);
+				ast_copy_string((char *) rxbuf, (char *) txbuf, rxmaxbytes);
 				return (strlen((char *) rxbuf));
 #else
 				ast_log(LOG_WARNING, "%d Serial device not responding on node %s\n", j, myrpt->name);

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -4082,7 +4082,7 @@ static void *el_reader(void *data)
 										}
 									}
 									if (x < MAXPENDING) { /* we found one */
-										strcpy(instp->pending[x].fromip, node_lookup.ip);
+										ast_copy_string(instp->pending[x].fromip, node_lookup.ip, sizeof(instp->pending[x].fromip));
 										instp->pending[x].reqtime = ast_tvnow();
 										time(&now);
 										if (instp->starttime < (now - EL_APRS_START_DELAY)) {

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -1385,7 +1385,7 @@ static int el_call(struct ast_channel *chan, const char *dest, int timeout)
 	ast_debug(1, "Calling %s/%s on %s.\n", dest, ipaddr, ast_channel_name(chan));
 
 	/* make the call */
-	snprintf(node_lookup.ip, sizeof(node_lookup.ip), "%s", ipaddr);
+	ast_copy_string(node_lookup.ip, ipaddr, sizeof(node_lookup.ip));
 	if (do_new_call(instp, p, "OUTBOUND", "OUTBOUND", &node_lookup) != 0) {
 		ast_log(LOG_WARNING, "Failed to initialize outbound call state for %s/%s.\n", dest, ipaddr);
 		return -1;
@@ -1517,7 +1517,7 @@ static int el_hangup(struct ast_channel *chan)
 	time_t now;
 
 	ast_debug(1, "Sent bye to IP address %s.\n", p->ip);
-	snprintf(node_lookup.ip, sizeof(node_lookup.ip), "%s", p->ip);
+	ast_copy_string(node_lookup.ip, p->ip, sizeof(node_lookup.ip));
 	find_delete(&node_lookup, instp);
 	n = rtcp_make_bye(bye, sizeof(bye), "disconnected");
 
@@ -2548,7 +2548,7 @@ static int el_xwrite(struct ast_channel *chan, struct ast_frame *frame)
 	if (p->txindex >= BLOCKING_FACTOR) {
 		struct el_node node_lookup;
 
-		snprintf(node_lookup.ip, sizeof(node_lookup.ip), "%s", p->ip);
+		ast_copy_string(node_lookup.ip, p->ip, sizeof(node_lookup.ip));
 		ast_mutex_lock(&el_nodelist_lock);
 		twalk_r(el_node_list, send_audio_only_one, &node_lookup);
 		ast_mutex_unlock(&el_nodelist_lock);
@@ -3665,7 +3665,7 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *p, const char *
 		ast_mutex_lock(&instp->lock);
 		time(&now);
 		if (p != NULL) {
-			snprintf(instp->lastcall, sizeof(instp->lastcall), "%s", mynode->callsign);
+			ast_copy_string(instp->lastcall, mynode->callsign, sizeof(instp->lastcall));
 		}
 		if (instp->starttime < (now - EL_APRS_START_DELAY)) {
 			instp->aprstime = now;

--- a/channels/chan_echolink.c
+++ b/channels/chan_echolink.c
@@ -1385,7 +1385,7 @@ static int el_call(struct ast_channel *chan, const char *dest, int timeout)
 	ast_debug(1, "Calling %s/%s on %s.\n", dest, ipaddr, ast_channel_name(chan));
 
 	/* make the call */
-	strcpy(node_lookup.ip, ipaddr);
+	snprintf(node_lookup.ip, sizeof(node_lookup.ip), "%s", ipaddr);
 	if (do_new_call(instp, p, "OUTBOUND", "OUTBOUND", &node_lookup) != 0) {
 		ast_log(LOG_WARNING, "Failed to initialize outbound call state for %s/%s.\n", dest, ipaddr);
 		return -1;
@@ -1517,7 +1517,7 @@ static int el_hangup(struct ast_channel *chan)
 	time_t now;
 
 	ast_debug(1, "Sent bye to IP address %s.\n", p->ip);
-	strcpy(node_lookup.ip, p->ip);
+	snprintf(node_lookup.ip, sizeof(node_lookup.ip), "%s", p->ip);
 	find_delete(&node_lookup, instp);
 	n = rtcp_make_bye(bye, sizeof(bye), "disconnected");
 
@@ -2548,7 +2548,7 @@ static int el_xwrite(struct ast_channel *chan, struct ast_frame *frame)
 	if (p->txindex >= BLOCKING_FACTOR) {
 		struct el_node node_lookup;
 
-		strcpy(node_lookup.ip, p->ip);
+		snprintf(node_lookup.ip, sizeof(node_lookup.ip), "%s", p->ip);
 		ast_mutex_lock(&el_nodelist_lock);
 		twalk_r(el_node_list, send_audio_only_one, &node_lookup);
 		ast_mutex_unlock(&el_nodelist_lock);
@@ -3665,7 +3665,7 @@ static int do_new_call(struct el_instance *instp, struct el_pvt *p, const char *
 		ast_mutex_lock(&instp->lock);
 		time(&now);
 		if (p != NULL) {
-			strcpy(instp->lastcall, mynode->callsign);
+			snprintf(instp->lastcall, sizeof(instp->lastcall), "%s", mynode->callsign);
 		}
 		if (instp->starttime < (now - EL_APRS_START_DELAY)) {
 			instp->aprstime = now;

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -834,8 +834,8 @@ static int load_tune_config(struct chan_simpleusb_pvt *o, const struct ast_confi
 	}
 	if (!reload) {
 		/* Using the ternary operator in CV_STR won't work, due to butchering the sizeof, so copy after if needed */
-		strcpy(o->devstr, devstr); /* Safe */
-		strcpy(o->serial, serial); /* Safe */
+		ast_copy_string(o->devstr, devstr, sizeof(o->devstr)); /* Safe */
+		ast_copy_string(o->serial, serial, sizeof(o->serial)); /* Safe */
 	}
 	if (opened) {
 		ast_config_destroy(cfg2);
@@ -2865,9 +2865,9 @@ static int usb_device_swap(int fd, const char *other)
 		return -1;
 	}
 	ast_mutex_lock(&usb_dev_lock);
-	strcpy(tmp, p->devstr);
+	ast_copy_string(tmp, p->devstr, sizeof(tmp));
 	d = p->devicenum;
-	strcpy(p->devstr, o->devstr);
+	ast_copy_string(p->devstr, o->devstr, sizeof(p->devstr));
 	p->devicenum = o->devicenum;
 	ast_copy_string(o->devstr, tmp, sizeof(o->devstr));
 	o->devicenum = d;

--- a/channels/chan_tlb.c
+++ b/channels/chan_tlb.c
@@ -856,7 +856,7 @@ static int TLB_call(struct ast_channel *ast, const char *dest, int timeout)
 	}
 
 	ast_mutex_lock(&instp->lock);
-	strcpy(instp->TLB_node_test.ip, strs[1]);
+	snprintf(instp->TLB_node_test.ip, sizeof(instp->TLB_node_test.ip), "%s", strs[1]);
 	instp->TLB_node_test.port = strtoul(strs[2], NULL, 0);
 	do_new_call(instp, p, "OUTBOUND", "OUTBOUND", strs[3]);
 
@@ -922,7 +922,7 @@ static struct TLB_pvt *TLB_alloc(const char *data)
 {
 	struct TLB_pvt *pvt;
 	int n;
-	char stream[256];
+	char stream[80];
 
 	if (ast_strlen_zero(data)) {
 		return NULL;
@@ -941,8 +941,8 @@ static struct TLB_pvt *TLB_alloc(const char *data)
 	pvt = ast_calloc(1, sizeof(struct TLB_pvt));
 	if (pvt) {
 		ast_mutex_init(&pvt->lock);
-		sprintf(stream, "%s-%lu", (char *) data, instances[n]->seqno++);
-		strcpy(pvt->stream, stream);
+		snprintf(stream, sizeof(stream), "%s-%lu", (char *) data, instances[n]->seqno++);
+		snprintf(pvt->stream, sizeof(pvt->stream), "%s", stream);
 		pvt->rxqast.qe_forw = &pvt->rxqast;
 		pvt->rxqast.qe_back = &pvt->rxqast;
 
@@ -978,7 +978,7 @@ static int TLB_hangup(struct ast_channel *ast)
 		ast_debug(1, "Sent bye to IP address %s\n", p->ip);
 
 		ast_mutex_lock(&instp->lock);
-		strcpy(instp->TLB_node_test.ip, p->ip);
+		snprintf(instp->TLB_node_test.ip, sizeof(instp->TLB_node_test.ip), "%s", p->ip);
 		instp->TLB_node_test.port = p->port;
 		find_delete(&instp->TLB_node_test);
 		ast_softhangup(ast, AST_SOFTHANGUP_DEV);
@@ -1060,7 +1060,7 @@ static int tlb_send_dtmf(struct ast_channel *ast, char digit)
 	 *  increment the seqno for the RTP packet
 	 */
 	ast_mutex_lock(&p->instp->lock);
-	strcpy(p->instp->TLB_node_test.ip, p->ip);
+	snprintf(p->instp->TLB_node_test.ip, sizeof(p->instp->TLB_node_test.ip), "%s", p->ip);
 	p->instp->TLB_node_test.port = p->port;
 	ast_mutex_lock(&p->instp->lock);
 	found_key = (struct TLB_node **) tfind(&p->instp->TLB_node_test, &TLB_node_list, compare_ip);
@@ -1089,7 +1089,7 @@ static int tlb_send_dtmf(struct ast_channel *ast, char digit)
 	pkt.time = htonl(now);
 	pkt.ssrc = htonl(p->instp->call_crc);
 	ast_mutex_lock(&p->lock); /* needs to be locked, since we are incrementing dtmfseq */
-	sprintf((char *) pkt.data, "DTMF%c %u %u", digit, ++p->dtmfseq, (uint32_t) now);
+	snprintf((char *) pkt.data, sizeof(pkt.data), "DTMF%c %u %u", digit, ++p->dtmfseq, (uint32_t) now);
 	ast_mutex_unlock(&p->lock);
 	for (i = 0; i < DTMF_NPACKETS; i++) {
 		sendto(p->instp->audio_sock, (char *) &pkt, strlen((char *) pkt.data) + 12, 0, (struct sockaddr *) &sin, sizeof(sin));
@@ -1610,7 +1610,7 @@ static int TLB_xwrite(struct ast_channel *ast, struct ast_frame *frame)
 			if (instp->confmode) {
 				twalk(TLB_node_list, send_audio_all);
 			} else {
-				strcpy(instp->TLB_node_test.ip, p->ip);
+				snprintf(instp->TLB_node_test.ip, sizeof(instp->TLB_node_test.ip), "%s", p->ip);
 				instp->TLB_node_test.port = p->port;
 				twalk(TLB_node_list, send_audio_only_one);
 			}
@@ -1700,7 +1700,7 @@ static struct ast_channel *TLB_new(struct TLB_pvt *i, int state, unsigned int no
 	if (nodenum > 0) {
 		char tmpstr[30];
 
-		sprintf(tmpstr, "%u", nodenum);
+		snprintf(tmpstr, sizeof(tmpstr), "%u", nodenum);
 		ast_set_callerid(tmp, tmpstr, NULL, NULL);
 	}
 	i->u = ast_module_user_add(tmp);

--- a/channels/chan_tlb.c
+++ b/channels/chan_tlb.c
@@ -560,7 +560,7 @@ static int rtcp_make_sdes(unsigned char *pkt, int pkt_len, const char *call)
 	memcpy(ap, line, l);
 	ap += l;
 
-	snprintf(line, sizeof(line), "%s", call);
+	ast_copy_string(line, call, sizeof(line));
 	*ap++ = 2;
 	*ap++ = l = strlen(line);
 	memcpy(ap, line, l);
@@ -856,7 +856,7 @@ static int TLB_call(struct ast_channel *ast, const char *dest, int timeout)
 	}
 
 	ast_mutex_lock(&instp->lock);
-	snprintf(instp->TLB_node_test.ip, sizeof(instp->TLB_node_test.ip), "%s", strs[1]);
+	ast_copy_string(instp->TLB_node_test.ip, strs[1], sizeof(instp->TLB_node_test.ip));
 	instp->TLB_node_test.port = strtoul(strs[2], NULL, 0);
 	do_new_call(instp, p, "OUTBOUND", "OUTBOUND", strs[3]);
 
@@ -922,7 +922,6 @@ static struct TLB_pvt *TLB_alloc(const char *data)
 {
 	struct TLB_pvt *pvt;
 	int n;
-	char stream[80];
 
 	if (ast_strlen_zero(data)) {
 		return NULL;
@@ -941,8 +940,7 @@ static struct TLB_pvt *TLB_alloc(const char *data)
 	pvt = ast_calloc(1, sizeof(struct TLB_pvt));
 	if (pvt) {
 		ast_mutex_init(&pvt->lock);
-		snprintf(stream, sizeof(stream), "%s-%lu", (char *) data, instances[n]->seqno++);
-		snprintf(pvt->stream, sizeof(pvt->stream), "%s", stream);
+		snprintf(pvt->stream, sizeof(pvt->stream), "%s-%lu", (char *) data, instances[n]->seqno++);
 		pvt->rxqast.qe_forw = &pvt->rxqast;
 		pvt->rxqast.qe_back = &pvt->rxqast;
 
@@ -978,7 +976,7 @@ static int TLB_hangup(struct ast_channel *ast)
 		ast_debug(1, "Sent bye to IP address %s\n", p->ip);
 
 		ast_mutex_lock(&instp->lock);
-		snprintf(instp->TLB_node_test.ip, sizeof(instp->TLB_node_test.ip), "%s", p->ip);
+		ast_copy_string(instp->TLB_node_test.ip, p->ip, sizeof(instp->TLB_node_test.ip));
 		instp->TLB_node_test.port = p->port;
 		find_delete(&instp->TLB_node_test);
 		ast_softhangup(ast, AST_SOFTHANGUP_DEV);
@@ -1060,7 +1058,7 @@ static int tlb_send_dtmf(struct ast_channel *ast, char digit)
 	 *  increment the seqno for the RTP packet
 	 */
 	ast_mutex_lock(&p->instp->lock);
-	snprintf(p->instp->TLB_node_test.ip, sizeof(p->instp->TLB_node_test.ip), "%s", p->ip);
+	ast_copy_string(p->instp->TLB_node_test.ip, p->ip, sizeof(p->instp->TLB_node_test.ip));
 	p->instp->TLB_node_test.port = p->port;
 	ast_mutex_lock(&p->instp->lock);
 	found_key = (struct TLB_node **) tfind(&p->instp->TLB_node_test, &TLB_node_list, compare_ip);
@@ -1610,7 +1608,7 @@ static int TLB_xwrite(struct ast_channel *ast, struct ast_frame *frame)
 			if (instp->confmode) {
 				twalk(TLB_node_list, send_audio_all);
 			} else {
-				snprintf(instp->TLB_node_test.ip, sizeof(instp->TLB_node_test.ip), "%s", p->ip);
+				ast_copy_string(instp->TLB_node_test.ip, p->ip, sizeof(instp->TLB_node_test.ip));
 				instp->TLB_node_test.port = p->port;
 				twalk(TLB_node_list, send_audio_only_one);
 			}

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -807,8 +807,8 @@ static int load_tune_config(struct chan_usbradio_pvt *o, const struct ast_config
 	}
 	if (!reload) {
 		/* Using the ternary operator in CV_STR won't work, due to butchering the sizeof, so copy after if needed */
-		snprintf(o->devstr, sizeof(o->devstr), "%s", devstr);
-		snprintf(o->serial, sizeof(o->serial), "%s", serial);
+		ast_copy_string(o->devstr, devstr, sizeof(o->devstr));
+		ast_copy_string(o->serial, serial, sizeof(o->serial));
 	}
 	if (opened) {
 		ast_config_destroy(cfg2);
@@ -1620,7 +1620,7 @@ static int setformat(struct chan_usbradio_pvt *o, int mode)
 		return 0;
 	}
 
-	snprintf(device, sizeof(device), "/dev/dsp");
+	ast_copy_string(device, "/dev/dsp", sizeof(device));
 	if (o->devicenum) {
 		snprintf(device, sizeof(device), "/dev/dsp%d", o->devicenum);
 	}
@@ -1861,8 +1861,8 @@ static int usbradio_text(struct ast_channel *c, const char *text)
 		o->set_txfreq = round(tx * (double) 1000000);
 		o->set_rxfreq = round(rx * (double) 1000000);
 		o->pmrChan->txpower = (pwr == 'H');
-		snprintf(o->set_rxctcssfreqs, sizeof(o->set_rxctcssfreqs), "%s", rxpl);
-		snprintf(o->set_txctcssfreqs, sizeof(o->set_txctcssfreqs), "%s", txpl);
+		ast_copy_string(o->set_rxctcssfreqs, rxpl, sizeof(o->set_rxctcssfreqs));
+		ast_copy_string(o->set_txctcssfreqs, txpl, sizeof(o->set_txctcssfreqs));
 
 		o->remoted = 1;
 		xpmr_config(o);
@@ -2240,7 +2240,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	if (o->pmrChan->b.ctcssRxEnable && o->pmrChan->rxCtcss->decode != o->rxctcssdecode) {
 		ast_debug(3, "Channel %s: rxctcssdecode = %i.\n", o->name, o->pmrChan->rxCtcss->decode);
 		o->rxctcssdecode = o->pmrChan->rxCtcss->decode;
-		snprintf(o->rxctcssfreq, sizeof(o->rxctcssfreq), "%s", o->pmrChan->rxctcssfreq);
+		ast_copy_string(o->rxctcssfreq, o->pmrChan->rxctcssfreq, sizeof(o->rxctcssfreq));
 	}
 
 	/* Check for SD - CTCSS active */
@@ -2263,13 +2263,13 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	if (o->pmrChan->decDcs->decode != o->rxdcsdecode) {
 		ast_debug(3, "Channel %s: rxdcsdecode = %s.\n", o->name, o->pmrChan->rxctcssfreq);
 		o->rxdcsdecode = o->pmrChan->decDcs->decode;
-		snprintf(o->rxctcssfreq, sizeof(o->rxctcssfreq), "%s", o->pmrChan->rxctcssfreq);
+		ast_copy_string(o->rxctcssfreq, o->pmrChan->rxctcssfreq, sizeof(o->rxctcssfreq));
 	}
 
 	if (o->pmrChan->rptnum && (o->pmrChan->pLsdCtl->cs[o->pmrChan->rptnum].b.rxkeyed != o->rxlsddecode)) {
 		ast_log(LOG_NOTICE, "Channel %s: rxLSDecode = %s.\n", o->name, o->pmrChan->rxctcssfreq);
 		o->rxlsddecode = o->pmrChan->pLsdCtl->cs[o->pmrChan->rptnum].b.rxkeyed;
-		snprintf(o->rxctcssfreq, sizeof(o->rxctcssfreq), "%s", o->pmrChan->rxctcssfreq);
+		as_copy_string(o->rxctcssfreq, o->pmrChan->rxctcssfreq, sizeof(o->rxctcssfreq));
 	}
 
 	if ((o->pmrChan->rptnum > 0 && o->pmrChan->smode == SMODE_LSD && o->pmrChan->pLsdCtl->cs[o->pmrChan->rptnum].b.rxkeyed) ||
@@ -2793,11 +2793,11 @@ static int usb_device_swap(int fd, const char *other)
 		return -1;
 	}
 	ast_mutex_lock(&usb_dev_lock);
-	snprintf(tmp, sizeof(tmp), "%s", p->devstr);
+	ast_copy_string(tmp, p->devstr, sizeof(tmp));
 	d = p->devicenum;
-	snprintf(p->devstr, sizeof(p->devstr), "%s", o->devstr);
+	ast_copy_string(p->devstr, o->devstr, sizeof(p->devstr));
 	p->devicenum = o->devicenum;
-	snprintf(o->devstr, sizeof(o->devstr), "%s", tmp);
+	ast_copy_string(o->devstr, tmp, sizeof(o->devstr));
 	o->devicenum = d;
 	o->hasusb = 0;
 	o->usbass = 0;

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -2267,9 +2267,9 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	}
 
 	if (o->pmrChan->rptnum && (o->pmrChan->pLsdCtl->cs[o->pmrChan->rptnum].b.rxkeyed != o->rxlsddecode)) {
-		ast_log(LOG_NOTICE, "Channel %s: rxLSDecode = %s.\n", o->name, o->pmrChan->rxctcssfreq);
+		ast_debug(3, "Channel %s: rxLSDecode = %s.\n", o->name, o->pmrChan->rxctcssfreq);
 		o->rxlsddecode = o->pmrChan->pLsdCtl->cs[o->pmrChan->rptnum].b.rxkeyed;
-		as_copy_string(o->rxctcssfreq, o->pmrChan->rxctcssfreq, sizeof(o->rxctcssfreq));
+		ast_copy_string(o->rxctcssfreq, o->pmrChan->rxctcssfreq, sizeof(o->rxctcssfreq));
 	}
 
 	if ((o->pmrChan->rptnum > 0 && o->pmrChan->smode == SMODE_LSD && o->pmrChan->pLsdCtl->cs[o->pmrChan->rptnum].b.rxkeyed) ||

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -807,8 +807,8 @@ static int load_tune_config(struct chan_usbradio_pvt *o, const struct ast_config
 	}
 	if (!reload) {
 		/* Using the ternary operator in CV_STR won't work, due to butchering the sizeof, so copy after if needed */
-		strcpy(o->devstr, devstr); /* Safe */
-		strcpy(o->serial, serial); /* Safe */
+		snprintf(o->devstr, sizeof(o->devstr), "%s", devstr);
+		snprintf(o->serial, sizeof(o->serial), "%s", serial);
 	}
 	if (opened) {
 		ast_config_destroy(cfg2);
@@ -1620,9 +1620,9 @@ static int setformat(struct chan_usbradio_pvt *o, int mode)
 		return 0;
 	}
 
-	strcpy(device, "/dev/dsp");
+	snprintf(device, sizeof(device), "/dev/dsp");
 	if (o->devicenum) {
-		sprintf(device, "/dev/dsp%d", o->devicenum);
+		snprintf(device, sizeof(device), "/dev/dsp%d", o->devicenum);
 	}
 	/* open the device */
 	fd = o->sounddev = open(device, mode | O_NONBLOCK);
@@ -1861,8 +1861,8 @@ static int usbradio_text(struct ast_channel *c, const char *text)
 		o->set_txfreq = round(tx * (double) 1000000);
 		o->set_rxfreq = round(rx * (double) 1000000);
 		o->pmrChan->txpower = (pwr == 'H');
-		strcpy(o->set_rxctcssfreqs, rxpl); /* Safe */
-		strcpy(o->set_txctcssfreqs, txpl); /* Safe */
+		snprintf(o->set_rxctcssfreqs, sizeof(o->set_rxctcssfreqs), "%s", rxpl);
+		snprintf(o->set_txctcssfreqs, sizeof(o->set_txctcssfreqs), "%s", txpl);
 
 		o->remoted = 1;
 		xpmr_config(o);
@@ -2240,7 +2240,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	if (o->pmrChan->b.ctcssRxEnable && o->pmrChan->rxCtcss->decode != o->rxctcssdecode) {
 		ast_debug(3, "Channel %s: rxctcssdecode = %i.\n", o->name, o->pmrChan->rxCtcss->decode);
 		o->rxctcssdecode = o->pmrChan->rxCtcss->decode;
-		strcpy(o->rxctcssfreq, o->pmrChan->rxctcssfreq);
+		snprintf(o->rxctcssfreq, sizeof(o->rxctcssfreq), "%s", o->pmrChan->rxctcssfreq);
 	}
 
 	/* Check for SD - CTCSS active */
@@ -2263,13 +2263,13 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	if (o->pmrChan->decDcs->decode != o->rxdcsdecode) {
 		ast_debug(3, "Channel %s: rxdcsdecode = %s.\n", o->name, o->pmrChan->rxctcssfreq);
 		o->rxdcsdecode = o->pmrChan->decDcs->decode;
-		strcpy(o->rxctcssfreq, o->pmrChan->rxctcssfreq);
+		snprintf(o->rxctcssfreq, sizeof(o->rxctcssfreq), "%s", o->pmrChan->rxctcssfreq);
 	}
 
 	if (o->pmrChan->rptnum && (o->pmrChan->pLsdCtl->cs[o->pmrChan->rptnum].b.rxkeyed != o->rxlsddecode)) {
 		ast_log(LOG_NOTICE, "Channel %s: rxLSDecode = %s.\n", o->name, o->pmrChan->rxctcssfreq);
 		o->rxlsddecode = o->pmrChan->pLsdCtl->cs[o->pmrChan->rptnum].b.rxkeyed;
-		strcpy(o->rxctcssfreq, o->pmrChan->rxctcssfreq);
+		snprintf(o->rxctcssfreq, sizeof(o->rxctcssfreq), "%s", o->pmrChan->rxctcssfreq);
 	}
 
 	if ((o->pmrChan->rptnum > 0 && o->pmrChan->smode == SMODE_LSD && o->pmrChan->pLsdCtl->cs[o->pmrChan->rptnum].b.rxkeyed) ||
@@ -2793,11 +2793,11 @@ static int usb_device_swap(int fd, const char *other)
 		return -1;
 	}
 	ast_mutex_lock(&usb_dev_lock);
-	strcpy(tmp, p->devstr);
+	snprintf(tmp, sizeof(tmp), "%s", p->devstr);
 	d = p->devicenum;
-	strcpy(p->devstr, o->devstr);
+	snprintf(p->devstr, sizeof(p->devstr), "%s", o->devstr);
 	p->devicenum = o->devicenum;
-	ast_copy_string(o->devstr, tmp, sizeof(o->devstr));
+	snprintf(o->devstr, sizeof(o->devstr), "%s", tmp);
 	o->devicenum = d;
 	o->hasusb = 0;
 	o->usbass = 0;
@@ -4969,7 +4969,7 @@ static struct chan_usbradio_pvt *store_config(struct ast_config *cfg, const char
 		CV_END;
 
 		for (i = 0; i < GPIO_PINCOUNT; i++) {
-			sprintf(buf, "gpio%d", i + 1);
+			snprintf(buf, sizeof(buf), "gpio%d", i + 1);
 			if (!strcmp(v->name, buf)) {
 				o->gpios[i] = ast_strdup(v->value);
 			}
@@ -4978,7 +4978,7 @@ static struct chan_usbradio_pvt *store_config(struct ast_config *cfg, const char
 			if (!((1 << i) & PP_MASK)) {
 				continue;
 			}
-			sprintf(buf, "pp%d", i);
+			snprintf(buf, sizeof(buf), "pp%d", i);
 			if (!strcasecmp(v->name, buf)) {
 				o->pps[i] = ast_strdup(v->value);
 				haspp = 1;

--- a/channels/chan_usrp.c
+++ b/channels/chan_usrp.c
@@ -199,8 +199,8 @@ static char *handle_usrp_show(struct ast_cli_entry *e, int cmd, struct ast_cli_a
 	for (i = 0; i < MAX_CHANS; i++) {
 		pvt = usrp_channels[i];
 		if (pvt) {
-			sprintf(s, "Channel %s: Tx keyed %-3s, Rx keyed %d, Read %lu, Write %lu", pvt->stream, (pvt->txkey) ? "yes" : "no",
-				pvt->rxkey, pvt->readct, pvt->writect);
+			snprintf(s, sizeof(s), "Channel %s: Tx keyed %-3s, Rx keyed %d, Read %lu, Write %lu", pvt->stream,
+				(pvt->txkey) ? "yes" : "no", pvt->rxkey, pvt->readct, pvt->writect);
 			ast_cli(a->fd, "%s\n", s);
 		}
 	}

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -2953,7 +2953,7 @@ static void *voter_primary_client(void *data)
 		if (!p->priconn && (ast_tvzero(lasttx) || (voter_tvdiff_ms(tv, lasttx) >= 500))) {
 			authpacket.vp.curtime.vtime_sec = htonl(master_time.vtime_sec);
 			authpacket.vp.curtime.vtime_nsec = htonl(voter_timing_count);
-			strcpy((char *) authpacket.vp.challenge, challenge);
+			snprintf((char *) authpacket.vp.challenge, sizeof(authpacket.vp.challenge), "%s", challenge);
 			authpacket.vp.digest = htonl(resp_digest);
 			authpacket.flags = 32;
 			ast_debug(3, "VOTER %i: Sent primary client auth to %s:%d\n", p->nodenum, ast_inet_ntoa(p->primary.sin_addr),
@@ -2968,7 +2968,7 @@ static void *voter_primary_client(void *data)
 		if (p->priconn && (ast_tvzero(lasttx) || (voter_tvdiff_ms(tv, lasttx) >= 1000))) {
 			authpacket.vp.curtime.vtime_sec = htonl(master_time.vtime_sec);
 			authpacket.vp.curtime.vtime_nsec = htonl(voter_timing_count);
-			strcpy((char *) authpacket.vp.challenge, challenge);
+			snprintf((char *) authpacket.vp.challenge, sizeof(authpacket.vp.challenge), "%s", challenge);
 			authpacket.vp.digest = htonl(resp_digest);
 			authpacket.vp.payload_type = htons(VOTER_PAYLOAD_GPS);
 			ast_debug(5, "VOTER %i: Sent primary client keepalive to %s:%d\n", p->nodenum, ast_inet_ntoa(p->primary.sin_addr),
@@ -3006,7 +3006,7 @@ static void *voter_primary_client(void *data)
 				/* If this is a new session. */
 				if (strcmp((char *) vph->challenge, p->primary_challenge)) {
 					resp_digest = crc32_bufs((char *) vph->challenge, p->primary_pswd);
-					strcpy(p->primary_challenge, (char *) vph->challenge);
+					snprintf(p->primary_challenge, sizeof(p->primary_challenge), "%s", (char *) vph->challenge);
 					p->priconn = 0;
 				} else {
 					if (!digest || !vph->digest || (digest != ntohl(vph->digest)) ||
@@ -3211,7 +3211,7 @@ static void *voter_xmit(void *data)
 		if (x || mx) {
 			memset(&audiopacket, 0, sizeof(audiopacket) - sizeof(audiopacket.audio));
 			memset(&audiopacket.audio, 0xff, sizeof(audiopacket.audio));
-			strcpy((char *) audiopacket.vp.challenge, challenge);
+			snprintf((char *) audiopacket.vp.challenge, sizeof(audiopacket.vp.challenge), "%s", challenge);
 			audiopacket.vp.payload_type = htons(VOTER_PAYLOAD_ULAW);
 			audiopacket.rssi = 0;
 			if (f1) {
@@ -3461,7 +3461,7 @@ static void *voter_xmit(void *data)
 				}
 				pingpacket.txtime = tv;
 				pingpacket.starttime = client->ping_txtime;
-				strcpy((char *) pingpacket.vp.challenge, challenge);
+				snprintf((char *) pingpacket.vp.challenge, sizeof(pingpacket.vp.challenge), "%s", challenge);
 				pingpacket.vp.payload_type = htons(VOTER_PAYLOAD_PING);
 				pingpacket.vp.curtime.vtime_sec = htonl(master_time.vtime_sec);
 				pingpacket.vp.curtime.vtime_nsec = htonl(master_time.vtime_nsec);
@@ -3492,7 +3492,7 @@ static void *voter_xmit(void *data)
 			 */
 			if (ast_tvzero(client->lastsenttime) || (voter_tvdiff_ms(tv, client->lastsenttime) >= TX_KEEPALIVE_MS)) {
 				memset(&audiopacket, 0, sizeof(audiopacket));
-				strcpy((char *) audiopacket.vp.challenge, challenge);
+				snprintf((char *) audiopacket.vp.challenge, sizeof(audiopacket.vp.challenge), "%s", challenge);
 				audiopacket.vp.curtime.vtime_sec = htonl(master_time.vtime_sec);
 				audiopacket.vp.payload_type = htons(VOTER_PAYLOAD_GPS);
 				audiopacket.vp.digest = htonl(client->respdigest);
@@ -3901,8 +3901,8 @@ static int reload(void)
 		/* Reset dmwdiag to disabled upon reload */
 		p->dmwdiag = 0;
 		oldctcss[0] = 0;
-		strcpy(oldctcss, p->txctcssfreq);
-		sprintf(data, "%d", p->nodenum);
+		snprintf(oldctcss, sizeof(oldctcss), "%s", p->txctcssfreq);
+		snprintf(data, sizeof(data), "%d", p->nodenum);
 		if (ast_variable_browse(cfg, data) == NULL) {
 			continue;
 		}
@@ -4729,7 +4729,7 @@ static void *voter_reader(void *data)
 							isproxy = 1;
 							if (!p->isprimary) {
 								vph->digest = htonl(client->respdigest);
-								strcpy((char *) vph->challenge, challenge);
+								snprintf((char *) vph->challenge, sizeof(vph->challenge), "%s", challenge);
 								sendto(udp_socket, buf, recvlen - sizeof(proxy), 0, (struct sockaddr *) &psin, sizeof(psin));
 								continue;
 							}
@@ -4894,7 +4894,7 @@ static void *voter_reader(void *data)
 							/* If otherwise (RSSI > 0), if ADPCM audio packet, translate it. */
 #ifdef ADPCM_LOOPBACK
 							memset(&audiopacket, 0, sizeof(audiopacket));
-							strcpy((char *) audiopacket.vp.challenge, challenge);
+							snprintf((char *) audiopacket.vp.challenge, sizeof(audiopacket.vp.challenge), "%s", challenge);
 							audiopacket.vp.payload_type = htons(VOTER_PAYLOAD_ADPCM);
 							audiopacket.rssi = 0;
 							memcpy(audiopacket.audio, buf + sizeof(VOTER_PACKET_HEADER) + 1, FRAME_SIZE + 3);
@@ -5259,12 +5259,13 @@ static void *voter_reader(void *data)
 								}
 								stream.curtime = master_time;
 								memcpy(stream.audio, p->buf + AST_FRIENDLY_OFFSET, FRAME_SIZE);
-								sprintf(stream.str, "%s", maxclient->name);
+								snprintf(stream.str, sizeof(stream.str), "%s", maxclient->name);
 								for (client = clients; client; client = client->next) {
 									if (client->nodenum != p->nodenum) {
 										continue;
 									}
-									sprintf(stream.str + strlen(stream.str), ",%s=%d", client->name, client->lastrssi);
+									snprintf(stream.str + strlen(stream.str), sizeof(stream.str) - strlen(stream.str), ",%s=%d",
+										client->name, client->lastrssi);
 								}
 								for (i = 0; i < p->nstreams; i++) {
 									cp = ast_strdup(p->streams[i]);
@@ -5467,7 +5468,7 @@ process_gps:
 		/* Our unique challenge is created in load_module. Copy our challenge into
 		 * the packet header.
 		 */
-		strcpy((char *) authpacket.vp.challenge, challenge);
+		snprintf((char *) authpacket.vp.challenge, sizeof(authpacket.vp.challenge), "%s", challenge);
 
 		/* Put our current system time into the packet header. */
 		gettimeofday(&tv, NULL);

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -329,7 +329,6 @@ Use "core show help voter <command>"" to display usage.
 #include "asterisk/format_compatibility.h"
 #include "asterisk/timing.h"
 #include "asterisk/rpt_chan_shared.h"
-
 #include "../apps/app_rpt/pocsag.c"
 
 /* This array is used by the voter tune CLI command to send a 1kHz tone at
@@ -2953,7 +2952,7 @@ static void *voter_primary_client(void *data)
 		if (!p->priconn && (ast_tvzero(lasttx) || (voter_tvdiff_ms(tv, lasttx) >= 500))) {
 			authpacket.vp.curtime.vtime_sec = htonl(master_time.vtime_sec);
 			authpacket.vp.curtime.vtime_nsec = htonl(voter_timing_count);
-			snprintf((char *) authpacket.vp.challenge, sizeof(authpacket.vp.challenge), "%s", challenge);
+			ast_copy_string((char *) authpacket.vp.challenge, challenge, sizeof(authpacket.vp.challenge));
 			authpacket.vp.digest = htonl(resp_digest);
 			authpacket.flags = 32;
 			ast_debug(3, "VOTER %i: Sent primary client auth to %s:%d\n", p->nodenum, ast_inet_ntoa(p->primary.sin_addr),
@@ -2968,7 +2967,7 @@ static void *voter_primary_client(void *data)
 		if (p->priconn && (ast_tvzero(lasttx) || (voter_tvdiff_ms(tv, lasttx) >= 1000))) {
 			authpacket.vp.curtime.vtime_sec = htonl(master_time.vtime_sec);
 			authpacket.vp.curtime.vtime_nsec = htonl(voter_timing_count);
-			snprintf((char *) authpacket.vp.challenge, sizeof(authpacket.vp.challenge), "%s", challenge);
+			ast_copy_string((char *) authpacket.vp.challenge, challenge, sizeof(authpacket.vp.challenge));
 			authpacket.vp.digest = htonl(resp_digest);
 			authpacket.vp.payload_type = htons(VOTER_PAYLOAD_GPS);
 			ast_debug(5, "VOTER %i: Sent primary client keepalive to %s:%d\n", p->nodenum, ast_inet_ntoa(p->primary.sin_addr),
@@ -3006,7 +3005,7 @@ static void *voter_primary_client(void *data)
 				/* If this is a new session. */
 				if (strcmp((char *) vph->challenge, p->primary_challenge)) {
 					resp_digest = crc32_bufs((char *) vph->challenge, p->primary_pswd);
-					snprintf(p->primary_challenge, sizeof(p->primary_challenge), "%.*s", (int) sizeof(vph->challenge) - 1, vph->challenge);
+					ast_copy_string((char *) p->primary_challenge, (char *) vph->challenge, sizeof(p->primary_challenge));
 					p->priconn = 0;
 				} else {
 					if (!digest || !vph->digest || (digest != ntohl(vph->digest)) ||
@@ -3211,7 +3210,7 @@ static void *voter_xmit(void *data)
 		if (x || mx) {
 			memset(&audiopacket, 0, sizeof(audiopacket) - sizeof(audiopacket.audio));
 			memset(&audiopacket.audio, 0xff, sizeof(audiopacket.audio));
-			snprintf((char *) audiopacket.vp.challenge, sizeof(audiopacket.vp.challenge), "%s", challenge);
+			ast_copy_string((char *) audiopacket.vp.challenge, challenge, sizeof(audiopacket.vp.challenge));
 			audiopacket.vp.payload_type = htons(VOTER_PAYLOAD_ULAW);
 			audiopacket.rssi = 0;
 			if (f1) {
@@ -3461,7 +3460,7 @@ static void *voter_xmit(void *data)
 				}
 				pingpacket.txtime = tv;
 				pingpacket.starttime = client->ping_txtime;
-				snprintf((char *) pingpacket.vp.challenge, sizeof(pingpacket.vp.challenge), "%s", challenge);
+				ast_copy_string((char *) pingpacket.vp.challenge, challenge, sizeof(pingpacket.vp.challenge));
 				pingpacket.vp.payload_type = htons(VOTER_PAYLOAD_PING);
 				pingpacket.vp.curtime.vtime_sec = htonl(master_time.vtime_sec);
 				pingpacket.vp.curtime.vtime_nsec = htonl(master_time.vtime_nsec);
@@ -3492,7 +3491,7 @@ static void *voter_xmit(void *data)
 			 */
 			if (ast_tvzero(client->lastsenttime) || (voter_tvdiff_ms(tv, client->lastsenttime) >= TX_KEEPALIVE_MS)) {
 				memset(&audiopacket, 0, sizeof(audiopacket));
-				snprintf((char *) audiopacket.vp.challenge, sizeof(audiopacket.vp.challenge), "%s", challenge);
+				ast_copy_string((char *) audiopacket.vp.challenge, challenge, sizeof(audiopacket.vp.challenge));
 				audiopacket.vp.curtime.vtime_sec = htonl(master_time.vtime_sec);
 				audiopacket.vp.payload_type = htons(VOTER_PAYLOAD_GPS);
 				audiopacket.vp.digest = htonl(client->respdigest);
@@ -3901,7 +3900,7 @@ static int reload(void)
 		/* Reset dmwdiag to disabled upon reload */
 		p->dmwdiag = 0;
 		oldctcss[0] = 0;
-		snprintf(oldctcss, sizeof(oldctcss), "%s", p->txctcssfreq);
+		ast_copy_string(oldctcss, p->txctcssfreq, sizeof(oldctcss));
 		snprintf(data, sizeof(data), "%d", p->nodenum);
 		if (ast_variable_browse(cfg, data) == NULL) {
 			continue;
@@ -4729,11 +4728,11 @@ static void *voter_reader(void *data)
 							isproxy = 1;
 							if (!p->isprimary) {
 								vph->digest = htonl(client->respdigest);
-								snprintf((char *) vph->challenge, sizeof(vph->challenge), "%s", challenge);
+								ast_copy_string((char *) vph->challenge, challenge, sizeof(vph->challenge));
 								sendto(udp_socket, buf, recvlen - sizeof(proxy), 0, (struct sockaddr *) &psin, sizeof(psin));
 								continue;
 							}
-							ast_copy_string(client->saved_challenge, proxy.challenge, sizeof(client->saved_challenge));
+							ast_copy_string((char *) client->saved_challenge, proxy.challenge, sizeof(client->saved_challenge));
 							client->proxy_sin = psin;
 							/* Is the mix mode flag being sent by the proxy client? */
 							if (proxy.flags & 32) {
@@ -4894,7 +4893,7 @@ static void *voter_reader(void *data)
 							/* If otherwise (RSSI > 0), if ADPCM audio packet, translate it. */
 #ifdef ADPCM_LOOPBACK
 							memset(&audiopacket, 0, sizeof(audiopacket));
-							snprintf((char *) audiopacket.vp.challenge, sizeof(audiopacket.vp.challenge), "%s", challenge);
+							ast_copy_string(audiopacket.vp.challenge, challenge, sizeof(audiopacket.vp.challenge));
 							audiopacket.vp.payload_type = htons(VOTER_PAYLOAD_ADPCM);
 							audiopacket.rssi = 0;
 							memcpy(audiopacket.audio, buf + sizeof(VOTER_PACKET_HEADER) + 1, FRAME_SIZE + 3);
@@ -5259,13 +5258,16 @@ static void *voter_reader(void *data)
 								}
 								stream.curtime = master_time;
 								memcpy(stream.audio, p->buf + AST_FRIENDLY_OFFSET, FRAME_SIZE);
-								snprintf(stream.str, sizeof(stream.str), "%s", maxclient->name);
+								ast_copy_string(stream.str, maxclient->name, sizeof(stream.str));
 								for (client = clients; client; client = client->next) {
+									int size;
+
 									if (client->nodenum != p->nodenum) {
 										continue;
 									}
-									snprintf(stream.str + strlen(stream.str), sizeof(stream.str) - strlen(stream.str), ",%s=%d",
-										client->name, client->lastrssi);
+
+									size = strlen(stream.str);
+									snprintf(stream.str + size, sizeof(stream.str) - size, ",%s=%d", client->name, client->lastrssi);
 								}
 								for (i = 0; i < p->nstreams; i++) {
 									cp = ast_strdup(p->streams[i]);
@@ -5468,7 +5470,7 @@ process_gps:
 		/* Our unique challenge is created in load_module. Copy our challenge into
 		 * the packet header.
 		 */
-		snprintf((char *) authpacket.vp.challenge, sizeof(authpacket.vp.challenge), "%s", challenge);
+		ast_copy_string((char *) authpacket.vp.challenge, challenge, sizeof(authpacket.vp.challenge));
 
 		/* Put our current system time into the packet header. */
 		gettimeofday(&tv, NULL);

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -3005,7 +3005,7 @@ static void *voter_primary_client(void *data)
 				/* If this is a new session. */
 				if (strcmp((char *) vph->challenge, p->primary_challenge)) {
 					resp_digest = crc32_bufs((char *) vph->challenge, p->primary_pswd);
-					ast_copy_string((char *) p->primary_challenge, (char *) vph->challenge, sizeof(p->primary_challenge));
+					ast_copy_string(p->primary_challenge, (char *) vph->challenge, sizeof(p->primary_challenge));
 					p->priconn = 0;
 				} else {
 					if (!digest || !vph->digest || (digest != ntohl(vph->digest)) ||
@@ -4732,7 +4732,7 @@ static void *voter_reader(void *data)
 								sendto(udp_socket, buf, recvlen - sizeof(proxy), 0, (struct sockaddr *) &psin, sizeof(psin));
 								continue;
 							}
-							ast_copy_string((char *) client->saved_challenge, proxy.challenge, sizeof(client->saved_challenge));
+							ast_copy_string(client->saved_challenge, proxy.challenge, sizeof(client->saved_challenge));
 							client->proxy_sin = psin;
 							/* Is the mix mode flag being sent by the proxy client? */
 							if (proxy.flags & 32) {
@@ -4893,7 +4893,7 @@ static void *voter_reader(void *data)
 							/* If otherwise (RSSI > 0), if ADPCM audio packet, translate it. */
 #ifdef ADPCM_LOOPBACK
 							memset(&audiopacket, 0, sizeof(audiopacket));
-							ast_copy_string(audiopacket.vp.challenge, challenge, sizeof(audiopacket.vp.challenge));
+							ast_copy_string((char *) audiopacket.vp.challenge, challenge, sizeof(audiopacket.vp.challenge));
 							audiopacket.vp.payload_type = htons(VOTER_PAYLOAD_ADPCM);
 							audiopacket.rssi = 0;
 							memcpy(audiopacket.audio, buf + sizeof(VOTER_PACKET_HEADER) + 1, FRAME_SIZE + 3);

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -3006,7 +3006,7 @@ static void *voter_primary_client(void *data)
 				/* If this is a new session. */
 				if (strcmp((char *) vph->challenge, p->primary_challenge)) {
 					resp_digest = crc32_bufs((char *) vph->challenge, p->primary_pswd);
-					snprintf(p->primary_challenge, sizeof(p->primary_challenge), "%s", (char *) vph->challenge);
+					snprintf(p->primary_challenge, sizeof(p->primary_challenge), "%.*s", (int) sizeof(vph->challenge) - 1, vph->challenge);
 					p->priconn = 0;
 				} else {
 					if (!digest || !vph->digest || (digest != ntohl(vph->digest)) ||

--- a/channels/xpmr/xpmr.c
+++ b/channels/xpmr/xpmr.c
@@ -1601,7 +1601,7 @@ i16 ctcss_detect(t_pmr_chan *pChan)
 	} else if (thit <= CTCSS_NULL && pChan->rxCtcss->decode > CTCSS_NULL) {
 		pChan->rxCtcss->BlankingTimer = SAMPLE_RATE_NETWORK / 5;
 		pChan->rxCtcss->decode = CTCSS_NULL;
-		snprintf(pChan->rxctcssfreq, sizeof(pChan->rxctcssfreq), "0");
+		ast_copy_string(pChan->rxctcssfreq, "0", sizeof(pChan->rxctcssfreq));
 		TRACEC(1, "ctcss decode  NULL\n");
 		for (tnum = 0; tnum < CTCSS_NUM_CODES; tnum++) {
 			t_tdet *ptdet = NULL;

--- a/channels/xpmr/xpmr.c
+++ b/channels/xpmr/xpmr.c
@@ -1596,12 +1596,12 @@ i16 ctcss_detect(t_pmr_chan *pChan)
 
 	if (thit > CTCSS_NULL && pChan->rxCtcss->decode <= CTCSS_NULL && !pChan->rxCtcss->BlankingTimer) {
 		pChan->rxCtcss->decode = thit;
-		sprintf(pChan->rxctcssfreq, "%.1f", freq_ctcss[thit]);
+		snprintf(pChan->rxctcssfreq, sizeof(pChan->rxctcssfreq), "%.1f", freq_ctcss[thit]);
 		TRACEC(1, "ctcss decode  %i  %.1f\n", thit, freq_ctcss[thit]);
 	} else if (thit <= CTCSS_NULL && pChan->rxCtcss->decode > CTCSS_NULL) {
 		pChan->rxCtcss->BlankingTimer = SAMPLE_RATE_NETWORK / 5;
 		pChan->rxCtcss->decode = CTCSS_NULL;
-		strcpy(pChan->rxctcssfreq, "0");
+		snprintf(pChan->rxctcssfreq, sizeof(pChan->rxctcssfreq), "0");
 		TRACEC(1, "ctcss decode  NULL\n");
 		for (tnum = 0; tnum < CTCSS_NUM_CODES; tnum++) {
 			t_tdet *ptdet = NULL;
@@ -2907,7 +2907,7 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 			}
 
 			memset(pChan->txctcssfreq, 0, sizeof(pChan->txctcssfreq));
-			sprintf(pChan->txctcssfreq, "%.1f", f);
+			snprintf(pChan->txctcssfreq, sizeof(pChan->txctcssfreq), "%.1f", f);
 			pChan->b.txCtcssReady = 1;
 
 			pChan->txState = CHAN_TXSTATE_ACTIVE;

--- a/res/res_rpt_http_registrations.c
+++ b/res/res_rpt_http_registrations.c
@@ -390,8 +390,8 @@ static int append_register(const char *hostname, const char *username, const cha
 	static int iaxport = 0;
 	size_t size;
 
-	size = strlen(hostname);
-	if (!(reg = ast_calloc(1, sizeof(*reg) + size + 1))) {
+	size = strlen(hostname) + 1;
+	if (!(reg = ast_calloc(1, sizeof(*reg) + size))) {
 		return -1;
 	}
 

--- a/res/res_rpt_http_registrations.c
+++ b/res/res_rpt_http_registrations.c
@@ -400,7 +400,7 @@ static int append_register(const char *hostname, const char *username, const cha
 	}
 
 	ast_copy_string(reg->username, username, sizeof(reg->username));
-	ast_copy_string(reg->hostname, hostname, sizeof(reg->hostname)); /* Note: This is safe */
+	strcpy(reg->hostname, hostname); /* Note: This is safe because we size it to the size of "hostname" at allocation.*/
 
 	if (secret) {
 		ast_copy_string(reg->secret, secret, sizeof(reg->secret));

--- a/res/res_rpt_http_registrations.c
+++ b/res/res_rpt_http_registrations.c
@@ -335,7 +335,7 @@ static char *handle_show_registrations(struct ast_cli_entry *e, int cmd, struct 
 		} else {
 			ast_copy_string(perceived, "<Unregistered>", sizeof(perceived));
 		}
-		snprintf(host, sizeof(host), "%s", ast_sockaddr_stringify(&reg->addr));
+		ast_copy_string(host, ast_sockaddr_stringify(&reg->addr), sizeof(host));
 		ast_cli(a->fd, FORMAT, host, reg->username, reg->perceived_port ? perceived : "<Unregistered>", reg->refresh,
 			reg->registered ? "Registered" : "Not Registered");
 		counter++;

--- a/res/res_rpt_http_registrations.c
+++ b/res/res_rpt_http_registrations.c
@@ -388,8 +388,10 @@ static int append_register(const char *hostname, const char *username, const cha
 {
 	struct http_registry *reg;
 	static int iaxport = 0;
+	size_t size;
 
-	if (!(reg = ast_calloc(1, sizeof(*reg) + strlen(hostname) + 1))) {
+	size = strlen(hostname);
+	if (!(reg = ast_calloc(1, sizeof(*reg) + size + 1))) {
 		return -1;
 	}
 
@@ -400,8 +402,7 @@ static int append_register(const char *hostname, const char *username, const cha
 	}
 
 	ast_copy_string(reg->username, username, sizeof(reg->username));
-	strcpy(reg->hostname, hostname); /* Note: This is safe because we size it to the size of "hostname" at allocation.*/
-
+	ast_copy_string(reg->hostname, hostname, size);
 	if (secret) {
 		ast_copy_string(reg->secret, secret, sizeof(reg->secret));
 	}

--- a/res/res_rpt_http_registrations.c
+++ b/res/res_rpt_http_registrations.c
@@ -400,7 +400,7 @@ static int append_register(const char *hostname, const char *username, const cha
 	}
 
 	ast_copy_string(reg->username, username, sizeof(reg->username));
-	strcpy(reg->hostname, hostname); /* Note: This is safe */
+	ast_copy_string(reg->hostname, hostname, sizeof(reg->hostname)); /* Note: This is safe */
 
 	if (secret) {
 		ast_copy_string(reg->secret, secret, sizeof(reg->secret));

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -509,7 +509,7 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 					if (i) {
 						snprintf(str, sizeof(str), "/sys/class/sound/dsp%d/device", i);
 					} else {
-						as_copy_string(str, "/sys/class/sound/dsp/device", sizeof(str));
+						ast_copy_string(str, "/sys/class/sound/dsp/device", sizeof(str));
 					}
 					memset(desdev, 0, sizeof(desdev));
 					if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
@@ -566,7 +566,7 @@ int ast_radio_usb_get_usbdev(const char *devstr)
 		if (i) {
 			snprintf(str, sizeof(str), "/sys/class/sound/dsp%d/device", i);
 		} else {
-			as_copy_string(str, "/sys/class/sound/dsp/device", sizeof(str));
+			ast_copy_string(str, "/sys/class/sound/dsp/device", sizeof(str));
 		}
 		memset(desdev, 0, sizeof(desdev));
 		if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -415,7 +415,7 @@ int ast_radio_hid_device_mklist(void)
 					if (i) {
 						snprintf(str, sizeof(str), "/sys/class/sound/dsp%d/device", i);
 					} else {
-						snprintf(str, sizeof(str), "/sys/class/sound/dsp/device");
+						ast_copy_string(str, "/sys/class/sound/dsp/device", sizeof(str));
 					}
 					memset(desdev, 0, sizeof(desdev));
 					if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
@@ -509,7 +509,7 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 					if (i) {
 						snprintf(str, sizeof(str), "/sys/class/sound/dsp%d/device", i);
 					} else {
-						snprintf(str, sizeof(str), "/sys/class/sound/dsp/device");
+						as_copy_string(str, "/sys/class/sound/dsp/device", sizeof(str));
 					}
 					memset(desdev, 0, sizeof(desdev));
 					if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
@@ -566,7 +566,7 @@ int ast_radio_usb_get_usbdev(const char *devstr)
 		if (i) {
 			snprintf(str, sizeof(str), "/sys/class/sound/dsp%d/device", i);
 		} else {
-			snprintf(str, sizeof(str), "/sys/class/sound/dsp/device");
+			as_copy_string(str, "/sys/class/sound/dsp/device", sizeof(str));
 		}
 		memset(desdev, 0, sizeof(desdev));
 		if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -129,7 +129,7 @@ int ast_radio_amixer_max(int devnum, char *param)
 	snd_hctl_elem_t *elem;
 	snd_ctl_elem_info_t *info;
 
-	sprintf(str, "hw:%d", devnum);
+	snprintf(str, sizeof(str), "hw:%d", devnum);
 	if (snd_hctl_open(&hctl, str, 0)) {
 		return -1;
 	}
@@ -168,7 +168,7 @@ int ast_radio_setamixer(int devnum, char *param, int v1, int v2)
 	snd_hctl_elem_t *elem;
 	snd_ctl_elem_info_t *info;
 
-	sprintf(str, "hw:%d", devnum);
+	snprintf(str, sizeof(str), "hw:%d", devnum);
 	if (snd_hctl_open(&hctl, str, 0)) {
 		return -1;
 	}
@@ -382,9 +382,9 @@ int ast_radio_hid_device_mklist(void)
 	for (usb_bus = usb_busses; usb_bus; usb_bus = usb_bus->next) {
 		for (dev = usb_bus->devices; dev; dev = dev->next) {
 			if (is_known_device(dev) || is_user_device(dev)) {
-				sprintf(devstr, "%s/%s", usb_bus->dirname, dev->filename);
+				snprintf(devstr, sizeof(devstr), "%s/%s", usb_bus->dirname, dev->filename);
 				for (i = 0; i < 32; i++) {
-					sprintf(str, "/proc/asound/card%d/usbbus", i);
+					snprintf(str, sizeof(str), "/proc/asound/card%d/usbbus", i);
 					fp = fopen(str, "r");
 					if (!fp) {
 						continue;
@@ -401,7 +401,7 @@ int ast_radio_hid_device_mklist(void)
 						continue;
 					}
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 20)) && !defined(AST_BUILDOPT_LIMEY)
-					sprintf(str, "/sys/class/sound/card%d/device", i);
+					snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
 					memset(desdev, 0, sizeof(desdev));
 					if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
 						continue;
@@ -413,13 +413,13 @@ int ast_radio_hid_device_mklist(void)
 					cp++;
 #else
 					if (i) {
-						sprintf(str, "/sys/class/sound/dsp%d/device", i);
+						snprintf(str, sizeof(str), "/sys/class/sound/dsp%d/device", i);
 					} else {
-						strcpy(str, "/sys/class/sound/dsp/device");
+						snprintf(str, sizeof(str), "/sys/class/sound/dsp/device");
 					}
 					memset(desdev, 0, sizeof(desdev));
 					if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
-						sprintf(str, "/sys/class/sound/controlC%d/device", i);
+						snprintf(str, sizeof(str), "/sys/class/sound/controlC%d/device", i);
 						memset(desdev, 0, sizeof(desdev));
 						if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
 							continue;
@@ -476,9 +476,9 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 	for (usb_bus = usb_busses; usb_bus; usb_bus = usb_bus->next) {
 		for (dev = usb_bus->devices; dev; dev = dev->next) {
 			if (is_known_device(dev) || is_user_device(dev)) {
-				sprintf(devstr, "%s/%s", usb_bus->dirname, dev->filename);
+				snprintf(devstr, sizeof(devstr), "%s/%s", usb_bus->dirname, dev->filename);
 				for (i = 0; i < 32; i++) {
-					sprintf(str, "/proc/asound/card%d/usbbus", i);
+					snprintf(str, sizeof(str), "/proc/asound/card%d/usbbus", i);
 					fp = fopen(str, "r");
 					if (!fp) {
 						continue;
@@ -495,7 +495,7 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 						continue;
 					}
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 20)) && !defined(AST_BUILDOPT_LIMEY)
-					sprintf(str, "/sys/class/sound/card%d/device", i);
+					snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
 					memset(desdev, 0, sizeof(desdev));
 					if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
 						continue;
@@ -507,13 +507,13 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 					cp++;
 #else
 					if (i) {
-						sprintf(str, "/sys/class/sound/dsp%d/device", i);
+						snprintf(str, sizeof(str), "/sys/class/sound/dsp%d/device", i);
 					} else {
-						strcpy(str, "/sys/class/sound/dsp/device");
+						snprintf(str, sizeof(str), "/sys/class/sound/dsp/device");
 					}
 					memset(desdev, 0, sizeof(desdev));
 					if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
-						sprintf(str, "/sys/class/sound/controlC%d/device", i);
+						snprintf(str, sizeof(str), "/sys/class/sound/controlC%d/device", i);
 						memset(desdev, 0, sizeof(desdev));
 						if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
 							continue;
@@ -552,7 +552,7 @@ int ast_radio_usb_get_usbdev(const char *devstr)
 
 	for (i = 0; i < 32; i++) {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 20)) && !defined(AST_BUILDOPT_LIMEY)
-		sprintf(str, "/sys/class/sound/card%d/device", i);
+		snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
 		memset(desdev, 0, sizeof(desdev));
 		if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
 			continue;
@@ -564,13 +564,13 @@ int ast_radio_usb_get_usbdev(const char *devstr)
 		cp++;
 #else
 		if (i) {
-			sprintf(str, "/sys/class/sound/dsp%d/device", i);
+			snprintf(str, sizeof(str), "/sys/class/sound/dsp%d/device", i);
 		} else {
-			strcpy(str, "/sys/class/sound/dsp/device");
+			snprintf(str, sizeof(str), "/sys/class/sound/dsp/device");
 		}
 		memset(desdev, 0, sizeof(desdev));
 		if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
-			sprintf(str, "/sys/class/sound/controlC%d/device", i);
+			snprintf(str, sizeof(str), "/sys/class/sound/controlC%d/device", i);
 			memset(desdev, 0, sizeof(desdev));
 			if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
 				continue;
@@ -889,7 +889,8 @@ void ast_radio_print_audio_stats(int fd, struct audiostatistics *o, const char *
 	dmin = minpwr ? 10 * log10(minpwr * scale) : -96.0;
 	dmax = maxpwr ? 10 * log10(maxpwr * scale) : -96.0;
 	/* Print stats */
-	sprintf(s1, "%sAudioStats: Pk %5.1f  Avg Pwr %3.0f  Min %3.0f  Max %3.0f  dBFS  ClipCnt %u", prefix_text, dpk, tpwr, dmin, dmax, clipcnt);
+	snprintf(s1, sizeof(s1), "%sAudioStats: Pk %5.1f  Avg Pwr %3.0f  Min %3.0f  Max %3.0f  dBFS  ClipCnt %u", prefix_text, dpk,
+		tpwr, dmin, dmax, clipcnt);
 	if (fd >= 0) {
 		ast_cli(fd, "%s\n", s1);
 	} else {


### PR DESCRIPTION
Prevent potential buffer overflows
Fixes #13 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Hardened string handling across the repeater app and multiple channel drivers by replacing unbounded `strcpy/sprintf` usage with bounded `ast_copy_string` and `snprintf`.
  * Improved safety in command/message formatting (including paging, COP/GPIO, rig payloads, link/rssi text, node index display, and IP/identifier copies).
  * Added fit-check handling for paging payload construction to prevent overflow.

* **Chores**
  * Tightened bounded formatting/copying in CLI stats output and HTTP registration display/storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->