### PR TITLE
app_rpt: Handle pchan hangup correctly

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4897,10 +4897,7 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 			if (f->frametype == AST_FRAME_CONTROL && f->subclass.integer == AST_CONTROL_HANGUP) {
 				ast_debug(1, "@@@@ rpt:Hung Up\n");
 				ast_frfree(f);
-				if (remote_hangup_helper(myrpt, l)) {
-					/* A reconnect is never possible on pchan hangup */
-					break;
-				}
+				remote_hangup_helper(myrpt, l); /* A reconnect is never possible on pchan hangup */
 				break;
 			}
 			ast_frfree(f);

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4898,8 +4898,8 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 				ast_debug(1, "@@@@ rpt:Hung Up\n");
 				ast_frfree(f);
 				if (remote_hangup_helper(myrpt, l)) {
-					/* A reconnect is possible */
-					continue;
+					/* A reconnect is never possible on pchan hangup */
+					break;
 				}
 				break;
 			}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of remote hangups during channel communication.
  * Prevented unnecessary reconnection attempts when the communication channel is closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->