### PR TITLE
app_rpt: honor hangup on main pchannel_read()

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4366,6 +4366,19 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 	return 0;
 }
 
+static inline int hangup_frame_helper(struct ast_channel *chan, const char *chantype, struct ast_frame *f)
+{
+	if (f->frametype == AST_FRAME_CONTROL) {
+		if (f->subclass.integer == AST_CONTROL_HANGUP) {
+			ast_debug(1, "%s (%s) received hangup frame\n", ast_channel_name(chan), chantype);
+			ast_frfree(f);
+			return -1;
+		}
+	}
+	ast_frfree(f);
+	return 0;
+}
+
 static inline int pchannel_read(struct rpt *myrpt)
 {
 	struct ast_frame *f = ast_read(myrpt->pchannel);
@@ -4382,26 +4395,7 @@ static inline int pchannel_read(struct rpt *myrpt)
 			ast_write(myrpt->txpchannel, f);
 		}
 	}
-	if (f->frametype == AST_FRAME_CONTROL) {
-		if (f->subclass.integer == AST_CONTROL_HANGUP) {
-			ast_debug(1, "@@@@ rpt:Hung Up\n");
-		}
-	}
-	ast_frfree(f);
-	return 0;
-}
-
-static inline int hangup_frame_helper(struct ast_channel *chan, const char *chantype, struct ast_frame *f)
-{
-	if (f->frametype == AST_FRAME_CONTROL) {
-		if (f->subclass.integer == AST_CONTROL_HANGUP) {
-			ast_debug(1, "%s (%s) received hangup frame\n", ast_channel_name(chan), chantype);
-			ast_frfree(f);
-			return -1;
-		}
-	}
-	ast_frfree(f);
-	return 0;
+	return hangup_frame_helper(myrpt->pchannel, "pchannel", f);
 }
 
 static inline int wait_for_hangup_helper(struct ast_channel *chan, const char *chantype)


### PR DESCRIPTION
## Summary
- Route main-node `pchannel_read()` through `hangup_frame_helper()` so `AST_CONTROL_HANGUP` exits the `rpt()` loop
- Move `hangup_frame_helper()` above `pchannel_read()` to avoid implicit declaration

## Problem
`exec_pchannel_read()` already handled hangup correctly; the main pseudo-channel path logged hangup but returned 0, leaving the repeater thread stuck.

## Test plan
- [ ] Build passes on amd64/arm64
- [ ] Repeater exits cleanly when main pchannel receives hangup control frame

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hangup handling so channel hangup events are correctly propagated and processing stops promptly.
  * Enhanced hangup logs with clearer channel identification and type details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->