### PR TITLE
app_rpt: Reset connection timers when reconnecting

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2547,6 +2547,7 @@ static void *attempt_reconnect(struct rpt *myrpt, struct rpt_link *l)
 	*tele++ = 0;
 	l->elaptime = 0;
 	l->connecttime = ast_tv(0, 0); /* not connected */
+	l->lastkeytime = 0;
 	l->thisconnected = 0;
 	l->linkmode = 0;
 	l->lastrx1 = 0;
@@ -4539,6 +4540,7 @@ static int remote_hangup_helper(struct rpt *myrpt, struct rpt_link *l)
 				l->retrytimer = RETRY_TIMER_MS;
 				l->elaptime = 0;
 				l->connecttime = ast_tv(0, 0); /* no longer connected */
+				l->lastkeytime = 0;
 				l->thisconnected = 0;
 				rpt_mutex_unlock(&myrpt->lock);
 				return 1;

--- a/apps/app_rpt/rpt_cli.c
+++ b/apps/app_rpt/rpt_cli.c
@@ -404,7 +404,7 @@ static int rpt_do_lstats(int fd, int argc, const char *const *argv)
 					strcpy(peer, "(none)");
 				}
 
-				connecttime = ast_tvdiff_ms(now, l->connecttime);
+				connecttime = ast_tvzero(l->connecttime) ? 0 : ast_tvdiff_ms(now, l->connecttime);
 				hours = connecttime / 3600000L;
 				connecttime %= 3600000L;
 				minutes = connecttime / 60000L;
@@ -586,7 +586,7 @@ static int rpt_do_xnode(int fd, int argc, const char *const *argv)
 			now = rpt_tvnow();
 			RPT_LIST_TRAVERSE(links_copy, l, l_it) {
 				int hours, minutes, seconds;
-				long long connecttime = ast_tvdiff_ms(now, l->connecttime);
+				long long connecttime = ast_tvzero(l->connecttime) ? 0 : ast_tvdiff_ms(now, l->connecttime);
 				char conntime[21];
 
 				if (l->name[0] == '0') {

--- a/apps/app_rpt/rpt_manager.c
+++ b/apps/app_rpt/rpt_manager.c
@@ -238,7 +238,7 @@ static int rpt_manager_do_xstat(struct mansession *ses, const struct message *m)
 
 			RPT_LIST_TRAVERSE(links_copy, l, l_it) {
 				int hours, minutes, seconds;
-				long long connecttime = ast_tvdiff_ms(rpt_tvnow(), l->connecttime);
+				long long connecttime = ast_tvzero(l->connecttime) ? 0 : ast_tvdiff_ms(rpt_tvnow(), l->connecttime);
 				char conntime[21];
 
 				if (l->name[0] == '0') {


### PR DESCRIPTION
When reconnecting, reset `lastkey` timer.  
Test for 0 in `connecttime`  preventing "connected" timers from showing time values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection-time reporting for links that have not yet established a connection, displaying zero instead of an invalid or misleading duration.
  * Reset connection timing when links are preparing to reconnect or disconnect while remaining eligible for reconnection.
  * Applied consistent timing behavior across command-line and manager status displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->