### PR TITLE
app_rpt.c: Restore mute detection for local channel bridge

### DIFF
--- a/apps/app_rpt/rpt_bridging.c
+++ b/apps/app_rpt/rpt_bridging.c
@@ -415,7 +415,12 @@ int __rpt_conf_add(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_ty
 	return res;
 }
 
-struct ast_bridge_channel *rpt_get_bridge_channel_from_chan(struct ast_channel *chan)
+/*!
+ * \brief Get the bridge channel associated with the underlying Asterisk channel.
+ * \note Returns a ref-counted bridge channel object that must be released with ao2_ref(..., -1).
+ */
+
+static struct ast_bridge_channel *rpt_get_bridge_channel_from_chan(struct ast_channel *chan)
 {
 	struct ast_unreal_pvt *p;
 	struct ast_channel *pchan;
@@ -441,7 +446,7 @@ struct ast_bridge_channel *rpt_get_bridge_channel_from_chan(struct ast_channel *
 int rpt_conf_get_muted(struct ast_channel *chan, struct rpt *myrpt)
 {
 	struct ast_bridge_channel *bc = rpt_get_bridge_channel_from_chan(chan);
-	char mute = 0;
+	int mute = 0;
 
 	if (bc) {
 		ast_bridge_channel_lock(bc);

--- a/apps/app_rpt/rpt_bridging.c
+++ b/apps/app_rpt/rpt_bridging.c
@@ -418,6 +418,7 @@ int __rpt_conf_add(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_ty
 struct ast_bridge_channel *rpt_get_bridge_channel_from_chan(struct ast_channel *chan)
 {
 	struct ast_unreal_pvt *p;
+	struct ast_channel *chan;
 	struct ast_bridge_channel *bridge_channel = NULL;
 
 	if (!chan) {
@@ -428,10 +429,11 @@ struct ast_bridge_channel *rpt_get_bridge_channel_from_chan(struct ast_channel *
 	if (!p || !p->chan) {
 		return NULL;
 	}
-
-	ast_channel_lock(p->chan);
-	bridge_channel = ast_channel_get_bridge_channel(p->chan);
-	ast_channel_unlock(p->chan);
+	chan = ast_channel_ref(p->chan);
+	ast_channel_lock(chan);
+	bridge_channel = ast_channel_get_bridge_channel(chan);
+	ast_channel_unlock(chan);
+	ast_channel_unref(chan);
 
 	return bridge_channel;
 }

--- a/apps/app_rpt/rpt_bridging.c
+++ b/apps/app_rpt/rpt_bridging.c
@@ -415,10 +415,57 @@ int __rpt_conf_add(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_ty
 	return res;
 }
 
+struct ast_bridge_channel *rpt_get_bridge_channel_from_chan(struct ast_channel *chan)
+{
+	struct ast_bridge *bridge;
+	struct ast_bridge_channel *bridge_channel = NULL;
+	struct ast_bridge_channel *iter;
+
+	if (!chan) {
+		return NULL;
+	}
+
+	// 1. Fetch the bridge associated with the channel (increments ref count)
+	bridge = ast_channel_get_bridge(chan);
+	if (!bridge) {
+		return NULL; // Channel is not currently in a bridge
+	}
+
+	// 2. Lock the bridge to safely inspect its channel list
+	ast_bridge_lock(bridge);
+
+	AST_LIST_TRAVERSE(&bridge->channels, iter, entry) {
+		if (iter->chan == chan) {
+			bridge_channel = iter;
+			// Bump reference count so it doesn't vanish when we unlock the bridge
+			ao2_ref(bridge_channel, +1);
+			break;
+		}
+	}
+
+	ast_bridge_unlock(bridge);
+
+	// 3. Decrement the reference count of the bridge we fetched
+	ao2_ref(bridge, -1);
+
+	return bridge_channel; // Returns ao2 reference-tracked bridge_channel object
+}
+
 int rpt_conf_get_muted(struct ast_channel *chan, struct rpt *myrpt)
 {
-	/*! \todo: Do we need to check mute? What should it do?*/
-	return 0;
+	struct ast_bridge_channel *bc = rpt_get_bridge_channel_from_chan(chan);
+	char mute = 0;
+
+	if (bc) {
+		ast_bridge_channel_lock(bc);
+		if (bc->features && bc->features->mute) {
+			mute = 1;
+		}
+		ast_bridge_channel_unlock(bc);
+		ao2_ref(bc, -1);
+	}
+
+	return mute;
 }
 
 int rpt_play_tone(struct ast_channel *chan, const char *tone)

--- a/apps/app_rpt/rpt_bridging.c
+++ b/apps/app_rpt/rpt_bridging.c
@@ -418,7 +418,7 @@ int __rpt_conf_add(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_ty
 struct ast_bridge_channel *rpt_get_bridge_channel_from_chan(struct ast_channel *chan)
 {
 	struct ast_unreal_pvt *p;
-	struct ast_channel *chan;
+	struct ast_channel *pchan;
 	struct ast_bridge_channel *bridge_channel = NULL;
 
 	if (!chan) {
@@ -429,11 +429,11 @@ struct ast_bridge_channel *rpt_get_bridge_channel_from_chan(struct ast_channel *
 	if (!p || !p->chan) {
 		return NULL;
 	}
-	chan = ast_channel_ref(p->chan);
-	ast_channel_lock(chan);
-	bridge_channel = ast_channel_get_bridge_channel(chan);
-	ast_channel_unlock(chan);
-	ast_channel_unref(chan);
+	pchan = ast_channel_ref(p->chan); /* The :2 side of the local channel */
+	ast_channel_lock(pchan);
+	bridge_channel = ast_channel_get_bridge_channel(pchan);
+	ast_channel_unlock(pchan);
+	ast_channel_unref(pchan);
 
 	return bridge_channel;
 }

--- a/apps/app_rpt/rpt_bridging.c
+++ b/apps/app_rpt/rpt_bridging.c
@@ -417,38 +417,23 @@ int __rpt_conf_add(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_ty
 
 struct ast_bridge_channel *rpt_get_bridge_channel_from_chan(struct ast_channel *chan)
 {
-	struct ast_bridge *bridge;
+	struct ast_unreal_pvt *p;
 	struct ast_bridge_channel *bridge_channel = NULL;
-	struct ast_bridge_channel *iter;
 
 	if (!chan) {
 		return NULL;
 	}
 
-	// 1. Fetch the bridge associated with the channel (increments ref count)
-	bridge = ast_channel_get_bridge(chan);
-	if (!bridge) {
-		return NULL; // Channel is not currently in a bridge
+	p = ast_channel_tech_pvt(chan);
+	if (!p || !p->chan) {
+		return NULL;
 	}
 
-	// 2. Lock the bridge to safely inspect its channel list
-	ast_bridge_lock(bridge);
+	ast_channel_lock(p->chan);
+	bridge_channel = ast_channel_get_bridge_channel(p->chan);
+	ast_channel_unlock(p->chan);
 
-	AST_LIST_TRAVERSE(&bridge->channels, iter, entry) {
-		if (iter->chan == chan) {
-			bridge_channel = iter;
-			// Bump reference count so it doesn't vanish when we unlock the bridge
-			ao2_ref(bridge_channel, +1);
-			break;
-		}
-	}
-
-	ast_bridge_unlock(bridge);
-
-	// 3. Decrement the reference count of the bridge we fetched
-	ao2_ref(bridge, -1);
-
-	return bridge_channel; // Returns ao2 reference-tracked bridge_channel object
+	return bridge_channel;
 }
 
 int rpt_conf_get_muted(struct ast_channel *chan, struct rpt *myrpt)

--- a/apps/app_rpt/rpt_bridging.h
+++ b/apps/app_rpt/rpt_bridging.h
@@ -76,12 +76,6 @@ int __rpt_conf_create(struct rpt *myrpt, enum rpt_conf_type type, const char *fi
 int __rpt_conf_add(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_type type, const char *file, int line);
 
 /*!
- * \brief Get the bridge channel associated with the underlying Asterisk channel.
- * \note Returns a ref-counted bridge channel object that must be released with ao2_ref(..., -1).
- */
-struct ast_bridge_channel *rpt_get_bridge_channel_from_chan(struct ast_channel *chan);
-
-/*!
  * \brief Create a conference for repeater channels to join
  * \param myrpt Repeater structure
  * \param type Conference type

--- a/apps/app_rpt/rpt_bridging.h
+++ b/apps/app_rpt/rpt_bridging.h
@@ -76,6 +76,12 @@ int __rpt_conf_create(struct rpt *myrpt, enum rpt_conf_type type, const char *fi
 int __rpt_conf_add(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_type type, const char *file, int line);
 
 /*!
+ * \brief Get the bridge channel associated with the underlying Asterisk channel.
+ * \note Returns a ref-counted bridge channel object that must be released with ao2_ref(..., -1).
+ */
+struct ast_bridge_channel *rpt_get_bridge_channel_from_chan(struct ast_channel *chan);
+
+/*!
  * \brief Create a conference for repeater channels to join
  * \param myrpt Repeater structure
  * \param type Conference type
@@ -164,9 +170,3 @@ int dahdi_set_hook(struct ast_channel *chan, int offhook);
  * \retval 0 on success, -1 on failure
  */
 int dahdi_set_echocancel(struct ast_channel *chan, int ec);
-
-/*!
- * \brief get bridge channel from an asterisk channel
- * \param chan the asterisk channel.
- */
-struct ast_bridge_channel *rpt_get_bridge_channel_from_chan(struct ast_channel *chan);

--- a/apps/app_rpt/rpt_bridging.h
+++ b/apps/app_rpt/rpt_bridging.h
@@ -164,3 +164,9 @@ int dahdi_set_hook(struct ast_channel *chan, int offhook);
  * \retval 0 on success, -1 on failure
  */
 int dahdi_set_echocancel(struct ast_channel *chan, int ec);
+
+/*!
+ * \brief get bridge channel from an asterisk channel
+ * \param chan the asterisk channel.
+ */
+struct ast_bridge_channel *rpt_get_bridge_channel_from_chan(struct ast_channel *chan);


### PR DESCRIPTION
This allows AMI muting to work with the local channel as it did with DAHDI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Muted status is now reported accurately for bridged channels (previously it always reported unmuted).
  * Improved mute detection by correctly deriving and reading bridge-channel mute features when evaluating a channel’s mute state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->