### PR TITLE
app_rpt: drain link pchan during disconnect grace

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4592,6 +4592,20 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 		if (!ms) {
 			/* No channels had activity before the timer expired,
 			 * so just continue to the next loop. */
+			if (l->disctime && l->pchan) {
+				struct ast_frame *f;
+				int ms_drain = 0;
+				struct ast_channel *cs_drain[1] = { l->pchan };
+
+				if (ast_waitfor_n(cs_drain, 1, &ms_drain) == l->pchan) {
+					f = ast_read(l->pchan);
+					if (!f) {
+						ast_debug(1, "@@@@ rpt:Hung Up\n");
+						break;
+					}
+					ast_frfree(f);
+				}
+			}
 			continue;
 		}
 		if (l->disctime) {
@@ -4606,6 +4620,20 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 				}
 				ast_frfree(f);
 				continue;
+			}
+			if (l->pchan) {
+				struct ast_frame *f;
+				int ms_drain = 0;
+				struct ast_channel *cs_drain[1] = { l->pchan };
+
+				if (ast_waitfor_n(cs_drain, 1, &ms_drain) == l->pchan) {
+					f = ast_read(l->pchan);
+					if (!f) {
+						ast_debug(1, "@@@@ rpt:Hung Up\n");
+						break;
+					}
+					ast_frfree(f);
+				}
 			}
 			continue;
 		}


### PR DESCRIPTION
## Summary
- Non-blockingly drain `l->pchan` while `l->disctime` is active
- Covers timer expiry and activity on `l->chan`, not only when waitfor selects pchan

## Problem
During link disconnect grace, pchan frames could back up when the wait loop timed out or serviced the link channel instead of the pseudo-channel.

## Test plan
- [ ] Build passes
- [ ] Disconnecting link does not leave backed-up frames on pchan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of disconnected links by clearing pending channel frames before processing continues.
  * Prevented stale frames from interfering with subsequent channel activity after timer expirations or disconnect events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->