### PR TITLE
app_rpt: Better link update

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4464,9 +4464,6 @@ static int remote_hangup_helper(struct rpt *myrpt, struct rpt_link *l)
 	} else if (l->disced != RPT_LINK_DISCONNECT_SILENT) {
 		rpt_telemetry(myrpt, REMDISC, l);
 	}
-	if (l->hasconnected) {
-		rpt_update_links(myrpt);
-	}
 	donodelog_fmt(myrpt, l->hasconnected ? "LINKDISC,%s" : "LINKFAIL,%s", l->name);
 	if (l->hasconnected) {
 		dodispgm(myrpt, l->name);
@@ -4476,6 +4473,11 @@ static int remote_hangup_helper(struct rpt *myrpt, struct rpt_link *l)
 	/* hang-up on call to device */
 	hangup_link_chan(l);
 	ast_hangup(l->pchan);
+
+	if (l->hasconnected) {
+		rpt_update_links(myrpt);
+	}
+
 	ast_audiohook_lock(&l->altaudio);
 	ast_audiohook_detach(&l->altaudio);
 	ast_audiohook_unlock(&l->altaudio);


### PR DESCRIPTION
We should update AFTER the link is removed.
This may bypass the need for #1077 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Link and node-list updates are now refreshed more reliably when inbound network data changes.
  * Improved cleanup handling during remote disconnects so link information stays up to date without affecting existing telemetry and logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->