### PR TITLE
chan_simpleusb: Migrate to shared PortAudio API (stack 2/3)

### DIFF
--- a/channels/Makefile.diff
+++ b/channels/Makefile.diff
@@ -1,8 +1,6 @@
-diff --git a/channels/Makefile b/channels/Makefile
-index 0f8d1328c5..c9523f6d69 100644
 --- a/channels/Makefile
 +++ b/channels/Makefile
-@@ -22,6 +22,8 @@ include $(ASTTOPDIR)/Makefile.moddir_rules
+@@ -22,6 +22,9 @@
  $(call MOD_ADD_C,chan_iax2,$(wildcard iax2/*.c))
  iax2/parser.o: _ASTCFLAGS+=$(call get_menuselect_cflags,MALLOC_DEBUG)
  

--- a/channels/Makefile.diff
+++ b/channels/Makefile.diff
@@ -2,7 +2,7 @@ diff --git a/channels/Makefile b/channels/Makefile
 index 0f8d1328c5..c9523f6d69 100644
 --- a/channels/Makefile
 +++ b/channels/Makefile
-@@ -22,6 +22,9 @@ include $(ASTTOPDIR)/Makefile.moddir_rules
+@@ -22,6 +22,8 @@ include $(ASTTOPDIR)/Makefile.moddir_rules
  $(call MOD_ADD_C,chan_iax2,$(wildcard iax2/*.c))
  iax2/parser.o: _ASTCFLAGS+=$(call get_menuselect_cflags,MALLOC_DEBUG)
  

--- a/channels/Makefile.diff
+++ b/channels/Makefile.diff
@@ -6,7 +6,7 @@ index 0f8d1328c5..c9523f6d69 100644
  $(call MOD_ADD_C,chan_iax2,$(wildcard iax2/*.c))
  iax2/parser.o: _ASTCFLAGS+=$(call get_menuselect_cflags,MALLOC_DEBUG)
  
-+chan_simpleusb.so: LIBS+=-lusb -lasound -lportaudio
++chan_simpleusb.so: LIBS+=-lusb -lasound
 +chan_usbradio.so: LIBS+=-lusb -lasound
 +
  $(call MOD_ADD_C,chan_pjsip,$(wildcard pjsip/*.c))

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -902,8 +902,7 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 			}
 			for (ao = simpleusb_default.next; ao && ao->name; ao = ao->next) {
 				if (ao != o && ao->usbass && ao->devicenum == o->devicenum) {
-					ast_log(LOG_ERROR, "Channel %s: Audio device %s is already assigned to channel %s\n",
-						o->name, o->hw_device, ao->name);
+					ast_log(LOG_ERROR, "Channel %s: Audio device %s is already assigned to channel %s\n", o->name, o->hw_device, ao->name);
 					ast_mutex_unlock(&usb_dev_lock);
 					return -1;
 				}

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1064,10 +1064,15 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 
 	o->device_error = 0;
 	ast_radio_time(&o->lasthidtime);
-	if (ast_radio_init_mixer_limits(o->devicenum, &o->micmax, &o->spkrmax, &o->micplaymax, &o->newname) < 0) {
-		ast_log(LOG_ERROR, "Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
-		ast_mutex_unlock(&usb_dev_lock);
-		return -1;
+	{
+		int use_newname = 0;
+
+		if (ast_radio_init_mixer_limits(o->devicenum, &o->micmax, &o->spkrmax, &o->micplaymax, &use_newname) < 0) {
+			ast_log(LOG_ERROR, "Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
+			ast_mutex_unlock(&usb_dev_lock);
+			return -1;
+		}
+		o->newname = use_newname;
 	}
 	o->usbass = 1;
 	ast_mutex_unlock(&usb_dev_lock);

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1064,19 +1064,13 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 
 	o->device_error = 0;
 	ast_radio_time(&o->lasthidtime);
+	if (ast_radio_init_mixer_limits(o->devicenum, &o->micmax, &o->spkrmax, &o->micplaymax, &o->newname) < 0) {
+		ast_log(LOG_ERROR, "Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
+		ast_mutex_unlock(&usb_dev_lock);
+		return -1;
+	}
 	o->usbass = 1;
 	ast_mutex_unlock(&usb_dev_lock);
-	/* set the audio mixer values */
-	o->micmax = ast_radio_mixer_limit(ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL));
-	o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL);
-	o->micplaymax = ast_radio_mixer_limit(ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_VOL));
-
-	if (o->spkrmax == -1) {
-		o->newname = 1;
-		o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW);
-	}
-	o->spkrmax = ast_radio_mixer_limit(o->spkrmax);
-
 	return 0;
 }
 

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -2001,12 +2001,15 @@ static int simpleusb_hangup(struct ast_channel *c)
 	struct chan_simpleusb_pvt *o = ast_channel_tech_pvt(c);
 
 	o->stopaudiothread = 1;
+	kickptt(o);
 	if (o->audiothread != AST_PTHREADT_NULL) {
 		pthread_join(o->audiothread, NULL);
 		o->audiothread = AST_PTHREADT_NULL;
 	}
+	stop_stream(o);
 
 	o->stophidthread = 1;
+	kickptt(o);
 	if (o->hidthread != AST_PTHREADT_NULL) {
 		pthread_join(o->hidthread, NULL);
 		o->hidthread = AST_PTHREADT_NULL;
@@ -4436,6 +4439,7 @@ static int unload_module(void)
 			pthread_join(o->audiothread, NULL); /* wait for audio thread to end */
 			o->audiothread = AST_PTHREADT_NULL;
 		}
+		stop_stream(o);
 		if (o->hidthread != AST_PTHREADT_NULL) {
 			pthread_join(o->hidthread, NULL);
 			o->hidthread = AST_PTHREADT_NULL;

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1068,14 +1068,15 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 	o->usbass = 1;
 	ast_mutex_unlock(&usb_dev_lock);
 	/* set the audio mixer values */
-	o->micmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL);
+	o->micmax = ast_radio_mixer_limit(ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL));
 	o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL);
-	o->micplaymax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_VOL);
+	o->micplaymax = ast_radio_mixer_limit(ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_VOL));
 
 	if (o->spkrmax == -1) {
 		o->newname = 1;
 		o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW);
 	}
+	o->spkrmax = ast_radio_mixer_limit(o->spkrmax);
 
 	return 0;
 }

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -29,14 +29,12 @@
 
 /*** MODULEINFO
 	<depend>alsa</depend>
-	<depend>portaudio</depend>
 	<depend>res_usbradio</depend>
 	<support_level>extended</support_level>
  ***/
 
 #include "asterisk.h"
 
-#include <portaudio.h>
 #include <alsa/asoundlib.h>
 
 #include <stdio.h>
@@ -81,13 +79,6 @@
 #define HID_POLL_RATE 50
 #define DEVICE_RETRY 500000 /* Retry time in uS when USB device is missing */
 #define MAX_FRAME_DELAY 200 /* 200ms (.2s) max time to queue audio frames before resetting usb audio */
-#ifdef __linux
-#include <linux/soundcard.h>
-#elif defined(__FreeBSD__)
-#include <sys/soundcard.h>
-#else
-#include <soundcard.h>
-#endif
 
 #include "asterisk/lock.h"
 #include "asterisk/frame.h"
@@ -107,29 +98,7 @@
 #include "asterisk/format_cache.h"
 #include "asterisk/format_compatibility.h"
 
-/*!
- * \brief The sample rate to request from PortAudio
- *
- * \todo Make this optional.  If this is only going to talk to 8 kHz endpoints,
- *       then it makes sense to use 8 kHz natively if possible.
- */
-#define PA_SAMPLE_RATE 48000 /* PortAudio Sample rate: Hardware likes 48k and is divisible by 6 for a "nice" down conversion. */
-
-/*!
- * \brief The number of samples to configure the PortAudio stream for.
- *
- * At 48kHz, 960 samples gives a 20ms frame, which aligns with Asterisk's
- * common frame size after resampling to 8kHz (160 samples @ 2 bytes per sample).
- * The number of short (2 byte) with paInt16 samples per PortAudio "frame".
- * This is 1920 bytes for stereo, or 960 bytes for mono
- */
-#define PA_NUM_FRAMES FRAME_SIZE * 6 /* Number of samples to read/write from PortAudio stream per Asterisk frame at 48k */
-
-/*! \brief Mono Input */
-#define PA_INPUT_CHANNELS 1 /* PortAudio: Mono input for Microphone / RX */
-
-/*! \brief Stereo Output */
-#define PA_OUTPUT_CHANNELS 2 /* PortAudio: Stereo output for Speaker / TX */
+#define PA_NUM_FRAMES AST_RADIO_PA_FRAMES_PER_BUFFER
 
 /*! \brief Global jitterbuffer configuration - by default, jb is disabled */
 static struct ast_jb_conf default_jbconf = {
@@ -224,7 +193,7 @@ struct chan_simpleusb_pvt {
 	struct usb_device *usb_dev;
 	struct ast_channel *owner;
 
-	PaStream *stream; /*! Current PortAudio stream for this device */
+	struct ast_radio_pa_stream pa;
 
 	char simpleusb_write_buf[FRAME_SIZE * 2]; /* buffer used for Asterisk to PA frames in 8k mono */
 
@@ -312,7 +281,6 @@ struct chan_simpleusb_pvt {
 	char had_pp_in;
 
 	/* bit fields */
-	unsigned int streamstate:1;			   /* indicator if stream is started */
 	unsigned int rxcapraw:1;			   /* indicator if receive capture is enabled */
 	unsigned int txcapraw:1;			   /* indicator if transmit capture is enabled */
 	unsigned int measure_enabled:1;		   /* indicator if measure mode is enabled */
@@ -428,267 +396,37 @@ static struct ast_channel_tech simpleusb_tech = {
 	.setoption = simpleusb_setoption,
 };
 
-static int64_t now_ms(void)
-{
-	struct timespec ts;
-	clock_gettime(CLOCK_MONOTONIC, &ts);
-	return (int64_t) ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
-}
-
-static PaError Pa_ReadStream_with_timeout(PaStream *s, short *buf, unsigned long frames, int timeout_ms, volatile sig_atomic_t *stop)
-{
-	int64_t start;
-
-	start = now_ms();
-	while (!(*stop)) {
-		long avail;
-		PaError err;
-
-		avail = Pa_GetStreamReadAvailable(s);
-		if (avail < 0) {
-			return (PaError) avail;
-		}
-
-		if ((now_ms() - start) > timeout_ms) {
-			return paTimedOut;
-		}
-
-		if (avail < frames) {
-			usleep(500); /*.5ms */
-			continue;
-		}
-
-		err = Pa_ReadStream(s, buf, frames);
-		return err;
-	}
-
-	return paTimedOut;
-}
-
-/*!
- * \brief Parse "hw:<card>" or "hw:<card>,<dev>" from anywhere in s.
- * \retval 1 if found; sets *card; sets *dev to parsed value or -1 if absent.
- */
-static int parse_hw_anywhere(const char *s, int *card, int *dev)
-{
-	const char *p = s;
-
-	if (!s || !card || !dev) {
-		return 0;
-	}
-
-	while ((p = strstr(p, "hw:")) != NULL) {
-		const char *q = p + 3; /* after "hw:" */
-		int c = 0;
-		int d = -1; /* dev absent by default */
-
-		/* card must start with digit */
-		if (!isdigit((unsigned char) *q)) {
-			p = q;
-			continue;
-		}
-
-		while (isdigit((unsigned char) *q)) {
-			if (c > 9999) {
-				/* reasonable upper bound for card numbers */
-				p = q;
-				break;
-			}
-
-			c = c * 10 + (*q - '0');
-			q++;
-		}
-
-		if (*q == ',') {
-			q++;
-			if (!isdigit((unsigned char) *q)) {
-				/* "hw:<card>," is malformed; skip this occurrence */
-				p = q;
-				continue;
-			}
-			d = 0;
-			while (isdigit((unsigned char) *q)) {
-				d = d * 10 + (*q - '0');
-				q++;
-			}
-		}
-
-		*card = c;
-		*dev = d;
-		return 1; /* first valid hw: occurrence */
-	}
-
-	return 0;
-}
-
-/*!
- * \brief Match rule:
- * - needle "hw:C" matches any "hw:C" or "hw:C,D" in haystack
- * - needle "hw:C,D" matches only "hw:C,D" in haystack
- */
-static int hw_match(const char *haystack, const char *needle)
-{
-	int haystack_c, haystack_d, needle_c, needle_d;
-	const char *p = haystack ? haystack : "";
-
-	if (!parse_hw_anywhere(needle, &needle_c, &needle_d)) {
-		return 0;
-	}
-
-	/* haystack may contain multiple hw: occurrences; scan all */
-	while ((p = strstr(p, "hw:")) != NULL) {
-		if (parse_hw_anywhere(p, &haystack_c, &haystack_d)) {
-			if (haystack_c == needle_c) {
-				if (needle_d < 0) {
-					/* needle is "hw:C" -> accept any dev (including absent) */
-					return 1;
-				} else if (haystack_d == needle_d) {
-					/* needle is "hw:C,D" -> require exact dev match */
-					return 1;
-				}
-			}
-		}
-		p += 3; /* move forward to find next occurrence */
-	}
-
-	return 0;
-}
-
-static int open_stream(struct chan_simpleusb_pvt *o)
-{
-	PaError res = paInternalError;
-	const PaStreamInfo *si;
-
-	if (!strcasecmp(o->hw_device, "default")) {
-		ast_debug(1, "Opening stream with default device\n");
-		res = Pa_OpenDefaultStream(&o->stream, PA_INPUT_CHANNELS, PA_OUTPUT_CHANNELS, paInt16, PA_SAMPLE_RATE, PA_NUM_FRAMES, NULL, NULL);
-	} else {
-		PaStreamParameters input_params = {
-			.channelCount = PA_INPUT_CHANNELS,
-			.sampleFormat = paInt16,
-			.suggestedLatency = (1.0 / 50.0), /* 20 ms */
-			.device = paNoDevice,
-		};
-		PaStreamParameters output_params = {
-			.channelCount = PA_OUTPUT_CHANNELS,
-			.sampleFormat = paInt16,
-			.suggestedLatency = (1.0 / 50.0), /* 20 ms */
-			.device = paNoDevice,
-		};
-		PaDeviceIndex idx, num_devices;
-		ast_debug(1, "Looking for device %s\n", o->hw_device);
-		ast_debug(5, "PortAudio host api count %d\n", Pa_GetHostApiCount());
-		num_devices = Pa_GetDeviceCount();
-		if (num_devices < 0) {
-			ast_debug(1, "No devices found\n");
-			return res;
-		} else {
-			ast_debug(6, "%d Devices found\n", num_devices);
-		}
-
-		for (idx = 0; idx < num_devices && (input_params.device == paNoDevice || output_params.device == paNoDevice); idx++) {
-			const PaDeviceInfo *dev = Pa_GetDeviceInfo(idx);
-			ast_debug(1, "Found device %s\n", dev->name);
-			if (dev->maxInputChannels) {
-				if (hw_match(dev->name, o->hw_device)) {
-					ast_debug(5, "Found input device %s\n", dev->name);
-					input_params.device = idx;
-				}
-			}
-
-			if (dev->maxOutputChannels) {
-				if (hw_match(dev->name, o->hw_device)) {
-					ast_debug(5, "Found output device %s\n", dev->name);
-					output_params.device = idx;
-				}
-			}
-		}
-
-		if (input_params.device == paNoDevice) {
-			ast_log(LOG_ERROR, "No input device found for simpleusb device '%s'\n", o->name);
-			return res;
-		}
-
-		if (output_params.device == paNoDevice) {
-			ast_log(LOG_ERROR, "No output device found for simpleusb device '%s'\n", o->name);
-			return res;
-		}
-		ast_debug(5, "Opening stream on device %s", o->hw_device);
-		res = Pa_OpenStream(&o->stream, &input_params, &output_params, PA_SAMPLE_RATE, PA_NUM_FRAMES, paNoFlag, NULL, NULL);
-		ast_debug(5, "Stream feedback: %s\n", Pa_GetErrorText(res));
-		if (res == paNoError) {
-			si = Pa_GetStreamInfo(o->stream);
-			if (si) {
-				ast_debug(5, "Stream output latency: %.3f ms\n", si->outputLatency * 1000.0);
-				ast_debug(5, "Stream input latency: %.3f ms\n", si->inputLatency * 1000.0);
-			}
-		}
-	}
-
-	return res;
-}
-
 static int start_stream(struct chan_simpleusb_pvt *pvt)
 {
 	PaError res;
 
 	ast_debug(5, "Starting PA Stream");
-	/* It is possible for simpleusb_hangup to be called before the
-	 * stream is started, if this is the case pvt->owner will be NULL
-	 * and start_stream should be aborted. */
-	if (pvt->streamstate || !pvt->owner)
-		return -1;
-
-	res = Pa_Initialize();
-	if (res != paNoError) {
-		ast_log(LOG_WARNING, "Failed to initialize audio system - (%d) %s\n", res, Pa_GetErrorText(res));
+	if (pvt->pa.active || !pvt->owner) {
 		return -1;
 	}
 
-	res = open_stream(pvt);
+	ast_copy_string(pvt->pa.hw_device, pvt->hw_device, sizeof(pvt->pa.hw_device));
+	pvt->pa.input_channels = 1;
+
+	res = ast_radio_pa_open(&pvt->pa);
 	if (res != paNoError) {
 		ast_log(LOG_WARNING, "Failed to open stream - (%d) %s\n", res, Pa_GetErrorText(res));
-		Pa_Terminate();
 		return -1;
 	}
 
-	res = Pa_StartStream(pvt->stream);
+	res = ast_radio_pa_start(&pvt->pa);
 	if (res != paNoError) {
 		ast_log(LOG_WARNING, "Failed to start stream - (%d) %s\n", res, Pa_GetErrorText(res));
-		Pa_CloseStream(pvt->stream);
-		pvt->stream = NULL;
-		pvt->streamstate = 0;
-		Pa_Terminate();
+		ast_radio_pa_stop(&pvt->pa);
 		return -1;
 	}
 
-	pvt->streamstate = 1;
 	return 0;
 }
 
-static int stop_stream(struct chan_simpleusb_pvt *pvt)
+static void stop_stream(struct chan_simpleusb_pvt *pvt)
 {
-	PaError err;
-
-	if (!pvt->streamstate) {
-		return 0;
-	}
-
-	/* Abort and close the stream */
-	err = Pa_AbortStream(pvt->stream);
-	if (err != paNoError) {
-		ast_log(LOG_WARNING, "Pa_AbortStream failed: %s\n", Pa_GetErrorText(err));
-	}
-
-	err = Pa_CloseStream(pvt->stream);
-	if (err != paNoError) {
-		ast_log(LOG_WARNING, "Pa_CloseStream failed: %s\n", Pa_GetErrorText(err));
-	}
-
-	pvt->stream = NULL;
-	pvt->streamstate = 0;
-	Pa_Terminate();
-	return 0;
+	ast_radio_pa_stop(&pvt->pa);
 }
 
 /*!
@@ -1078,6 +816,7 @@ static int load_tune_config(struct chan_simpleusb_pvt *o, const struct ast_confi
 	int configured = 0;
 	char devstr[sizeof(o->devstr)];
 	char serial[sizeof(o->serial)];
+	char hw_device[sizeof(o->hw_device)];
 
 	o->rxmixerset = 500;
 	o->txmixaset = 500;
@@ -1085,6 +824,7 @@ static int load_tune_config(struct chan_simpleusb_pvt *o, const struct ast_confi
 
 	devstr[0] = '\0';
 	serial[0] = '\0';
+	hw_device[0] = '\0';
 
 	if (!cfg) {
 		struct ast_flags zeroflag = { 0 };
@@ -1105,15 +845,18 @@ static int load_tune_config(struct chan_simpleusb_pvt *o, const struct ast_confi
 		CV_UINT("txmixbset", o->txmixbset);
 		CV_STR("devstr", devstr);
 		CV_STR("serial", serial);
-		if (o->devstr[0] == '\0') {
-			CV_STR("audiodev", o->hw_device); /* use audiodevice as opposed to the usb device path (devstr) */
-		}
+		CV_STR("audiodev", hw_device); /* use audiodevice as opposed to the usb device path (devstr) */
 		CV_END;
 	}
 	if (!reload) {
 		/* Using the ternary operator in CV_STR won't work, due to butchering the sizeof, so copy after if needed */
 		ast_copy_string(o->devstr, devstr, sizeof(o->devstr)); /* Safe */
 		ast_copy_string(o->serial, serial, sizeof(o->serial)); /* Safe */
+		if (ast_strlen_zero(devstr)) {
+			ast_copy_string(o->hw_device, hw_device, sizeof(o->hw_device));
+		} else {
+			o->hw_device[0] = '\0';
+		}
 	}
 	if (opened) {
 		ast_config_destroy(cfg2);
@@ -1133,7 +876,8 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 	char serial[sizeof(o->serial)] = { '\0' };
 	char *s;
 	struct chan_simpleusb_pvt *ao;
-	register int i;
+	int i;
+	int subdev;
 
 	ast_radio_time(&o->lasthidtime);
 	ast_mutex_lock(&usb_dev_lock);
@@ -1148,7 +892,7 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 			ast_log(LOG_ERROR, "audiodev=default is not supported for SimpleUSB until HID-less startup is implemented\n");
 			ast_mutex_unlock(&usb_dev_lock);
 			return -1;
-		} else if (sscanf(o->hw_device, "hw:%d", &o->devicenum) == 1) {
+		} else if (ast_radio_parse_hw_anywhere(o->hw_device, &o->devicenum, &subdev)) {
 			ast_debug(5, "audiodev is defined: %s, Device %d", o->hw_device, o->devicenum);
 			o->usb_dev = ast_radio_usb_device_from_alsa_card(o->devicenum);
 			if (!o->usb_dev) {
@@ -1156,9 +900,17 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 				ast_mutex_unlock(&usb_dev_lock);
 				return -1;
 			}
+			for (ao = simpleusb_default.next; ao && ao->name; ao = ao->next) {
+				if (ao != o && ao->usbass && ao->devicenum == o->devicenum) {
+					ast_log(LOG_ERROR, "Channel %s: Audio device %s is already assigned to channel %s\n",
+						o->name, o->hw_device, ao->name);
+					ast_mutex_unlock(&usb_dev_lock);
+					return -1;
+				}
+			}
 
 		} else {
-			ast_log(LOG_ERROR, "Incorrect audio parameter audiodev (should be hw:0 format), found %s\n", o->hw_device);
+			ast_log(LOG_ERROR, "Incorrect audio parameter audiodev (should be hw:0 or hw:0,0 format), found %s\n", o->hw_device);
 			ast_mutex_unlock(&usb_dev_lock);
 			return -1;
 		}
@@ -1471,6 +1223,11 @@ static void *hidthread(void *arg)
 		}
 		if (pipe2(o->pttkick, O_NONBLOCK) == -1) {
 			ast_log(LOG_ERROR, "Channel %s: Is not able to create a pipe\n", o->name);
+			ast_mutex_lock(&usb_dev_lock);
+			o->usbass = 0;
+			o->hasusb = 0;
+			o->usb_dev = NULL;
+			ast_mutex_unlock(&usb_dev_lock);
 			usb_close(usb_handle);
 			usb_handle = NULL;
 			return NULL;
@@ -1525,6 +1282,8 @@ static void *hidthread(void *arg)
 				ast_radio_time(&audio_time_now);
 				if ((audio_time_now - o->lastaudiotime) > 1) {
 					ast_log(LOG_ERROR, "Channel %s: Audio process has died or is not responding.\n", o->name);
+					o->hasusb = 0;
+					break;
 				}
 			}
 
@@ -1893,11 +1652,9 @@ static int soundcard_writeframe(struct chan_simpleusb_pvt *o, short *data)
 	 * a number of failures, to restart the output chain.
 	 */
 
-	res = Pa_WriteStream(o->stream, data, PA_NUM_FRAMES);
+	res = ast_radio_pa_write(&o->pa, data, PA_NUM_FRAMES);
 	if (res == paOutputUnderflowed) {
-		short null_buf[PA_NUM_FRAMES * 2] = { 0 };
 		ast_debug(6, "PortAudio write stream underflow, writing a 0 frame");
-		Pa_WriteStream(o->stream, null_buf, PA_NUM_FRAMES);
 	} else if (res < 0) {
 		ast_debug(2, "Pa_WriteStream Error %s", Pa_GetErrorText(res));
 	}
@@ -2391,7 +2148,7 @@ static void *simpleusb_audio_thread(void *arg)
 			continue;
 		}
 
-		if (!o->streamstate && start_stream(o) < 0) {
+		if (!o->pa.active && start_stream(o) < 0) {
 			ast_log(LOG_ERROR, "Channel %s: Failed to start audio stream %s\n", o->name, o->hw_device);
 			o->hasusb = 0;
 			usleep(DEVICE_RETRY);
@@ -2507,7 +2264,7 @@ static void *simpleusb_audio_thread(void *arg)
 				/* Check for room in the write buffer.  If the device goes unavailable or
 				 * there is not room in the buffer, Pa_WriteStream will hang.
 				 */
-				frames_available = Pa_GetStreamWriteAvailable(o->stream);
+				frames_available = ast_radio_pa_write_available(&o->pa);
 
 				if (frames_available < 0) {
 					if (frames_available != paOutputUnderflowed) {
@@ -2517,6 +2274,7 @@ static void *simpleusb_audio_thread(void *arg)
 						ast_debug(2, "Pa_GetStreamWriteAvailable error %s", Pa_GetErrorText(frames_available));
 						o->hasusb = 0;
 						stream_cleanup(o);
+						break;
 					}
 				}
 
@@ -2615,6 +2373,7 @@ static void *simpleusb_audio_thread(void *arg)
 									ast_debug(2, "Pa_WriteStream error %s", Pa_GetErrorText(res));
 									o->hasusb = 0;
 									stream_cleanup(o);
+									break;
 								}
 							}
 
@@ -2647,6 +2406,9 @@ static void *simpleusb_audio_thread(void *arg)
 						}
 					}
 					ast_frfree(f1);
+					if (!o->hasusb) {
+						break;
+					}
 					continue;
 				}
 
@@ -2660,16 +2422,23 @@ static void *simpleusb_audio_thread(void *arg)
 				break;
 			}
 
+			if (!o->hasusb || !o->pa.active) {
+				break;
+			}
+
 			/* Read audio data from the USB sound device.
 			 * Sound data will arrive at 48000 samples per second
 			 * in mono format.  We should always have 20ms frames, 40ms timeout
 			 * as a reasonable max wait time.
 			 */
-			res = Pa_ReadStream_with_timeout(o->stream, o->simpleusb_read_buf, PA_NUM_FRAMES, 40, &o->stopaudiothread);
+			res = ast_radio_pa_read(&o->pa, o->simpleusb_read_buf, PA_NUM_FRAMES, 40, &o->stopaudiothread);
 			if (res != paNoError) {
 				/* audio data not ready */
 				if (res == paInputOverflowed) {
 					ast_debug(6, "PortAudio read overflow on channel %s\n", o->name);
+				} else if (res == paTimedOut) {
+					ast_debug(6, "PortAudio read timeout on channel %s\n", o->name);
+					continue;
 				} else {
 					ast_log(LOG_ERROR, "Pa_ReadStream Error on channel %s : %s\n", o->name, Pa_GetErrorText(res));
 					o->hasusb = 0;
@@ -4650,6 +4419,7 @@ static int load_module(void)
 static int unload_module(void)
 {
 	struct chan_simpleusb_pvt *o, *no;
+	int i;
 
 	stoppulser = 1;
 
@@ -4658,6 +4428,9 @@ static int unload_module(void)
 		if (o->owner) {
 			ast_softhangup(o->owner, AST_SOFTHANGUP_APPUNLOAD);
 		}
+		o->stopaudiothread = 1;
+		o->stophidthread = 1;
+		kickptt(o);
 
 		if (o->audiothread != AST_PTHREADT_NULL) {
 			pthread_join(o->audiothread, NULL); /* wait for audio thread to end */
@@ -4670,9 +4443,14 @@ static int unload_module(void)
 		if (o->dsp) {
 			ast_dsp_free(o->dsp);
 		}
+		for (i = 0; i < GPIO_PINCOUNT; i++) {
+			ast_free(o->gpios[i]);
+		}
+		for (i = 0; i < ARRAY_LEN(o->pps); i++) {
+			ast_free(o->pps[i]);
+		}
+		ast_free(o->name);
 		ast_free(o);
-
-		/* XXX what about the memory allocated ? */
 	}
 
 #if DEBUG_CAPTURES == 1

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -1036,13 +1036,12 @@ static void *hidthread(void *arg)
 		o->usbass = 1;
 		ast_mutex_unlock(&usb_dev_lock);
 		/* set the audio mixer values */
-		o->micmax = ast_radio_mixer_limit(ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL));
+		o->micmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL);
 		o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL);
 		if (o->spkrmax == -1) {
 			o->newname = 1;
 			o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW);
 		}
-		o->spkrmax = ast_radio_mixer_limit(o->spkrmax);
 		/* initialize the usb device */
 		usb_dev = ast_radio_hid_device_init(o->devstr);
 		if (usb_dev == NULL) {

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -1036,12 +1036,13 @@ static void *hidthread(void *arg)
 		o->usbass = 1;
 		ast_mutex_unlock(&usb_dev_lock);
 		/* set the audio mixer values */
-		o->micmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL);
+		o->micmax = ast_radio_mixer_limit(ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL));
 		o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL);
 		if (o->spkrmax == -1) {
 			o->newname = 1;
 			o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW);
 		}
+		o->spkrmax = ast_radio_mixer_limit(o->spkrmax);
 		/* initialize the usb device */
 		usb_dev = ast_radio_hid_device_init(o->devstr);
 		if (usb_dev == NULL) {

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -84,14 +84,6 @@
 #define AUDIO_ADJUSTMENT 1000
 
 /*!
- * \brief Default ALSA mixer maximum when hardware lookup fails.
- *
- * CM108-class devices commonly expose a 0-31 capture range; use this
- * instead of propagating -1 into volume scaling math.
- */
-#define AST_RADIO_MIXER_MAX_DEFAULT 31
-
-/*!
  * \brief EEPROM memory layout
  *	The AT93C46 eeprom has 64 addresses that contain 2 bytes (one word).
  *	The CMxxx sound card device will use this eeprom to read manuafacturer
@@ -257,13 +249,21 @@ int ast_radio_make_spkr_playback_value(int spkrmax, int request_value, int devty
 int ast_radio_amixer_max(int devnum, char *param);
 
 /*!
- * \brief Return a usable mixer maximum for volume scaling.
+ * \brief Query required ALSA mixer maximums for a USB radio device.
  *
- * \param limit Value from ast_radio_amixer_max(), or another mixer limit.
+ * Reads mic capture, speaker playback (with alternate control name), and
+ * mic playback limits. Fails when any required limit is unavailable.
  *
- * \retval limit if positive, otherwise AST_RADIO_MIXER_MAX_DEFAULT.
+ * \param devnum ALSA card number.
+ * \param micmax Returned Mic Capture Volume maximum.
+ * \param spkrmax Returned Speaker Playback Volume maximum.
+ * \param micplaymax Returned Mic Playback Volume maximum.
+ * \param newname Set to 1 when the alternate speaker control name is used.
+ *
+ * \retval 0 on success.
+ * \retval -1 if any required mixer limit is unavailable.
  */
-int ast_radio_mixer_limit(int limit);
+int ast_radio_init_mixer_limits(int devnum, int *micmax, int *spkrmax, int *micplaymax, int *newname);
 
 /*!
  * \brief Set mixer

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -80,6 +80,14 @@
 #define AUDIO_ADJUSTMENT 1000
 
 /*!
+ * \brief Default ALSA mixer maximum when hardware lookup fails.
+ *
+ * CM108-class devices commonly expose a 0-31 capture range; use this
+ * instead of propagating -1 into volume scaling math.
+ */
+#define AST_RADIO_MIXER_MAX_DEFAULT 31
+
+/*!
  * \brief EEPROM memory layout
  *	The AT93C46 eeprom has 64 addresses that contain 2 bytes (one word).
  *	The CMxxx sound card device will use this eeprom to read manuafacturer
@@ -243,6 +251,15 @@ int ast_radio_make_spkr_playback_value(int spkrmax, int request_value, int devty
  * \retval 				The maximum value.
  */
 int ast_radio_amixer_max(int devnum, char *param);
+
+/*!
+ * \brief Return a usable mixer maximum for volume scaling.
+ *
+ * \param limit Value from ast_radio_amixer_max(), or another mixer limit.
+ *
+ * \retval limit if positive, otherwise AST_RADIO_MIXER_MAX_DEFAULT.
+ */
+int ast_radio_mixer_limit(int limit);
 
 /*!
  * \brief Set mixer

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -23,7 +23,11 @@
  * \brief USB sound card resources.
  */
 
-/*! \note <sys/io.h> is not portable to all architectures, so don't call non-portable functions if we don't have them */
+/*! \note <sys/io.h> is not portable to all architectures; guard parallel-port helpers with HAVE_SYS_IO */
+#if __has_include(<sys/io.h>)
+#define HAVE_SYS_IO
+#endif
+
 #include <portaudio.h>
 
 /*!

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -570,7 +570,6 @@ PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps);
 PaError ast_radio_pa_start(struct ast_radio_pa_stream *ps);
 void ast_radio_pa_stop(struct ast_radio_pa_stream *ps);
 
-PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned long frames, int timeout_ms,
-	volatile sig_atomic_t *stop);
+PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned long frames, int timeout_ms, volatile sig_atomic_t *stop);
 PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, unsigned long frames);
 long ast_radio_pa_write_available(struct ast_radio_pa_stream *ps);

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -24,9 +24,7 @@
  */
 
 /*! \note <sys/io.h> is not portable to all architectures, so don't call non-portable functions if we don't have them */
-#if __has_include(<sys/io.h>)
-#define HAVE_SYS_IO
-#endif
+#include <portaudio.h>
 
 /*!
  * \brief Defines for interacting with ALSA controls.
@@ -529,3 +527,33 @@ void ast_radio_print_audio_stats(int fd, struct audiostatistics *o, const char *
  * \param cardno The ALSA card number as found in HW:<cardno>
  */
 struct usb_device *ast_radio_usb_device_from_alsa_card(int cardno);
+
+#define AST_RADIO_PA_SAMPLE_RATE 48000
+#define AST_RADIO_PA_FRAMES_PER_BUFFER (FRAME_SIZE * 6)
+#define AST_RADIO_PA_OUTPUT_CHANNELS 2
+
+/*!
+ * \brief PortAudio stream state shared by chan_simpleusb and chan_usbradio.
+ */
+struct ast_radio_pa_stream {
+	PaStream *stream;
+	int active;
+	unsigned int input_channels; /*!< 1 for mono RX, 2 for stereo RX */
+	char hw_device[100];
+};
+
+int ast_radio_pa_startup(void);
+void ast_radio_pa_shutdown(void);
+void ast_radio_pa_shutdown_all(void);
+
+int ast_radio_parse_hw_anywhere(const char *s, int *card, int *dev);
+int ast_radio_hw_match(const char *haystack, const char *needle);
+
+PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps);
+PaError ast_radio_pa_start(struct ast_radio_pa_stream *ps);
+void ast_radio_pa_stop(struct ast_radio_pa_stream *ps);
+
+PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned long frames, int timeout_ms,
+	volatile sig_atomic_t *stop);
+PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, unsigned long frames);
+long ast_radio_pa_write_available(struct ast_radio_pa_stream *ps);

--- a/res/Makefile.diff
+++ b/res/Makefile.diff
@@ -6,7 +6,7 @@ index 0987f43a43..2f18773cba 100644
  snmp/agent.o: _ASTCFLAGS+=-fPIC
  res_snmp.o: _ASTCFLAGS+=-fPIC
  
-+res_usbradio.so: LIBS+=-lusb -lasound
++res_usbradio.so: LIBS+=-lusb -lasound -lportaudio
 +
  # Dependencies for res_ari_*.so are generated, so they're in this file
  include ari.make

--- a/res/Makefile.diff
+++ b/res/Makefile.diff
@@ -1,13 +1,11 @@
-diff --git a/res/Makefile b/res/Makefile
-index 0987f43a43..2f18773cba 100644
 --- a/res/Makefile
 +++ b/res/Makefile
-@@ -79,6 +79,8 @@ res_parking.o: _ASTCFLAGS+=$(AST_NO_FORMAT_TRUNCATION)
+@@ -78,6 +78,8 @@
+ res_parking.o: _ASTCFLAGS+=$(AST_NO_FORMAT_TRUNCATION)
  snmp/agent.o: _ASTCFLAGS+=-fPIC
  res_snmp.o: _ASTCFLAGS+=-fPIC
  
 +res_usbradio.so: LIBS+=-lusb -lasound -lportaudio
 +
- # Dependencies for res_ari_*.so are generated, so they're in this file
- include ari.make
+ MODULE_EXCLUDE=ENABLE_SRTP_AES_192 ENABLE_SRTP_AES_256 ENABLE_SRTP_AES_GCM
  

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -1186,8 +1186,8 @@ PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
 			return paDeviceUnavailable;
 		}
 
-		res = Pa_OpenStream(&ps->stream, &input_params, &output_params, AST_RADIO_PA_SAMPLE_RATE,
-			AST_RADIO_PA_FRAMES_PER_BUFFER, paNoFlag, NULL, NULL);
+		res = Pa_OpenStream(&ps->stream, &input_params, &output_params, AST_RADIO_PA_SAMPLE_RATE, AST_RADIO_PA_FRAMES_PER_BUFFER,
+			paNoFlag, NULL, NULL);
 	}
 
 	if (res != paNoError) {
@@ -1201,8 +1201,7 @@ PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
 
 	si = Pa_GetStreamInfo(ps->stream);
 	if (si) {
-		ast_debug(5, "PortAudio stream latency in %.3f ms out %.3f ms\n", si->inputLatency * 1000.0,
-			si->outputLatency * 1000.0);
+		ast_debug(5, "PortAudio stream latency in %.3f ms out %.3f ms\n", si->inputLatency * 1000.0, si->outputLatency * 1000.0);
 	}
 
 	return res;
@@ -1248,8 +1247,7 @@ void ast_radio_pa_stop(struct ast_radio_pa_stream *ps)
 	ast_radio_pa_shutdown();
 }
 
-PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned long frames, int timeout_ms,
-	volatile sig_atomic_t *stop)
+PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned long frames, int timeout_ms, volatile sig_atomic_t *stop)
 {
 	int64_t start;
 	PaError err;

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -444,6 +444,8 @@ int ast_radio_hid_device_mklist(void)
 	struct usb_bus *usb_bus;
 	struct usb_device *dev;
 	char devstr[10000], str[200], desdev[200], *cp;
+	ssize_t linklen;
+	size_t cplen;
 	int i;
 
 	ast_mutex_lock(&usb_list_lock);
@@ -483,9 +485,11 @@ int ast_radio_hid_device_mklist(void)
 
 				snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
 				memset(desdev, 0, sizeof(desdev));
-				if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
+				linklen = readlink(str, desdev, sizeof(desdev) - 1);
+				if (linklen == -1) {
 					continue;
 				}
+				desdev[linklen] = '\0';
 				cp = strrchr(desdev, '/');
 				if (!cp) {
 					continue;
@@ -498,22 +502,23 @@ int ast_radio_hid_device_mklist(void)
 				continue;
 			}
 
-			new_list = ast_realloc(usb_device_list, usb_device_list_size + 2 + strlen(cp));
+			cplen = strlen(cp);
+			new_list = ast_realloc(usb_device_list, usb_device_list_size + 2 + cplen);
 			if (!new_list) {
 				ast_mutex_unlock(&usb_list_lock);
 				return -1;
 			}
 
 			usb_device_list = new_list;
-			usb_device_list_size += strlen(cp) + 2;
+			usb_device_list_size += cplen + 2;
 			i = 0;
 
 			while (usb_device_list[i]) {
 				i += strlen(usb_device_list + i) + 1;
 			}
 
-			memcpy(usb_device_list + i, cp, strlen(cp) + 1);
-			usb_device_list[strlen(cp) + i + 1] = 0;
+			memcpy(usb_device_list + i, cp, cplen + 1);
+			usb_device_list[i + cplen + 1] = 0;
 		}
 	}
 	ast_mutex_unlock(&usb_list_lock);
@@ -525,6 +530,7 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 	struct usb_bus *usb_bus;
 	struct usb_device *dev;
 	char devstr[10000], str[200], desdev[200], *cp;
+	ssize_t linklen;
 	int i;
 
 	usb_init();
@@ -549,9 +555,11 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 
 				snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
 				memset(desdev, 0, sizeof(desdev));
-				if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
+				linklen = readlink(str, desdev, sizeof(desdev) - 1);
+				if (linklen == -1) {
 					continue;
 				}
+				desdev[linklen] = '\0';
 				cp = strrchr(desdev, '/');
 				if (!cp) {
 					continue;

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -1094,6 +1094,7 @@ static int match_card_id(const char *devname, int card)
 static int pa_device_matches(const PaDeviceInfo *dev, const char *hw_device, int want_input, int want_output)
 {
 	int card, devnum;
+	int hay_card, hay_dev;
 
 	if (!dev || !hw_device || !hw_device[0]) {
 		return 0;
@@ -1111,11 +1112,20 @@ static int pa_device_matches(const PaDeviceInfo *dev, const char *hw_device, int
 		return 1;
 	}
 
-	if (ast_radio_parse_hw_anywhere(hw_device, &card, &devnum) && match_card_id(dev->name, card)) {
+	if (!ast_radio_parse_hw_anywhere(hw_device, &card, &devnum) || !match_card_id(dev->name, card)) {
+		return 0;
+	}
+
+	/* Card-id fallback is only unambiguous for hw:C; hw:C,D must match subdevice too. */
+	if (devnum < 0) {
 		return 1;
 	}
 
-	return 0;
+	if (!ast_radio_parse_hw_anywhere(dev->name, &hay_card, &hay_dev)) {
+		return 0;
+	}
+
+	return hay_card == card && hay_dev == devnum;
 }
 
 static PaDeviceIndex pa_find_device(const char *hw_device, int want_input, int want_output)

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -28,6 +28,7 @@
 
 /*** MODULEINFO
 	<depend>alsa</depend>
+	<depend>portaudio</depend>
 	<support_level>extended</support_level>
  ***/
 
@@ -48,6 +49,7 @@
 #include <linux/parport.h>
 #include <linux/version.h>
 #include <alsa/asoundlib.h>
+#include <portaudio.h>
 
 #include "asterisk/res_usbradio.h"
 
@@ -151,7 +153,10 @@ int ast_radio_amixer_max(int devnum, char *param)
 	}
 
 	snd_ctl_elem_info_alloca(&info);
-	snd_hctl_elem_info(elem, info);
+	if (snd_hctl_elem_info(elem, info) < 0) {
+		snd_hctl_close(hctl);
+		return -1;
+	}
 	type = snd_ctl_elem_info_get_type(info);
 	rv = 0;
 
@@ -199,7 +204,10 @@ int ast_radio_setamixer(int devnum, char *param, int v1, int v2)
 	}
 
 	snd_ctl_elem_info_alloca(&info);
-	snd_hctl_elem_info(elem, info);
+	if (snd_hctl_elem_info(elem, info) < 0) {
+		snd_hctl_close(hctl);
+		return -1;
+	}
 	type = snd_ctl_elem_info_get_type(info);
 	snd_ctl_elem_value_alloca(&control);
 	snd_ctl_elem_value_set_id(control, id);
@@ -464,11 +472,9 @@ int ast_radio_hid_device_mklist(void)
 
 				snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
 				memset(desdev, 0, sizeof(desdev));
-
 				if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
 					continue;
 				}
-
 				cp = strrchr(desdev, '/');
 				if (!cp) {
 					continue;
@@ -482,7 +488,6 @@ int ast_radio_hid_device_mklist(void)
 			}
 
 			new_list = ast_realloc(usb_device_list, usb_device_list_size + 2 + strlen(cp));
-
 			if (!new_list) {
 				ast_mutex_unlock(&usb_list_lock);
 				return -1;
@@ -496,7 +501,7 @@ int ast_radio_hid_device_mklist(void)
 				i += strlen(usb_device_list + i) + 1;
 			}
 
-			strcat(usb_device_list + i, cp);
+			memcpy(usb_device_list + i, cp, strlen(cp) + 1);
 			usb_device_list[strlen(cp) + i + 1] = 0;
 		}
 	}
@@ -530,6 +535,7 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 				if (strcasecmp(desdev, devstr)) {
 					continue;
 				}
+
 				snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
 				memset(desdev, 0, sizeof(desdev));
 				if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
@@ -542,11 +548,9 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 				cp++;
 				break;
 			}
-
 			if (i >= 32) {
 				continue;
 			}
-
 			if (!strcmp(cp, desired_device)) {
 				return dev;
 			}
@@ -926,6 +930,376 @@ static void cleanup_user_devices(void)
 }
 
 /*
+ * PortAudio helpers shared by chan_simpleusb and chan_usbradio.
+ */
+AST_MUTEX_DEFINE_STATIC(pa_lock);
+static int pa_refcount;
+
+static int64_t pa_now_ms(void)
+{
+	struct timespec ts;
+
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (int64_t) ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
+int ast_radio_pa_startup(void)
+{
+	PaError res;
+
+	ast_mutex_lock(&pa_lock);
+	if (pa_refcount == 0) {
+		res = Pa_Initialize();
+		if (res != paNoError) {
+			ast_mutex_unlock(&pa_lock);
+			ast_log(LOG_WARNING, "Failed to initialize PortAudio - (%d) %s\n", res, Pa_GetErrorText(res));
+			return -1;
+		}
+	}
+	pa_refcount++;
+	ast_mutex_unlock(&pa_lock);
+	return 0;
+}
+
+void ast_radio_pa_shutdown(void)
+{
+	ast_mutex_lock(&pa_lock);
+	if (pa_refcount > 0) {
+		pa_refcount--;
+		if (pa_refcount == 0) {
+			Pa_Terminate();
+		}
+	}
+	ast_mutex_unlock(&pa_lock);
+}
+
+void ast_radio_pa_shutdown_all(void)
+{
+	ast_mutex_lock(&pa_lock);
+	if (pa_refcount > 0) {
+		Pa_Terminate();
+		pa_refcount = 0;
+	}
+	ast_mutex_unlock(&pa_lock);
+}
+
+int ast_radio_parse_hw_anywhere(const char *s, int *card, int *dev)
+{
+	const char *p = s;
+
+	if (!s || !card || !dev) {
+		return 0;
+	}
+
+	while ((p = strstr(p, "hw:")) != NULL) {
+		const char *q = p + 3;
+		int c = 0;
+		int d = -1;
+
+		if (!isdigit((unsigned char) *q)) {
+			p = q;
+			continue;
+		}
+
+		while (isdigit((unsigned char) *q)) {
+			if (c > 9999) {
+				p = q;
+				break;
+			}
+			c = c * 10 + (*q - '0');
+			q++;
+		}
+
+		if (*q == ',') {
+			q++;
+			if (!isdigit((unsigned char) *q)) {
+				p = q;
+				continue;
+			}
+			d = 0;
+			while (isdigit((unsigned char) *q)) {
+				d = d * 10 + (*q - '0');
+				q++;
+			}
+		}
+
+		*card = c;
+		*dev = d;
+		return 1;
+	}
+
+	return 0;
+}
+
+int ast_radio_hw_match(const char *haystack, const char *needle)
+{
+	int haystack_c, haystack_d, needle_c, needle_d;
+	const char *p = haystack ? haystack : "";
+
+	if (!ast_radio_parse_hw_anywhere(needle, &needle_c, &needle_d)) {
+		return 0;
+	}
+
+	while ((p = strstr(p, "hw:")) != NULL) {
+		if (ast_radio_parse_hw_anywhere(p, &haystack_c, &haystack_d)) {
+			if (haystack_c == needle_c) {
+				if (needle_d < 0 || haystack_d == needle_d) {
+					return 1;
+				}
+			}
+		}
+		p += 3;
+	}
+
+	return 0;
+}
+
+static int match_card_id(const char *devname, int card)
+{
+	char path[128], id[64];
+	FILE *fp;
+	size_t n;
+
+	snprintf(path, sizeof(path), "/proc/asound/card%d/id", card);
+	fp = fopen(path, "r");
+	if (!fp) {
+		return 0;
+	}
+
+	if (!fgets(id, sizeof(id), fp) || !id[0]) {
+		fclose(fp);
+		return 0;
+	}
+	fclose(fp);
+
+	n = strlen(id);
+	while (n > 0 && isspace((unsigned char) id[n - 1])) {
+		id[--n] = '\0';
+	}
+
+	return n > 0 && strstr(devname, id) != NULL;
+}
+
+static int pa_device_matches(const PaDeviceInfo *dev, const char *hw_device, int want_input, int want_output)
+{
+	int card, devnum;
+
+	if (!dev || !hw_device || !hw_device[0]) {
+		return 0;
+	}
+
+	if (want_input && !dev->maxInputChannels) {
+		return 0;
+	}
+
+	if (want_output && !dev->maxOutputChannels) {
+		return 0;
+	}
+
+	if (ast_radio_hw_match(dev->name, hw_device)) {
+		return 1;
+	}
+
+	if (ast_radio_parse_hw_anywhere(hw_device, &card, &devnum) && match_card_id(dev->name, card)) {
+		return 1;
+	}
+
+	return 0;
+}
+
+static PaDeviceIndex pa_find_device(const char *hw_device, int want_input, int want_output)
+{
+	PaDeviceIndex idx, num_devices;
+
+	num_devices = Pa_GetDeviceCount();
+	if (num_devices < 0) {
+		return paNoDevice;
+	}
+
+	for (idx = 0; idx < num_devices; idx++) {
+		const PaDeviceInfo *dev = Pa_GetDeviceInfo(idx);
+
+		if (pa_device_matches(dev, hw_device, want_input, want_output)) {
+			return idx;
+		}
+	}
+
+	return paNoDevice;
+}
+
+PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
+{
+	PaError res = paInternalError;
+	const PaStreamInfo *si;
+
+	if (!ps) {
+		return paBadStreamPtr;
+	}
+
+	ps->stream = NULL;
+	ps->active = 0;
+
+	if (ast_radio_pa_startup() < 0) {
+		return paInternalError;
+	}
+
+	if (!strcasecmp(ps->hw_device, "default")) {
+		res = Pa_OpenDefaultStream(&ps->stream, ps->input_channels, AST_RADIO_PA_OUTPUT_CHANNELS, paInt16,
+			AST_RADIO_PA_SAMPLE_RATE, AST_RADIO_PA_FRAMES_PER_BUFFER, NULL, NULL);
+	} else {
+		PaStreamParameters input_params = {
+			.channelCount = ps->input_channels,
+			.sampleFormat = paInt16,
+			.suggestedLatency = (1.0 / 50.0),
+			.device = paNoDevice,
+		};
+		PaStreamParameters output_params = {
+			.channelCount = AST_RADIO_PA_OUTPUT_CHANNELS,
+			.sampleFormat = paInt16,
+			.suggestedLatency = (1.0 / 50.0),
+			.device = paNoDevice,
+		};
+
+		input_params.device = pa_find_device(ps->hw_device, 1, 0);
+		output_params.device = pa_find_device(ps->hw_device, 0, 1);
+
+		if (input_params.device == paNoDevice) {
+			ast_log(LOG_ERROR, "No PortAudio input device found for '%s'\n", ps->hw_device);
+			ast_radio_pa_shutdown();
+			return paDeviceUnavailable;
+		}
+
+		if (output_params.device == paNoDevice) {
+			ast_log(LOG_ERROR, "No PortAudio output device found for '%s'\n", ps->hw_device);
+			ast_radio_pa_shutdown();
+			return paDeviceUnavailable;
+		}
+
+		res = Pa_OpenStream(&ps->stream, &input_params, &output_params, AST_RADIO_PA_SAMPLE_RATE,
+			AST_RADIO_PA_FRAMES_PER_BUFFER, paNoFlag, NULL, NULL);
+	}
+
+	if (res != paNoError) {
+		ast_radio_pa_shutdown();
+		return res;
+	}
+
+	si = Pa_GetStreamInfo(ps->stream);
+	if (si) {
+		ast_debug(5, "PortAudio stream latency in %.3f ms out %.3f ms\n", si->inputLatency * 1000.0,
+			si->outputLatency * 1000.0);
+	}
+
+	return res;
+}
+
+PaError ast_radio_pa_start(struct ast_radio_pa_stream *ps)
+{
+	PaError res;
+
+	if (!ps || !ps->stream) {
+		return paBadStreamPtr;
+	}
+
+	res = Pa_StartStream(ps->stream);
+	if (res == paNoError) {
+		ps->active = 1;
+	}
+	return res;
+}
+
+void ast_radio_pa_stop(struct ast_radio_pa_stream *ps)
+{
+	PaError err;
+
+	if (!ps || !ps->stream) {
+		return;
+	}
+
+	if (ps->active) {
+		err = Pa_AbortStream(ps->stream);
+		if (err != paNoError) {
+			ast_log(LOG_WARNING, "Pa_AbortStream failed: %s\n", Pa_GetErrorText(err));
+		}
+	}
+
+	err = Pa_CloseStream(ps->stream);
+	if (err != paNoError) {
+		ast_log(LOG_WARNING, "Pa_CloseStream failed: %s\n", Pa_GetErrorText(err));
+	}
+
+	ps->stream = NULL;
+	ps->active = 0;
+	ast_radio_pa_shutdown();
+}
+
+PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned long frames, int timeout_ms,
+	volatile sig_atomic_t *stop)
+{
+	int64_t start;
+	PaError err;
+
+	if (!ps || !ps->stream || !buf) {
+		return paBadStreamPtr;
+	}
+
+	start = pa_now_ms();
+	while (!stop || !(*stop)) {
+		long avail = Pa_GetStreamReadAvailable(ps->stream);
+
+		if (avail < 0) {
+			return (PaError) avail;
+		}
+
+		if ((pa_now_ms() - start) > timeout_ms) {
+			return paTimedOut;
+		}
+
+		if ((unsigned long) avail < frames) {
+			usleep(500);
+			continue;
+		}
+
+		err = Pa_ReadStream(ps->stream, buf, frames);
+		return err;
+	}
+
+	return paTimedOut;
+}
+
+PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, unsigned long frames)
+{
+	PaError res;
+	short null_buf[AST_RADIO_PA_FRAMES_PER_BUFFER * AST_RADIO_PA_OUTPUT_CHANNELS];
+
+	if (!ps || !ps->stream || !data) {
+		return paBadStreamPtr;
+	}
+
+	if (frames > AST_RADIO_PA_FRAMES_PER_BUFFER) {
+		ast_log(LOG_WARNING, "ast_radio_pa_write: frames %lu exceeds buffer capacity\n", frames);
+		return paBufferTooBig;
+	}
+
+	res = Pa_WriteStream(ps->stream, data, frames);
+	if (res == paOutputUnderflowed) {
+		memset(null_buf, 0, sizeof(null_buf));
+		Pa_WriteStream(ps->stream, null_buf, frames);
+	}
+
+	return res;
+}
+
+long ast_radio_pa_write_available(struct ast_radio_pa_stream *ps)
+{
+	if (!ps || !ps->stream) {
+		return -1;
+	}
+
+	return Pa_GetStreamWriteAvailable(ps->stream);
+}
+
+/*
  * Returns the libusb device that backs ALSA /proc/asound/card<cardno>/usbbus.
  * On success: returns a pointer to a libusb struct usb_device.
  * On failure: returns NULL.
@@ -1047,6 +1421,7 @@ static int load_module(void)
 static int unload_module(void)
 {
 	cleanup_user_devices();
+	ast_radio_pa_shutdown_all();
 
 	return 0;
 }

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -119,18 +119,47 @@ long ast_radio_lround(double x)
 
 int ast_radio_make_spkr_playback_value(int spkrmax, int request_value, int devtype)
 {
-	spkrmax = ast_radio_mixer_limit(spkrmax);
+	if (spkrmax <= 0) {
+		return 0;
+	}
 	return (request_value * spkrmax) / AUDIO_ADJUSTMENT;
 }
 
-int ast_radio_mixer_limit(int limit)
+int ast_radio_init_mixer_limits(int devnum, int *micmax, int *spkrmax, int *micplaymax, int *newname)
 {
-	if (limit > 0) {
-		return limit;
+	int rv;
+
+	if (!micmax || !spkrmax || !micplaymax || !newname) {
+		return -1;
 	}
 
-	ast_log(LOG_WARNING, "Mixer max lookup failed, using default %d\n", AST_RADIO_MIXER_MAX_DEFAULT);
-	return AST_RADIO_MIXER_MAX_DEFAULT;
+	rv = ast_radio_amixer_max(devnum, MIXER_PARAM_MIC_CAPTURE_VOL);
+	if (rv <= 0) {
+		ast_log(LOG_ERROR, "Mixer limit not available for hw:%d (%s)\n", devnum, MIXER_PARAM_MIC_CAPTURE_VOL);
+		return -1;
+	}
+	*micmax = rv;
+
+	*newname = 0;
+	rv = ast_radio_amixer_max(devnum, MIXER_PARAM_SPKR_PLAYBACK_VOL);
+	if (rv <= 0) {
+		rv = ast_radio_amixer_max(devnum, MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW);
+		if (rv <= 0) {
+			ast_log(LOG_ERROR, "Mixer limit not available for hw:%d (speaker playback)\n", devnum);
+			return -1;
+		}
+		*newname = 1;
+	}
+	*spkrmax = rv;
+
+	rv = ast_radio_amixer_max(devnum, MIXER_PARAM_MIC_PLAYBACK_VOL);
+	if (rv <= 0) {
+		ast_log(LOG_ERROR, "Mixer limit not available for hw:%d (%s)\n", devnum, MIXER_PARAM_MIC_PLAYBACK_VOL);
+		return -1;
+	}
+	*micplaymax = rv;
+
+	return 0;
 }
 
 int ast_radio_amixer_max(int devnum, char *param)

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -119,7 +119,18 @@ long ast_radio_lround(double x)
 
 int ast_radio_make_spkr_playback_value(int spkrmax, int request_value, int devtype)
 {
+	spkrmax = ast_radio_mixer_limit(spkrmax);
 	return (request_value * spkrmax) / AUDIO_ADJUSTMENT;
+}
+
+int ast_radio_mixer_limit(int limit)
+{
+	if (limit > 0) {
+		return limit;
+	}
+
+	ast_log(LOG_WARNING, "Mixer max lookup failed, using default %d\n", AST_RADIO_MIXER_MAX_DEFAULT);
+	return AST_RADIO_MIXER_MAX_DEFAULT;
 }
 
 int ast_radio_amixer_max(int devnum, char *param)

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -1180,6 +1180,10 @@ PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
 	}
 
 	if (res != paNoError) {
+		if (ps->stream) {
+			Pa_CloseStream(ps->stream);
+			ps->stream = NULL;
+		}
 		ast_radio_pa_shutdown();
 		return res;
 	}


### PR DESCRIPTION
## Summary
- Replace OSS `/dev/dsp` I/O with `ast_radio_pa_*` from `res_usbradio`
- Add `audiodev=hw:N` device binding via ALSA card → USB HID lookup
- Harden stream lifecycle (refcounted Pa init, break on stream errors)
- Fix `register int` usage for arm64 builds

## Stack
**PR 2 of 3** — **merge after #1091** is merged, then rebase this branch onto `master` before final review.

Incremental diff vs PR 1: https://github.com/hardenedpenguin/app_rpt/compare/portaudio/1-res-usbradio...portaudio/2-simpleusb

## Test plan
- [ ] Builds on amd64 and arm64
- [ ] URI binds to correct ALSA card
- [ ] RX/TX audio and PTT on SimpleUSB node

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PortAudio-based audio handling for USB radio modules, improving audio streaming support.
  * Expanded device detection and selection so hardware can be matched more reliably from common audio/card identifiers.

* **Bug Fixes**
  * Improved audio processing for mono and stereo paths.
  * Made audio and HID startup/shutdown more reliable, reducing issues during module load, hangup, and unload.
  * Fixed mixer/device initialization error handling to stop on failed hardware access.

* **Chores**
  * Updated build support to link the required audio and USB libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->