### PR TITLE
rpt_functions: fix function_macro digit validation loop

### DIFF
--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -1245,7 +1245,7 @@ enum rpt_function_response function_macro(struct rpt *myrpt, char *param, char *
 		return DC_INDETERMINATE;
 	}
 
-	for (i = 0; i < digitbuf[i]; i++) {
+	for (i = 0; digitbuf[i]; i++) {
 		if ((digitbuf[i] < '0') || (digitbuf[i] > '9')) {
 			return DC_ERROR;
 		}


### PR DESCRIPTION
## Summary
- Validate macro digits with `for (i = 0; digitbuf[i]; i++)` instead of using ASCII value of first digit as loop bound

## Problem
`function_macro()` used `digitbuf[i]` as both bound and index, causing wrong validation and out-of-bounds reads.

## Test plan
- [ ] Build passes
- [ ] Macro dial strings with multiple digits validate correctly