### PR TITLE
app_rpt: Standardize mixed continue / not continue in `else if` test

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -5841,12 +5841,10 @@ static void *rpt(void *this)
 			if (rxchannel_read(myrpt, lasttx)) {
 				break;
 			}
-			continue;
 		} else if (who == myrpt->pchannel) { /* if it was a read from pseudo */
 			if (pchannel_read(myrpt)) {
 				break;
 			}
-			continue;
 		} else if (who == myrpt->rxpchannel) {
 			if (rxpchannel_read(myrpt)) {
 				break;
@@ -5855,12 +5853,10 @@ static void *rpt(void *this)
 			if (txchannel_read(myrpt)) {
 				break;
 			}
-			continue;
 		} else if (who == myrpt->localtxchannel) { /* if it was a read from local-tx */
 			if (localtxchannel_read(myrpt, &myfirst)) {
 				break;
 			}
-			continue;
 		} else if (who == myrpt->txpchannel) { /* if it was a read from remote tx */
 			if (txpchannel_read(myrpt)) {
 				break;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event-loop control flow to ensure channel events are processed consistently.
  * Removed redundant flow interruptions that could prevent subsequent event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->