### PR TITLE
chan_usbradio: PortAudio migration and install/docs (stack 3/3)

### DIFF
--- a/.dev/pre-commit
+++ b/.dev/pre-commit
@@ -1,14 +1,26 @@
-#!/bin/sh
-#
-# An example hook script to verify what is about to be committed.
-# Called by "git commit" with no arguments.  The hook should
-# exit with non-zero status after issuing an appropriate message if
-# it wants to stop the commit.
-#
-# To enable this hook, rename this file to "pre-commit".
-
+#!/usr/bin/env bash
+# pre‑commit hook: warn if committing directly to a protected branch
+# This script should be symlinked or referenced by the actual Git hook.
 # Redirect output to stderr.
 exec 1>&2
+
+# Get the current branch name (fallback to HEAD if detached)
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "HEAD")
+
+# Detect protected branches via GitHub rulesets (requires gh CLI)
+# If gh fails or returns no rules, fall back to a static list.
+if command -v gh >/dev/null 2>&1; then
+	# gh ruleset check returns lines starting with '-' for each rule
+	PROTECTED_COUNT=$(gh ruleset check "$branch" 2>/dev/null | grep -c '^-')
+	if [ "$PROTECTED_COUNT" -gt 0 ]; then
+		echo "          Warning: You are trying to commit directly to a protected branch '$branch' (detected via GitHub rules)."
+		echo "          Please create a new feature branch first (e.g., git checkout -b feature/your-task) and open a PR."
+		echo "          Commit aborted."
+		exit 1
+	fi
+else
+	echo "          Branch protection rule checks not available, Please install GitHub CLI (gh)"
+fi
 
 BEFORE_DIFF="$(git diff --no-ext-diff --binary)"
 # Test clang-format
@@ -49,4 +61,3 @@ then
    echo "Please review the changes and stage the files again."
    exit 1
 fi
-

--- a/apps/app_gps.c
+++ b/apps/app_gps.c
@@ -41,14 +41,13 @@
  *
  * app_gps can connect to a serial GPS receiver to get position information.
  * If a GPS receiver is not configured, it can provide default position information
- * entered in the gps.conf file.  It decodes NMEA-0183 GGA sentences ($GPGGA,
- * $GNGGA, etc.).
+ * entered in the gps.conf file.  It decodes the NEMA-0183 $GPGGA sentence.
  *
  * The $GPGGA sentence looks like the following:
  * $GPGGA,011530.00,3255.21780,N,08556.91695,W,2,06,3.45,217.4,M,-30.3,M,,0000*63
  *
  * Name	                  Example Data        Description
- * Sentence Identifier	  $xxGGA              Global Positioning System Fix Data
+ * Sentence Identifier	  $GPGGA              Global Positioning System Fix Data
  * Time                   011530.00           01:15:30 UTC
  * Latitude               3255.21780          32.920297°N or 32° 55' 13.0692"N
  * Latitude direction	  N                   N = North or S = South
@@ -479,7 +478,7 @@ static void *aprs_connection_thread(void *data)
 
 	if (!(cfg = ast_config_load(config, zeroflag))) {
 		ast_log(LOG_NOTICE, "Unable to load config %s\n", config);
-		return NULL;
+		pthread_exit(NULL);
 	}
 	val = ast_variable_retrieve(cfg, "general", "call");
 	if (val) {
@@ -498,7 +497,7 @@ static void *aprs_connection_thread(void *data)
 	/* Verify that we have a callsign and password */
 	if ((!call) || (!password)) {
 		ast_log(LOG_ERROR, "You must specify call and password\n");
-		return NULL;
+		pthread_exit(NULL);
 	}
 
 	while (run_forever) {
@@ -710,7 +709,8 @@ static int report_aprs(const char *ctg, char *lat, char *lon, const char *elev)
 
 	/* Setup optional elevation */
 	elev_f = 0;
-	if (sscanf(elev, "%f", &elev_f) == 1) {
+	sscanf(elev, "%f", &elev_f);
+	if (elev_f > 0) {
 		snprintf(elev_str, sizeof(elev_str), "/A=%06.0f", elev_f * 3.28);
 	} else {
 		elev_str[0] = '\0';
@@ -889,136 +889,6 @@ static void lon_decimal_to_DMS(float dec, char *value, int len)
 }
 
 /*!
- * \brief Format a default elevation string with a meters unit suffix.
- */
-static void format_def_elevation(const char *defelev, char *elevation, size_t elen)
-{
-	if (defelev) {
-		float eleva, elevd;
-
-		eleva = strtof(defelev, NULL);
-		elevd = (eleva - floor(eleva)) * 10 + 0.5;
-		snprintf(elevation, elen, "%03d.%1dM", (int) eleva, (int) elevd);
-	} else {
-		ast_copy_string(elevation, "000.0M", elen);
-	}
-}
-
-/*!
- * \brief Test whether a sentence is an NMEA GGA fix record.
- */
-static int is_gga_sentence(const char *sentence)
-{
-	size_t len;
-
-	if (ast_strlen_zero(sentence) || sentence[0] != '$') {
-		return 0;
-	}
-
-	len = strlen(sentence);
-	if (len < 6) {
-		return 0;
-	}
-
-	return !strcasecmp(sentence + len - 3, "GGA");
-}
-
-/*!
- * \brief Apply a minute offset to an APRS-format latitude string.
- *
- * \retval 1 on success
- * \retval 0 on parse failure
- */
-static int aprs_lat_apply_offset(const char *in_lat, int minute_offset, char *out_lat, size_t out_len)
-{
-	char work[25];
-	char dir;
-	int deg;
-	double minutes, decimal;
-
-	if (ast_strlen_zero(in_lat) || strlen(in_lat) < 4) {
-		return 0;
-	}
-
-	ast_copy_string(work, in_lat, sizeof(work));
-	dir = work[strlen(work) - 1];
-	if (dir != 'N' && dir != 'S') {
-		return 0;
-	}
-	work[strlen(work) - 1] = '\0';
-
-	deg = (work[0] - '0') * 10 + (work[1] - '0');
-	minutes = strtod(work + 2, NULL);
-	if (minutes < 0.0 || minutes >= 60.0) {
-		return 0;
-	}
-
-	decimal = (double) deg + minutes / 60.0;
-	if (dir == 'S') {
-		decimal = -decimal;
-	}
-	decimal += minute_offset / 60.0;
-
-	if (decimal >= 0.0) {
-		dir = 'N';
-	} else {
-		dir = 'S';
-		decimal = -decimal;
-	}
-
-	deg = (int) decimal;
-	minutes = (decimal - deg) * 60.0;
-	snprintf(out_lat, out_len, "%02d%05.2f%c", deg, minutes, dir);
-	return 1;
-}
-
-/*!
- * \brief Open and configure the GPS serial port.
- *
- * \retval fd on success
- * \retval -1 on failure
- */
-static int gps_serial_open(void)
-{
-	int fd;
-	struct termios mode;
-
-	fd = open(comport, O_RDWR);
-	if (fd == -1) {
-		ast_log(LOG_WARNING, "Cannot open serial port %s: %s\n", comport, strerror(errno));
-		return -1;
-	}
-
-	memset(&mode, 0, sizeof(mode));
-	if (tcgetattr(fd, &mode)) {
-		ast_log(LOG_WARNING, "Unable to get serial parameters on %s: %s\n", comport, strerror(errno));
-		close(fd);
-		return -1;
-	}
-#ifndef SOLARIS
-	cfmakeraw(&mode);
-#else
-	mode.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON);
-	mode.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
-	mode.c_cflag &= ~(CSIZE | PARENB | CRTSCTS);
-	mode.c_cflag |= CS8;
-	mode.c_cc[VTIME] = 3;
-	mode.c_cc[VMIN] = 1;
-#endif
-
-	cfsetispeed(&mode, baudrate);
-	cfsetospeed(&mode, baudrate);
-	if (tcsetattr(fd, TCSANOW, &mode)) {
-		ast_log(LOG_WARNING, "Unable to set serial parameters on %s: %s\n", comport, strerror(errno));
-		close(fd);
-		return -1;
-	}
-
-	usleep(100000);
-	return fd;
-}
-
-/*!
  * \brief GPS device processing thread.
  * This routine continuously reads and parses the serial GPS data.
  *
@@ -1030,34 +900,61 @@ static int gps_serial_open(void)
 static void *gps_reader(void *data)
 {
 	char buf[300], c, *strs[100];
-	int res, i, n, fd, star_idx, rx_checksum;
+	int res, i, n, fd, has_comport = 0;
+	struct termios mode;
 	struct position_info *selected_info;
 	time_t now_mono;
 
-	fd = -1;
+	if (comport) {
+		has_comport = 1;
+	} else {
+		comport = "/dev/null";
+	}
+
+	/* Open the serial port configured for the GPS device */
+	fd = open(comport, O_RDWR);
+	if (fd == -1) {
+		ast_log(LOG_WARNING, "Cannot open serial port %s: %s\n", comport, strerror(errno));
+		goto err;
+	}
+
+	if (has_comport) {
+		memset(&mode, 0, sizeof(mode));
+		if (tcgetattr(fd, &mode)) {
+			ast_log(LOG_WARNING, "Unable to get serial parameters on %s: %s\n", comport, strerror(errno));
+			close(fd);
+			goto err;
+		}
+#ifndef SOLARIS
+		cfmakeraw(&mode);
+#else
+		mode.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON);
+		mode.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
+		mode.c_cflag &= ~(CSIZE | PARENB | CRTSCTS);
+		mode.c_cflag |= CS8;
+		mode.c_cc[VTIME] = 3;
+		mode.c_cc[VMIN] = 1;
+#endif
+
+		cfsetispeed(&mode, baudrate);
+		cfsetospeed(&mode, baudrate);
+		if (tcsetattr(fd, TCSANOW, &mode)) {
+			ast_log(LOG_WARNING, "Unable to set serial parameters on %s: %s\n", comport, strerror(errno));
+			close(fd);
+			goto err;
+		}
+	}
+
+	/* Give the device a few milliseconds to come on-line */
+	usleep(100000);
+
+	/*! \todo we need to deal with someone unplugging the device */
 
 	while (run_forever) {
-		if (fd < 0) {
-			fd = gps_serial_open();
-			if (fd < 0) {
-				ast_mutex_lock(&position_update_lock);
-				current_gps_position.is_valid = 0;
-				ast_mutex_unlock(&position_update_lock);
-				sleep(2);
-				continue;
-			}
-		}
-
 		/* Read a line from the serial port */
 		res = getserialline(fd, buf, sizeof(buf) - 1);
 		if (res < 0) {
-			ast_log(LOG_WARNING, "GPS serial read error on %s, reconnecting\n", comport);
-			close(fd);
-			fd = -1;
-			ast_mutex_lock(&position_update_lock);
-			current_gps_position.is_valid = 0;
-			ast_mutex_unlock(&position_update_lock);
-			sleep(1);
+			ast_log(LOG_ERROR, "GPS fatal error!\n");
 			continue;
 		}
 		if (!res) {
@@ -1098,12 +995,11 @@ static void *gps_reader(void *data)
 				}
 				c ^= buf[i];
 			}
-			star_idx = i;
-			if ((!buf[star_idx]) || (strlen(buf) < (star_idx + 3))) {
+			if ((!buf[i]) || (strlen(buf) < (i + 3))) {
 				ast_log(LOG_WARNING, "GPS Invalid data format (checksum format)\n");
 				continue;
 			}
-			if ((sscanf(buf + star_idx + 1, "%x", &rx_checksum) != 1) || (c != rx_checksum)) {
+			if ((sscanf(buf + i + 1, "%x", &i) != 1) || (c != i)) {
 				ast_log(LOG_WARNING, "GPS Invalid checksum\n");
 				continue;
 			}
@@ -1113,8 +1009,8 @@ static void *gps_reader(void *data)
 				ast_log(LOG_WARNING, "GPS Invalid data format (no data)\n");
 				continue;
 			}
-			/* Process NMEA GGA sentences ($GPGGA, $GNGGA, etc.) */
-			if (!is_gga_sentence(strs[0])) {
+			/* We only process the $GPGGA sentence */
+			if (strcasecmp(strs[0], "$GPGGA")) {
 				continue;
 			}
 			if (n != 15) {
@@ -1156,6 +1052,7 @@ static void *gps_reader(void *data)
 		close(fd);
 	}
 
+err:
 	ast_debug(2, "%s has exited\n", __FUNCTION__);
 	return NULL;
 }
@@ -1190,7 +1087,7 @@ static void *aprs_sender_thread(void *data)
 
 	if (!(cfg = ast_config_load(config, zeroflag))) {
 		ast_log(LOG_NOTICE, "Unable to load config %s\n", config);
-		return NULL;
+		pthread_exit(NULL);
 	}
 	val = ast_variable_retrieve(cfg, ctg, "lat");
 	if (val) {
@@ -1236,7 +1133,15 @@ static void *aprs_sender_thread(void *data)
 		this_def_position.is_valid = 1;
 		lat_decimal_to_DMS(strtof(deflat, NULL), this_def_position.latitude, sizeof(this_def_position.latitude));
 		lon_decimal_to_DMS(strtof(deflon, NULL), this_def_position.longitude, sizeof(this_def_position.longitude));
-		format_def_elevation(defelev, this_def_position.elevation, sizeof(this_def_position.elevation));
+		/* See if we have a default elevation */
+		if (defelev) {
+			float eleva, elevd;
+			eleva = strtof(defelev, NULL);
+			elevd = (eleva - floor(eleva)) * 10 + 0.5;
+			snprintf(this_def_position.elevation, sizeof(this_def_position.elevation), "%03d.%1d", (int) eleva, (int) elevd);
+		} else {
+			strcpy(this_def_position.elevation, "000.0");
+		}
 	}
 
 	memset(&selected_position, 0, sizeof(selected_position));
@@ -1290,8 +1195,8 @@ static void *aprstt_sender_thread(void *data)
 {
 	struct ast_config *cfg = NULL;
 	struct ast_flags zeroflag = { 0 };
-	int i, ttlist, ttoffset, ttslot, myoffset;
-	char *ctg;
+	int i, j, ttlist, ttoffset, ttslot, myoffset;
+	char *ctg, c;
 	char *deflat, *deflon, *defelev, ttsplit, *ttlat, *ttlon;
 	const char *val, *resolved_lat, *resolved_lon;
 	char fname[200], lat[25], theircall[20], overlay;
@@ -1311,7 +1216,7 @@ static void *aprstt_sender_thread(void *data)
 	/* Load our configuration */
 	if (!(cfg = ast_config_load(config, zeroflag))) {
 		ast_log(LOG_NOTICE, "Unable to load config %s\n", config);
-		return NULL;
+		pthread_exit(NULL);
 	}
 	val = ast_variable_retrieve(cfg, ctg, "lat");
 	if (val) {
@@ -1382,7 +1287,15 @@ static void *aprstt_sender_thread(void *data)
 		this_def_position.is_valid = 1;
 		lat_decimal_to_DMS(strtof(resolved_lat, NULL), this_def_position.latitude, sizeof(this_def_position.latitude));
 		lon_decimal_to_DMS(strtof(resolved_lon, NULL), this_def_position.longitude, sizeof(this_def_position.longitude));
-		format_def_elevation(defelev, this_def_position.elevation, sizeof(this_def_position.elevation));
+		/* See if we have a default elevation */
+		if (defelev) {
+			float eleva, elevd;
+			eleva = strtof(defelev, NULL);
+			elevd = (eleva - floor(eleva)) * 10 + 0.5;
+			snprintf(this_def_position.elevation, sizeof(this_def_position.elevation), "%03d.%1d", (int) eleva, (int) elevd);
+		} else {
+			strcpy(this_def_position.elevation, "000.0");
+		}
 	}
 
 	/*
@@ -1399,56 +1312,55 @@ static void *aprstt_sender_thread(void *data)
 		mfp = fopen(fname, "w");
 		if (!mfp) {
 			ast_log(LOG_ERROR, "Can not create aprstt common block file %s: %s\n", fname, strerror(errno));
-			return NULL;
+			pthread_exit(NULL);
 		}
 		memset(&ttempty, 0, sizeof(ttempty));
 		for (i = 0; i < ttlist; i++) {
 			if (fwrite(&ttempty, 1, sizeof(ttempty), mfp) != sizeof(ttempty)) {
 				ast_log(LOG_ERROR, "Error initializing aprtss common block file %s: %s\n", fname, strerror(errno));
 				fclose(mfp);
-				return NULL;
+				pthread_exit(NULL);
 			}
 		}
 		fclose(mfp);
 		if (stat(fname, &mystat) == -1) {
 			ast_log(LOG_ERROR, "Unable to stat new aprstt common block file %s: %s\n", fname, strerror(errno));
-			return NULL;
+			pthread_exit(NULL);
 		}
 	}
 	if (mystat.st_size < (sizeof(struct ttentry) * ttlist)) {
 		mfp = fopen(fname, "r+");
 		if (!mfp) {
 			ast_log(LOG_ERROR, "Can not open aprstt common block file %s: %s\n", fname, strerror(errno));
-			return NULL;
+			pthread_exit(NULL);
 		}
 		memset(&ttempty, 0, sizeof(ttempty));
 		if (fseek(mfp, 0, SEEK_END)) {
 			ast_log(LOG_ERROR, "Can not seek aprstt common block file %s: %s\n", fname, strerror(errno));
-			return NULL;
+			pthread_exit(NULL);
 		}
 		for (i = mystat.st_size; i < (sizeof(struct ttentry) * ttlist); i += sizeof(struct ttentry)) {
 			if (fwrite(&ttempty, 1, sizeof(ttempty), mfp) != sizeof(ttempty)) {
 				ast_log(LOG_ERROR, "Error growing aprtss common block file %s: %s\n", fname, strerror(errno));
 				fclose(mfp);
-				return NULL;
+				pthread_exit(NULL);
 			}
 		}
 		fclose(mfp);
 		if (stat(fname, &mystat) == -1) {
 			ast_log(LOG_ERROR, "Unable to stat updated aprstt common block file %s: %s\n", fname, strerror(errno));
-			return NULL;
+			pthread_exit(NULL);
 		}
 	}
 	mfp = fopen(fname, "r+");
 	if (!mfp) {
 		ast_log(LOG_ERROR, "Can not open aprstt common block file %s: %s\n", fname, strerror(errno));
-		return NULL;
+		pthread_exit(NULL);
 	}
 	ttentries = mmap(NULL, mystat.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, fileno(mfp), 0);
-	if (ttentries == MAP_FAILED) {
+	if (ttentries == NULL) {
 		ast_log(LOG_ERROR, "Cannot map aprtss common file %s: %s\n", fname, strerror(errno));
-		fclose(mfp);
-		return NULL;
+		pthread_exit(NULL);
 	}
 
 	while (run_forever) {
@@ -1534,7 +1446,22 @@ static void *aprstt_sender_thread(void *data)
 		ast_mutex_unlock(&position_update_lock);
 
 		if (selected_position.is_valid) {
-			if (aprs_lat_apply_offset(selected_position.latitude, myoffset, lat, sizeof(lat))) {
+			if (sscanf(selected_position.latitude, "%d.%d%c", &i, &j, &c) == 3) {
+				/* Adjust the latitude for the offset */
+				if (c == 'S') {
+					i = -i;
+				}
+				if (i >= 0) {
+					j -= myoffset;
+				} else {
+					j += myoffset;
+				}
+				i += (j / 60);
+				if (j < 0) {
+					snprintf(lat, sizeof(lat), "%04d.%02d%c", (i >= 0) ? i : -i, -j % 60, (i >= 0) ? 'N' : 'S');
+				} else {
+					snprintf(lat, sizeof(lat), "%04d.%02d%c", (i >= 0) ? i : -i, j % 60, (i >= 0) ? 'N' : 'S');
+				}
 				/* If our last position update is good, send an update */
 				if ((selected_position.last_updated + GPS_VALID_SECS) >= now) {
 					report_aprstt(ctg, lat, selected_position.longitude, theircall, overlay);
@@ -1850,8 +1777,7 @@ static int load_module(void)
 			baudrate = B57600;
 			break;
 		default:
-			ast_log(LOG_ERROR, "%s is not valid baud rate, using %d\n", val, 4800);
-			baudrate = GPS_DEFAULT_BAUDRATE;
+			ast_log(LOG_ERROR, "%s is not valid baud rate for iospeed\n", val);
 			break;
 		}
 	} else {
@@ -1866,7 +1792,15 @@ static int load_module(void)
 		general_def_position.is_valid = 1;
 		lat_decimal_to_DMS(strtof(def_lat, NULL), general_def_position.latitude, sizeof(general_def_position.latitude));
 		lon_decimal_to_DMS(strtof(def_lon, NULL), general_def_position.longitude, sizeof(general_def_position.longitude));
-		format_def_elevation(def_elev, general_def_position.elevation, sizeof(general_def_position.elevation));
+		/* See if we have a default elevation */
+		if (def_elev) {
+			float eleva, elevd;
+			eleva = strtof(def_elev, NULL);
+			elevd = (eleva - floor(eleva)) * 10 + 0.5;
+			snprintf(general_def_position.elevation, sizeof(general_def_position.elevation), "%03d.%1dM", (int) eleva, (int) elevd);
+		} else {
+			strcpy(general_def_position.elevation, "000.0M");
+		}
 	}
 
 	/* Create the aprs connection thread */

--- a/apps/app_gps.c
+++ b/apps/app_gps.c
@@ -41,13 +41,14 @@
  *
  * app_gps can connect to a serial GPS receiver to get position information.
  * If a GPS receiver is not configured, it can provide default position information
- * entered in the gps.conf file.  It decodes the NEMA-0183 $GPGGA sentence.
+ * entered in the gps.conf file.  It decodes NMEA-0183 GGA sentences ($GPGGA,
+ * $GNGGA, etc.).
  *
  * The $GPGGA sentence looks like the following:
  * $GPGGA,011530.00,3255.21780,N,08556.91695,W,2,06,3.45,217.4,M,-30.3,M,,0000*63
  *
  * Name	                  Example Data        Description
- * Sentence Identifier	  $GPGGA              Global Positioning System Fix Data
+ * Sentence Identifier	  $xxGGA              Global Positioning System Fix Data
  * Time                   011530.00           01:15:30 UTC
  * Latitude               3255.21780          32.920297°N or 32° 55' 13.0692"N
  * Latitude direction	  N                   N = North or S = South
@@ -478,7 +479,7 @@ static void *aprs_connection_thread(void *data)
 
 	if (!(cfg = ast_config_load(config, zeroflag))) {
 		ast_log(LOG_NOTICE, "Unable to load config %s\n", config);
-		pthread_exit(NULL);
+		return NULL;
 	}
 	val = ast_variable_retrieve(cfg, "general", "call");
 	if (val) {
@@ -497,7 +498,7 @@ static void *aprs_connection_thread(void *data)
 	/* Verify that we have a callsign and password */
 	if ((!call) || (!password)) {
 		ast_log(LOG_ERROR, "You must specify call and password\n");
-		pthread_exit(NULL);
+		return NULL;
 	}
 
 	while (run_forever) {
@@ -709,8 +710,7 @@ static int report_aprs(const char *ctg, char *lat, char *lon, const char *elev)
 
 	/* Setup optional elevation */
 	elev_f = 0;
-	sscanf(elev, "%f", &elev_f);
-	if (elev_f > 0) {
+	if (sscanf(elev, "%f", &elev_f) == 1) {
 		snprintf(elev_str, sizeof(elev_str), "/A=%06.0f", elev_f * 3.28);
 	} else {
 		elev_str[0] = '\0';
@@ -889,6 +889,136 @@ static void lon_decimal_to_DMS(float dec, char *value, int len)
 }
 
 /*!
+ * \brief Format a default elevation string with a meters unit suffix.
+ */
+static void format_def_elevation(const char *defelev, char *elevation, size_t elen)
+{
+	if (defelev) {
+		float eleva, elevd;
+
+		eleva = strtof(defelev, NULL);
+		elevd = (eleva - floor(eleva)) * 10 + 0.5;
+		snprintf(elevation, elen, "%03d.%1dM", (int) eleva, (int) elevd);
+	} else {
+		ast_copy_string(elevation, "000.0M", elen);
+	}
+}
+
+/*!
+ * \brief Test whether a sentence is an NMEA GGA fix record.
+ */
+static int is_gga_sentence(const char *sentence)
+{
+	size_t len;
+
+	if (ast_strlen_zero(sentence) || sentence[0] != '$') {
+		return 0;
+	}
+
+	len = strlen(sentence);
+	if (len < 6) {
+		return 0;
+	}
+
+	return !strcasecmp(sentence + len - 3, "GGA");
+}
+
+/*!
+ * \brief Apply a minute offset to an APRS-format latitude string.
+ *
+ * \retval 1 on success
+ * \retval 0 on parse failure
+ */
+static int aprs_lat_apply_offset(const char *in_lat, int minute_offset, char *out_lat, size_t out_len)
+{
+	char work[25];
+	char dir;
+	int deg;
+	double minutes, decimal;
+
+	if (ast_strlen_zero(in_lat) || strlen(in_lat) < 4) {
+		return 0;
+	}
+
+	ast_copy_string(work, in_lat, sizeof(work));
+	dir = work[strlen(work) - 1];
+	if (dir != 'N' && dir != 'S') {
+		return 0;
+	}
+	work[strlen(work) - 1] = '\0';
+
+	deg = (work[0] - '0') * 10 + (work[1] - '0');
+	minutes = strtod(work + 2, NULL);
+	if (minutes < 0.0 || minutes >= 60.0) {
+		return 0;
+	}
+
+	decimal = (double) deg + minutes / 60.0;
+	if (dir == 'S') {
+		decimal = -decimal;
+	}
+	decimal += minute_offset / 60.0;
+
+	if (decimal >= 0.0) {
+		dir = 'N';
+	} else {
+		dir = 'S';
+		decimal = -decimal;
+	}
+
+	deg = (int) decimal;
+	minutes = (decimal - deg) * 60.0;
+	snprintf(out_lat, out_len, "%02d%05.2f%c", deg, minutes, dir);
+	return 1;
+}
+
+/*!
+ * \brief Open and configure the GPS serial port.
+ *
+ * \retval fd on success
+ * \retval -1 on failure
+ */
+static int gps_serial_open(void)
+{
+	int fd;
+	struct termios mode;
+
+	fd = open(comport, O_RDWR);
+	if (fd == -1) {
+		ast_log(LOG_WARNING, "Cannot open serial port %s: %s\n", comport, strerror(errno));
+		return -1;
+	}
+
+	memset(&mode, 0, sizeof(mode));
+	if (tcgetattr(fd, &mode)) {
+		ast_log(LOG_WARNING, "Unable to get serial parameters on %s: %s\n", comport, strerror(errno));
+		close(fd);
+		return -1;
+	}
+#ifndef SOLARIS
+	cfmakeraw(&mode);
+#else
+	mode.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON);
+	mode.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
+	mode.c_cflag &= ~(CSIZE | PARENB | CRTSCTS);
+	mode.c_cflag |= CS8;
+	mode.c_cc[VTIME] = 3;
+	mode.c_cc[VMIN] = 1;
+#endif
+
+	cfsetispeed(&mode, baudrate);
+	cfsetospeed(&mode, baudrate);
+	if (tcsetattr(fd, TCSANOW, &mode)) {
+		ast_log(LOG_WARNING, "Unable to set serial parameters on %s: %s\n", comport, strerror(errno));
+		close(fd);
+		return -1;
+	}
+
+	usleep(100000);
+	return fd;
+}
+
+/*!
  * \brief GPS device processing thread.
  * This routine continuously reads and parses the serial GPS data.
  *
@@ -900,61 +1030,34 @@ static void lon_decimal_to_DMS(float dec, char *value, int len)
 static void *gps_reader(void *data)
 {
 	char buf[300], c, *strs[100];
-	int res, i, n, fd, has_comport = 0;
-	struct termios mode;
+	int res, i, n, fd, star_idx, rx_checksum;
 	struct position_info *selected_info;
 	time_t now_mono;
 
-	if (comport) {
-		has_comport = 1;
-	} else {
-		comport = "/dev/null";
-	}
-
-	/* Open the serial port configured for the GPS device */
-	fd = open(comport, O_RDWR);
-	if (fd == -1) {
-		ast_log(LOG_WARNING, "Cannot open serial port %s: %s\n", comport, strerror(errno));
-		goto err;
-	}
-
-	if (has_comport) {
-		memset(&mode, 0, sizeof(mode));
-		if (tcgetattr(fd, &mode)) {
-			ast_log(LOG_WARNING, "Unable to get serial parameters on %s: %s\n", comport, strerror(errno));
-			close(fd);
-			goto err;
-		}
-#ifndef SOLARIS
-		cfmakeraw(&mode);
-#else
-		mode.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON);
-		mode.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
-		mode.c_cflag &= ~(CSIZE | PARENB | CRTSCTS);
-		mode.c_cflag |= CS8;
-		mode.c_cc[VTIME] = 3;
-		mode.c_cc[VMIN] = 1;
-#endif
-
-		cfsetispeed(&mode, baudrate);
-		cfsetospeed(&mode, baudrate);
-		if (tcsetattr(fd, TCSANOW, &mode)) {
-			ast_log(LOG_WARNING, "Unable to set serial parameters on %s: %s\n", comport, strerror(errno));
-			close(fd);
-			goto err;
-		}
-	}
-
-	/* Give the device a few milliseconds to come on-line */
-	usleep(100000);
-
-	/*! \todo we need to deal with someone unplugging the device */
+	fd = -1;
 
 	while (run_forever) {
+		if (fd < 0) {
+			fd = gps_serial_open();
+			if (fd < 0) {
+				ast_mutex_lock(&position_update_lock);
+				current_gps_position.is_valid = 0;
+				ast_mutex_unlock(&position_update_lock);
+				sleep(2);
+				continue;
+			}
+		}
+
 		/* Read a line from the serial port */
 		res = getserialline(fd, buf, sizeof(buf) - 1);
 		if (res < 0) {
-			ast_log(LOG_ERROR, "GPS fatal error!\n");
+			ast_log(LOG_WARNING, "GPS serial read error on %s, reconnecting\n", comport);
+			close(fd);
+			fd = -1;
+			ast_mutex_lock(&position_update_lock);
+			current_gps_position.is_valid = 0;
+			ast_mutex_unlock(&position_update_lock);
+			sleep(1);
 			continue;
 		}
 		if (!res) {
@@ -995,11 +1098,12 @@ static void *gps_reader(void *data)
 				}
 				c ^= buf[i];
 			}
-			if ((!buf[i]) || (strlen(buf) < (i + 3))) {
+			star_idx = i;
+			if ((!buf[star_idx]) || (strlen(buf) < (star_idx + 3))) {
 				ast_log(LOG_WARNING, "GPS Invalid data format (checksum format)\n");
 				continue;
 			}
-			if ((sscanf(buf + i + 1, "%x", &i) != 1) || (c != i)) {
+			if ((sscanf(buf + star_idx + 1, "%x", &rx_checksum) != 1) || (c != rx_checksum)) {
 				ast_log(LOG_WARNING, "GPS Invalid checksum\n");
 				continue;
 			}
@@ -1009,8 +1113,8 @@ static void *gps_reader(void *data)
 				ast_log(LOG_WARNING, "GPS Invalid data format (no data)\n");
 				continue;
 			}
-			/* We only process the $GPGGA sentence */
-			if (strcasecmp(strs[0], "$GPGGA")) {
+			/* Process NMEA GGA sentences ($GPGGA, $GNGGA, etc.) */
+			if (!is_gga_sentence(strs[0])) {
 				continue;
 			}
 			if (n != 15) {
@@ -1052,7 +1156,6 @@ static void *gps_reader(void *data)
 		close(fd);
 	}
 
-err:
 	ast_debug(2, "%s has exited\n", __FUNCTION__);
 	return NULL;
 }
@@ -1087,7 +1190,7 @@ static void *aprs_sender_thread(void *data)
 
 	if (!(cfg = ast_config_load(config, zeroflag))) {
 		ast_log(LOG_NOTICE, "Unable to load config %s\n", config);
-		pthread_exit(NULL);
+		return NULL;
 	}
 	val = ast_variable_retrieve(cfg, ctg, "lat");
 	if (val) {
@@ -1133,15 +1236,7 @@ static void *aprs_sender_thread(void *data)
 		this_def_position.is_valid = 1;
 		lat_decimal_to_DMS(strtof(deflat, NULL), this_def_position.latitude, sizeof(this_def_position.latitude));
 		lon_decimal_to_DMS(strtof(deflon, NULL), this_def_position.longitude, sizeof(this_def_position.longitude));
-		/* See if we have a default elevation */
-		if (defelev) {
-			float eleva, elevd;
-			eleva = strtof(defelev, NULL);
-			elevd = (eleva - floor(eleva)) * 10 + 0.5;
-			snprintf(this_def_position.elevation, sizeof(this_def_position.elevation), "%03d.%1d", (int) eleva, (int) elevd);
-		} else {
-			strcpy(this_def_position.elevation, "000.0");
-		}
+		format_def_elevation(defelev, this_def_position.elevation, sizeof(this_def_position.elevation));
 	}
 
 	memset(&selected_position, 0, sizeof(selected_position));
@@ -1195,8 +1290,8 @@ static void *aprstt_sender_thread(void *data)
 {
 	struct ast_config *cfg = NULL;
 	struct ast_flags zeroflag = { 0 };
-	int i, j, ttlist, ttoffset, ttslot, myoffset;
-	char *ctg, c;
+	int i, ttlist, ttoffset, ttslot, myoffset;
+	char *ctg;
 	char *deflat, *deflon, *defelev, ttsplit, *ttlat, *ttlon;
 	const char *val, *resolved_lat, *resolved_lon;
 	char fname[200], lat[25], theircall[20], overlay;
@@ -1216,7 +1311,7 @@ static void *aprstt_sender_thread(void *data)
 	/* Load our configuration */
 	if (!(cfg = ast_config_load(config, zeroflag))) {
 		ast_log(LOG_NOTICE, "Unable to load config %s\n", config);
-		pthread_exit(NULL);
+		return NULL;
 	}
 	val = ast_variable_retrieve(cfg, ctg, "lat");
 	if (val) {
@@ -1287,15 +1382,7 @@ static void *aprstt_sender_thread(void *data)
 		this_def_position.is_valid = 1;
 		lat_decimal_to_DMS(strtof(resolved_lat, NULL), this_def_position.latitude, sizeof(this_def_position.latitude));
 		lon_decimal_to_DMS(strtof(resolved_lon, NULL), this_def_position.longitude, sizeof(this_def_position.longitude));
-		/* See if we have a default elevation */
-		if (defelev) {
-			float eleva, elevd;
-			eleva = strtof(defelev, NULL);
-			elevd = (eleva - floor(eleva)) * 10 + 0.5;
-			snprintf(this_def_position.elevation, sizeof(this_def_position.elevation), "%03d.%1d", (int) eleva, (int) elevd);
-		} else {
-			strcpy(this_def_position.elevation, "000.0");
-		}
+		format_def_elevation(defelev, this_def_position.elevation, sizeof(this_def_position.elevation));
 	}
 
 	/*
@@ -1312,55 +1399,56 @@ static void *aprstt_sender_thread(void *data)
 		mfp = fopen(fname, "w");
 		if (!mfp) {
 			ast_log(LOG_ERROR, "Can not create aprstt common block file %s: %s\n", fname, strerror(errno));
-			pthread_exit(NULL);
+			return NULL;
 		}
 		memset(&ttempty, 0, sizeof(ttempty));
 		for (i = 0; i < ttlist; i++) {
 			if (fwrite(&ttempty, 1, sizeof(ttempty), mfp) != sizeof(ttempty)) {
 				ast_log(LOG_ERROR, "Error initializing aprtss common block file %s: %s\n", fname, strerror(errno));
 				fclose(mfp);
-				pthread_exit(NULL);
+				return NULL;
 			}
 		}
 		fclose(mfp);
 		if (stat(fname, &mystat) == -1) {
 			ast_log(LOG_ERROR, "Unable to stat new aprstt common block file %s: %s\n", fname, strerror(errno));
-			pthread_exit(NULL);
+			return NULL;
 		}
 	}
 	if (mystat.st_size < (sizeof(struct ttentry) * ttlist)) {
 		mfp = fopen(fname, "r+");
 		if (!mfp) {
 			ast_log(LOG_ERROR, "Can not open aprstt common block file %s: %s\n", fname, strerror(errno));
-			pthread_exit(NULL);
+			return NULL;
 		}
 		memset(&ttempty, 0, sizeof(ttempty));
 		if (fseek(mfp, 0, SEEK_END)) {
 			ast_log(LOG_ERROR, "Can not seek aprstt common block file %s: %s\n", fname, strerror(errno));
-			pthread_exit(NULL);
+			return NULL;
 		}
 		for (i = mystat.st_size; i < (sizeof(struct ttentry) * ttlist); i += sizeof(struct ttentry)) {
 			if (fwrite(&ttempty, 1, sizeof(ttempty), mfp) != sizeof(ttempty)) {
 				ast_log(LOG_ERROR, "Error growing aprtss common block file %s: %s\n", fname, strerror(errno));
 				fclose(mfp);
-				pthread_exit(NULL);
+				return NULL;
 			}
 		}
 		fclose(mfp);
 		if (stat(fname, &mystat) == -1) {
 			ast_log(LOG_ERROR, "Unable to stat updated aprstt common block file %s: %s\n", fname, strerror(errno));
-			pthread_exit(NULL);
+			return NULL;
 		}
 	}
 	mfp = fopen(fname, "r+");
 	if (!mfp) {
 		ast_log(LOG_ERROR, "Can not open aprstt common block file %s: %s\n", fname, strerror(errno));
-		pthread_exit(NULL);
+		return NULL;
 	}
 	ttentries = mmap(NULL, mystat.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, fileno(mfp), 0);
-	if (ttentries == NULL) {
+	if (ttentries == MAP_FAILED) {
 		ast_log(LOG_ERROR, "Cannot map aprtss common file %s: %s\n", fname, strerror(errno));
-		pthread_exit(NULL);
+		fclose(mfp);
+		return NULL;
 	}
 
 	while (run_forever) {
@@ -1446,22 +1534,7 @@ static void *aprstt_sender_thread(void *data)
 		ast_mutex_unlock(&position_update_lock);
 
 		if (selected_position.is_valid) {
-			if (sscanf(selected_position.latitude, "%d.%d%c", &i, &j, &c) == 3) {
-				/* Adjust the latitude for the offset */
-				if (c == 'S') {
-					i = -i;
-				}
-				if (i >= 0) {
-					j -= myoffset;
-				} else {
-					j += myoffset;
-				}
-				i += (j / 60);
-				if (j < 0) {
-					snprintf(lat, sizeof(lat), "%04d.%02d%c", (i >= 0) ? i : -i, -j % 60, (i >= 0) ? 'N' : 'S');
-				} else {
-					snprintf(lat, sizeof(lat), "%04d.%02d%c", (i >= 0) ? i : -i, j % 60, (i >= 0) ? 'N' : 'S');
-				}
+			if (aprs_lat_apply_offset(selected_position.latitude, myoffset, lat, sizeof(lat))) {
 				/* If our last position update is good, send an update */
 				if ((selected_position.last_updated + GPS_VALID_SECS) >= now) {
 					report_aprstt(ctg, lat, selected_position.longitude, theircall, overlay);
@@ -1777,7 +1850,8 @@ static int load_module(void)
 			baudrate = B57600;
 			break;
 		default:
-			ast_log(LOG_ERROR, "%s is not valid baud rate for iospeed\n", val);
+			ast_log(LOG_ERROR, "%s is not valid baud rate, using %d\n", val, 4800);
+			baudrate = GPS_DEFAULT_BAUDRATE;
 			break;
 		}
 	} else {
@@ -1792,15 +1866,7 @@ static int load_module(void)
 		general_def_position.is_valid = 1;
 		lat_decimal_to_DMS(strtof(def_lat, NULL), general_def_position.latitude, sizeof(general_def_position.latitude));
 		lon_decimal_to_DMS(strtof(def_lon, NULL), general_def_position.longitude, sizeof(general_def_position.longitude));
-		/* See if we have a default elevation */
-		if (def_elev) {
-			float eleva, elevd;
-			eleva = strtof(def_elev, NULL);
-			elevd = (eleva - floor(eleva)) * 10 + 0.5;
-			snprintf(general_def_position.elevation, sizeof(general_def_position.elevation), "%03d.%1dM", (int) eleva, (int) elevd);
-		} else {
-			strcpy(general_def_position.elevation, "000.0M");
-		}
+		format_def_elevation(def_elev, general_def_position.elevation, sizeof(general_def_position.elevation));
 	}
 
 	/* Create the aprs connection thread */

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4366,6 +4366,19 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 	return 0;
 }
 
+static inline int hangup_frame_helper(struct ast_channel *chan, const char *chantype, struct ast_frame *f)
+{
+	if (f->frametype == AST_FRAME_CONTROL) {
+		if (f->subclass.integer == AST_CONTROL_HANGUP) {
+			ast_debug(1, "%s (%s) received hangup frame\n", ast_channel_name(chan), chantype);
+			ast_frfree(f);
+			return -1;
+		}
+	}
+	ast_frfree(f);
+	return 0;
+}
+
 static inline int pchannel_read(struct rpt *myrpt)
 {
 	struct ast_frame *f = ast_read(myrpt->pchannel);
@@ -4382,26 +4395,7 @@ static inline int pchannel_read(struct rpt *myrpt)
 			ast_write(myrpt->txpchannel, f);
 		}
 	}
-	if (f->frametype == AST_FRAME_CONTROL) {
-		if (f->subclass.integer == AST_CONTROL_HANGUP) {
-			ast_debug(1, "@@@@ rpt:Hung Up\n");
-		}
-	}
-	ast_frfree(f);
-	return 0;
-}
-
-static inline int hangup_frame_helper(struct ast_channel *chan, const char *chantype, struct ast_frame *f)
-{
-	if (f->frametype == AST_FRAME_CONTROL) {
-		if (f->subclass.integer == AST_CONTROL_HANGUP) {
-			ast_debug(1, "%s (%s) received hangup frame\n", ast_channel_name(chan), chantype);
-			ast_frfree(f);
-			return -1;
-		}
-	}
-	ast_frfree(f);
-	return 0;
+	return hangup_frame_helper(myrpt->pchannel, "pchannel", f);
 }
 
 static inline int wait_for_hangup_helper(struct ast_channel *chan, const char *chantype)

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -1245,7 +1245,7 @@ enum rpt_function_response function_macro(struct rpt *myrpt, char *param, char *
 		return DC_INDETERMINATE;
 	}
 
-	for (i = 0; i < digitbuf[i]; i++) {
+	for (i = 0; digitbuf[i]; i++) {
 		if ((digitbuf[i] < '0') || (digitbuf[i] > '9')) {
 			return DC_ERROR;
 		}

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -3451,7 +3451,7 @@ treataslocal:
 	}
 #endif
 	myrpt->noduck = 0;
-	pthread_exit(NULL);
+	return NULL;
 abort:
 	telem_done(myrpt, mytele);
 abort2:
@@ -3471,7 +3471,7 @@ abort3:
 		ast_channel_unref(mychannel);
 	}
 
-	pthread_exit(NULL);
+	return NULL;
 }
 
 static const char *rpt_tele_mode_str(enum rpt_tele_mode mode)

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -3849,6 +3849,7 @@ void rpt_telemetry(struct rpt *myrpt, enum rpt_tele_mode mode, void *data)
 			strs = ast_malloc(n * sizeof(char *));
 			if (!strs) {
 				ast_free(lbuf);
+				ast_free(lbuf2);
 				return;
 			}
 			ns = finddelim(ast_str_buffer(lbuf), strs, n);

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -3778,6 +3778,7 @@ void rpt_telemetry(struct rpt *myrpt, enum rpt_tele_mode mode, void *data)
 
 			lbuf = ast_str_create(RPT_AST_STR_INIT_SIZE);
 			if (!lbuf) {
+				rpt_mutex_unlock(&myrpt->lock);
 				return;
 			}
 

--- a/channels/Makefile.diff
+++ b/channels/Makefile.diff
@@ -1,8 +1,6 @@
-diff --git a/channels/Makefile b/channels/Makefile
-index 0f8d1328c5..c9523f6d69 100644
 --- a/channels/Makefile
 +++ b/channels/Makefile
-@@ -22,6 +22,8 @@ include $(ASTTOPDIR)/Makefile.moddir_rules
+@@ -22,6 +22,9 @@
  $(call MOD_ADD_C,chan_iax2,$(wildcard iax2/*.c))
  iax2/parser.o: _ASTCFLAGS+=$(call get_menuselect_cflags,MALLOC_DEBUG)
  

--- a/channels/Makefile.diff
+++ b/channels/Makefile.diff
@@ -2,7 +2,7 @@ diff --git a/channels/Makefile b/channels/Makefile
 index 0f8d1328c5..c9523f6d69 100644
 --- a/channels/Makefile
 +++ b/channels/Makefile
-@@ -22,6 +22,9 @@ include $(ASTTOPDIR)/Makefile.moddir_rules
+@@ -22,6 +22,8 @@ include $(ASTTOPDIR)/Makefile.moddir_rules
  $(call MOD_ADD_C,chan_iax2,$(wildcard iax2/*.c))
  iax2/parser.o: _ASTCFLAGS+=$(call get_menuselect_cflags,MALLOC_DEBUG)
  

--- a/channels/Makefile.diff
+++ b/channels/Makefile.diff
@@ -6,7 +6,7 @@ index 0f8d1328c5..c9523f6d69 100644
  $(call MOD_ADD_C,chan_iax2,$(wildcard iax2/*.c))
  iax2/parser.o: _ASTCFLAGS+=$(call get_menuselect_cflags,MALLOC_DEBUG)
  
-+chan_simpleusb.so: LIBS+=-lusb -lasound -lportaudio
++chan_simpleusb.so: LIBS+=-lusb -lasound
 +chan_usbradio.so: LIBS+=-lusb -lasound
 +
  $(call MOD_ADD_C,chan_pjsip,$(wildcard pjsip/*.c))

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -902,8 +902,7 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 			}
 			for (ao = simpleusb_default.next; ao && ao->name; ao = ao->next) {
 				if (ao != o && ao->usbass && ao->devicenum == o->devicenum) {
-					ast_log(LOG_ERROR, "Channel %s: Audio device %s is already assigned to channel %s\n",
-						o->name, o->hw_device, ao->name);
+					ast_log(LOG_ERROR, "Channel %s: Audio device %s is already assigned to channel %s\n", o->name, o->hw_device, ao->name);
 					ast_mutex_unlock(&usb_dev_lock);
 					return -1;
 				}

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1064,10 +1064,15 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 
 	o->device_error = 0;
 	ast_radio_time(&o->lasthidtime);
-	if (ast_radio_init_mixer_limits(o->devicenum, &o->micmax, &o->spkrmax, &o->micplaymax, &o->newname) < 0) {
-		ast_log(LOG_ERROR, "Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
-		ast_mutex_unlock(&usb_dev_lock);
-		return -1;
+	{
+		int use_newname = 0;
+
+		if (ast_radio_init_mixer_limits(o->devicenum, &o->micmax, &o->spkrmax, &o->micplaymax, &use_newname) < 0) {
+			ast_log(LOG_ERROR, "Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
+			ast_mutex_unlock(&usb_dev_lock);
+			return -1;
+		}
+		o->newname = use_newname;
 	}
 	o->usbass = 1;
 	ast_mutex_unlock(&usb_dev_lock);

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1064,19 +1064,13 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 
 	o->device_error = 0;
 	ast_radio_time(&o->lasthidtime);
+	if (ast_radio_init_mixer_limits(o->devicenum, &o->micmax, &o->spkrmax, &o->micplaymax, &o->newname) < 0) {
+		ast_log(LOG_ERROR, "Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
+		ast_mutex_unlock(&usb_dev_lock);
+		return -1;
+	}
 	o->usbass = 1;
 	ast_mutex_unlock(&usb_dev_lock);
-	/* set the audio mixer values */
-	o->micmax = ast_radio_mixer_limit(ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL));
-	o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL);
-	o->micplaymax = ast_radio_mixer_limit(ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_VOL));
-
-	if (o->spkrmax == -1) {
-		o->newname = 1;
-		o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW);
-	}
-	o->spkrmax = ast_radio_mixer_limit(o->spkrmax);
-
 	return 0;
 }
 

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -2001,12 +2001,15 @@ static int simpleusb_hangup(struct ast_channel *c)
 	struct chan_simpleusb_pvt *o = ast_channel_tech_pvt(c);
 
 	o->stopaudiothread = 1;
+	kickptt(o);
 	if (o->audiothread != AST_PTHREADT_NULL) {
 		pthread_join(o->audiothread, NULL);
 		o->audiothread = AST_PTHREADT_NULL;
 	}
+	stop_stream(o);
 
 	o->stophidthread = 1;
+	kickptt(o);
 	if (o->hidthread != AST_PTHREADT_NULL) {
 		pthread_join(o->hidthread, NULL);
 		o->hidthread = AST_PTHREADT_NULL;
@@ -4436,6 +4439,7 @@ static int unload_module(void)
 			pthread_join(o->audiothread, NULL); /* wait for audio thread to end */
 			o->audiothread = AST_PTHREADT_NULL;
 		}
+		stop_stream(o);
 		if (o->hidthread != AST_PTHREADT_NULL) {
 			pthread_join(o->hidthread, NULL);
 			o->hidthread = AST_PTHREADT_NULL;

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1068,14 +1068,15 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 	o->usbass = 1;
 	ast_mutex_unlock(&usb_dev_lock);
 	/* set the audio mixer values */
-	o->micmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL);
+	o->micmax = ast_radio_mixer_limit(ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL));
 	o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL);
-	o->micplaymax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_VOL);
+	o->micplaymax = ast_radio_mixer_limit(ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_VOL));
 
 	if (o->spkrmax == -1) {
 		o->newname = 1;
 		o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW);
 	}
+	o->spkrmax = ast_radio_mixer_limit(o->spkrmax);
 
 	return 0;
 }

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -29,14 +29,12 @@
 
 /*** MODULEINFO
 	<depend>alsa</depend>
-	<depend>portaudio</depend>
 	<depend>res_usbradio</depend>
 	<support_level>extended</support_level>
  ***/
 
 #include "asterisk.h"
 
-#include <portaudio.h>
 #include <alsa/asoundlib.h>
 
 #include <stdio.h>
@@ -81,13 +79,6 @@
 #define HID_POLL_RATE 50
 #define DEVICE_RETRY 500000 /* Retry time in uS when USB device is missing */
 #define MAX_FRAME_DELAY 200 /* 200ms (.2s) max time to queue audio frames before resetting usb audio */
-#ifdef __linux
-#include <linux/soundcard.h>
-#elif defined(__FreeBSD__)
-#include <sys/soundcard.h>
-#else
-#include <soundcard.h>
-#endif
 
 #include "asterisk/lock.h"
 #include "asterisk/frame.h"
@@ -107,29 +98,7 @@
 #include "asterisk/format_cache.h"
 #include "asterisk/format_compatibility.h"
 
-/*!
- * \brief The sample rate to request from PortAudio
- *
- * \todo Make this optional.  If this is only going to talk to 8 kHz endpoints,
- *       then it makes sense to use 8 kHz natively if possible.
- */
-#define PA_SAMPLE_RATE 48000 /* PortAudio Sample rate: Hardware likes 48k and is divisible by 6 for a "nice" down conversion. */
-
-/*!
- * \brief The number of samples to configure the PortAudio stream for.
- *
- * At 48kHz, 960 samples gives a 20ms frame, which aligns with Asterisk's
- * common frame size after resampling to 8kHz (160 samples @ 2 bytes per sample).
- * The number of short (2 byte) with paInt16 samples per PortAudio "frame".
- * This is 1920 bytes for stereo, or 960 bytes for mono
- */
-#define PA_NUM_FRAMES FRAME_SIZE * 6 /* Number of samples to read/write from PortAudio stream per Asterisk frame at 48k */
-
-/*! \brief Mono Input */
-#define PA_INPUT_CHANNELS 1 /* PortAudio: Mono input for Microphone / RX */
-
-/*! \brief Stereo Output */
-#define PA_OUTPUT_CHANNELS 2 /* PortAudio: Stereo output for Speaker / TX */
+#define PA_NUM_FRAMES AST_RADIO_PA_FRAMES_PER_BUFFER
 
 /*! \brief Global jitterbuffer configuration - by default, jb is disabled */
 static struct ast_jb_conf default_jbconf = {
@@ -224,7 +193,7 @@ struct chan_simpleusb_pvt {
 	struct usb_device *usb_dev;
 	struct ast_channel *owner;
 
-	PaStream *stream; /*! Current PortAudio stream for this device */
+	struct ast_radio_pa_stream pa;
 
 	char simpleusb_write_buf[FRAME_SIZE * 2]; /* buffer used for Asterisk to PA frames in 8k mono */
 
@@ -312,7 +281,6 @@ struct chan_simpleusb_pvt {
 	char had_pp_in;
 
 	/* bit fields */
-	unsigned int streamstate:1;			   /* indicator if stream is started */
 	unsigned int rxcapraw:1;			   /* indicator if receive capture is enabled */
 	unsigned int txcapraw:1;			   /* indicator if transmit capture is enabled */
 	unsigned int measure_enabled:1;		   /* indicator if measure mode is enabled */
@@ -428,267 +396,37 @@ static struct ast_channel_tech simpleusb_tech = {
 	.setoption = simpleusb_setoption,
 };
 
-static int64_t now_ms(void)
-{
-	struct timespec ts;
-	clock_gettime(CLOCK_MONOTONIC, &ts);
-	return (int64_t) ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
-}
-
-static PaError Pa_ReadStream_with_timeout(PaStream *s, short *buf, unsigned long frames, int timeout_ms, volatile sig_atomic_t *stop)
-{
-	int64_t start;
-
-	start = now_ms();
-	while (!(*stop)) {
-		long avail;
-		PaError err;
-
-		avail = Pa_GetStreamReadAvailable(s);
-		if (avail < 0) {
-			return (PaError) avail;
-		}
-
-		if ((now_ms() - start) > timeout_ms) {
-			return paTimedOut;
-		}
-
-		if (avail < frames) {
-			usleep(500); /*.5ms */
-			continue;
-		}
-
-		err = Pa_ReadStream(s, buf, frames);
-		return err;
-	}
-
-	return paTimedOut;
-}
-
-/*!
- * \brief Parse "hw:<card>" or "hw:<card>,<dev>" from anywhere in s.
- * \retval 1 if found; sets *card; sets *dev to parsed value or -1 if absent.
- */
-static int parse_hw_anywhere(const char *s, int *card, int *dev)
-{
-	const char *p = s;
-
-	if (!s || !card || !dev) {
-		return 0;
-	}
-
-	while ((p = strstr(p, "hw:")) != NULL) {
-		const char *q = p + 3; /* after "hw:" */
-		int c = 0;
-		int d = -1; /* dev absent by default */
-
-		/* card must start with digit */
-		if (!isdigit((unsigned char) *q)) {
-			p = q;
-			continue;
-		}
-
-		while (isdigit((unsigned char) *q)) {
-			if (c > 9999) {
-				/* reasonable upper bound for card numbers */
-				p = q;
-				break;
-			}
-
-			c = c * 10 + (*q - '0');
-			q++;
-		}
-
-		if (*q == ',') {
-			q++;
-			if (!isdigit((unsigned char) *q)) {
-				/* "hw:<card>," is malformed; skip this occurrence */
-				p = q;
-				continue;
-			}
-			d = 0;
-			while (isdigit((unsigned char) *q)) {
-				d = d * 10 + (*q - '0');
-				q++;
-			}
-		}
-
-		*card = c;
-		*dev = d;
-		return 1; /* first valid hw: occurrence */
-	}
-
-	return 0;
-}
-
-/*!
- * \brief Match rule:
- * - needle "hw:C" matches any "hw:C" or "hw:C,D" in haystack
- * - needle "hw:C,D" matches only "hw:C,D" in haystack
- */
-static int hw_match(const char *haystack, const char *needle)
-{
-	int haystack_c, haystack_d, needle_c, needle_d;
-	const char *p = haystack ? haystack : "";
-
-	if (!parse_hw_anywhere(needle, &needle_c, &needle_d)) {
-		return 0;
-	}
-
-	/* haystack may contain multiple hw: occurrences; scan all */
-	while ((p = strstr(p, "hw:")) != NULL) {
-		if (parse_hw_anywhere(p, &haystack_c, &haystack_d)) {
-			if (haystack_c == needle_c) {
-				if (needle_d < 0) {
-					/* needle is "hw:C" -> accept any dev (including absent) */
-					return 1;
-				} else if (haystack_d == needle_d) {
-					/* needle is "hw:C,D" -> require exact dev match */
-					return 1;
-				}
-			}
-		}
-		p += 3; /* move forward to find next occurrence */
-	}
-
-	return 0;
-}
-
-static int open_stream(struct chan_simpleusb_pvt *o)
-{
-	PaError res = paInternalError;
-	const PaStreamInfo *si;
-
-	if (!strcasecmp(o->hw_device, "default")) {
-		ast_debug(1, "Opening stream with default device\n");
-		res = Pa_OpenDefaultStream(&o->stream, PA_INPUT_CHANNELS, PA_OUTPUT_CHANNELS, paInt16, PA_SAMPLE_RATE, PA_NUM_FRAMES, NULL, NULL);
-	} else {
-		PaStreamParameters input_params = {
-			.channelCount = PA_INPUT_CHANNELS,
-			.sampleFormat = paInt16,
-			.suggestedLatency = (1.0 / 50.0), /* 20 ms */
-			.device = paNoDevice,
-		};
-		PaStreamParameters output_params = {
-			.channelCount = PA_OUTPUT_CHANNELS,
-			.sampleFormat = paInt16,
-			.suggestedLatency = (1.0 / 50.0), /* 20 ms */
-			.device = paNoDevice,
-		};
-		PaDeviceIndex idx, num_devices;
-		ast_debug(1, "Looking for device %s\n", o->hw_device);
-		ast_debug(5, "PortAudio host api count %d\n", Pa_GetHostApiCount());
-		num_devices = Pa_GetDeviceCount();
-		if (num_devices < 0) {
-			ast_debug(1, "No devices found\n");
-			return res;
-		} else {
-			ast_debug(6, "%d Devices found\n", num_devices);
-		}
-
-		for (idx = 0; idx < num_devices && (input_params.device == paNoDevice || output_params.device == paNoDevice); idx++) {
-			const PaDeviceInfo *dev = Pa_GetDeviceInfo(idx);
-			ast_debug(1, "Found device %s\n", dev->name);
-			if (dev->maxInputChannels) {
-				if (hw_match(dev->name, o->hw_device)) {
-					ast_debug(5, "Found input device %s\n", dev->name);
-					input_params.device = idx;
-				}
-			}
-
-			if (dev->maxOutputChannels) {
-				if (hw_match(dev->name, o->hw_device)) {
-					ast_debug(5, "Found output device %s\n", dev->name);
-					output_params.device = idx;
-				}
-			}
-		}
-
-		if (input_params.device == paNoDevice) {
-			ast_log(LOG_ERROR, "No input device found for simpleusb device '%s'\n", o->name);
-			return res;
-		}
-
-		if (output_params.device == paNoDevice) {
-			ast_log(LOG_ERROR, "No output device found for simpleusb device '%s'\n", o->name);
-			return res;
-		}
-		ast_debug(5, "Opening stream on device %s", o->hw_device);
-		res = Pa_OpenStream(&o->stream, &input_params, &output_params, PA_SAMPLE_RATE, PA_NUM_FRAMES, paNoFlag, NULL, NULL);
-		ast_debug(5, "Stream feedback: %s\n", Pa_GetErrorText(res));
-		if (res == paNoError) {
-			si = Pa_GetStreamInfo(o->stream);
-			if (si) {
-				ast_debug(5, "Stream output latency: %.3f ms\n", si->outputLatency * 1000.0);
-				ast_debug(5, "Stream input latency: %.3f ms\n", si->inputLatency * 1000.0);
-			}
-		}
-	}
-
-	return res;
-}
-
 static int start_stream(struct chan_simpleusb_pvt *pvt)
 {
 	PaError res;
 
 	ast_debug(5, "Starting PA Stream");
-	/* It is possible for simpleusb_hangup to be called before the
-	 * stream is started, if this is the case pvt->owner will be NULL
-	 * and start_stream should be aborted. */
-	if (pvt->streamstate || !pvt->owner)
-		return -1;
-
-	res = Pa_Initialize();
-	if (res != paNoError) {
-		ast_log(LOG_WARNING, "Failed to initialize audio system - (%d) %s\n", res, Pa_GetErrorText(res));
+	if (pvt->pa.active || !pvt->owner) {
 		return -1;
 	}
 
-	res = open_stream(pvt);
+	ast_copy_string(pvt->pa.hw_device, pvt->hw_device, sizeof(pvt->pa.hw_device));
+	pvt->pa.input_channels = 1;
+
+	res = ast_radio_pa_open(&pvt->pa);
 	if (res != paNoError) {
 		ast_log(LOG_WARNING, "Failed to open stream - (%d) %s\n", res, Pa_GetErrorText(res));
-		Pa_Terminate();
 		return -1;
 	}
 
-	res = Pa_StartStream(pvt->stream);
+	res = ast_radio_pa_start(&pvt->pa);
 	if (res != paNoError) {
 		ast_log(LOG_WARNING, "Failed to start stream - (%d) %s\n", res, Pa_GetErrorText(res));
-		Pa_CloseStream(pvt->stream);
-		pvt->stream = NULL;
-		pvt->streamstate = 0;
-		Pa_Terminate();
+		ast_radio_pa_stop(&pvt->pa);
 		return -1;
 	}
 
-	pvt->streamstate = 1;
 	return 0;
 }
 
-static int stop_stream(struct chan_simpleusb_pvt *pvt)
+static void stop_stream(struct chan_simpleusb_pvt *pvt)
 {
-	PaError err;
-
-	if (!pvt->streamstate) {
-		return 0;
-	}
-
-	/* Abort and close the stream */
-	err = Pa_AbortStream(pvt->stream);
-	if (err != paNoError) {
-		ast_log(LOG_WARNING, "Pa_AbortStream failed: %s\n", Pa_GetErrorText(err));
-	}
-
-	err = Pa_CloseStream(pvt->stream);
-	if (err != paNoError) {
-		ast_log(LOG_WARNING, "Pa_CloseStream failed: %s\n", Pa_GetErrorText(err));
-	}
-
-	pvt->stream = NULL;
-	pvt->streamstate = 0;
-	Pa_Terminate();
-	return 0;
+	ast_radio_pa_stop(&pvt->pa);
 }
 
 /*!
@@ -1078,6 +816,7 @@ static int load_tune_config(struct chan_simpleusb_pvt *o, const struct ast_confi
 	int configured = 0;
 	char devstr[sizeof(o->devstr)];
 	char serial[sizeof(o->serial)];
+	char hw_device[sizeof(o->hw_device)];
 
 	o->rxmixerset = 500;
 	o->txmixaset = 500;
@@ -1085,6 +824,7 @@ static int load_tune_config(struct chan_simpleusb_pvt *o, const struct ast_confi
 
 	devstr[0] = '\0';
 	serial[0] = '\0';
+	hw_device[0] = '\0';
 
 	if (!cfg) {
 		struct ast_flags zeroflag = { 0 };
@@ -1105,15 +845,18 @@ static int load_tune_config(struct chan_simpleusb_pvt *o, const struct ast_confi
 		CV_UINT("txmixbset", o->txmixbset);
 		CV_STR("devstr", devstr);
 		CV_STR("serial", serial);
-		if (o->devstr[0] == '\0') {
-			CV_STR("audiodev", o->hw_device); /* use audiodevice as opposed to the usb device path (devstr) */
-		}
+		CV_STR("audiodev", hw_device); /* use audiodevice as opposed to the usb device path (devstr) */
 		CV_END;
 	}
 	if (!reload) {
 		/* Using the ternary operator in CV_STR won't work, due to butchering the sizeof, so copy after if needed */
 		ast_copy_string(o->devstr, devstr, sizeof(o->devstr)); /* Safe */
 		ast_copy_string(o->serial, serial, sizeof(o->serial)); /* Safe */
+		if (ast_strlen_zero(devstr)) {
+			ast_copy_string(o->hw_device, hw_device, sizeof(o->hw_device));
+		} else {
+			o->hw_device[0] = '\0';
+		}
 	}
 	if (opened) {
 		ast_config_destroy(cfg2);
@@ -1133,7 +876,8 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 	char serial[sizeof(o->serial)] = { '\0' };
 	char *s;
 	struct chan_simpleusb_pvt *ao;
-	register int i;
+	int i;
+	int subdev;
 
 	ast_radio_time(&o->lasthidtime);
 	ast_mutex_lock(&usb_dev_lock);
@@ -1148,7 +892,7 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 			ast_log(LOG_ERROR, "audiodev=default is not supported for SimpleUSB until HID-less startup is implemented\n");
 			ast_mutex_unlock(&usb_dev_lock);
 			return -1;
-		} else if (sscanf(o->hw_device, "hw:%d", &o->devicenum) == 1) {
+		} else if (ast_radio_parse_hw_anywhere(o->hw_device, &o->devicenum, &subdev)) {
 			ast_debug(5, "audiodev is defined: %s, Device %d", o->hw_device, o->devicenum);
 			o->usb_dev = ast_radio_usb_device_from_alsa_card(o->devicenum);
 			if (!o->usb_dev) {
@@ -1156,9 +900,17 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 				ast_mutex_unlock(&usb_dev_lock);
 				return -1;
 			}
+			for (ao = simpleusb_default.next; ao && ao->name; ao = ao->next) {
+				if (ao != o && ao->usbass && ao->devicenum == o->devicenum) {
+					ast_log(LOG_ERROR, "Channel %s: Audio device %s is already assigned to channel %s\n",
+						o->name, o->hw_device, ao->name);
+					ast_mutex_unlock(&usb_dev_lock);
+					return -1;
+				}
+			}
 
 		} else {
-			ast_log(LOG_ERROR, "Incorrect audio parameter audiodev (should be hw:0 format), found %s\n", o->hw_device);
+			ast_log(LOG_ERROR, "Incorrect audio parameter audiodev (should be hw:0 or hw:0,0 format), found %s\n", o->hw_device);
 			ast_mutex_unlock(&usb_dev_lock);
 			return -1;
 		}
@@ -1471,6 +1223,11 @@ static void *hidthread(void *arg)
 		}
 		if (pipe2(o->pttkick, O_NONBLOCK) == -1) {
 			ast_log(LOG_ERROR, "Channel %s: Is not able to create a pipe\n", o->name);
+			ast_mutex_lock(&usb_dev_lock);
+			o->usbass = 0;
+			o->hasusb = 0;
+			o->usb_dev = NULL;
+			ast_mutex_unlock(&usb_dev_lock);
 			usb_close(usb_handle);
 			usb_handle = NULL;
 			return NULL;
@@ -1525,6 +1282,8 @@ static void *hidthread(void *arg)
 				ast_radio_time(&audio_time_now);
 				if ((audio_time_now - o->lastaudiotime) > 1) {
 					ast_log(LOG_ERROR, "Channel %s: Audio process has died or is not responding.\n", o->name);
+					o->hasusb = 0;
+					break;
 				}
 			}
 
@@ -1893,11 +1652,9 @@ static int soundcard_writeframe(struct chan_simpleusb_pvt *o, short *data)
 	 * a number of failures, to restart the output chain.
 	 */
 
-	res = Pa_WriteStream(o->stream, data, PA_NUM_FRAMES);
+	res = ast_radio_pa_write(&o->pa, data, PA_NUM_FRAMES);
 	if (res == paOutputUnderflowed) {
-		short null_buf[PA_NUM_FRAMES * 2] = { 0 };
 		ast_debug(6, "PortAudio write stream underflow, writing a 0 frame");
-		Pa_WriteStream(o->stream, null_buf, PA_NUM_FRAMES);
 	} else if (res < 0) {
 		ast_debug(2, "Pa_WriteStream Error %s", Pa_GetErrorText(res));
 	}
@@ -2391,7 +2148,7 @@ static void *simpleusb_audio_thread(void *arg)
 			continue;
 		}
 
-		if (!o->streamstate && start_stream(o) < 0) {
+		if (!o->pa.active && start_stream(o) < 0) {
 			ast_log(LOG_ERROR, "Channel %s: Failed to start audio stream %s\n", o->name, o->hw_device);
 			o->hasusb = 0;
 			usleep(DEVICE_RETRY);
@@ -2507,7 +2264,7 @@ static void *simpleusb_audio_thread(void *arg)
 				/* Check for room in the write buffer.  If the device goes unavailable or
 				 * there is not room in the buffer, Pa_WriteStream will hang.
 				 */
-				frames_available = Pa_GetStreamWriteAvailable(o->stream);
+				frames_available = ast_radio_pa_write_available(&o->pa);
 
 				if (frames_available < 0) {
 					if (frames_available != paOutputUnderflowed) {
@@ -2517,6 +2274,7 @@ static void *simpleusb_audio_thread(void *arg)
 						ast_debug(2, "Pa_GetStreamWriteAvailable error %s", Pa_GetErrorText(frames_available));
 						o->hasusb = 0;
 						stream_cleanup(o);
+						break;
 					}
 				}
 
@@ -2615,6 +2373,7 @@ static void *simpleusb_audio_thread(void *arg)
 									ast_debug(2, "Pa_WriteStream error %s", Pa_GetErrorText(res));
 									o->hasusb = 0;
 									stream_cleanup(o);
+									break;
 								}
 							}
 
@@ -2647,6 +2406,9 @@ static void *simpleusb_audio_thread(void *arg)
 						}
 					}
 					ast_frfree(f1);
+					if (!o->hasusb) {
+						break;
+					}
 					continue;
 				}
 
@@ -2660,16 +2422,23 @@ static void *simpleusb_audio_thread(void *arg)
 				break;
 			}
 
+			if (!o->hasusb || !o->pa.active) {
+				break;
+			}
+
 			/* Read audio data from the USB sound device.
 			 * Sound data will arrive at 48000 samples per second
 			 * in mono format.  We should always have 20ms frames, 40ms timeout
 			 * as a reasonable max wait time.
 			 */
-			res = Pa_ReadStream_with_timeout(o->stream, o->simpleusb_read_buf, PA_NUM_FRAMES, 40, &o->stopaudiothread);
+			res = ast_radio_pa_read(&o->pa, o->simpleusb_read_buf, PA_NUM_FRAMES, 40, &o->stopaudiothread);
 			if (res != paNoError) {
 				/* audio data not ready */
 				if (res == paInputOverflowed) {
 					ast_debug(6, "PortAudio read overflow on channel %s\n", o->name);
+				} else if (res == paTimedOut) {
+					ast_debug(6, "PortAudio read timeout on channel %s\n", o->name);
+					continue;
 				} else {
 					ast_log(LOG_ERROR, "Pa_ReadStream Error on channel %s : %s\n", o->name, Pa_GetErrorText(res));
 					o->hasusb = 0;
@@ -4650,6 +4419,7 @@ static int load_module(void)
 static int unload_module(void)
 {
 	struct chan_simpleusb_pvt *o, *no;
+	int i;
 
 	stoppulser = 1;
 
@@ -4658,6 +4428,9 @@ static int unload_module(void)
 		if (o->owner) {
 			ast_softhangup(o->owner, AST_SOFTHANGUP_APPUNLOAD);
 		}
+		o->stopaudiothread = 1;
+		o->stophidthread = 1;
+		kickptt(o);
 
 		if (o->audiothread != AST_PTHREADT_NULL) {
 			pthread_join(o->audiothread, NULL); /* wait for audio thread to end */
@@ -4670,9 +4443,14 @@ static int unload_module(void)
 		if (o->dsp) {
 			ast_dsp_free(o->dsp);
 		}
+		for (i = 0; i < GPIO_PINCOUNT; i++) {
+			ast_free(o->gpios[i]);
+		}
+		for (i = 0; i < ARRAY_LEN(o->pps); i++) {
+			ast_free(o->pps[i]);
+		}
+		ast_free(o->name);
 		ast_free(o);
-
-		/* XXX what about the memory allocated ? */
 	}
 
 #if DEBUG_CAPTURES == 1

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -958,17 +958,24 @@ static void *hidthread(void *arg)
 					continue;
 				}
 				o->devicenum = i;
+				{
+					int use_newname = 0;
+
+					if (ast_radio_init_mixer_limits(o->devicenum, &o->micmax, &o->spkrmax, &o->micplaymax, &use_newname) < 0) {
+						if (!o->device_error) {
+							ast_log(LOG_ERROR, "Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
+							o->device_error = 1;
+						}
+						ast_mutex_unlock(&usb_dev_lock);
+						usleep(500000);
+						continue;
+					}
+					o->newname = use_newname;
+				}
 				o->device_error = 0;
 				ast_radio_time(&o->lasthidtime);
 				o->usbass = 1;
 				ast_mutex_unlock(&usb_dev_lock);
-				o->micmax = ast_radio_mixer_limit(ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL));
-				o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL);
-				if (o->spkrmax == -1) {
-					o->newname = 1;
-					o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW);
-				}
-				o->spkrmax = ast_radio_mixer_limit(o->spkrmax);
 				goto usb_device_ready;
 			}
 			if (!o->device_error) {
@@ -1116,17 +1123,24 @@ static void *hidthread(void *arg)
 		}
 		o->devicenum = i;
 		snprintf(o->hw_device, sizeof(o->hw_device), "hw:%d", i);
+		{
+			int use_newname = 0;
+
+			if (ast_radio_init_mixer_limits(o->devicenum, &o->micmax, &o->spkrmax, &o->micplaymax, &use_newname) < 0) {
+				if (!o->device_error) {
+					ast_log(LOG_ERROR, "Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
+					o->device_error = 1;
+				}
+				ast_mutex_unlock(&usb_dev_lock);
+				usleep(500000);
+				continue;
+			}
+			o->newname = use_newname;
+		}
 		o->device_error = 0;
 		ast_radio_time(&o->lasthidtime);
 		o->usbass = 1;
 		ast_mutex_unlock(&usb_dev_lock);
-		/* set the audio mixer values */
-		o->micmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL);
-		o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL);
-		if (o->spkrmax == -1) {
-			o->newname = 1;
-			o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW);
-		}
 		/* initialize the usb device */
 		usb_dev = ast_radio_hid_device_init(o->devstr);
 		if (usb_dev == NULL) {

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -1957,7 +1957,7 @@ static int usbradio_write(struct ast_channel *c, struct ast_frame *f)
  */
 static struct ast_frame *usbradio_read(struct ast_channel *c)
 {
-	PaError pres;
+	PaError pa_res;
 	int oldpttout;
 	int cd, sd;
 	struct chan_usbradio_pvt *o = ast_channel_tech_pvt(c);
@@ -2039,12 +2039,12 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 		}
 	}
 
-	pres = ast_radio_pa_read(&o->pa, (short *) (o->usbradio_read_buf + AST_FRIENDLY_OFFSET), AST_RADIO_PA_FRAMES_PER_BUFFER, 40, NULL);
-	if (pres != paNoError) {
-		if (pres == paTimedOut || pres == paInputOverflowed) {
+	pa_res = ast_radio_pa_read(&o->pa, (short *) (o->usbradio_read_buf + AST_FRIENDLY_OFFSET), AST_RADIO_PA_FRAMES_PER_BUFFER, 40, NULL);
+	if (pa_res != paNoError) {
+		if (pa_res == paTimedOut || pa_res == paInputOverflowed) {
 			return &ast_null_frame;
 		}
-		ast_log(LOG_ERROR, "Channel %s: PortAudio read error %s\n", o->name, Pa_GetErrorText(pres));
+		ast_log(LOG_ERROR, "Channel %s: PortAudio read error %s\n", o->name, Pa_GetErrorText(pa_res));
 		o->hasusb = 0;
 		return &ast_null_frame;
 	}

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -1036,13 +1036,12 @@ static void *hidthread(void *arg)
 		o->usbass = 1;
 		ast_mutex_unlock(&usb_dev_lock);
 		/* set the audio mixer values */
-		o->micmax = ast_radio_mixer_limit(ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL));
+		o->micmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL);
 		o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL);
 		if (o->spkrmax == -1) {
 			o->newname = 1;
 			o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW);
 		}
-		o->spkrmax = ast_radio_mixer_limit(o->spkrmax);
 		/* initialize the usb device */
 		usb_dev = ast_radio_hid_device_init(o->devstr);
 		if (usb_dev == NULL) {

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -102,13 +102,6 @@
 #include "./xpmrx/bitweight.h"
 #endif
 
-#ifdef __linux
-#include <linux/soundcard.h>
-#elif defined(__FreeBSD__)
-#include <sys/soundcard.h>
-#else
-#include <soundcard.h>
-#endif
 
 #include "asterisk/lock.h"
 #include "asterisk/frame.h"
@@ -183,10 +176,11 @@ struct chan_usbradio_pvt {
 	struct chan_usbradio_pvt *next;
 
 	char *name;		  /* the internal name of our channel */
+	char hw_device[100]; /* ALSA/PortAudio device (hw:N or hw:N,M) */
 	int devtype;	  /* actual type of device */
 	int pttkick[2];	  /* ptt kick pipe */
-	int total_blocks; /* total blocks in the output device */
-	int sounddev;
+	int total_blocks; /* legacy queue depth hint for TX buffering */
+	struct ast_radio_pa_stream pa;
 	enum {
 		M_UNSET,
 		M_FULL,
@@ -426,7 +420,6 @@ struct chan_usbradio_pvt {
  * \brief Default channel descriptor
  */
 static struct chan_usbradio_pvt usbradio_default = {
-	.sounddev = -1,
 	.duplex = M_UNSET,
 	.queuesize = QUEUE_SIZE,
 	.frags = FRAGS,
@@ -450,7 +443,8 @@ static struct chan_usbradio_pvt usbradio_default = {
 
 static int hidhdwconfig(struct chan_usbradio_pvt *o);
 static void mixer_write(struct chan_usbradio_pvt *o);
-static int setformat(struct chan_usbradio_pvt *o, int mode);
+static int usbradio_start_audio(struct chan_usbradio_pvt *o);
+static void usbradio_stop_audio(struct chan_usbradio_pvt *o);
 static struct ast_channel *usbradio_request(const char *type, struct ast_format_cap *cap,
 	const struct ast_assigned_ids *assignedids, const struct ast_channel *requestor, const char *data, int *cause);
 static int usbradio_digit_begin(struct ast_channel *c, char digit);
@@ -780,6 +774,7 @@ static int load_tune_config(struct chan_usbradio_pvt *o, const struct ast_config
 	if (!reload) {
 		o->devstr[0] = 0;
 		o->serial[0] = 0;
+		o->hw_device[0] = '\0';
 	}
 
 	if (!cfg) {
@@ -807,6 +802,9 @@ static int load_tune_config(struct chan_usbradio_pvt *o, const struct ast_config
 		CV_UINT("fever", o->fever);
 		CV_STR("devstr", devstr);
 		CV_STR("serial", serial);
+		if (o->devstr[0] == '\0') {
+			CV_STR("audiodev", o->hw_device);
+		}
 		CV_END;
 	}
 	if (!reload) {
@@ -822,6 +820,42 @@ static int load_tune_config(struct chan_usbradio_pvt *o, const struct ast_config
 		return -1;
 	}
 	return 0;
+}
+
+static int usbradio_start_audio(struct chan_usbradio_pvt *o)
+{
+	PaError res;
+
+	if (o->pa.active) {
+		return 0;
+	}
+
+	if (!o->hw_device[0]) {
+		snprintf(o->hw_device, sizeof(o->hw_device), "hw:%d", (int) (unsigned char) o->devicenum);
+	}
+
+	ast_copy_string(o->pa.hw_device, o->hw_device, sizeof(o->pa.hw_device));
+	o->pa.input_channels = 2;
+
+	res = ast_radio_pa_open(&o->pa);
+	if (res != paNoError) {
+		ast_log(LOG_ERROR, "Channel %s: Unable to open PortAudio stream %s\n", o->name, o->hw_device);
+		return -1;
+	}
+
+	res = ast_radio_pa_start(&o->pa);
+	if (res != paNoError) {
+		ast_log(LOG_ERROR, "Channel %s: Unable to start PortAudio stream %s\n", o->name, o->hw_device);
+		ast_radio_pa_stop(&o->pa);
+		return -1;
+	}
+
+	return 0;
+}
+
+static void usbradio_stop_audio(struct chan_usbradio_pvt *o)
+{
+	ast_radio_pa_stop(&o->pa);
 }
 
 /*!
@@ -857,7 +891,7 @@ static void *hidthread(void *arg)
 {
 	unsigned char buf[4], bufsave[4], keyed, ctcssed;
 	char *s, lasttxtmp;
-	register int i, j, k;
+	int i, j, k;
 	int res;
 	struct usb_device *usb_dev;
 	struct usb_dev_handle *usb_handle;
@@ -895,6 +929,52 @@ static void *hidthread(void *arg)
 		usb_handle = NULL;
 		usb_dev = NULL;
 		ast_radio_hid_device_mklist();
+
+		/* audiodev without devstr: bind HID to ALSA card number */
+		if (o->hw_device[0] && ast_strlen_zero(o->devstr)) {
+			int subdev;
+
+			if (ast_radio_parse_hw_anywhere(o->hw_device, &i, &subdev)) {
+				for (ao = usbradio_default.next; ao && ao->name; ao = ao->next) {
+					if (ao != o && ao->usbass && ao->devicenum == i) {
+						ast_log(LOG_ERROR, "Channel %s: Audio device %s is already assigned to channel %s\n",
+							o->name, o->hw_device, ao->name);
+						ast_mutex_unlock(&usb_dev_lock);
+						usleep(500000);
+						continue;
+					}
+				}
+				usb_dev = ast_radio_usb_device_from_alsa_card(i);
+				if (!usb_dev) {
+					if (!o->device_error) {
+						ast_log(LOG_ERROR, "Channel %s: No USB device for audiodev %s\n", o->name, o->hw_device);
+						o->device_error = 1;
+					}
+					ast_mutex_unlock(&usb_dev_lock);
+					usleep(500000);
+					continue;
+				}
+				o->devicenum = i;
+				o->device_error = 0;
+				ast_radio_time(&o->lasthidtime);
+				o->usbass = 1;
+				ast_mutex_unlock(&usb_dev_lock);
+				o->micmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL);
+				o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL);
+				if (o->spkrmax == -1) {
+					o->newname = 1;
+					o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW);
+				}
+				goto usb_device_ready;
+			}
+			if (!o->device_error) {
+				ast_log(LOG_ERROR, "Channel %s: Invalid audiodev '%s' (use hw:N or hw:N,M)\n", o->name, o->hw_device);
+				o->device_error = 1;
+			}
+			ast_mutex_unlock(&usb_dev_lock);
+			usleep(500000);
+			continue;
+		}
 
 		/* Check to see if our specified device string
 		 * matches to a device that is attached to this system, or exists
@@ -1031,6 +1111,7 @@ static void *hidthread(void *arg)
 			continue;
 		}
 		o->devicenum = i;
+		snprintf(o->hw_device, sizeof(o->hw_device), "hw:%d", i);
 		o->device_error = 0;
 		ast_radio_time(&o->lasthidtime);
 		o->usbass = 1;
@@ -1049,6 +1130,7 @@ static void *hidthread(void *arg)
 			usleep(500000);
 			continue;
 		}
+usb_device_ready:
 		/* open the usb device device */
 		usb_handle = usb_open(usb_dev);
 		if (usb_handle == NULL) {
@@ -1209,7 +1291,14 @@ static void *hidthread(void *arg)
 		}
 		ast_mutex_unlock(&o->eepromlock);
 
-		setformat(o, O_RDWR);
+		if (usbradio_start_audio(o) < 0) {
+			ast_log(LOG_ERROR, "Channel %s: Unable to start audio for %s\n", o->name, o->hw_device);
+			ast_mutex_lock(&usb_dev_lock);
+			o->usbass = 0;
+			ast_mutex_unlock(&usb_dev_lock);
+			usleep(500000);
+			continue;
+		}
 		o->hasusb = 1;
 		o->had_gpios_in = 0;
 
@@ -1514,32 +1603,30 @@ static void *hidthread(void *arg)
  */
 static int used_blocks(struct chan_usbradio_pvt *o)
 {
-	struct audio_buf_info info;
+	long avail;
 
-	if (ioctl(o->sounddev, SNDCTL_DSP_GETOSPACE, &info)) {
+	if (!o->pa.active) {
+		return 0;
+	}
+
+	avail = ast_radio_pa_write_available(&o->pa);
+	if (avail < 0) {
 		if (!(o->warned & WARN_used_blocks)) {
-			ast_log(LOG_WARNING, "Channel %s: Error reading output space.\n", o->name);
+			ast_log(LOG_WARNING, "Channel %s: Error reading PortAudio output space.\n", o->name);
 			o->warned |= WARN_used_blocks;
 		}
-		return 1;
+		return o->queuesize + 1;
 	}
 
-	/* Set the total blocks */
 	if (o->total_blocks == 0) {
-		ast_debug(1, "Channel %s: fragment total %d, size %d, available %d, bytes %d\n", o->name, info.fragstotal, info.fragsize,
-			info.fragments, info.bytes);
-		o->total_blocks = info.fragments;
-		/* Check the queue size, it cannot exceed the total fragments */
-		if (o->queuesize >= info.fragstotal) {
-			o->queuesize = info.fragstotal - 1;
-			if (o->queuesize < 2) {
-				o->queuesize = QUEUE_SIZE;
-			}
-			ast_debug(1, "Channel %s: Queue size reset to %d\n", o->name, o->queuesize);
-		}
+		o->total_blocks = o->queuesize ? o->queuesize : QUEUE_SIZE;
 	}
 
-	return o->total_blocks - info.fragments;
+	if (avail < AST_RADIO_PA_FRAMES_PER_BUFFER) {
+		return o->total_blocks;
+	}
+
+	return 0;
 }
 
 /*!
@@ -1552,161 +1639,39 @@ static int used_blocks(struct chan_usbradio_pvt *o)
  */
 static int soundcard_writeframe(struct chan_usbradio_pvt *o, short *data)
 {
-	int res;
+	PaError res;
 	short outbuf[FRAME_SIZE * 2 * 6];
 
-	/* If the sound device is not open, setformat will open the device */
-	if (o->sounddev < 0) {
-		setformat(o, O_RDWR);
+	if (!o->pa.active) {
+		if (usbradio_start_audio(o) < 0) {
+			return 0;
+		}
 	}
-	if (o->sounddev < 0) {
-		return 0; /* not fatal */
-	}
-	/*  This may or may not be a good thing
-	 *  drop the frame if not transmitting, this keeps from gradually
-	 *  filling the buffer when asterisk clock > usb sound clock
-	 */
+
 	if (!o->pmrChan->txPttIn && !o->pmrChan->txPttOut) {
 		return 0;
 	}
-	/*
-	 * Nothing complex to manage the audio device queue.
-	 * If the buffer is full just drop the extra, otherwise write.
-	 * In some cases it might be useful to write anyways after
-	 * a number of failures, to restart the output chain.
-	 */
-	res = used_blocks(o);
-	if (res > o->queuesize) { /* no room to write a block */
-		/* Only report a buffer overflow when we are transmitting */
+
+	if (used_blocks(o) > o->queuesize) {
 		if (o->pmrChan->txPttIn || o->pmrChan->txPttOut) {
-			ast_log(LOG_WARNING, "Channel %s: Sound device write buffer overflow - used %d blocks\n", o->name, res);
+			ast_log(LOG_WARNING, "Channel %s: Sound device write buffer overflow\n", o->name);
 		}
 		return 0;
 	}
-	if (res == 0) { /* We are not keeping the buffer full, add 1 frame */
+
+	if (used_blocks(o) == 0) {
 		memset(outbuf, 0, sizeof(outbuf));
-		res = write(o->sounddev, ((void *) outbuf), sizeof(outbuf));
-		if (res < 0) {
-			ast_log(LOG_ERROR, "Channel %s: Sound card write error %s\n", o->name, strerror(errno));
-		}
+		ast_radio_pa_write(&o->pa, outbuf, AST_RADIO_PA_FRAMES_PER_BUFFER);
 		ast_debug(7, "A null frame has been added");
 	}
-	res = write(o->sounddev, ((void *) data), FRAME_SIZE * 2 * 2 * 6);
-	if (res < 0) {
-		ast_log(LOG_ERROR, "Channel %s: Sound card write error %s\n", o->name, strerror(errno));
-	} else if (res != FRAME_SIZE * 2 * 2 * 6) {
-		ast_log(LOG_ERROR, "Channel %s: Sound card wrote %d bytes of %d\n", o->name, res, (FRAME_SIZE * 2 * 2 * 6));
-	}
 
-	return res;
-}
-
-/*!
- * \brief Open the sound card device.
- * If the device is already open, this will close the device
- * and open it again.
- * It initializes the device based on our requirements and triggers
- * reads and writes.
- * \param o		Channel private data.
- * \param mode	The mode to open the file.  This is the flags argument to open.
- * \retval 0	Success.
- * \retval -1	Failed.
- */
-static int setformat(struct chan_usbradio_pvt *o, int mode)
-{
-	int fmt, desired, res, fd;
-	char device[100];
-
-	/* If the device is open, close it */
-	if (o->sounddev >= 0) {
-		ioctl(o->sounddev, SNDCTL_DSP_RESET, 0);
-		close(o->sounddev);
-		o->duplex = M_UNSET;
-		o->sounddev = -1;
-	}
-	if (mode == O_CLOSE) { /* we are done */
+	res = ast_radio_pa_write(&o->pa, data, AST_RADIO_PA_FRAMES_PER_BUFFER);
+	if (res < 0 && res != paOutputUnderflowed) {
+		ast_log(LOG_ERROR, "Channel %s: PortAudio write error %s\n", o->name, Pa_GetErrorText(res));
 		return 0;
 	}
 
-	ast_copy_string(device, "/dev/dsp", sizeof(device));
-	if (o->devicenum) {
-		snprintf(device, sizeof(device), "/dev/dsp%d", o->devicenum);
-	}
-	/* open the device */
-	fd = o->sounddev = open(device, mode | O_NONBLOCK);
-	if (fd < 0) {
-		ast_log(LOG_ERROR, "Channel %s: Unable to open DSP device %d: %s.\n", o->name, o->devicenum, strerror(errno));
-		return -1;
-	}
-	if (o->owner) {
-		ast_channel_internal_fd_set(o->owner, 0, fd);
-	}
-
-#if __BYTE_ORDER == __LITTLE_ENDIAN
-	fmt = AFMT_S16_LE;
-#else
-	fmt = AFMT_S16_BE;
-#endif
-	res = ioctl(fd, SNDCTL_DSP_SETFMT, &fmt);
-	if (res < 0) {
-		ast_log(LOG_WARNING, "Channel %s: Unable to set format to 16-bit signed\n", o->name);
-		return -1;
-	}
-	/* set our duplex mode based on the way we opened the device. */
-	switch (mode) {
-	case O_RDWR:
-		res = ioctl(fd, SNDCTL_DSP_SETDUPLEX, 0);
-		/* Check to see if duplex set (FreeBSD Bug) */
-		res = ioctl(fd, SNDCTL_DSP_GETCAPS, &fmt);
-		if (res == 0 && (fmt & DSP_CAP_DUPLEX)) {
-			o->duplex = M_FULL;
-		};
-		break;
-	case O_WRONLY:
-		o->duplex = M_WRITE;
-		break;
-	case O_RDONLY:
-		o->duplex = M_READ;
-		break;
-	}
-
-	fmt = 1;
-	res = ioctl(fd, SNDCTL_DSP_STEREO, &fmt);
-	if (res < 0) {
-		ast_log(LOG_WARNING, "Channel %s: Failed to set audio device to stereo\n", o->name);
-		return -1;
-	}
-	fmt = desired = 48000; /* 48000 Hz desired */
-	res = ioctl(fd, SNDCTL_DSP_SPEED, &fmt);
-	if (res < 0) {
-		ast_log(LOG_WARNING, "Channel %s: Failed to set audio device sample rate.\n", o->name);
-		return -1;
-	}
-	if (fmt != desired) {
-		if (!(o->warned & WARN_speed)) {
-			ast_log(LOG_WARNING, "Channel %s: Requested %d Hz, got %d Hz -- sound may be choppy.\n", o->name, desired, fmt);
-			o->warned |= WARN_speed;
-		}
-	}
-	/*
-	 * on Freebsd, SETFRAGMENT does not work very well on some cards.
-	 * Default to use 256 bytes, let the user override
-	 */
-	if (o->frags) {
-		fmt = o->frags;
-		res = ioctl(fd, SNDCTL_DSP_SETFRAGMENT, &fmt);
-		if (res < 0) {
-			if (!(o->warned & WARN_frag)) {
-				ast_log(LOG_WARNING, "Channel %s: Unable to set fragment size -- sound may be choppy.\n", o->name);
-				o->warned |= WARN_frag;
-			}
-		}
-	}
-	/* on some cards, we need SNDCTL_DSP_SETTRIGGER to start outputting */
-	res = PCM_ENABLE_INPUT | PCM_ENABLE_OUTPUT;
-	res = ioctl(fd, SNDCTL_DSP_SETTRIGGER, &res);
-	/* it may fail if we are in half duplex, never mind */
-	return 0;
+	return FRAME_SIZE * 2 * 2 * 6;
 }
 
 /*!
@@ -1924,7 +1889,7 @@ static int usbradio_hangup(struct ast_channel *c)
 	ast_module_unref(ast_module_info->self);
 	if (o->hookstate) {
 		o->hookstate = 0;
-		setformat(o, O_CLOSE);
+		usbradio_stop_audio(o);
 	}
 	o->stophid = 1;
 	pthread_join(o->hidthread, NULL);
@@ -1945,11 +1910,10 @@ static int usbradio_write(struct ast_channel *c, struct ast_frame *f)
 	if (!o->hasusb) {
 		return 0;
 	}
-	if (o->sounddev < 0) {
-		setformat(o, O_RDWR);
-	}
-	if (o->sounddev < 0) {
-		return 0; /* not fatal */
+	if (!o->pa.active) {
+		if (usbradio_start_audio(o) < 0) {
+			return 0;
+		}
 	}
 	/*
 	 * we could receive a block which is not a multiple of our
@@ -1988,7 +1952,8 @@ static int usbradio_write(struct ast_channel *c, struct ast_frame *f)
  */
 static struct ast_frame *usbradio_read(struct ast_channel *c)
 {
-	int res, oldpttout;
+	PaError pres;
+	int oldpttout;
 	int cd, sd;
 	struct chan_usbradio_pvt *o = ast_channel_tech_pvt(c);
 	struct ast_frame *f = &o->read_f, *f1;
@@ -2062,44 +2027,32 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 		ast_mutex_unlock(&o->echolock);
 	}
 
-	/* Read audio data from the USB sound device.
-	 * Sound data will arrive at 48000 samples per second
-	 * in stereo format.
-	 */
-	res = read(o->sounddev, o->usbradio_read_buf + o->readpos, sizeof(o->usbradio_read_buf) - o->readpos);
-	if (res < 0) { /* Audio data not ready, return a NULL frame */
-		if (errno != EAGAIN) {
-			o->readerrs = 0;
-			o->hasusb = 0;
+	/* Read audio data from the USB sound device (48 kHz stereo via PortAudio). */
+	if (!o->pa.active) {
+		if (usbradio_start_audio(o) < 0) {
 			return &ast_null_frame;
 		}
-		if (o->readerrs++ > READERR_THRESHOLD) {
-			ast_log(LOG_ERROR, "Stuck USB read channel [%s], un-sticking it!\n", o->name);
-			o->readerrs = 0;
-			o->hasusb = 0;
+	}
+
+	pres = ast_radio_pa_read(&o->pa, (short *) (o->usbradio_read_buf + AST_FRIENDLY_OFFSET),
+		AST_RADIO_PA_FRAMES_PER_BUFFER, 40, NULL);
+	if (pres != paNoError) {
+		if (pres == paTimedOut || pres == paInputOverflowed) {
 			return &ast_null_frame;
 		}
-		if (o->readerrs == 1) {
-			ast_log(LOG_WARNING, "Possibly stuck USB read channel. [%s]\n", o->name);
-		}
+		ast_log(LOG_ERROR, "Channel %s: PortAudio read error %s\n", o->name, Pa_GetErrorText(pres));
+		o->hasusb = 0;
 		return &ast_null_frame;
 	}
 
 #if DEBUG_CAPTURES == 1
 	if (o->rxcapraw && frxcapraw) {
-		fwrite(o->usbradio_read_buf + o->readpos, 1, res, frxcapraw);
+		fwrite(o->usbradio_read_buf + AST_FRIENDLY_OFFSET, 1, FRAME_SIZE * 2 * 2 * 6, frxcapraw);
 	}
 #endif
 
-	if (o->readerrs) {
-		ast_log(LOG_WARNING, "USB read channel [%s] was not stuck.\n", o->name);
-	}
-
 	o->readerrs = 0;
-	o->readpos += res;
-	if (o->readpos < sizeof(o->usbradio_read_buf)) { /* not enough samples */
-		return &ast_null_frame;
-	}
+	o->readpos = sizeof(o->usbradio_read_buf);
 
 	/* Check for ADC clipping and input audio statistics before any filtering is done.
 	 * FRAME_SIZE define refers to 8Ksps mono which is 160 samples per 20mS USB frame.
@@ -2107,7 +2060,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	 * extracts the mono 48K channel, checks amplitude and distortion characteristics,
 	 * and returns true if clipping was detected.
 	 */
-	if (ast_radio_check_audio((short *) o->usbradio_read_buf, &o->rxaudiostats, 12 * FRAME_SIZE, 0)) {
+	if (ast_radio_check_audio((short *) (o->usbradio_read_buf + AST_FRIENDLY_OFFSET), &o->rxaudiostats, 12 * FRAME_SIZE, 0)) {
 		if (o->clipledgpio) {
 			/* Set Clip LED GPIO pulsetimer if not already set */
 			if (!o->hid_gpio_pulsetimer[o->clipledgpio - 1]) {
@@ -2127,13 +2080,11 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	 */
 	/* Decrease the audio level for CM119 A/B devices */
 	if (o->legacyaudioscaling && o->devtype != C108_PRODUCT_ID) {
-		/* Subtract res from o->readpos in below assignment (o->readpos was incremented
-		   above prior to check of if enough samples were received) */
-		register short *sp = (short *) (o->usbradio_read_buf + (o->readpos - res));
+		register short *sp = (short *) (o->usbradio_read_buf + AST_FRIENDLY_OFFSET);
 		register float v;
 		register int i;
 
-		for (i = 0; i < res / 2; i++) {
+		for (i = 0; i < FRAME_SIZE * 2 * 6; i++) {
 			v = ((float) *sp) * 0.800;
 			*sp++ = (int) v;
 		}
@@ -2624,10 +2575,9 @@ static struct ast_channel *usbradio_new(struct chan_usbradio_pvt *o, char *ext, 
 		return NULL;
 	}
 	ast_channel_tech_set(c, &usbradio_tech);
-	if ((o->sounddev < 0) && o->hasusb) {
-		setformat(o, O_RDWR);
+	if (!o->pa.active && o->hasusb) {
+		usbradio_start_audio(o);
 	}
-	ast_channel_internal_fd_set(c, 0, o->sounddev); /* -1 if device closed, override later */
 	ast_channel_nativeformats_set(c, usbradio_tech.capabilities);
 	ast_channel_set_readformat(c, ast_format_slin);
 	ast_channel_set_writeformat(c, ast_format_slin);
@@ -4910,6 +4860,7 @@ static struct chan_usbradio_pvt *store_config(struct ast_config *cfg, const char
 			o->name = ast_strdup(ctg);
 			o->pttkick[0] = -1;
 			o->pttkick[1] = -1;
+			o->hw_device[0] = '\0';
 			if (!usbradio_active) {
 				usbradio_active = o->name;
 			}
@@ -5567,21 +5518,16 @@ static int unload_module(void)
 		}
 #endif
 
-		if (o->sounddev >= 0) {
-			close(o->sounddev);
-			o->sounddev = -1;
-		}
-		if (o->dsp) {
-			ast_dsp_free(o->dsp);
-		}
 		if (o->owner) {
 			ast_softhangup(o->owner, AST_SOFTHANGUP_APPUNLOAD);
 		}
-		if (o->owner) { /* XXX how ??? */
-			return -1;
+		o->stophid = 1;
+		kickptt(o);
+		pthread_join(o->hidthread, NULL);
+		usbradio_stop_audio(o);
+		if (o->dsp) {
+			ast_dsp_free(o->dsp);
 		}
-		/* XXX what about the thread ? */
-		/* XXX what about the memory allocated ? */
 	}
 
 	ao2_cleanup(usbradio_tech.capabilities);

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -1171,6 +1171,12 @@ usb_device_ready:
 		}
 		if (pipe2(o->pttkick, O_NONBLOCK) == -1) {
 			ast_log(LOG_ERROR, "Channel %s: Is not able to create a pipe\n", o->name);
+			usb_close(usb_handle);
+			usb_handle = NULL;
+			ast_mutex_lock(&usb_dev_lock);
+			o->usbass = 0;
+			o->hasusb = 0;
+			ast_mutex_unlock(&usb_dev_lock);
 			pthread_exit(NULL);
 		}
 		if ((usb_dev->descriptor.idProduct & 0xfffc) == C108_PRODUCT_ID) {
@@ -1887,12 +1893,13 @@ static int usbradio_hangup(struct ast_channel *c)
 	ast_channel_tech_pvt_set(c, NULL);
 	o->owner = NULL;
 	ast_module_unref(ast_module_info->self);
+	o->stophid = 1;
+	kickptt(o);
+	pthread_join(o->hidthread, NULL);
 	if (o->hookstate) {
 		o->hookstate = 0;
-		usbradio_stop_audio(o);
 	}
-	o->stophid = 1;
-	pthread_join(o->hidthread, NULL);
+	usbradio_stop_audio(o);
 	return 0;
 }
 
@@ -2576,7 +2583,9 @@ static struct ast_channel *usbradio_new(struct chan_usbradio_pvt *o, char *ext, 
 	}
 	ast_channel_tech_set(c, &usbradio_tech);
 	if (!o->pa.active && o->hasusb) {
-		usbradio_start_audio(o);
+		if (usbradio_start_audio(o) < 0) {
+			return NULL;
+		}
 	}
 	ast_channel_nativeformats_set(c, usbradio_tech.capabilities);
 	ast_channel_set_readformat(c, ast_format_slin);

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -1036,12 +1036,13 @@ static void *hidthread(void *arg)
 		o->usbass = 1;
 		ast_mutex_unlock(&usb_dev_lock);
 		/* set the audio mixer values */
-		o->micmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL);
+		o->micmax = ast_radio_mixer_limit(ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL));
 		o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL);
 		if (o->spkrmax == -1) {
 			o->newname = 1;
 			o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW);
 		}
+		o->spkrmax = ast_radio_mixer_limit(o->spkrmax);
 		/* initialize the usb device */
 		usb_dev = ast_radio_hid_device_init(o->devstr);
 		if (usb_dev == NULL) {

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -757,6 +757,7 @@ static int load_tune_config(struct chan_usbradio_pvt *o, const struct ast_config
 	int configured = 0;
 	char devstr[sizeof(o->devstr)];
 	char serial[sizeof(o->serial)];
+	char hw_device[sizeof(o->hw_device)];
 
 	/* No load defaults */
 	o->rxmixerset = 500;
@@ -770,6 +771,7 @@ static int load_tune_config(struct chan_usbradio_pvt *o, const struct ast_config
 
 	devstr[0] = '\0';
 	serial[0] = '\0';
+	hw_device[0] = '\0';
 	if (!reload) {
 		o->devstr[0] = 0;
 		o->serial[0] = 0;
@@ -801,15 +803,18 @@ static int load_tune_config(struct chan_usbradio_pvt *o, const struct ast_config
 		CV_UINT("fever", o->fever);
 		CV_STR("devstr", devstr);
 		CV_STR("serial", serial);
-		if (o->devstr[0] == '\0') {
-			CV_STR("audiodev", o->hw_device);
-		}
+		CV_STR("audiodev", hw_device);
 		CV_END;
 	}
 	if (!reload) {
 		/* Using the ternary operator in CV_STR won't work, due to butchering the sizeof, so copy after if needed */
 		ast_copy_string(o->devstr, devstr, sizeof(o->devstr));
 		ast_copy_string(o->serial, serial, sizeof(o->serial));
+		if (ast_strlen_zero(devstr)) {
+			ast_copy_string(o->hw_device, hw_device, sizeof(o->hw_device));
+		} else {
+			o->hw_device[0] = '\0';
+		}
 	}
 	if (opened) {
 		ast_config_destroy(cfg2);
@@ -957,12 +962,13 @@ static void *hidthread(void *arg)
 				ast_radio_time(&o->lasthidtime);
 				o->usbass = 1;
 				ast_mutex_unlock(&usb_dev_lock);
-				o->micmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL);
+				o->micmax = ast_radio_mixer_limit(ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL));
 				o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL);
 				if (o->spkrmax == -1) {
 					o->newname = 1;
 					o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW);
 				}
+				o->spkrmax = ast_radio_mixer_limit(o->spkrmax);
 				goto usb_device_ready;
 			}
 			if (!o->device_error) {

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -102,7 +102,6 @@
 #include "./xpmrx/bitweight.h"
 #endif
 
-
 #include "asterisk/lock.h"
 #include "asterisk/frame.h"
 #include "asterisk/logger.h"
@@ -175,11 +174,11 @@ static const char *const mixer_type[] = { "no", "voice", "tone", "composite", "a
 struct chan_usbradio_pvt {
 	struct chan_usbradio_pvt *next;
 
-	char *name;		  /* the internal name of our channel */
+	char *name;			 /* the internal name of our channel */
 	char hw_device[100]; /* ALSA/PortAudio device (hw:N or hw:N,M) */
-	int devtype;	  /* actual type of device */
-	int pttkick[2];	  /* ptt kick pipe */
-	int total_blocks; /* legacy queue depth hint for TX buffering */
+	int devtype;		 /* actual type of device */
+	int pttkick[2];		 /* ptt kick pipe */
+	int total_blocks;	 /* legacy queue depth hint for TX buffering */
 	struct ast_radio_pa_stream pa;
 	enum {
 		M_UNSET,
@@ -937,8 +936,7 @@ static void *hidthread(void *arg)
 			if (ast_radio_parse_hw_anywhere(o->hw_device, &i, &subdev)) {
 				for (ao = usbradio_default.next; ao && ao->name; ao = ao->next) {
 					if (ao != o && ao->usbass && ao->devicenum == i) {
-						ast_log(LOG_ERROR, "Channel %s: Audio device %s is already assigned to channel %s\n",
-							o->name, o->hw_device, ao->name);
+						ast_log(LOG_ERROR, "Channel %s: Audio device %s is already assigned to channel %s\n", o->name, o->hw_device, ao->name);
 						ast_mutex_unlock(&usb_dev_lock);
 						usleep(500000);
 						continue;
@@ -2041,8 +2039,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 		}
 	}
 
-	pres = ast_radio_pa_read(&o->pa, (short *) (o->usbradio_read_buf + AST_FRIENDLY_OFFSET),
-		AST_RADIO_PA_FRAMES_PER_BUFFER, 40, NULL);
+	pres = ast_radio_pa_read(&o->pa, (short *) (o->usbradio_read_buf + AST_FRIENDLY_OFFSET), AST_RADIO_PA_FRAMES_PER_BUFFER, 40, NULL);
 	if (pres != paNoError) {
 		if (pres == paTimedOut || pres == paInputOverflowed) {
 			return &ast_null_frame;

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -402,7 +402,7 @@ char context[100];
 #define ENDPAGE_STR "ENDPAGE"
 #define AMPVAL 30000
 #define AST_SAMPLE_RATE 8000 /* (Sample Rate) */
-#define DIVLCM 192000 /* (A common multiple of 512,1200,2400,8000) */
+#define DIVLCM 192000		 /* (A common multiple of 512,1200,2400,8000) */
 #define PREAMBLE_BITS 576
 #define MESSAGE_BITS 544 /* (17 * 32), 1 longword SYNC plus 16 longwords data */
 /* We have to send "inverted"... probably because of inverting AMP in Voter board. */

--- a/configs/samples/simpleusb.conf.sample
+++ b/configs/samples/simpleusb.conf.sample
@@ -117,6 +117,8 @@ legacyaudioscaling = no     ; If yes, continue to do raw audio sample scaling an
 ;;;;; Tune settings ;;;;;
 ;devstr=
 ;serial=
+;audiodev=hw:0             ; Optional ALSA device for PortAudio audio (hw:N or hw:N,M).
+                            ; Use instead of devstr when binding audio by card number.
 ;rxmixerset=500
 ;txmixaset=500
 ;txmixbset=500

--- a/configs/samples/usbradio.conf.sample
+++ b/configs/samples/usbradio.conf.sample
@@ -185,6 +185,8 @@ legacyaudioscaling = no     ; If yes, continue to do raw audio sample scaling an
 ;;;;; Tune settings ;;;;;
 ;devstr=
 ;serial=
+;audiodev=hw:0             ; Optional ALSA device for PortAudio audio (hw:N or hw:N,M).
+                            ; Use instead of devstr when binding audio by card number.
 ;rxmixerset=500
 ;txmixaset=500
 ;txmixbset=500

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -84,14 +84,6 @@
 #define AUDIO_ADJUSTMENT 1000
 
 /*!
- * \brief Default ALSA mixer maximum when hardware lookup fails.
- *
- * CM108-class devices commonly expose a 0-31 capture range; use this
- * instead of propagating -1 into volume scaling math.
- */
-#define AST_RADIO_MIXER_MAX_DEFAULT 31
-
-/*!
  * \brief EEPROM memory layout
  *	The AT93C46 eeprom has 64 addresses that contain 2 bytes (one word).
  *	The CMxxx sound card device will use this eeprom to read manuafacturer
@@ -257,13 +249,21 @@ int ast_radio_make_spkr_playback_value(int spkrmax, int request_value, int devty
 int ast_radio_amixer_max(int devnum, char *param);
 
 /*!
- * \brief Return a usable mixer maximum for volume scaling.
+ * \brief Query required ALSA mixer maximums for a USB radio device.
  *
- * \param limit Value from ast_radio_amixer_max(), or another mixer limit.
+ * Reads mic capture, speaker playback (with alternate control name), and
+ * mic playback limits. Fails when any required limit is unavailable.
  *
- * \retval limit if positive, otherwise AST_RADIO_MIXER_MAX_DEFAULT.
+ * \param devnum ALSA card number.
+ * \param micmax Returned Mic Capture Volume maximum.
+ * \param spkrmax Returned Speaker Playback Volume maximum.
+ * \param micplaymax Returned Mic Playback Volume maximum.
+ * \param newname Set to 1 when the alternate speaker control name is used.
+ *
+ * \retval 0 on success.
+ * \retval -1 if any required mixer limit is unavailable.
  */
-int ast_radio_mixer_limit(int limit);
+int ast_radio_init_mixer_limits(int devnum, int *micmax, int *spkrmax, int *micplaymax, int *newname);
 
 /*!
  * \brief Set mixer

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -80,6 +80,14 @@
 #define AUDIO_ADJUSTMENT 1000
 
 /*!
+ * \brief Default ALSA mixer maximum when hardware lookup fails.
+ *
+ * CM108-class devices commonly expose a 0-31 capture range; use this
+ * instead of propagating -1 into volume scaling math.
+ */
+#define AST_RADIO_MIXER_MAX_DEFAULT 31
+
+/*!
  * \brief EEPROM memory layout
  *	The AT93C46 eeprom has 64 addresses that contain 2 bytes (one word).
  *	The CMxxx sound card device will use this eeprom to read manuafacturer
@@ -243,6 +251,15 @@ int ast_radio_make_spkr_playback_value(int spkrmax, int request_value, int devty
  * \retval 				The maximum value.
  */
 int ast_radio_amixer_max(int devnum, char *param);
+
+/*!
+ * \brief Return a usable mixer maximum for volume scaling.
+ *
+ * \param limit Value from ast_radio_amixer_max(), or another mixer limit.
+ *
+ * \retval limit if positive, otherwise AST_RADIO_MIXER_MAX_DEFAULT.
+ */
+int ast_radio_mixer_limit(int limit);
 
 /*!
  * \brief Set mixer

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -23,7 +23,11 @@
  * \brief USB sound card resources.
  */
 
-/*! \note <sys/io.h> is not portable to all architectures, so don't call non-portable functions if we don't have them */
+/*! \note <sys/io.h> is not portable to all architectures; guard parallel-port helpers with HAVE_SYS_IO */
+#if __has_include(<sys/io.h>)
+#define HAVE_SYS_IO
+#endif
+
 #include <portaudio.h>
 
 /*!

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -570,7 +570,6 @@ PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps);
 PaError ast_radio_pa_start(struct ast_radio_pa_stream *ps);
 void ast_radio_pa_stop(struct ast_radio_pa_stream *ps);
 
-PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned long frames, int timeout_ms,
-	volatile sig_atomic_t *stop);
+PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned long frames, int timeout_ms, volatile sig_atomic_t *stop);
 PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, unsigned long frames);
 long ast_radio_pa_write_available(struct ast_radio_pa_stream *ps);

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -24,9 +24,7 @@
  */
 
 /*! \note <sys/io.h> is not portable to all architectures, so don't call non-portable functions if we don't have them */
-#if __has_include(<sys/io.h>)
-#define HAVE_SYS_IO
-#endif
+#include <portaudio.h>
 
 /*!
  * \brief Defines for interacting with ALSA controls.
@@ -529,3 +527,33 @@ void ast_radio_print_audio_stats(int fd, struct audiostatistics *o, const char *
  * \param cardno The ALSA card number as found in HW:<cardno>
  */
 struct usb_device *ast_radio_usb_device_from_alsa_card(int cardno);
+
+#define AST_RADIO_PA_SAMPLE_RATE 48000
+#define AST_RADIO_PA_FRAMES_PER_BUFFER (FRAME_SIZE * 6)
+#define AST_RADIO_PA_OUTPUT_CHANNELS 2
+
+/*!
+ * \brief PortAudio stream state shared by chan_simpleusb and chan_usbradio.
+ */
+struct ast_radio_pa_stream {
+	PaStream *stream;
+	int active;
+	unsigned int input_channels; /*!< 1 for mono RX, 2 for stereo RX */
+	char hw_device[100];
+};
+
+int ast_radio_pa_startup(void);
+void ast_radio_pa_shutdown(void);
+void ast_radio_pa_shutdown_all(void);
+
+int ast_radio_parse_hw_anywhere(const char *s, int *card, int *dev);
+int ast_radio_hw_match(const char *haystack, const char *needle);
+
+PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps);
+PaError ast_radio_pa_start(struct ast_radio_pa_stream *ps);
+void ast_radio_pa_stop(struct ast_radio_pa_stream *ps);
+
+PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned long frames, int timeout_ms,
+	volatile sig_atomic_t *stop);
+PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, unsigned long frames);
+long ast_radio_pa_write_available(struct ast_radio_pa_stream *ps);

--- a/res/Makefile.diff
+++ b/res/Makefile.diff
@@ -6,7 +6,7 @@ index 0987f43a43..2f18773cba 100644
  snmp/agent.o: _ASTCFLAGS+=-fPIC
  res_snmp.o: _ASTCFLAGS+=-fPIC
  
-+res_usbradio.so: LIBS+=-lusb -lasound
++res_usbradio.so: LIBS+=-lusb -lasound -lportaudio
 +
  # Dependencies for res_ari_*.so are generated, so they're in this file
  include ari.make

--- a/res/Makefile.diff
+++ b/res/Makefile.diff
@@ -1,13 +1,11 @@
-diff --git a/res/Makefile b/res/Makefile
-index 0987f43a43..2f18773cba 100644
 --- a/res/Makefile
 +++ b/res/Makefile
-@@ -79,6 +79,8 @@ res_parking.o: _ASTCFLAGS+=$(AST_NO_FORMAT_TRUNCATION)
+@@ -78,6 +78,8 @@
+ res_parking.o: _ASTCFLAGS+=$(AST_NO_FORMAT_TRUNCATION)
  snmp/agent.o: _ASTCFLAGS+=-fPIC
  res_snmp.o: _ASTCFLAGS+=-fPIC
  
 +res_usbradio.so: LIBS+=-lusb -lasound -lportaudio
 +
- # Dependencies for res_ari_*.so are generated, so they're in this file
- include ari.make
+ MODULE_EXCLUDE=ENABLE_SRTP_AES_192 ENABLE_SRTP_AES_256 ENABLE_SRTP_AES_GCM
  

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -1186,8 +1186,8 @@ PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
 			return paDeviceUnavailable;
 		}
 
-		res = Pa_OpenStream(&ps->stream, &input_params, &output_params, AST_RADIO_PA_SAMPLE_RATE,
-			AST_RADIO_PA_FRAMES_PER_BUFFER, paNoFlag, NULL, NULL);
+		res = Pa_OpenStream(&ps->stream, &input_params, &output_params, AST_RADIO_PA_SAMPLE_RATE, AST_RADIO_PA_FRAMES_PER_BUFFER,
+			paNoFlag, NULL, NULL);
 	}
 
 	if (res != paNoError) {
@@ -1201,8 +1201,7 @@ PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
 
 	si = Pa_GetStreamInfo(ps->stream);
 	if (si) {
-		ast_debug(5, "PortAudio stream latency in %.3f ms out %.3f ms\n", si->inputLatency * 1000.0,
-			si->outputLatency * 1000.0);
+		ast_debug(5, "PortAudio stream latency in %.3f ms out %.3f ms\n", si->inputLatency * 1000.0, si->outputLatency * 1000.0);
 	}
 
 	return res;
@@ -1248,8 +1247,7 @@ void ast_radio_pa_stop(struct ast_radio_pa_stream *ps)
 	ast_radio_pa_shutdown();
 }
 
-PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned long frames, int timeout_ms,
-	volatile sig_atomic_t *stop)
+PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned long frames, int timeout_ms, volatile sig_atomic_t *stop)
 {
 	int64_t start;
 	PaError err;

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -444,6 +444,8 @@ int ast_radio_hid_device_mklist(void)
 	struct usb_bus *usb_bus;
 	struct usb_device *dev;
 	char devstr[10000], str[200], desdev[200], *cp;
+	ssize_t linklen;
+	size_t cplen;
 	int i;
 
 	ast_mutex_lock(&usb_list_lock);
@@ -483,9 +485,11 @@ int ast_radio_hid_device_mklist(void)
 
 				snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
 				memset(desdev, 0, sizeof(desdev));
-				if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
+				linklen = readlink(str, desdev, sizeof(desdev) - 1);
+				if (linklen == -1) {
 					continue;
 				}
+				desdev[linklen] = '\0';
 				cp = strrchr(desdev, '/');
 				if (!cp) {
 					continue;
@@ -498,22 +502,23 @@ int ast_radio_hid_device_mklist(void)
 				continue;
 			}
 
-			new_list = ast_realloc(usb_device_list, usb_device_list_size + 2 + strlen(cp));
+			cplen = strlen(cp);
+			new_list = ast_realloc(usb_device_list, usb_device_list_size + 2 + cplen);
 			if (!new_list) {
 				ast_mutex_unlock(&usb_list_lock);
 				return -1;
 			}
 
 			usb_device_list = new_list;
-			usb_device_list_size += strlen(cp) + 2;
+			usb_device_list_size += cplen + 2;
 			i = 0;
 
 			while (usb_device_list[i]) {
 				i += strlen(usb_device_list + i) + 1;
 			}
 
-			memcpy(usb_device_list + i, cp, strlen(cp) + 1);
-			usb_device_list[strlen(cp) + i + 1] = 0;
+			memcpy(usb_device_list + i, cp, cplen + 1);
+			usb_device_list[i + cplen + 1] = 0;
 		}
 	}
 	ast_mutex_unlock(&usb_list_lock);
@@ -525,6 +530,7 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 	struct usb_bus *usb_bus;
 	struct usb_device *dev;
 	char devstr[10000], str[200], desdev[200], *cp;
+	ssize_t linklen;
 	int i;
 
 	usb_init();
@@ -549,9 +555,11 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 
 				snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
 				memset(desdev, 0, sizeof(desdev));
-				if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
+				linklen = readlink(str, desdev, sizeof(desdev) - 1);
+				if (linklen == -1) {
 					continue;
 				}
+				desdev[linklen] = '\0';
 				cp = strrchr(desdev, '/');
 				if (!cp) {
 					continue;

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -1094,6 +1094,7 @@ static int match_card_id(const char *devname, int card)
 static int pa_device_matches(const PaDeviceInfo *dev, const char *hw_device, int want_input, int want_output)
 {
 	int card, devnum;
+	int hay_card, hay_dev;
 
 	if (!dev || !hw_device || !hw_device[0]) {
 		return 0;
@@ -1111,11 +1112,20 @@ static int pa_device_matches(const PaDeviceInfo *dev, const char *hw_device, int
 		return 1;
 	}
 
-	if (ast_radio_parse_hw_anywhere(hw_device, &card, &devnum) && match_card_id(dev->name, card)) {
+	if (!ast_radio_parse_hw_anywhere(hw_device, &card, &devnum) || !match_card_id(dev->name, card)) {
+		return 0;
+	}
+
+	/* Card-id fallback is only unambiguous for hw:C; hw:C,D must match subdevice too. */
+	if (devnum < 0) {
 		return 1;
 	}
 
-	return 0;
+	if (!ast_radio_parse_hw_anywhere(dev->name, &hay_card, &hay_dev)) {
+		return 0;
+	}
+
+	return hay_card == card && hay_dev == devnum;
 }
 
 static PaDeviceIndex pa_find_device(const char *hw_device, int want_input, int want_output)

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -28,6 +28,7 @@
 
 /*** MODULEINFO
 	<depend>alsa</depend>
+	<depend>portaudio</depend>
 	<support_level>extended</support_level>
  ***/
 
@@ -48,6 +49,7 @@
 #include <linux/parport.h>
 #include <linux/version.h>
 #include <alsa/asoundlib.h>
+#include <portaudio.h>
 
 #include "asterisk/res_usbradio.h"
 
@@ -151,7 +153,10 @@ int ast_radio_amixer_max(int devnum, char *param)
 	}
 
 	snd_ctl_elem_info_alloca(&info);
-	snd_hctl_elem_info(elem, info);
+	if (snd_hctl_elem_info(elem, info) < 0) {
+		snd_hctl_close(hctl);
+		return -1;
+	}
 	type = snd_ctl_elem_info_get_type(info);
 	rv = 0;
 
@@ -199,7 +204,10 @@ int ast_radio_setamixer(int devnum, char *param, int v1, int v2)
 	}
 
 	snd_ctl_elem_info_alloca(&info);
-	snd_hctl_elem_info(elem, info);
+	if (snd_hctl_elem_info(elem, info) < 0) {
+		snd_hctl_close(hctl);
+		return -1;
+	}
 	type = snd_ctl_elem_info_get_type(info);
 	snd_ctl_elem_value_alloca(&control);
 	snd_ctl_elem_value_set_id(control, id);
@@ -464,11 +472,9 @@ int ast_radio_hid_device_mklist(void)
 
 				snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
 				memset(desdev, 0, sizeof(desdev));
-
 				if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
 					continue;
 				}
-
 				cp = strrchr(desdev, '/');
 				if (!cp) {
 					continue;
@@ -482,7 +488,6 @@ int ast_radio_hid_device_mklist(void)
 			}
 
 			new_list = ast_realloc(usb_device_list, usb_device_list_size + 2 + strlen(cp));
-
 			if (!new_list) {
 				ast_mutex_unlock(&usb_list_lock);
 				return -1;
@@ -496,7 +501,7 @@ int ast_radio_hid_device_mklist(void)
 				i += strlen(usb_device_list + i) + 1;
 			}
 
-			strcat(usb_device_list + i, cp);
+			memcpy(usb_device_list + i, cp, strlen(cp) + 1);
 			usb_device_list[strlen(cp) + i + 1] = 0;
 		}
 	}
@@ -530,6 +535,7 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 				if (strcasecmp(desdev, devstr)) {
 					continue;
 				}
+
 				snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
 				memset(desdev, 0, sizeof(desdev));
 				if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
@@ -542,11 +548,9 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 				cp++;
 				break;
 			}
-
 			if (i >= 32) {
 				continue;
 			}
-
 			if (!strcmp(cp, desired_device)) {
 				return dev;
 			}
@@ -926,6 +930,376 @@ static void cleanup_user_devices(void)
 }
 
 /*
+ * PortAudio helpers shared by chan_simpleusb and chan_usbradio.
+ */
+AST_MUTEX_DEFINE_STATIC(pa_lock);
+static int pa_refcount;
+
+static int64_t pa_now_ms(void)
+{
+	struct timespec ts;
+
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (int64_t) ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
+int ast_radio_pa_startup(void)
+{
+	PaError res;
+
+	ast_mutex_lock(&pa_lock);
+	if (pa_refcount == 0) {
+		res = Pa_Initialize();
+		if (res != paNoError) {
+			ast_mutex_unlock(&pa_lock);
+			ast_log(LOG_WARNING, "Failed to initialize PortAudio - (%d) %s\n", res, Pa_GetErrorText(res));
+			return -1;
+		}
+	}
+	pa_refcount++;
+	ast_mutex_unlock(&pa_lock);
+	return 0;
+}
+
+void ast_radio_pa_shutdown(void)
+{
+	ast_mutex_lock(&pa_lock);
+	if (pa_refcount > 0) {
+		pa_refcount--;
+		if (pa_refcount == 0) {
+			Pa_Terminate();
+		}
+	}
+	ast_mutex_unlock(&pa_lock);
+}
+
+void ast_radio_pa_shutdown_all(void)
+{
+	ast_mutex_lock(&pa_lock);
+	if (pa_refcount > 0) {
+		Pa_Terminate();
+		pa_refcount = 0;
+	}
+	ast_mutex_unlock(&pa_lock);
+}
+
+int ast_radio_parse_hw_anywhere(const char *s, int *card, int *dev)
+{
+	const char *p = s;
+
+	if (!s || !card || !dev) {
+		return 0;
+	}
+
+	while ((p = strstr(p, "hw:")) != NULL) {
+		const char *q = p + 3;
+		int c = 0;
+		int d = -1;
+
+		if (!isdigit((unsigned char) *q)) {
+			p = q;
+			continue;
+		}
+
+		while (isdigit((unsigned char) *q)) {
+			if (c > 9999) {
+				p = q;
+				break;
+			}
+			c = c * 10 + (*q - '0');
+			q++;
+		}
+
+		if (*q == ',') {
+			q++;
+			if (!isdigit((unsigned char) *q)) {
+				p = q;
+				continue;
+			}
+			d = 0;
+			while (isdigit((unsigned char) *q)) {
+				d = d * 10 + (*q - '0');
+				q++;
+			}
+		}
+
+		*card = c;
+		*dev = d;
+		return 1;
+	}
+
+	return 0;
+}
+
+int ast_radio_hw_match(const char *haystack, const char *needle)
+{
+	int haystack_c, haystack_d, needle_c, needle_d;
+	const char *p = haystack ? haystack : "";
+
+	if (!ast_radio_parse_hw_anywhere(needle, &needle_c, &needle_d)) {
+		return 0;
+	}
+
+	while ((p = strstr(p, "hw:")) != NULL) {
+		if (ast_radio_parse_hw_anywhere(p, &haystack_c, &haystack_d)) {
+			if (haystack_c == needle_c) {
+				if (needle_d < 0 || haystack_d == needle_d) {
+					return 1;
+				}
+			}
+		}
+		p += 3;
+	}
+
+	return 0;
+}
+
+static int match_card_id(const char *devname, int card)
+{
+	char path[128], id[64];
+	FILE *fp;
+	size_t n;
+
+	snprintf(path, sizeof(path), "/proc/asound/card%d/id", card);
+	fp = fopen(path, "r");
+	if (!fp) {
+		return 0;
+	}
+
+	if (!fgets(id, sizeof(id), fp) || !id[0]) {
+		fclose(fp);
+		return 0;
+	}
+	fclose(fp);
+
+	n = strlen(id);
+	while (n > 0 && isspace((unsigned char) id[n - 1])) {
+		id[--n] = '\0';
+	}
+
+	return n > 0 && strstr(devname, id) != NULL;
+}
+
+static int pa_device_matches(const PaDeviceInfo *dev, const char *hw_device, int want_input, int want_output)
+{
+	int card, devnum;
+
+	if (!dev || !hw_device || !hw_device[0]) {
+		return 0;
+	}
+
+	if (want_input && !dev->maxInputChannels) {
+		return 0;
+	}
+
+	if (want_output && !dev->maxOutputChannels) {
+		return 0;
+	}
+
+	if (ast_radio_hw_match(dev->name, hw_device)) {
+		return 1;
+	}
+
+	if (ast_radio_parse_hw_anywhere(hw_device, &card, &devnum) && match_card_id(dev->name, card)) {
+		return 1;
+	}
+
+	return 0;
+}
+
+static PaDeviceIndex pa_find_device(const char *hw_device, int want_input, int want_output)
+{
+	PaDeviceIndex idx, num_devices;
+
+	num_devices = Pa_GetDeviceCount();
+	if (num_devices < 0) {
+		return paNoDevice;
+	}
+
+	for (idx = 0; idx < num_devices; idx++) {
+		const PaDeviceInfo *dev = Pa_GetDeviceInfo(idx);
+
+		if (pa_device_matches(dev, hw_device, want_input, want_output)) {
+			return idx;
+		}
+	}
+
+	return paNoDevice;
+}
+
+PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
+{
+	PaError res = paInternalError;
+	const PaStreamInfo *si;
+
+	if (!ps) {
+		return paBadStreamPtr;
+	}
+
+	ps->stream = NULL;
+	ps->active = 0;
+
+	if (ast_radio_pa_startup() < 0) {
+		return paInternalError;
+	}
+
+	if (!strcasecmp(ps->hw_device, "default")) {
+		res = Pa_OpenDefaultStream(&ps->stream, ps->input_channels, AST_RADIO_PA_OUTPUT_CHANNELS, paInt16,
+			AST_RADIO_PA_SAMPLE_RATE, AST_RADIO_PA_FRAMES_PER_BUFFER, NULL, NULL);
+	} else {
+		PaStreamParameters input_params = {
+			.channelCount = ps->input_channels,
+			.sampleFormat = paInt16,
+			.suggestedLatency = (1.0 / 50.0),
+			.device = paNoDevice,
+		};
+		PaStreamParameters output_params = {
+			.channelCount = AST_RADIO_PA_OUTPUT_CHANNELS,
+			.sampleFormat = paInt16,
+			.suggestedLatency = (1.0 / 50.0),
+			.device = paNoDevice,
+		};
+
+		input_params.device = pa_find_device(ps->hw_device, 1, 0);
+		output_params.device = pa_find_device(ps->hw_device, 0, 1);
+
+		if (input_params.device == paNoDevice) {
+			ast_log(LOG_ERROR, "No PortAudio input device found for '%s'\n", ps->hw_device);
+			ast_radio_pa_shutdown();
+			return paDeviceUnavailable;
+		}
+
+		if (output_params.device == paNoDevice) {
+			ast_log(LOG_ERROR, "No PortAudio output device found for '%s'\n", ps->hw_device);
+			ast_radio_pa_shutdown();
+			return paDeviceUnavailable;
+		}
+
+		res = Pa_OpenStream(&ps->stream, &input_params, &output_params, AST_RADIO_PA_SAMPLE_RATE,
+			AST_RADIO_PA_FRAMES_PER_BUFFER, paNoFlag, NULL, NULL);
+	}
+
+	if (res != paNoError) {
+		ast_radio_pa_shutdown();
+		return res;
+	}
+
+	si = Pa_GetStreamInfo(ps->stream);
+	if (si) {
+		ast_debug(5, "PortAudio stream latency in %.3f ms out %.3f ms\n", si->inputLatency * 1000.0,
+			si->outputLatency * 1000.0);
+	}
+
+	return res;
+}
+
+PaError ast_radio_pa_start(struct ast_radio_pa_stream *ps)
+{
+	PaError res;
+
+	if (!ps || !ps->stream) {
+		return paBadStreamPtr;
+	}
+
+	res = Pa_StartStream(ps->stream);
+	if (res == paNoError) {
+		ps->active = 1;
+	}
+	return res;
+}
+
+void ast_radio_pa_stop(struct ast_radio_pa_stream *ps)
+{
+	PaError err;
+
+	if (!ps || !ps->stream) {
+		return;
+	}
+
+	if (ps->active) {
+		err = Pa_AbortStream(ps->stream);
+		if (err != paNoError) {
+			ast_log(LOG_WARNING, "Pa_AbortStream failed: %s\n", Pa_GetErrorText(err));
+		}
+	}
+
+	err = Pa_CloseStream(ps->stream);
+	if (err != paNoError) {
+		ast_log(LOG_WARNING, "Pa_CloseStream failed: %s\n", Pa_GetErrorText(err));
+	}
+
+	ps->stream = NULL;
+	ps->active = 0;
+	ast_radio_pa_shutdown();
+}
+
+PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned long frames, int timeout_ms,
+	volatile sig_atomic_t *stop)
+{
+	int64_t start;
+	PaError err;
+
+	if (!ps || !ps->stream || !buf) {
+		return paBadStreamPtr;
+	}
+
+	start = pa_now_ms();
+	while (!stop || !(*stop)) {
+		long avail = Pa_GetStreamReadAvailable(ps->stream);
+
+		if (avail < 0) {
+			return (PaError) avail;
+		}
+
+		if ((pa_now_ms() - start) > timeout_ms) {
+			return paTimedOut;
+		}
+
+		if ((unsigned long) avail < frames) {
+			usleep(500);
+			continue;
+		}
+
+		err = Pa_ReadStream(ps->stream, buf, frames);
+		return err;
+	}
+
+	return paTimedOut;
+}
+
+PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, unsigned long frames)
+{
+	PaError res;
+	short null_buf[AST_RADIO_PA_FRAMES_PER_BUFFER * AST_RADIO_PA_OUTPUT_CHANNELS];
+
+	if (!ps || !ps->stream || !data) {
+		return paBadStreamPtr;
+	}
+
+	if (frames > AST_RADIO_PA_FRAMES_PER_BUFFER) {
+		ast_log(LOG_WARNING, "ast_radio_pa_write: frames %lu exceeds buffer capacity\n", frames);
+		return paBufferTooBig;
+	}
+
+	res = Pa_WriteStream(ps->stream, data, frames);
+	if (res == paOutputUnderflowed) {
+		memset(null_buf, 0, sizeof(null_buf));
+		Pa_WriteStream(ps->stream, null_buf, frames);
+	}
+
+	return res;
+}
+
+long ast_radio_pa_write_available(struct ast_radio_pa_stream *ps)
+{
+	if (!ps || !ps->stream) {
+		return -1;
+	}
+
+	return Pa_GetStreamWriteAvailable(ps->stream);
+}
+
+/*
  * Returns the libusb device that backs ALSA /proc/asound/card<cardno>/usbbus.
  * On success: returns a pointer to a libusb struct usb_device.
  * On failure: returns NULL.
@@ -1047,6 +1421,7 @@ static int load_module(void)
 static int unload_module(void)
 {
 	cleanup_user_devices();
+	ast_radio_pa_shutdown_all();
 
 	return 0;
 }

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -119,18 +119,47 @@ long ast_radio_lround(double x)
 
 int ast_radio_make_spkr_playback_value(int spkrmax, int request_value, int devtype)
 {
-	spkrmax = ast_radio_mixer_limit(spkrmax);
+	if (spkrmax <= 0) {
+		return 0;
+	}
 	return (request_value * spkrmax) / AUDIO_ADJUSTMENT;
 }
 
-int ast_radio_mixer_limit(int limit)
+int ast_radio_init_mixer_limits(int devnum, int *micmax, int *spkrmax, int *micplaymax, int *newname)
 {
-	if (limit > 0) {
-		return limit;
+	int rv;
+
+	if (!micmax || !spkrmax || !micplaymax || !newname) {
+		return -1;
 	}
 
-	ast_log(LOG_WARNING, "Mixer max lookup failed, using default %d\n", AST_RADIO_MIXER_MAX_DEFAULT);
-	return AST_RADIO_MIXER_MAX_DEFAULT;
+	rv = ast_radio_amixer_max(devnum, MIXER_PARAM_MIC_CAPTURE_VOL);
+	if (rv <= 0) {
+		ast_log(LOG_ERROR, "Mixer limit not available for hw:%d (%s)\n", devnum, MIXER_PARAM_MIC_CAPTURE_VOL);
+		return -1;
+	}
+	*micmax = rv;
+
+	*newname = 0;
+	rv = ast_radio_amixer_max(devnum, MIXER_PARAM_SPKR_PLAYBACK_VOL);
+	if (rv <= 0) {
+		rv = ast_radio_amixer_max(devnum, MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW);
+		if (rv <= 0) {
+			ast_log(LOG_ERROR, "Mixer limit not available for hw:%d (speaker playback)\n", devnum);
+			return -1;
+		}
+		*newname = 1;
+	}
+	*spkrmax = rv;
+
+	rv = ast_radio_amixer_max(devnum, MIXER_PARAM_MIC_PLAYBACK_VOL);
+	if (rv <= 0) {
+		ast_log(LOG_ERROR, "Mixer limit not available for hw:%d (%s)\n", devnum, MIXER_PARAM_MIC_PLAYBACK_VOL);
+		return -1;
+	}
+	*micplaymax = rv;
+
+	return 0;
 }
 
 int ast_radio_amixer_max(int devnum, char *param)

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -119,7 +119,18 @@ long ast_radio_lround(double x)
 
 int ast_radio_make_spkr_playback_value(int spkrmax, int request_value, int devtype)
 {
+	spkrmax = ast_radio_mixer_limit(spkrmax);
 	return (request_value * spkrmax) / AUDIO_ADJUSTMENT;
+}
+
+int ast_radio_mixer_limit(int limit)
+{
+	if (limit > 0) {
+		return limit;
+	}
+
+	ast_log(LOG_WARNING, "Mixer max lookup failed, using default %d\n", AST_RADIO_MIXER_MAX_DEFAULT);
+	return AST_RADIO_MIXER_MAX_DEFAULT;
 }
 
 int ast_radio_amixer_max(int devnum, char *param)

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -1180,6 +1180,10 @@ PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
 	}
 
 	if (res != paNoError) {
+		if (ps->stream) {
+			Pa_CloseStream(ps->stream);
+			ps->stream = NULL;
+		}
 		ast_radio_pa_shutdown();
 		return res;
 	}

--- a/rpt_install.sh
+++ b/rpt_install.sh
@@ -47,7 +47,12 @@ git apply /tmp/channels_Makefile.diff
 cp ../$MYDIR/utils/Makefile.diff /tmp/utils_makefile.diff
 git apply /tmp/utils_makefile.diff
 
-git apply ../$MYDIR/res/Makefile.diff
+tmpdiff="$(mktemp)" || exit 1
+trap 'rm -f "$tmpdiff"' EXIT
+cp "../$MYDIR/res/Makefile.diff" "$tmpdiff" || exit 1
+if ! git apply "$tmpdiff"; then
+	patch -p1 < "$tmpdiff" || exit 1
+fi
 
 echoerr() {
 	printf "\e[31;1m%s\e[0m\n" "$*" >&2;

--- a/rpt_install.sh
+++ b/rpt_install.sh
@@ -34,25 +34,29 @@ printf "Script is now the latest version\n"
 ls -d -v */ | grep "^asterisk" | tail -1
 cd $( ls -d -v */ | grep "^asterisk" | tail -1 )
 
-apt-get install -y libusb-dev # chan_simpleusb and chan_usbradio require libusb-dev on Debian
-modprobe snd-pcm-oss # /dev/dsp1 needs to exist for chan_simpleusb and chan_usbradio to work
-echo "snd-pcm-oss" >> /etc/modules # load module at startup for USB
+apt-get install -y libusb-dev libasound2-dev libportaudio2 portaudio19-dev # USB radio drivers and PortAudio
 
-cp ../$MYDIR/apps/Makefile.diff /tmp/app_Makefile.diff
-git apply /tmp/app_Makefile.diff
+apply_diff() {
+	src="$1"
+	tmpdiff="$(mktemp)" || exit 1
 
-cp ../$MYDIR/channels/Makefile.diff /tmp/channels_Makefile.diff
-git apply /tmp/channels_Makefile.diff
+	cp "$src" "$tmpdiff" || {
+		rm -f "$tmpdiff"
+		exit 1
+	}
+	if ! git apply "$tmpdiff"; then
+		patch -p1 < "$tmpdiff" || {
+			rm -f "$tmpdiff"
+			exit 1
+		}
+	fi
+	rm -f "$tmpdiff"
+}
 
-cp ../$MYDIR/utils/Makefile.diff /tmp/utils_makefile.diff
-git apply /tmp/utils_makefile.diff
-
-tmpdiff="$(mktemp)" || exit 1
-trap 'rm -f "$tmpdiff"' EXIT
-cp "../$MYDIR/res/Makefile.diff" "$tmpdiff" || exit 1
-if ! git apply "$tmpdiff"; then
-	patch -p1 < "$tmpdiff" || exit 1
-fi
+apply_diff "../$MYDIR/apps/Makefile.diff"
+apply_diff "../$MYDIR/channels/Makefile.diff"
+apply_diff "../$MYDIR/utils/Makefile.diff"
+apply_diff "../$MYDIR/res/Makefile.diff"
 
 echoerr() {
 	printf "\e[31;1m%s\e[0m\n" "$*" >&2;


### PR DESCRIPTION
## Summary
- Migrate `chan_usbradio` off OSS to shared PortAudio API
- Add `audiodev`-only HID binding path
- Document `audiodev=hw:N` in sample configs
- Update `rpt_install.sh`: drop `snd-pcm-oss`, add PortAudio deps
- Rename `SAMPRATE` → `AST_SAMPLE_RATE` in chan_voter

## Stack
**PR 3 of 3** — merge after #1091 and #1092. Rebase onto `master` before final review.

Incremental diff vs PR 2: https://github.com/hardenedpenguin/app_rpt/compare/portaudio/2-simpleusb...portaudio/3-usbradio-packaging

Full stack supersedes #1029.

## Test plan
- [ ] Validated on amd64 (trixie) and arm64 (wrinkles URI, crazytrain)
- [ ] `libportaudio2` dependency; no `asl3-oss.conf`
- [ ] Companion packaging PR: AllStarLink/asl3-asterisk#85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * USB radio modules now use a modern audio backend, improving compatibility with supported audio devices.
  * Added support for selecting an audio device by ALSA card number in sample configuration files.

* **Bug Fixes**
  * Improved audio handling and device cleanup for more reliable channel startup and shutdown.
  * Updated audio processing to better handle mono and stereo streams.
  * Increased robustness when applying installation patches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->