### PR TITLE
rpt_telemetry: unlock mutex on LOCALSTATUS allocation failure

### DIFF
--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -3778,6 +3778,7 @@ void rpt_telemetry(struct rpt *myrpt, enum rpt_tele_mode mode, void *data)
 
 			lbuf = ast_str_create(RPT_AST_STR_INIT_SIZE);
 			if (!lbuf) {
+				rpt_mutex_unlock(&myrpt->lock);
 				return;
 			}
 


### PR DESCRIPTION
## Summary
- Unlock `myrpt->lock` when `ast_str_create()` fails in STATUS/LOCALSTATUS path

## Problem
Status command 713 could deadlock the repeater on OOM because the mutex was held before allocation.

## Test plan
- [ ] Build passes