### PR TITLE
res_usbradio: Add shared PortAudio API for USB radio drivers

### DIFF
--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -1036,13 +1036,12 @@ static void *hidthread(void *arg)
 		o->usbass = 1;
 		ast_mutex_unlock(&usb_dev_lock);
 		/* set the audio mixer values */
-		o->micmax = ast_radio_mixer_limit(ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL));
+		o->micmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL);
 		o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL);
 		if (o->spkrmax == -1) {
 			o->newname = 1;
 			o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW);
 		}
-		o->spkrmax = ast_radio_mixer_limit(o->spkrmax);
 		/* initialize the usb device */
 		usb_dev = ast_radio_hid_device_init(o->devstr);
 		if (usb_dev == NULL) {

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -1036,12 +1036,13 @@ static void *hidthread(void *arg)
 		o->usbass = 1;
 		ast_mutex_unlock(&usb_dev_lock);
 		/* set the audio mixer values */
-		o->micmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL);
+		o->micmax = ast_radio_mixer_limit(ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL));
 		o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL);
 		if (o->spkrmax == -1) {
 			o->newname = 1;
 			o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW);
 		}
+		o->spkrmax = ast_radio_mixer_limit(o->spkrmax);
 		/* initialize the usb device */
 		usb_dev = ast_radio_hid_device_init(o->devstr);
 		if (usb_dev == NULL) {

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -84,14 +84,6 @@
 #define AUDIO_ADJUSTMENT 1000
 
 /*!
- * \brief Default ALSA mixer maximum when hardware lookup fails.
- *
- * CM108-class devices commonly expose a 0-31 capture range; use this
- * instead of propagating -1 into volume scaling math.
- */
-#define AST_RADIO_MIXER_MAX_DEFAULT 31
-
-/*!
  * \brief EEPROM memory layout
  *	The AT93C46 eeprom has 64 addresses that contain 2 bytes (one word).
  *	The CMxxx sound card device will use this eeprom to read manuafacturer
@@ -257,13 +249,21 @@ int ast_radio_make_spkr_playback_value(int spkrmax, int request_value, int devty
 int ast_radio_amixer_max(int devnum, char *param);
 
 /*!
- * \brief Return a usable mixer maximum for volume scaling.
+ * \brief Query required ALSA mixer maximums for a USB radio device.
  *
- * \param limit Value from ast_radio_amixer_max(), or another mixer limit.
+ * Reads mic capture, speaker playback (with alternate control name), and
+ * mic playback limits. Fails when any required limit is unavailable.
  *
- * \retval limit if positive, otherwise AST_RADIO_MIXER_MAX_DEFAULT.
+ * \param devnum ALSA card number.
+ * \param micmax Returned Mic Capture Volume maximum.
+ * \param spkrmax Returned Speaker Playback Volume maximum.
+ * \param micplaymax Returned Mic Playback Volume maximum.
+ * \param newname Set to 1 when the alternate speaker control name is used.
+ *
+ * \retval 0 on success.
+ * \retval -1 if any required mixer limit is unavailable.
  */
-int ast_radio_mixer_limit(int limit);
+int ast_radio_init_mixer_limits(int devnum, int *micmax, int *spkrmax, int *micplaymax, int *newname);
 
 /*!
  * \brief Set mixer

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -80,6 +80,14 @@
 #define AUDIO_ADJUSTMENT 1000
 
 /*!
+ * \brief Default ALSA mixer maximum when hardware lookup fails.
+ *
+ * CM108-class devices commonly expose a 0-31 capture range; use this
+ * instead of propagating -1 into volume scaling math.
+ */
+#define AST_RADIO_MIXER_MAX_DEFAULT 31
+
+/*!
  * \brief EEPROM memory layout
  *	The AT93C46 eeprom has 64 addresses that contain 2 bytes (one word).
  *	The CMxxx sound card device will use this eeprom to read manuafacturer
@@ -243,6 +251,15 @@ int ast_radio_make_spkr_playback_value(int spkrmax, int request_value, int devty
  * \retval 				The maximum value.
  */
 int ast_radio_amixer_max(int devnum, char *param);
+
+/*!
+ * \brief Return a usable mixer maximum for volume scaling.
+ *
+ * \param limit Value from ast_radio_amixer_max(), or another mixer limit.
+ *
+ * \retval limit if positive, otherwise AST_RADIO_MIXER_MAX_DEFAULT.
+ */
+int ast_radio_mixer_limit(int limit);
 
 /*!
  * \brief Set mixer

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -23,7 +23,11 @@
  * \brief USB sound card resources.
  */
 
-/*! \note <sys/io.h> is not portable to all architectures, so don't call non-portable functions if we don't have them */
+/*! \note <sys/io.h> is not portable to all architectures; guard parallel-port helpers with HAVE_SYS_IO */
+#if __has_include(<sys/io.h>)
+#define HAVE_SYS_IO
+#endif
+
 #include <portaudio.h>
 
 /*!

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -570,7 +570,6 @@ PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps);
 PaError ast_radio_pa_start(struct ast_radio_pa_stream *ps);
 void ast_radio_pa_stop(struct ast_radio_pa_stream *ps);
 
-PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned long frames, int timeout_ms,
-	volatile sig_atomic_t *stop);
+PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned long frames, int timeout_ms, volatile sig_atomic_t *stop);
 PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, unsigned long frames);
 long ast_radio_pa_write_available(struct ast_radio_pa_stream *ps);

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -24,9 +24,7 @@
  */
 
 /*! \note <sys/io.h> is not portable to all architectures, so don't call non-portable functions if we don't have them */
-#if __has_include(<sys/io.h>)
-#define HAVE_SYS_IO
-#endif
+#include <portaudio.h>
 
 /*!
  * \brief Defines for interacting with ALSA controls.
@@ -529,3 +527,33 @@ void ast_radio_print_audio_stats(int fd, struct audiostatistics *o, const char *
  * \param cardno The ALSA card number as found in HW:<cardno>
  */
 struct usb_device *ast_radio_usb_device_from_alsa_card(int cardno);
+
+#define AST_RADIO_PA_SAMPLE_RATE 48000
+#define AST_RADIO_PA_FRAMES_PER_BUFFER (FRAME_SIZE * 6)
+#define AST_RADIO_PA_OUTPUT_CHANNELS 2
+
+/*!
+ * \brief PortAudio stream state shared by chan_simpleusb and chan_usbradio.
+ */
+struct ast_radio_pa_stream {
+	PaStream *stream;
+	int active;
+	unsigned int input_channels; /*!< 1 for mono RX, 2 for stereo RX */
+	char hw_device[100];
+};
+
+int ast_radio_pa_startup(void);
+void ast_radio_pa_shutdown(void);
+void ast_radio_pa_shutdown_all(void);
+
+int ast_radio_parse_hw_anywhere(const char *s, int *card, int *dev);
+int ast_radio_hw_match(const char *haystack, const char *needle);
+
+PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps);
+PaError ast_radio_pa_start(struct ast_radio_pa_stream *ps);
+void ast_radio_pa_stop(struct ast_radio_pa_stream *ps);
+
+PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned long frames, int timeout_ms,
+	volatile sig_atomic_t *stop);
+PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, unsigned long frames);
+long ast_radio_pa_write_available(struct ast_radio_pa_stream *ps);

--- a/res/Makefile.diff
+++ b/res/Makefile.diff
@@ -6,7 +6,7 @@ index 0987f43a43..2f18773cba 100644
  snmp/agent.o: _ASTCFLAGS+=-fPIC
  res_snmp.o: _ASTCFLAGS+=-fPIC
  
-+res_usbradio.so: LIBS+=-lusb -lasound
++res_usbradio.so: LIBS+=-lusb -lasound -lportaudio
 +
  # Dependencies for res_ari_*.so are generated, so they're in this file
  include ari.make

--- a/res/Makefile.diff
+++ b/res/Makefile.diff
@@ -1,13 +1,11 @@
-diff --git a/res/Makefile b/res/Makefile
-index 0987f43a43..2f18773cba 100644
 --- a/res/Makefile
 +++ b/res/Makefile
-@@ -79,6 +79,8 @@ res_parking.o: _ASTCFLAGS+=$(AST_NO_FORMAT_TRUNCATION)
+@@ -78,6 +78,8 @@
+ res_parking.o: _ASTCFLAGS+=$(AST_NO_FORMAT_TRUNCATION)
  snmp/agent.o: _ASTCFLAGS+=-fPIC
  res_snmp.o: _ASTCFLAGS+=-fPIC
  
 +res_usbradio.so: LIBS+=-lusb -lasound -lportaudio
 +
- # Dependencies for res_ari_*.so are generated, so they're in this file
- include ari.make
+ MODULE_EXCLUDE=ENABLE_SRTP_AES_192 ENABLE_SRTP_AES_256 ENABLE_SRTP_AES_GCM
  

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -1186,8 +1186,8 @@ PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
 			return paDeviceUnavailable;
 		}
 
-		res = Pa_OpenStream(&ps->stream, &input_params, &output_params, AST_RADIO_PA_SAMPLE_RATE,
-			AST_RADIO_PA_FRAMES_PER_BUFFER, paNoFlag, NULL, NULL);
+		res = Pa_OpenStream(&ps->stream, &input_params, &output_params, AST_RADIO_PA_SAMPLE_RATE, AST_RADIO_PA_FRAMES_PER_BUFFER,
+			paNoFlag, NULL, NULL);
 	}
 
 	if (res != paNoError) {
@@ -1201,8 +1201,7 @@ PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
 
 	si = Pa_GetStreamInfo(ps->stream);
 	if (si) {
-		ast_debug(5, "PortAudio stream latency in %.3f ms out %.3f ms\n", si->inputLatency * 1000.0,
-			si->outputLatency * 1000.0);
+		ast_debug(5, "PortAudio stream latency in %.3f ms out %.3f ms\n", si->inputLatency * 1000.0, si->outputLatency * 1000.0);
 	}
 
 	return res;
@@ -1248,8 +1247,7 @@ void ast_radio_pa_stop(struct ast_radio_pa_stream *ps)
 	ast_radio_pa_shutdown();
 }
 
-PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned long frames, int timeout_ms,
-	volatile sig_atomic_t *stop)
+PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned long frames, int timeout_ms, volatile sig_atomic_t *stop)
 {
 	int64_t start;
 	PaError err;

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -444,6 +444,8 @@ int ast_radio_hid_device_mklist(void)
 	struct usb_bus *usb_bus;
 	struct usb_device *dev;
 	char devstr[10000], str[200], desdev[200], *cp;
+	ssize_t linklen;
+	size_t cplen;
 	int i;
 
 	ast_mutex_lock(&usb_list_lock);
@@ -483,9 +485,11 @@ int ast_radio_hid_device_mklist(void)
 
 				snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
 				memset(desdev, 0, sizeof(desdev));
-				if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
+				linklen = readlink(str, desdev, sizeof(desdev) - 1);
+				if (linklen == -1) {
 					continue;
 				}
+				desdev[linklen] = '\0';
 				cp = strrchr(desdev, '/');
 				if (!cp) {
 					continue;
@@ -498,22 +502,23 @@ int ast_radio_hid_device_mklist(void)
 				continue;
 			}
 
-			new_list = ast_realloc(usb_device_list, usb_device_list_size + 2 + strlen(cp));
+			cplen = strlen(cp);
+			new_list = ast_realloc(usb_device_list, usb_device_list_size + 2 + cplen);
 			if (!new_list) {
 				ast_mutex_unlock(&usb_list_lock);
 				return -1;
 			}
 
 			usb_device_list = new_list;
-			usb_device_list_size += strlen(cp) + 2;
+			usb_device_list_size += cplen + 2;
 			i = 0;
 
 			while (usb_device_list[i]) {
 				i += strlen(usb_device_list + i) + 1;
 			}
 
-			memcpy(usb_device_list + i, cp, strlen(cp) + 1);
-			usb_device_list[strlen(cp) + i + 1] = 0;
+			memcpy(usb_device_list + i, cp, cplen + 1);
+			usb_device_list[i + cplen + 1] = 0;
 		}
 	}
 	ast_mutex_unlock(&usb_list_lock);
@@ -525,6 +530,7 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 	struct usb_bus *usb_bus;
 	struct usb_device *dev;
 	char devstr[10000], str[200], desdev[200], *cp;
+	ssize_t linklen;
 	int i;
 
 	usb_init();
@@ -549,9 +555,11 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 
 				snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
 				memset(desdev, 0, sizeof(desdev));
-				if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
+				linklen = readlink(str, desdev, sizeof(desdev) - 1);
+				if (linklen == -1) {
 					continue;
 				}
+				desdev[linklen] = '\0';
 				cp = strrchr(desdev, '/');
 				if (!cp) {
 					continue;

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -1094,6 +1094,7 @@ static int match_card_id(const char *devname, int card)
 static int pa_device_matches(const PaDeviceInfo *dev, const char *hw_device, int want_input, int want_output)
 {
 	int card, devnum;
+	int hay_card, hay_dev;
 
 	if (!dev || !hw_device || !hw_device[0]) {
 		return 0;
@@ -1111,11 +1112,20 @@ static int pa_device_matches(const PaDeviceInfo *dev, const char *hw_device, int
 		return 1;
 	}
 
-	if (ast_radio_parse_hw_anywhere(hw_device, &card, &devnum) && match_card_id(dev->name, card)) {
+	if (!ast_radio_parse_hw_anywhere(hw_device, &card, &devnum) || !match_card_id(dev->name, card)) {
+		return 0;
+	}
+
+	/* Card-id fallback is only unambiguous for hw:C; hw:C,D must match subdevice too. */
+	if (devnum < 0) {
 		return 1;
 	}
 
-	return 0;
+	if (!ast_radio_parse_hw_anywhere(dev->name, &hay_card, &hay_dev)) {
+		return 0;
+	}
+
+	return hay_card == card && hay_dev == devnum;
 }
 
 static PaDeviceIndex pa_find_device(const char *hw_device, int want_input, int want_output)

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -28,6 +28,7 @@
 
 /*** MODULEINFO
 	<depend>alsa</depend>
+	<depend>portaudio</depend>
 	<support_level>extended</support_level>
  ***/
 
@@ -48,6 +49,7 @@
 #include <linux/parport.h>
 #include <linux/version.h>
 #include <alsa/asoundlib.h>
+#include <portaudio.h>
 
 #include "asterisk/res_usbradio.h"
 
@@ -151,7 +153,10 @@ int ast_radio_amixer_max(int devnum, char *param)
 	}
 
 	snd_ctl_elem_info_alloca(&info);
-	snd_hctl_elem_info(elem, info);
+	if (snd_hctl_elem_info(elem, info) < 0) {
+		snd_hctl_close(hctl);
+		return -1;
+	}
 	type = snd_ctl_elem_info_get_type(info);
 	rv = 0;
 
@@ -199,7 +204,10 @@ int ast_radio_setamixer(int devnum, char *param, int v1, int v2)
 	}
 
 	snd_ctl_elem_info_alloca(&info);
-	snd_hctl_elem_info(elem, info);
+	if (snd_hctl_elem_info(elem, info) < 0) {
+		snd_hctl_close(hctl);
+		return -1;
+	}
 	type = snd_ctl_elem_info_get_type(info);
 	snd_ctl_elem_value_alloca(&control);
 	snd_ctl_elem_value_set_id(control, id);
@@ -464,11 +472,9 @@ int ast_radio_hid_device_mklist(void)
 
 				snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
 				memset(desdev, 0, sizeof(desdev));
-
 				if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
 					continue;
 				}
-
 				cp = strrchr(desdev, '/');
 				if (!cp) {
 					continue;
@@ -482,7 +488,6 @@ int ast_radio_hid_device_mklist(void)
 			}
 
 			new_list = ast_realloc(usb_device_list, usb_device_list_size + 2 + strlen(cp));
-
 			if (!new_list) {
 				ast_mutex_unlock(&usb_list_lock);
 				return -1;
@@ -496,7 +501,7 @@ int ast_radio_hid_device_mklist(void)
 				i += strlen(usb_device_list + i) + 1;
 			}
 
-			strcat(usb_device_list + i, cp);
+			memcpy(usb_device_list + i, cp, strlen(cp) + 1);
 			usb_device_list[strlen(cp) + i + 1] = 0;
 		}
 	}
@@ -530,6 +535,7 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 				if (strcasecmp(desdev, devstr)) {
 					continue;
 				}
+
 				snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
 				memset(desdev, 0, sizeof(desdev));
 				if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
@@ -542,11 +548,9 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 				cp++;
 				break;
 			}
-
 			if (i >= 32) {
 				continue;
 			}
-
 			if (!strcmp(cp, desired_device)) {
 				return dev;
 			}
@@ -926,6 +930,376 @@ static void cleanup_user_devices(void)
 }
 
 /*
+ * PortAudio helpers shared by chan_simpleusb and chan_usbradio.
+ */
+AST_MUTEX_DEFINE_STATIC(pa_lock);
+static int pa_refcount;
+
+static int64_t pa_now_ms(void)
+{
+	struct timespec ts;
+
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (int64_t) ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
+int ast_radio_pa_startup(void)
+{
+	PaError res;
+
+	ast_mutex_lock(&pa_lock);
+	if (pa_refcount == 0) {
+		res = Pa_Initialize();
+		if (res != paNoError) {
+			ast_mutex_unlock(&pa_lock);
+			ast_log(LOG_WARNING, "Failed to initialize PortAudio - (%d) %s\n", res, Pa_GetErrorText(res));
+			return -1;
+		}
+	}
+	pa_refcount++;
+	ast_mutex_unlock(&pa_lock);
+	return 0;
+}
+
+void ast_radio_pa_shutdown(void)
+{
+	ast_mutex_lock(&pa_lock);
+	if (pa_refcount > 0) {
+		pa_refcount--;
+		if (pa_refcount == 0) {
+			Pa_Terminate();
+		}
+	}
+	ast_mutex_unlock(&pa_lock);
+}
+
+void ast_radio_pa_shutdown_all(void)
+{
+	ast_mutex_lock(&pa_lock);
+	if (pa_refcount > 0) {
+		Pa_Terminate();
+		pa_refcount = 0;
+	}
+	ast_mutex_unlock(&pa_lock);
+}
+
+int ast_radio_parse_hw_anywhere(const char *s, int *card, int *dev)
+{
+	const char *p = s;
+
+	if (!s || !card || !dev) {
+		return 0;
+	}
+
+	while ((p = strstr(p, "hw:")) != NULL) {
+		const char *q = p + 3;
+		int c = 0;
+		int d = -1;
+
+		if (!isdigit((unsigned char) *q)) {
+			p = q;
+			continue;
+		}
+
+		while (isdigit((unsigned char) *q)) {
+			if (c > 9999) {
+				p = q;
+				break;
+			}
+			c = c * 10 + (*q - '0');
+			q++;
+		}
+
+		if (*q == ',') {
+			q++;
+			if (!isdigit((unsigned char) *q)) {
+				p = q;
+				continue;
+			}
+			d = 0;
+			while (isdigit((unsigned char) *q)) {
+				d = d * 10 + (*q - '0');
+				q++;
+			}
+		}
+
+		*card = c;
+		*dev = d;
+		return 1;
+	}
+
+	return 0;
+}
+
+int ast_radio_hw_match(const char *haystack, const char *needle)
+{
+	int haystack_c, haystack_d, needle_c, needle_d;
+	const char *p = haystack ? haystack : "";
+
+	if (!ast_radio_parse_hw_anywhere(needle, &needle_c, &needle_d)) {
+		return 0;
+	}
+
+	while ((p = strstr(p, "hw:")) != NULL) {
+		if (ast_radio_parse_hw_anywhere(p, &haystack_c, &haystack_d)) {
+			if (haystack_c == needle_c) {
+				if (needle_d < 0 || haystack_d == needle_d) {
+					return 1;
+				}
+			}
+		}
+		p += 3;
+	}
+
+	return 0;
+}
+
+static int match_card_id(const char *devname, int card)
+{
+	char path[128], id[64];
+	FILE *fp;
+	size_t n;
+
+	snprintf(path, sizeof(path), "/proc/asound/card%d/id", card);
+	fp = fopen(path, "r");
+	if (!fp) {
+		return 0;
+	}
+
+	if (!fgets(id, sizeof(id), fp) || !id[0]) {
+		fclose(fp);
+		return 0;
+	}
+	fclose(fp);
+
+	n = strlen(id);
+	while (n > 0 && isspace((unsigned char) id[n - 1])) {
+		id[--n] = '\0';
+	}
+
+	return n > 0 && strstr(devname, id) != NULL;
+}
+
+static int pa_device_matches(const PaDeviceInfo *dev, const char *hw_device, int want_input, int want_output)
+{
+	int card, devnum;
+
+	if (!dev || !hw_device || !hw_device[0]) {
+		return 0;
+	}
+
+	if (want_input && !dev->maxInputChannels) {
+		return 0;
+	}
+
+	if (want_output && !dev->maxOutputChannels) {
+		return 0;
+	}
+
+	if (ast_radio_hw_match(dev->name, hw_device)) {
+		return 1;
+	}
+
+	if (ast_radio_parse_hw_anywhere(hw_device, &card, &devnum) && match_card_id(dev->name, card)) {
+		return 1;
+	}
+
+	return 0;
+}
+
+static PaDeviceIndex pa_find_device(const char *hw_device, int want_input, int want_output)
+{
+	PaDeviceIndex idx, num_devices;
+
+	num_devices = Pa_GetDeviceCount();
+	if (num_devices < 0) {
+		return paNoDevice;
+	}
+
+	for (idx = 0; idx < num_devices; idx++) {
+		const PaDeviceInfo *dev = Pa_GetDeviceInfo(idx);
+
+		if (pa_device_matches(dev, hw_device, want_input, want_output)) {
+			return idx;
+		}
+	}
+
+	return paNoDevice;
+}
+
+PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
+{
+	PaError res = paInternalError;
+	const PaStreamInfo *si;
+
+	if (!ps) {
+		return paBadStreamPtr;
+	}
+
+	ps->stream = NULL;
+	ps->active = 0;
+
+	if (ast_radio_pa_startup() < 0) {
+		return paInternalError;
+	}
+
+	if (!strcasecmp(ps->hw_device, "default")) {
+		res = Pa_OpenDefaultStream(&ps->stream, ps->input_channels, AST_RADIO_PA_OUTPUT_CHANNELS, paInt16,
+			AST_RADIO_PA_SAMPLE_RATE, AST_RADIO_PA_FRAMES_PER_BUFFER, NULL, NULL);
+	} else {
+		PaStreamParameters input_params = {
+			.channelCount = ps->input_channels,
+			.sampleFormat = paInt16,
+			.suggestedLatency = (1.0 / 50.0),
+			.device = paNoDevice,
+		};
+		PaStreamParameters output_params = {
+			.channelCount = AST_RADIO_PA_OUTPUT_CHANNELS,
+			.sampleFormat = paInt16,
+			.suggestedLatency = (1.0 / 50.0),
+			.device = paNoDevice,
+		};
+
+		input_params.device = pa_find_device(ps->hw_device, 1, 0);
+		output_params.device = pa_find_device(ps->hw_device, 0, 1);
+
+		if (input_params.device == paNoDevice) {
+			ast_log(LOG_ERROR, "No PortAudio input device found for '%s'\n", ps->hw_device);
+			ast_radio_pa_shutdown();
+			return paDeviceUnavailable;
+		}
+
+		if (output_params.device == paNoDevice) {
+			ast_log(LOG_ERROR, "No PortAudio output device found for '%s'\n", ps->hw_device);
+			ast_radio_pa_shutdown();
+			return paDeviceUnavailable;
+		}
+
+		res = Pa_OpenStream(&ps->stream, &input_params, &output_params, AST_RADIO_PA_SAMPLE_RATE,
+			AST_RADIO_PA_FRAMES_PER_BUFFER, paNoFlag, NULL, NULL);
+	}
+
+	if (res != paNoError) {
+		ast_radio_pa_shutdown();
+		return res;
+	}
+
+	si = Pa_GetStreamInfo(ps->stream);
+	if (si) {
+		ast_debug(5, "PortAudio stream latency in %.3f ms out %.3f ms\n", si->inputLatency * 1000.0,
+			si->outputLatency * 1000.0);
+	}
+
+	return res;
+}
+
+PaError ast_radio_pa_start(struct ast_radio_pa_stream *ps)
+{
+	PaError res;
+
+	if (!ps || !ps->stream) {
+		return paBadStreamPtr;
+	}
+
+	res = Pa_StartStream(ps->stream);
+	if (res == paNoError) {
+		ps->active = 1;
+	}
+	return res;
+}
+
+void ast_radio_pa_stop(struct ast_radio_pa_stream *ps)
+{
+	PaError err;
+
+	if (!ps || !ps->stream) {
+		return;
+	}
+
+	if (ps->active) {
+		err = Pa_AbortStream(ps->stream);
+		if (err != paNoError) {
+			ast_log(LOG_WARNING, "Pa_AbortStream failed: %s\n", Pa_GetErrorText(err));
+		}
+	}
+
+	err = Pa_CloseStream(ps->stream);
+	if (err != paNoError) {
+		ast_log(LOG_WARNING, "Pa_CloseStream failed: %s\n", Pa_GetErrorText(err));
+	}
+
+	ps->stream = NULL;
+	ps->active = 0;
+	ast_radio_pa_shutdown();
+}
+
+PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned long frames, int timeout_ms,
+	volatile sig_atomic_t *stop)
+{
+	int64_t start;
+	PaError err;
+
+	if (!ps || !ps->stream || !buf) {
+		return paBadStreamPtr;
+	}
+
+	start = pa_now_ms();
+	while (!stop || !(*stop)) {
+		long avail = Pa_GetStreamReadAvailable(ps->stream);
+
+		if (avail < 0) {
+			return (PaError) avail;
+		}
+
+		if ((pa_now_ms() - start) > timeout_ms) {
+			return paTimedOut;
+		}
+
+		if ((unsigned long) avail < frames) {
+			usleep(500);
+			continue;
+		}
+
+		err = Pa_ReadStream(ps->stream, buf, frames);
+		return err;
+	}
+
+	return paTimedOut;
+}
+
+PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, unsigned long frames)
+{
+	PaError res;
+	short null_buf[AST_RADIO_PA_FRAMES_PER_BUFFER * AST_RADIO_PA_OUTPUT_CHANNELS];
+
+	if (!ps || !ps->stream || !data) {
+		return paBadStreamPtr;
+	}
+
+	if (frames > AST_RADIO_PA_FRAMES_PER_BUFFER) {
+		ast_log(LOG_WARNING, "ast_radio_pa_write: frames %lu exceeds buffer capacity\n", frames);
+		return paBufferTooBig;
+	}
+
+	res = Pa_WriteStream(ps->stream, data, frames);
+	if (res == paOutputUnderflowed) {
+		memset(null_buf, 0, sizeof(null_buf));
+		Pa_WriteStream(ps->stream, null_buf, frames);
+	}
+
+	return res;
+}
+
+long ast_radio_pa_write_available(struct ast_radio_pa_stream *ps)
+{
+	if (!ps || !ps->stream) {
+		return -1;
+	}
+
+	return Pa_GetStreamWriteAvailable(ps->stream);
+}
+
+/*
  * Returns the libusb device that backs ALSA /proc/asound/card<cardno>/usbbus.
  * On success: returns a pointer to a libusb struct usb_device.
  * On failure: returns NULL.
@@ -1047,6 +1421,7 @@ static int load_module(void)
 static int unload_module(void)
 {
 	cleanup_user_devices();
+	ast_radio_pa_shutdown_all();
 
 	return 0;
 }

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -119,18 +119,47 @@ long ast_radio_lround(double x)
 
 int ast_radio_make_spkr_playback_value(int spkrmax, int request_value, int devtype)
 {
-	spkrmax = ast_radio_mixer_limit(spkrmax);
+	if (spkrmax <= 0) {
+		return 0;
+	}
 	return (request_value * spkrmax) / AUDIO_ADJUSTMENT;
 }
 
-int ast_radio_mixer_limit(int limit)
+int ast_radio_init_mixer_limits(int devnum, int *micmax, int *spkrmax, int *micplaymax, int *newname)
 {
-	if (limit > 0) {
-		return limit;
+	int rv;
+
+	if (!micmax || !spkrmax || !micplaymax || !newname) {
+		return -1;
 	}
 
-	ast_log(LOG_WARNING, "Mixer max lookup failed, using default %d\n", AST_RADIO_MIXER_MAX_DEFAULT);
-	return AST_RADIO_MIXER_MAX_DEFAULT;
+	rv = ast_radio_amixer_max(devnum, MIXER_PARAM_MIC_CAPTURE_VOL);
+	if (rv <= 0) {
+		ast_log(LOG_ERROR, "Mixer limit not available for hw:%d (%s)\n", devnum, MIXER_PARAM_MIC_CAPTURE_VOL);
+		return -1;
+	}
+	*micmax = rv;
+
+	*newname = 0;
+	rv = ast_radio_amixer_max(devnum, MIXER_PARAM_SPKR_PLAYBACK_VOL);
+	if (rv <= 0) {
+		rv = ast_radio_amixer_max(devnum, MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW);
+		if (rv <= 0) {
+			ast_log(LOG_ERROR, "Mixer limit not available for hw:%d (speaker playback)\n", devnum);
+			return -1;
+		}
+		*newname = 1;
+	}
+	*spkrmax = rv;
+
+	rv = ast_radio_amixer_max(devnum, MIXER_PARAM_MIC_PLAYBACK_VOL);
+	if (rv <= 0) {
+		ast_log(LOG_ERROR, "Mixer limit not available for hw:%d (%s)\n", devnum, MIXER_PARAM_MIC_PLAYBACK_VOL);
+		return -1;
+	}
+	*micplaymax = rv;
+
+	return 0;
 }
 
 int ast_radio_amixer_max(int devnum, char *param)

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -119,7 +119,18 @@ long ast_radio_lround(double x)
 
 int ast_radio_make_spkr_playback_value(int spkrmax, int request_value, int devtype)
 {
+	spkrmax = ast_radio_mixer_limit(spkrmax);
 	return (request_value * spkrmax) / AUDIO_ADJUSTMENT;
+}
+
+int ast_radio_mixer_limit(int limit)
+{
+	if (limit > 0) {
+		return limit;
+	}
+
+	ast_log(LOG_WARNING, "Mixer max lookup failed, using default %d\n", AST_RADIO_MIXER_MAX_DEFAULT);
+	return AST_RADIO_MIXER_MAX_DEFAULT;
 }
 
 int ast_radio_amixer_max(int devnum, char *param)

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -1180,6 +1180,10 @@ PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
 	}
 
 	if (res != paNoError) {
+		if (ps->stream) {
+			Pa_CloseStream(ps->stream);
+			ps->stream = NULL;
+		}
 		ast_radio_pa_shutdown();
 		return res;
 	}


### PR DESCRIPTION
## Summary
- Add refcounted PortAudio lifecycle (`ast_radio_pa_startup` / `shutdown`)
- Add `ast_radio_pa_*` stream helpers shared by USB channel drivers
- Match ALSA devices via `hw:N` parsing and `/proc/asound/cardN/id` fallback
- Link `-lportaudio` on `res_usbradio.so`

## Stack
This is **PR 1 of 3** in the OSS → PortAudio migration. Merge in order:
1. This PR (res_usbradio foundation)
2. #TBD — chan_simpleusb
3. #TBD — chan_usbradio + packaging

Supersedes the monolithic approach in #1029.

## Test plan
- [ ] `res_usbradio.so` builds and links `libportaudio`
- [ ] Module loads on ASL3 22.9 without errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enhanced PortAudio-based USB radio streaming with wider hardware/device matching support, including mapping an ALSA card to a connected device.
* **Bug Fixes**
  * Improved mono vs. stereo audio validation and statistics handling, including safer behavior when downsampling produces no samples.
  * More robust mixer level limiting for both microphone capture and speaker playback.
  * Strengthened mixer element error handling, USB/HID device matching, and PortAudio startup/shutdown behavior for more reliable unloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->