### PR TITLE
app_rpt: update RPT_LINKS varlable when `L` message is received.

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -1942,6 +1942,7 @@ static void handle_link_data(struct rpt *myrpt, struct rpt_link *mylink, char *s
 		ast_str_set(&mylink->linklist, 0, "%s", str + 2); /* Dropping the "L " of the message */
 		rpt_mutex_unlock(&myrpt->lock);
 		ast_debug(7, "@@@@ node %s received node list %s from node %s\n", myrpt->name, str, mylink->name);
+		rpt_update_links(myrpt);
 		return;
 	}
 	if (*str == 'M') {


### PR DESCRIPTION
RPT_LINKS remains "stale" after a node disconnects or changes until the local repeater keys or unkeys.  This change updates the values on receipt of a new L message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Link list updates now properly trigger a refresh of network links instead of being stored without processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->