### PR TITLE
app_rpt: remove `scram`, reduce size of `cs` to match maximum possible

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -5272,7 +5272,7 @@ static void *rpt(void *this)
 	ast_autoservice_stop(myrpt->rxchannel);
 	while (ms >= 0) {
 		struct ast_channel *who;
-		struct ast_channel *cs[300], *cs1[300];
+		struct ast_channel *cs[8];
 		int totx = 0, elap = 0, n, x;
 		time_t t, t_mono;
 		struct rpt_link *l;
@@ -5775,12 +5775,7 @@ static void *rpt(void *this)
 			myrpt->topkeystate = 3;
 		}
 		ms = MSWAIT;
-		for (x = 0; x < n; x++) {
-			int s = -(-x - myrpt->scram - 1) % n;
-			cs1[x] = cs[s];
-		}
-		myrpt->scram++;
-		who = ast_waitfor_n(cs1, n, &ms);
+		who = ast_waitfor_n(cs, n, &ms);
 		if (who == NULL) {
 			ms = 0;
 		}

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -781,7 +781,6 @@ struct rpt {
 	char *txchanname;
 	rpt_bool remote:1;
 	char *remoterig;
-	unsigned int scram;
 #ifdef _MDC_DECODE_H_
 	mdc_decoder_t *mdc;
 #endif


### PR DESCRIPTION
In the previous design, it was possible in the single thread to exceed the capacity of the thread.  Now that each link channel runs in its own thread, we no longer need the rotation "magic" and can reduce the size of the cs[] buffer