### PR TITLE
app_rpt: replace `pthread_exit()` with `return`

### DIFF
--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -3451,7 +3451,7 @@ treataslocal:
 	}
 #endif
 	myrpt->noduck = 0;
-	pthread_exit(NULL);
+	return NULL;
 abort:
 	telem_done(myrpt, mytele);
 abort2:
@@ -3471,7 +3471,7 @@ abort3:
 		ast_channel_unref(mychannel);
 	}
 
-	pthread_exit(NULL);
+	return NULL;
 }
 
 static const char *rpt_tele_mode_str(enum rpt_tele_mode mode)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined telemetry thread exit handling without changing observable behavior or control flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->