### PR TITLE
rpt_telemetry: free lbuf2 on FULLSTATUS strs allocation failure

### DIFF
--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -3848,6 +3848,7 @@ void rpt_telemetry(struct rpt *myrpt, enum rpt_tele_mode mode, void *data)
 			strs = ast_malloc(n * sizeof(char *));
 			if (!strs) {
 				ast_free(lbuf);
+				ast_free(lbuf2);
 				return;
 			}
 			ns = finddelim(ast_str_buffer(lbuf), strs, n);


### PR DESCRIPTION
## Summary
- Free `lbuf2` as well as `lbuf` when `ast_malloc()` for `strs` fails in FULLSTATUS/LOCALFULLSTATUS

## Problem
Status command 714 leaked `lbuf2` on allocation failure.

## Test plan
- [ ] Build passes