### PR TITLE
res_usbradio: Add shared PortAudio API for USB radio drivers

### DIFF
--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -563,10 +563,6 @@ struct ast_radio_pa_stream {
 	char hw_device[100];
 };
 
-int ast_radio_pa_startup(void);
-void ast_radio_pa_shutdown(void);
-void ast_radio_pa_shutdown_all(void);
-
 int ast_radio_parse_hw_anywhere(const char *s, int *card, int *dev);
 int ast_radio_hw_match(const char *haystack, const char *needle);
 

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -552,14 +552,20 @@ struct usb_device *ast_radio_usb_device_from_alsa_card(int cardno);
 #define AST_RADIO_PA_SAMPLE_RATE 48000
 #define AST_RADIO_PA_FRAMES_PER_BUFFER (FRAME_SIZE * 6)
 #define AST_RADIO_PA_OUTPUT_CHANNELS 2
+#define AST_RADIO_PA_48K_MONO_SAMPLES (6 * FRAME_SIZE)
+#define AST_RADIO_PA_48K_STEREO_SAMPLES (12 * FRAME_SIZE)
 
 /*!
  * \brief PortAudio stream state shared by chan_simpleusb and chan_usbradio.
+ *
+ * After ast_radio_pa_open(), use ps->input_channels for RX buffer layout.
+ * ast_radio_pa_read() and ast_radio_pa_write() take frames per channel
+ * (typically AST_RADIO_PA_FRAMES_PER_BUFFER). TX is always stereo interleaved.
  */
 struct ast_radio_pa_stream {
 	PaStream *stream;
 	int active;
-	unsigned int input_channels; /*!< 1 for mono RX, 2 for stereo RX */
+	unsigned int input_channels; /*!< Actual RX channel count after ast_radio_pa_open() */
 	char hw_device[100];
 };
 
@@ -573,3 +579,14 @@ void ast_radio_pa_stop(struct ast_radio_pa_stream *ps);
 PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned long frames, int timeout_ms, volatile sig_atomic_t *stop);
 PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, unsigned long frames);
 long ast_radio_pa_write_available(struct ast_radio_pa_stream *ps);
+
+/*!
+ * \brief Check RX clipping/stats on a 48 kHz buffer from PortAudio.
+ * \param input_channels ps->input_channels after ast_radio_pa_open()
+ */
+int ast_radio_check_audio_pa_rx(short *sbuf, struct audiostatistics *o, unsigned int input_channels);
+
+/*!
+ * \brief Check clipping/stats on a normalized 48 kHz stereo interleaved buffer.
+ */
+int ast_radio_check_audio_stereo_48k(short *sbuf, struct audiostatistics *o);

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -569,8 +569,11 @@ struct ast_radio_pa_stream {
 	char hw_device[100];
 };
 
-int ast_radio_parse_hw_anywhere(const char *s, int *card, int *dev);
-int ast_radio_hw_match(const char *haystack, const char *needle);
+/*!
+ * \brief Parse "hw:<card>" or "hw:<card>,<dev>" from anywhere in s.
+ * \retval 1 if found; sets *card; sets *dev to parsed value or -1 if absent.
+ */
+int ast_radio_parse_alsa_hw_device(const char *s, int *card, int *dev);
 
 PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps);
 PaError ast_radio_pa_start(struct ast_radio_pa_stream *ps);
@@ -579,14 +582,3 @@ void ast_radio_pa_stop(struct ast_radio_pa_stream *ps);
 PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned long frames, int timeout_ms, volatile sig_atomic_t *stop);
 PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, unsigned long frames);
 long ast_radio_pa_write_available(struct ast_radio_pa_stream *ps);
-
-/*!
- * \brief Check RX clipping/stats on a 48 kHz buffer from PortAudio.
- * \param input_channels ps->input_channels after ast_radio_pa_open()
- */
-int ast_radio_check_audio_pa_rx(short *sbuf, struct audiostatistics *o, unsigned int input_channels);
-
-/*!
- * \brief Check clipping/stats on a normalized 48 kHz stereo interleaved buffer.
- */
-int ast_radio_check_audio_stereo_48k(short *sbuf, struct audiostatistics *o);

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -23,10 +23,12 @@
  * \brief USB sound card resources.
  */
 
-/*! \note <sys/io.h> is not portable to all architectures, so don't call non-portable functions if we don't have them */
+/*! \note <sys/io.h> is not portable to all architectures; guard parallel-port helpers with HAVE_SYS_IO */
 #if __has_include(<sys/io.h>)
 #define HAVE_SYS_IO
 #endif
+
+#include <portaudio.h>
 
 /*!
  * \brief Defines for interacting with ALSA controls.
@@ -245,6 +247,23 @@ int ast_radio_make_spkr_playback_value(int spkrmax, int request_value, int devty
  * \retval 				The maximum value.
  */
 int ast_radio_amixer_max(int devnum, char *param);
+
+/*!
+ * \brief Query required ALSA mixer maximums for a USB radio device.
+ *
+ * Reads mic capture, speaker playback (with alternate control name), and
+ * mic playback limits. Fails when any required limit is unavailable.
+ *
+ * \param devnum ALSA card number.
+ * \param micmax Returned Mic Capture Volume maximum.
+ * \param spkrmax Returned Speaker Playback Volume maximum.
+ * \param micplaymax Returned Mic Playback Volume maximum.
+ * \param newname Set to 1 when the alternate speaker control name is used.
+ *
+ * \retval 0 on success.
+ * \retval -1 if any required mixer limit is unavailable.
+ */
+int ast_radio_init_mixer_limits(int devnum, int *micmax, int *spkrmax, int *micplaymax, int *newname);
 
 /*!
  * \brief Set mixer
@@ -529,3 +548,32 @@ void ast_radio_print_audio_stats(int fd, struct audiostatistics *o, const char *
  * \param cardno The ALSA card number as found in HW:<cardno>
  */
 struct usb_device *ast_radio_usb_device_from_alsa_card(int cardno);
+
+#define AST_RADIO_PA_SAMPLE_RATE 48000
+#define AST_RADIO_PA_FRAMES_PER_BUFFER (FRAME_SIZE * 6)
+#define AST_RADIO_PA_OUTPUT_CHANNELS 2
+
+/*!
+ * \brief PortAudio stream state shared by chan_simpleusb and chan_usbradio.
+ */
+struct ast_radio_pa_stream {
+	PaStream *stream;
+	int active;
+	unsigned int input_channels; /*!< 1 for mono RX, 2 for stereo RX */
+	char hw_device[100];
+};
+
+int ast_radio_pa_startup(void);
+void ast_radio_pa_shutdown(void);
+void ast_radio_pa_shutdown_all(void);
+
+int ast_radio_parse_hw_anywhere(const char *s, int *card, int *dev);
+int ast_radio_hw_match(const char *haystack, const char *needle);
+
+PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps);
+PaError ast_radio_pa_start(struct ast_radio_pa_stream *ps);
+void ast_radio_pa_stop(struct ast_radio_pa_stream *ps);
+
+PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned long frames, int timeout_ms, volatile sig_atomic_t *stop);
+PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, unsigned long frames);
+long ast_radio_pa_write_available(struct ast_radio_pa_stream *ps);

--- a/res/Makefile.diff
+++ b/res/Makefile.diff
@@ -1,13 +1,11 @@
-diff --git a/res/Makefile b/res/Makefile
-index 0987f43a43..2f18773cba 100644
 --- a/res/Makefile
 +++ b/res/Makefile
-@@ -79,6 +79,8 @@ res_parking.o: _ASTCFLAGS+=$(AST_NO_FORMAT_TRUNCATION)
+@@ -78,6 +78,8 @@
+ res_parking.o: _ASTCFLAGS+=$(AST_NO_FORMAT_TRUNCATION)
  snmp/agent.o: _ASTCFLAGS+=-fPIC
  res_snmp.o: _ASTCFLAGS+=-fPIC
  
-+res_usbradio.so: LIBS+=-lusb -lasound
++res_usbradio.so: LIBS+=-lusb -lasound -lportaudio
 +
- # Dependencies for res_ari_*.so are generated, so they're in this file
- include ari.make
+ MODULE_EXCLUDE=ENABLE_SRTP_AES_192 ENABLE_SRTP_AES_256 ENABLE_SRTP_AES_GCM
  

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -1010,16 +1010,6 @@ static void pa_lib_release(void)
 	ast_mutex_unlock(&pa_lock);
 }
 
-static void pa_lib_release_all(void)
-{
-	ast_mutex_lock(&pa_lock);
-	if (pa_refcount > 0) {
-		Pa_Terminate();
-		pa_refcount = 0;
-	}
-	ast_mutex_unlock(&pa_lock);
-}
-
 #define AST_RADIO_HW_CARD_MAX 9999
 #define AST_RADIO_HW_DEV_MAX 255
 
@@ -1490,7 +1480,9 @@ static int load_module(void)
 static int unload_module(void)
 {
 	cleanup_user_devices();
-	pa_lib_release_all();
+	ast_mutex_lock(&pa_lock);
+	ast_assert(pa_refcount == 0);
+	ast_mutex_unlock(&pa_lock);
 
 	return 0;
 }

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -28,6 +28,7 @@
 
 /*** MODULEINFO
 	<depend>alsa</depend>
+	<depend>portaudio</depend>
 	<support_level>extended</support_level>
  ***/
 
@@ -48,6 +49,7 @@
 #include <linux/parport.h>
 #include <linux/version.h>
 #include <alsa/asoundlib.h>
+#include <portaudio.h>
 
 #include "asterisk/res_usbradio.h"
 
@@ -117,7 +119,47 @@ long ast_radio_lround(double x)
 
 int ast_radio_make_spkr_playback_value(int spkrmax, int request_value, int devtype)
 {
+	if (spkrmax <= 0) {
+		return 0;
+	}
 	return (request_value * spkrmax) / AUDIO_ADJUSTMENT;
+}
+
+int ast_radio_init_mixer_limits(int devnum, int *micmax, int *spkrmax, int *micplaymax, int *newname)
+{
+	int rv;
+
+	if (!micmax || !spkrmax || !micplaymax || !newname) {
+		return -1;
+	}
+
+	rv = ast_radio_amixer_max(devnum, MIXER_PARAM_MIC_CAPTURE_VOL);
+	if (rv <= 0) {
+		ast_log(LOG_ERROR, "Mixer limit not available for hw:%d (%s)\n", devnum, MIXER_PARAM_MIC_CAPTURE_VOL);
+		return -1;
+	}
+	*micmax = rv;
+
+	*newname = 0;
+	rv = ast_radio_amixer_max(devnum, MIXER_PARAM_SPKR_PLAYBACK_VOL);
+	if (rv <= 0) {
+		rv = ast_radio_amixer_max(devnum, MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW);
+		if (rv <= 0) {
+			ast_log(LOG_ERROR, "Mixer limit not available for hw:%d (speaker playback)\n", devnum);
+			return -1;
+		}
+		*newname = 1;
+	}
+	*spkrmax = rv;
+
+	rv = ast_radio_amixer_max(devnum, MIXER_PARAM_MIC_PLAYBACK_VOL);
+	if (rv <= 0) {
+		ast_log(LOG_ERROR, "Mixer limit not available for hw:%d (%s)\n", devnum, MIXER_PARAM_MIC_PLAYBACK_VOL);
+		return -1;
+	}
+	*micplaymax = rv;
+
+	return 0;
 }
 
 int ast_radio_amixer_max(int devnum, char *param)
@@ -151,7 +193,10 @@ int ast_radio_amixer_max(int devnum, char *param)
 	}
 
 	snd_ctl_elem_info_alloca(&info);
-	snd_hctl_elem_info(elem, info);
+	if (snd_hctl_elem_info(elem, info) < 0) {
+		snd_hctl_close(hctl);
+		return -1;
+	}
 	type = snd_ctl_elem_info_get_type(info);
 	rv = 0;
 
@@ -199,7 +244,10 @@ int ast_radio_setamixer(int devnum, char *param, int v1, int v2)
 	}
 
 	snd_ctl_elem_info_alloca(&info);
-	snd_hctl_elem_info(elem, info);
+	if (snd_hctl_elem_info(elem, info) < 0) {
+		snd_hctl_close(hctl);
+		return -1;
+	}
 	type = snd_ctl_elem_info_get_type(info);
 	snd_ctl_elem_value_alloca(&control);
 	snd_ctl_elem_value_set_id(control, id);
@@ -425,6 +473,8 @@ int ast_radio_hid_device_mklist(void)
 	struct usb_bus *usb_bus;
 	struct usb_device *dev;
 	char devstr[10000], str[200], desdev[200], *cp;
+	ssize_t linklen;
+	size_t cplen;
 	int i;
 
 	ast_mutex_lock(&usb_list_lock);
@@ -464,11 +514,11 @@ int ast_radio_hid_device_mklist(void)
 
 				snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
 				memset(desdev, 0, sizeof(desdev));
-
-				if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
+				linklen = readlink(str, desdev, sizeof(desdev) - 1);
+				if (linklen == -1) {
 					continue;
 				}
-
+				desdev[linklen] = '\0';
 				cp = strrchr(desdev, '/');
 				if (!cp) {
 					continue;
@@ -481,23 +531,23 @@ int ast_radio_hid_device_mklist(void)
 				continue;
 			}
 
-			new_list = ast_realloc(usb_device_list, usb_device_list_size + 2 + strlen(cp));
-
+			cplen = strlen(cp);
+			new_list = ast_realloc(usb_device_list, usb_device_list_size + 2 + cplen);
 			if (!new_list) {
 				ast_mutex_unlock(&usb_list_lock);
 				return -1;
 			}
 
 			usb_device_list = new_list;
-			usb_device_list_size += strlen(cp) + 2;
+			usb_device_list_size += cplen + 2;
 			i = 0;
 
 			while (usb_device_list[i]) {
 				i += strlen(usb_device_list + i) + 1;
 			}
 
-			strcat(usb_device_list + i, cp);
-			usb_device_list[strlen(cp) + i + 1] = 0;
+			memcpy(usb_device_list + i, cp, cplen + 1);
+			usb_device_list[i + cplen + 1] = 0;
 		}
 	}
 	ast_mutex_unlock(&usb_list_lock);
@@ -509,6 +559,7 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 	struct usb_bus *usb_bus;
 	struct usb_device *dev;
 	char devstr[10000], str[200], desdev[200], *cp;
+	ssize_t linklen;
 	int i;
 
 	usb_init();
@@ -530,11 +581,14 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 				if (strcasecmp(desdev, devstr)) {
 					continue;
 				}
+
 				snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
 				memset(desdev, 0, sizeof(desdev));
-				if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
+				linklen = readlink(str, desdev, sizeof(desdev) - 1);
+				if (linklen == -1) {
 					continue;
 				}
+				desdev[linklen] = '\0';
 				cp = strrchr(desdev, '/');
 				if (!cp) {
 					continue;
@@ -542,11 +596,9 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 				cp++;
 				break;
 			}
-
 			if (i >= 32) {
 				continue;
 			}
-
 			if (!strcmp(cp, desired_device)) {
 				return dev;
 			}
@@ -926,6 +978,388 @@ static void cleanup_user_devices(void)
 }
 
 /*
+ * PortAudio helpers shared by chan_simpleusb and chan_usbradio.
+ */
+AST_MUTEX_DEFINE_STATIC(pa_lock);
+static int pa_refcount;
+
+static int64_t pa_now_ms(void)
+{
+	struct timespec ts;
+
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (int64_t) ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
+int ast_radio_pa_startup(void)
+{
+	PaError res;
+
+	ast_mutex_lock(&pa_lock);
+	if (pa_refcount == 0) {
+		res = Pa_Initialize();
+		if (res != paNoError) {
+			ast_mutex_unlock(&pa_lock);
+			ast_log(LOG_WARNING, "Failed to initialize PortAudio - (%d) %s\n", res, Pa_GetErrorText(res));
+			return -1;
+		}
+	}
+	pa_refcount++;
+	ast_mutex_unlock(&pa_lock);
+	return 0;
+}
+
+void ast_radio_pa_shutdown(void)
+{
+	ast_mutex_lock(&pa_lock);
+	if (pa_refcount > 0) {
+		pa_refcount--;
+		if (pa_refcount == 0) {
+			Pa_Terminate();
+		}
+	}
+	ast_mutex_unlock(&pa_lock);
+}
+
+void ast_radio_pa_shutdown_all(void)
+{
+	ast_mutex_lock(&pa_lock);
+	if (pa_refcount > 0) {
+		Pa_Terminate();
+		pa_refcount = 0;
+	}
+	ast_mutex_unlock(&pa_lock);
+}
+
+int ast_radio_parse_hw_anywhere(const char *s, int *card, int *dev)
+{
+	const char *p = s;
+
+	if (!s || !card || !dev) {
+		return 0;
+	}
+
+	while ((p = strstr(p, "hw:")) != NULL) {
+		const char *q = p + 3;
+		int c = 0;
+		int d = -1;
+
+		if (!isdigit((unsigned char) *q)) {
+			p = q;
+			continue;
+		}
+
+		while (isdigit((unsigned char) *q)) {
+			if (c > 9999) {
+				p = q;
+				break;
+			}
+			c = c * 10 + (*q - '0');
+			q++;
+		}
+
+		if (*q == ',') {
+			q++;
+			if (!isdigit((unsigned char) *q)) {
+				p = q;
+				continue;
+			}
+			d = 0;
+			while (isdigit((unsigned char) *q)) {
+				d = d * 10 + (*q - '0');
+				q++;
+			}
+		}
+
+		*card = c;
+		*dev = d;
+		return 1;
+	}
+
+	return 0;
+}
+
+int ast_radio_hw_match(const char *haystack, const char *needle)
+{
+	int haystack_c, haystack_d, needle_c, needle_d;
+	const char *p = haystack ? haystack : "";
+
+	if (!ast_radio_parse_hw_anywhere(needle, &needle_c, &needle_d)) {
+		return 0;
+	}
+
+	while ((p = strstr(p, "hw:")) != NULL) {
+		if (ast_radio_parse_hw_anywhere(p, &haystack_c, &haystack_d)) {
+			if (haystack_c == needle_c) {
+				if (needle_d < 0 || haystack_d == needle_d) {
+					return 1;
+				}
+			}
+		}
+		p += 3;
+	}
+
+	return 0;
+}
+
+static int match_card_id(const char *devname, int card)
+{
+	char path[128], id[64];
+	FILE *fp;
+	size_t n;
+
+	snprintf(path, sizeof(path), "/proc/asound/card%d/id", card);
+	fp = fopen(path, "r");
+	if (!fp) {
+		return 0;
+	}
+
+	if (!fgets(id, sizeof(id), fp) || !id[0]) {
+		fclose(fp);
+		return 0;
+	}
+	fclose(fp);
+
+	n = strlen(id);
+	while (n > 0 && isspace((unsigned char) id[n - 1])) {
+		id[--n] = '\0';
+	}
+
+	return n > 0 && strstr(devname, id) != NULL;
+}
+
+static int pa_device_matches(const PaDeviceInfo *dev, const char *hw_device, int want_input, int want_output)
+{
+	int card, devnum;
+	int hay_card, hay_dev;
+
+	if (!dev || !hw_device || !hw_device[0]) {
+		return 0;
+	}
+
+	if (want_input && !dev->maxInputChannels) {
+		return 0;
+	}
+
+	if (want_output && !dev->maxOutputChannels) {
+		return 0;
+	}
+
+	if (ast_radio_hw_match(dev->name, hw_device)) {
+		return 1;
+	}
+
+	if (!ast_radio_parse_hw_anywhere(hw_device, &card, &devnum) || !match_card_id(dev->name, card)) {
+		return 0;
+	}
+
+	/* Card-id fallback is only unambiguous for hw:C; hw:C,D must match subdevice too. */
+	if (devnum < 0) {
+		return 1;
+	}
+
+	if (!ast_radio_parse_hw_anywhere(dev->name, &hay_card, &hay_dev)) {
+		return 0;
+	}
+
+	return hay_card == card && hay_dev == devnum;
+}
+
+static PaDeviceIndex pa_find_device(const char *hw_device, int want_input, int want_output)
+{
+	PaDeviceIndex idx, num_devices;
+
+	num_devices = Pa_GetDeviceCount();
+	if (num_devices < 0) {
+		return paNoDevice;
+	}
+
+	for (idx = 0; idx < num_devices; idx++) {
+		const PaDeviceInfo *dev = Pa_GetDeviceInfo(idx);
+
+		if (pa_device_matches(dev, hw_device, want_input, want_output)) {
+			return idx;
+		}
+	}
+
+	return paNoDevice;
+}
+
+PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
+{
+	PaError res = paInternalError;
+	const PaStreamInfo *si;
+
+	if (!ps) {
+		return paBadStreamPtr;
+	}
+
+	ps->stream = NULL;
+	ps->active = 0;
+
+	if (ast_radio_pa_startup() < 0) {
+		return paInternalError;
+	}
+
+	if (!strcasecmp(ps->hw_device, "default")) {
+		res = Pa_OpenDefaultStream(&ps->stream, ps->input_channels, AST_RADIO_PA_OUTPUT_CHANNELS, paInt16,
+			AST_RADIO_PA_SAMPLE_RATE, AST_RADIO_PA_FRAMES_PER_BUFFER, NULL, NULL);
+	} else {
+		PaStreamParameters input_params = {
+			.channelCount = ps->input_channels,
+			.sampleFormat = paInt16,
+			.suggestedLatency = (1.0 / 50.0),
+			.device = paNoDevice,
+		};
+		PaStreamParameters output_params = {
+			.channelCount = AST_RADIO_PA_OUTPUT_CHANNELS,
+			.sampleFormat = paInt16,
+			.suggestedLatency = (1.0 / 50.0),
+			.device = paNoDevice,
+		};
+
+		input_params.device = pa_find_device(ps->hw_device, 1, 0);
+		output_params.device = pa_find_device(ps->hw_device, 0, 1);
+
+		if (input_params.device == paNoDevice) {
+			ast_log(LOG_ERROR, "No PortAudio input device found for '%s'\n", ps->hw_device);
+			ast_radio_pa_shutdown();
+			return paDeviceUnavailable;
+		}
+
+		if (output_params.device == paNoDevice) {
+			ast_log(LOG_ERROR, "No PortAudio output device found for '%s'\n", ps->hw_device);
+			ast_radio_pa_shutdown();
+			return paDeviceUnavailable;
+		}
+
+		res = Pa_OpenStream(&ps->stream, &input_params, &output_params, AST_RADIO_PA_SAMPLE_RATE, AST_RADIO_PA_FRAMES_PER_BUFFER,
+			paNoFlag, NULL, NULL);
+	}
+
+	if (res != paNoError) {
+		if (ps->stream) {
+			Pa_CloseStream(ps->stream);
+			ps->stream = NULL;
+		}
+		ast_radio_pa_shutdown();
+		return res;
+	}
+
+	si = Pa_GetStreamInfo(ps->stream);
+	if (si) {
+		ast_debug(5, "PortAudio stream latency in %.3f ms out %.3f ms\n", si->inputLatency * 1000.0, si->outputLatency * 1000.0);
+	}
+
+	return res;
+}
+
+PaError ast_radio_pa_start(struct ast_radio_pa_stream *ps)
+{
+	PaError res;
+
+	if (!ps || !ps->stream) {
+		return paBadStreamPtr;
+	}
+
+	res = Pa_StartStream(ps->stream);
+	if (res == paNoError) {
+		ps->active = 1;
+	}
+	return res;
+}
+
+void ast_radio_pa_stop(struct ast_radio_pa_stream *ps)
+{
+	PaError err;
+
+	if (!ps || !ps->stream) {
+		return;
+	}
+
+	if (ps->active) {
+		err = Pa_AbortStream(ps->stream);
+		if (err != paNoError) {
+			ast_log(LOG_WARNING, "Pa_AbortStream failed: %s\n", Pa_GetErrorText(err));
+		}
+	}
+
+	err = Pa_CloseStream(ps->stream);
+	if (err != paNoError) {
+		ast_log(LOG_WARNING, "Pa_CloseStream failed: %s\n", Pa_GetErrorText(err));
+	}
+
+	ps->stream = NULL;
+	ps->active = 0;
+	ast_radio_pa_shutdown();
+}
+
+PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned long frames, int timeout_ms, volatile sig_atomic_t *stop)
+{
+	int64_t start;
+	PaError err;
+
+	if (!ps || !ps->stream || !buf) {
+		return paBadStreamPtr;
+	}
+
+	start = pa_now_ms();
+	while (!stop || !(*stop)) {
+		long avail = Pa_GetStreamReadAvailable(ps->stream);
+
+		if (avail < 0) {
+			return (PaError) avail;
+		}
+
+		if ((pa_now_ms() - start) > timeout_ms) {
+			return paTimedOut;
+		}
+
+		if ((unsigned long) avail < frames) {
+			usleep(500);
+			continue;
+		}
+
+		err = Pa_ReadStream(ps->stream, buf, frames);
+		return err;
+	}
+
+	return paTimedOut;
+}
+
+PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, unsigned long frames)
+{
+	PaError res;
+	short null_buf[AST_RADIO_PA_FRAMES_PER_BUFFER * AST_RADIO_PA_OUTPUT_CHANNELS];
+
+	if (!ps || !ps->stream || !data) {
+		return paBadStreamPtr;
+	}
+
+	if (frames > AST_RADIO_PA_FRAMES_PER_BUFFER) {
+		ast_log(LOG_WARNING, "ast_radio_pa_write: frames %lu exceeds buffer capacity\n", frames);
+		return paBufferTooBig;
+	}
+
+	res = Pa_WriteStream(ps->stream, data, frames);
+	if (res == paOutputUnderflowed) {
+		memset(null_buf, 0, sizeof(null_buf));
+		Pa_WriteStream(ps->stream, null_buf, frames);
+	}
+
+	return res;
+}
+
+long ast_radio_pa_write_available(struct ast_radio_pa_stream *ps)
+{
+	if (!ps || !ps->stream) {
+		return -1;
+	}
+
+	return Pa_GetStreamWriteAvailable(ps->stream);
+}
+
+/*
  * Returns the libusb device that backs ALSA /proc/asound/card<cardno>/usbbus.
  * On success: returns a pointer to a libusb struct usb_device.
  * On failure: returns NULL.
@@ -1047,6 +1481,7 @@ static int load_module(void)
 static int unload_module(void)
 {
 	cleanup_user_devices();
+	ast_radio_pa_shutdown_all();
 
 	return 0;
 }

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -119,19 +119,13 @@ long ast_radio_lround(double x)
 
 int ast_radio_make_spkr_playback_value(int spkrmax, int request_value, int devtype)
 {
-	if (spkrmax <= 0) {
-		return 0;
-	}
+	/* spkrmax is validated by ast_radio_init_mixer_limits() before use. */
 	return (request_value * spkrmax) / AUDIO_ADJUSTMENT;
 }
 
 int ast_radio_init_mixer_limits(int devnum, int *micmax, int *spkrmax, int *micplaymax, int *newname)
 {
 	int rv;
-
-	if (!micmax || !spkrmax || !micplaymax || !newname) {
-		return -1;
-	}
 
 	rv = ast_radio_amixer_max(devnum, MIXER_PARAM_MIC_CAPTURE_VOL);
 	if (rv <= 0) {
@@ -510,7 +504,6 @@ int ast_radio_hid_device_mklist(void)
 				}
 
 				snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
-				memset(desdev, 0, sizeof(desdev));
 				linklen = readlink(str, desdev, sizeof(desdev) - 1);
 				if (linklen == -1) {
 					continue;
@@ -580,7 +573,6 @@ struct usb_device *ast_radio_hid_device_init(const char *desired_device)
 				}
 
 				snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
-				memset(desdev, 0, sizeof(desdev));
 				linklen = readlink(str, desdev, sizeof(desdev) - 1);
 				if (linklen == -1) {
 					continue;
@@ -988,7 +980,7 @@ static int64_t pa_now_ms(void)
 	return (int64_t) ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
 }
 
-int ast_radio_pa_startup(void)
+static int pa_lib_acquire(void)
 {
 	PaError res;
 
@@ -1006,7 +998,7 @@ int ast_radio_pa_startup(void)
 	return 0;
 }
 
-void ast_radio_pa_shutdown(void)
+static void pa_lib_release(void)
 {
 	ast_mutex_lock(&pa_lock);
 	if (pa_refcount > 0) {
@@ -1018,7 +1010,7 @@ void ast_radio_pa_shutdown(void)
 	ast_mutex_unlock(&pa_lock);
 }
 
-void ast_radio_pa_shutdown_all(void)
+static void pa_lib_release_all(void)
 {
 	ast_mutex_lock(&pa_lock);
 	if (pa_refcount > 0) {
@@ -1223,7 +1215,7 @@ PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
 	ps->stream = NULL;
 	ps->active = 0;
 
-	if (ast_radio_pa_startup() < 0) {
+	if (pa_lib_acquire() < 0) {
 		return paInternalError;
 	}
 
@@ -1249,13 +1241,13 @@ PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
 
 		if (input_params.device == paNoDevice) {
 			ast_log(LOG_ERROR, "No PortAudio input device found for '%s'\n", ps->hw_device);
-			ast_radio_pa_shutdown();
+			pa_lib_release();
 			return paDeviceUnavailable;
 		}
 
 		if (output_params.device == paNoDevice) {
 			ast_log(LOG_ERROR, "No PortAudio output device found for '%s'\n", ps->hw_device);
-			ast_radio_pa_shutdown();
+			pa_lib_release();
 			return paDeviceUnavailable;
 		}
 
@@ -1268,7 +1260,7 @@ PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
 			Pa_CloseStream(ps->stream);
 			ps->stream = NULL;
 		}
-		ast_radio_pa_shutdown();
+		pa_lib_release();
 		return res;
 	}
 
@@ -1317,7 +1309,7 @@ void ast_radio_pa_stop(struct ast_radio_pa_stream *ps)
 
 	ps->stream = NULL;
 	ps->active = 0;
-	ast_radio_pa_shutdown();
+	pa_lib_release();
 }
 
 PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned long frames, int timeout_ms, volatile sig_atomic_t *stop)
@@ -1498,7 +1490,7 @@ static int load_module(void)
 static int unload_module(void)
 {
 	cleanup_user_devices();
-	ast_radio_pa_shutdown_all();
+	pa_lib_release_all();
 
 	return 0;
 }

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -910,20 +910,6 @@ int ast_radio_check_audio(short *sbuf, struct audiostatistics *o, short len, sho
 	return (seq_clips >= CLIP_EVENT_MIN_SAMPLES);
 }
 
-int ast_radio_check_audio_pa_rx(short *sbuf, struct audiostatistics *o, unsigned int input_channels)
-{
-	if (input_channels == 1) {
-		return ast_radio_check_audio(sbuf, o, AST_RADIO_PA_48K_MONO_SAMPLES, 1);
-	}
-
-	return ast_radio_check_audio(sbuf, o, AST_RADIO_PA_48K_STEREO_SAMPLES, 0);
-}
-
-int ast_radio_check_audio_stereo_48k(short *sbuf, struct audiostatistics *o)
-{
-	return ast_radio_check_audio(sbuf, o, AST_RADIO_PA_48K_STEREO_SAMPLES, 0);
-}
-
 void ast_radio_print_audio_stats(int fd, struct audiostatistics *o, const char *prefix_text)
 {
 	unsigned int i, pk = 0, pwr = 0, minpwr = 0x40000000, maxpwr = 0, clipcnt = 0;
@@ -1062,7 +1048,11 @@ static int hw_token_boundary_ok(char c)
 	return strchr("):],;.-", c) != NULL;
 }
 
-int ast_radio_parse_hw_anywhere(const char *s, int *card, int *dev)
+/*!
+ * \brief Parse "hw:<card>" or "hw:<card>,<dev>" from anywhere in s.
+ * \retval 1 if found; sets *card; sets *dev to parsed value or -1 if absent.
+ */
+int ast_radio_parse_alsa_hw_device(const char *s, int *card, int *dev)
 {
 	const char *p = s;
 
@@ -1101,17 +1091,17 @@ int ast_radio_parse_hw_anywhere(const char *s, int *card, int *dev)
 	return 0;
 }
 
-int ast_radio_hw_match(const char *haystack, const char *needle)
+static int pa_hw_match(const char *haystack, const char *needle)
 {
 	int haystack_c, haystack_d, needle_c, needle_d;
 	const char *p = haystack ? haystack : "";
 
-	if (!ast_radio_parse_hw_anywhere(needle, &needle_c, &needle_d)) {
+	if (!ast_radio_parse_alsa_hw_device(needle, &needle_c, &needle_d)) {
 		return 0;
 	}
 
 	while ((p = strstr(p, "hw:")) != NULL) {
-		if (ast_radio_parse_hw_anywhere(p, &haystack_c, &haystack_d)) {
+		if (ast_radio_parse_alsa_hw_device(p, &haystack_c, &haystack_d)) {
 			if (haystack_c == needle_c) {
 				if (needle_d < 0 || haystack_d == needle_d) {
 					return 1;
@@ -1167,11 +1157,11 @@ static int pa_device_matches(const PaDeviceInfo *dev, const char *hw_device, int
 		return 0;
 	}
 
-	if (ast_radio_hw_match(dev->name, hw_device)) {
+	if (pa_hw_match(dev->name, hw_device)) {
 		return 1;
 	}
 
-	if (!ast_radio_parse_hw_anywhere(hw_device, &card, &devnum) || !match_card_id(dev->name, card)) {
+	if (!ast_radio_parse_alsa_hw_device(hw_device, &card, &devnum) || !match_card_id(dev->name, card)) {
 		return 0;
 	}
 
@@ -1180,7 +1170,7 @@ static int pa_device_matches(const PaDeviceInfo *dev, const char *hw_device, int
 		return 1;
 	}
 
-	if (!ast_radio_parse_hw_anywhere(dev->name, &hay_card, &hay_dev)) {
+	if (!ast_radio_parse_alsa_hw_device(dev->name, &hay_card, &hay_dev)) {
 		return 0;
 	}
 

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -910,6 +910,20 @@ int ast_radio_check_audio(short *sbuf, struct audiostatistics *o, short len, sho
 	return (seq_clips >= CLIP_EVENT_MIN_SAMPLES);
 }
 
+int ast_radio_check_audio_pa_rx(short *sbuf, struct audiostatistics *o, unsigned int input_channels)
+{
+	if (input_channels == 1) {
+		return ast_radio_check_audio(sbuf, o, AST_RADIO_PA_48K_MONO_SAMPLES, 1);
+	}
+
+	return ast_radio_check_audio(sbuf, o, AST_RADIO_PA_48K_STEREO_SAMPLES, 0);
+}
+
+int ast_radio_check_audio_stereo_48k(short *sbuf, struct audiostatistics *o)
+{
+	return ast_radio_check_audio(sbuf, o, AST_RADIO_PA_48K_STEREO_SAMPLES, 0);
+}
+
 void ast_radio_print_audio_stats(int fd, struct audiostatistics *o, const char *prefix_text)
 {
 	unsigned int i, pk = 0, pwr = 0, minpwr = 0x40000000, maxpwr = 0, clipcnt = 0;
@@ -1193,6 +1207,20 @@ static PaDeviceIndex pa_find_device(const char *hw_device, int want_input, int w
 	return paNoDevice;
 }
 
+static void pa_clamp_input_channels(PaDeviceIndex device, unsigned int *input_channels)
+{
+	const PaDeviceInfo *in_dev;
+
+	if (!input_channels || device == paNoDevice) {
+		return;
+	}
+
+	in_dev = Pa_GetDeviceInfo(device);
+	if (in_dev && *input_channels > (unsigned int) in_dev->maxInputChannels) {
+		*input_channels = in_dev->maxInputChannels ? (unsigned int) in_dev->maxInputChannels : 1;
+	}
+}
+
 PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
 {
 	PaError res = paInternalError;
@@ -1210,6 +1238,7 @@ PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
 	}
 
 	if (!strcasecmp(ps->hw_device, "default")) {
+		pa_clamp_input_channels(Pa_GetDefaultInputDevice(), &ps->input_channels);
 		res = Pa_OpenDefaultStream(&ps->stream, ps->input_channels, AST_RADIO_PA_OUTPUT_CHANNELS, paInt16,
 			AST_RADIO_PA_SAMPLE_RATE, AST_RADIO_PA_FRAMES_PER_BUFFER, NULL, NULL);
 	} else {
@@ -1241,14 +1270,8 @@ PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
 			return paDeviceUnavailable;
 		}
 
-		{
-			const PaDeviceInfo *in_dev = Pa_GetDeviceInfo(input_params.device);
-
-			if (in_dev && ps->input_channels > (unsigned int) in_dev->maxInputChannels) {
-				ps->input_channels = in_dev->maxInputChannels ? (unsigned int) in_dev->maxInputChannels : 1;
-				input_params.channelCount = ps->input_channels;
-			}
-		}
+		pa_clamp_input_channels(input_params.device, &ps->input_channels);
+		input_params.channelCount = ps->input_channels;
 
 		res = Pa_OpenStream(&ps->stream, &input_params, &output_params, AST_RADIO_PA_SAMPLE_RATE, AST_RADIO_PA_FRAMES_PER_BUFFER,
 			paNoFlag, NULL, NULL);
@@ -1267,6 +1290,8 @@ PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
 	if (si) {
 		ast_debug(5, "PortAudio stream latency in %.3f ms out %.3f ms\n", si->inputLatency * 1000.0, si->outputLatency * 1000.0);
 	}
+
+	ast_debug(3, "PortAudio opened '%s' with %u input and %u output channel(s)\n", ps->hw_device, ps->input_channels, AST_RADIO_PA_OUTPUT_CHANNELS);
 
 	return res;
 }

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -1053,6 +1053,19 @@ static int parse_hw_field(const char **q, int max_value, int *out)
 	return 1;
 }
 
+static int hw_token_boundary_ok(char c)
+{
+	if (c == '\0') {
+		return 1;
+	}
+	if (isspace((unsigned char) c)) {
+		return 1;
+	}
+
+	/* Trailing punctuation in PA/ALSA device name strings, not part of hw:C,D. */
+	return strchr("):],;.-", c) != NULL;
+}
+
 int ast_radio_parse_hw_anywhere(const char *s, int *card, int *dev)
 {
 	const char *p = s;
@@ -1077,6 +1090,11 @@ int ast_radio_parse_hw_anywhere(const char *s, int *card, int *dev)
 				p = q;
 				continue;
 			}
+		}
+
+		if (!hw_token_boundary_ok(*q)) {
+			p = q;
+			continue;
 		}
 
 		*card = c;

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -135,7 +135,6 @@ int ast_radio_init_mixer_limits(int devnum, int *micmax, int *spkrmax, int *micp
 
 	rv = ast_radio_amixer_max(devnum, MIXER_PARAM_MIC_CAPTURE_VOL);
 	if (rv <= 0) {
-		ast_log(LOG_ERROR, "Mixer limit not available for hw:%d (%s)\n", devnum, MIXER_PARAM_MIC_CAPTURE_VOL);
 		return -1;
 	}
 	*micmax = rv;
@@ -145,7 +144,6 @@ int ast_radio_init_mixer_limits(int devnum, int *micmax, int *spkrmax, int *micp
 	if (rv <= 0) {
 		rv = ast_radio_amixer_max(devnum, MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW);
 		if (rv <= 0) {
-			ast_log(LOG_ERROR, "Mixer limit not available for hw:%d (speaker playback)\n", devnum);
 			return -1;
 		}
 		*newname = 1;
@@ -154,7 +152,6 @@ int ast_radio_init_mixer_limits(int devnum, int *micmax, int *spkrmax, int *micp
 
 	rv = ast_radio_amixer_max(devnum, MIXER_PARAM_MIC_PLAYBACK_VOL);
 	if (rv <= 0) {
-		ast_log(LOG_ERROR, "Mixer limit not available for hw:%d (%s)\n", devnum, MIXER_PARAM_MIC_PLAYBACK_VOL);
 		return -1;
 	}
 	*micplaymax = rv;
@@ -1031,6 +1028,31 @@ void ast_radio_pa_shutdown_all(void)
 	ast_mutex_unlock(&pa_lock);
 }
 
+#define AST_RADIO_HW_CARD_MAX 9999
+#define AST_RADIO_HW_DEV_MAX 255
+
+static int parse_hw_field(const char **q, int max_value, int *out)
+{
+	int value = 0;
+
+	if (!q || !*q || !out || !isdigit((unsigned char) **q)) {
+		return 0;
+	}
+
+	while (isdigit((unsigned char) **q)) {
+		int digit = **q - '0';
+
+		if (value > max_value / 10 || value * 10 + digit > max_value) {
+			return 0;
+		}
+		value = value * 10 + digit;
+		(*q)++;
+	}
+
+	*out = value;
+	return 1;
+}
+
 int ast_radio_parse_hw_anywhere(const char *s, int *card, int *dev)
 {
 	const char *p = s;
@@ -1041,33 +1063,19 @@ int ast_radio_parse_hw_anywhere(const char *s, int *card, int *dev)
 
 	while ((p = strstr(p, "hw:")) != NULL) {
 		const char *q = p + 3;
-		int c = 0;
+		int c;
 		int d = -1;
 
-		if (!isdigit((unsigned char) *q)) {
+		if (!parse_hw_field(&q, AST_RADIO_HW_CARD_MAX, &c)) {
 			p = q;
 			continue;
 		}
 
-		while (isdigit((unsigned char) *q)) {
-			if (c > 9999) {
-				p = q;
-				break;
-			}
-			c = c * 10 + (*q - '0');
-			q++;
-		}
-
 		if (*q == ',') {
 			q++;
-			if (!isdigit((unsigned char) *q)) {
+			if (!parse_hw_field(&q, AST_RADIO_HW_DEV_MAX, &d)) {
 				p = q;
 				continue;
-			}
-			d = 0;
-			while (isdigit((unsigned char) *q)) {
-				d = d * 10 + (*q - '0');
-				q++;
 			}
 		}
 
@@ -1343,8 +1351,14 @@ PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, un
 
 	res = Pa_WriteStream(ps->stream, data, frames);
 	if (res == paOutputUnderflowed) {
+		PaError retry;
+
 		memset(null_buf, 0, sizeof(null_buf));
-		Pa_WriteStream(ps->stream, null_buf, frames);
+		retry = Pa_WriteStream(ps->stream, null_buf, frames);
+		if (retry < 0 && retry != paOutputUnderflowed) {
+			return retry;
+		}
+		return paNoError;
 	}
 
 	return res;

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -1355,9 +1355,6 @@ PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned l
 
 PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, unsigned long frames)
 {
-	PaError res;
-	short null_buf[AST_RADIO_PA_FRAMES_PER_BUFFER * AST_RADIO_PA_OUTPUT_CHANNELS];
-
 	if (!ps || !ps->stream || !data) {
 		return paBadStreamPtr;
 	}
@@ -1367,19 +1364,7 @@ PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, un
 		return paBufferTooBig;
 	}
 
-	res = Pa_WriteStream(ps->stream, data, frames);
-	if (res == paOutputUnderflowed) {
-		PaError retry;
-
-		memset(null_buf, 0, sizeof(null_buf));
-		retry = Pa_WriteStream(ps->stream, null_buf, frames);
-		if (retry < 0 && retry != paOutputUnderflowed) {
-			return retry;
-		}
-		return paNoError;
-	}
-
-	return res;
+	return Pa_WriteStream(ps->stream, data, frames);
 }
 
 long ast_radio_pa_write_available(struct ast_radio_pa_stream *ps)

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -1241,6 +1241,15 @@ PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
 			return paDeviceUnavailable;
 		}
 
+		{
+			const PaDeviceInfo *in_dev = Pa_GetDeviceInfo(input_params.device);
+
+			if (in_dev && ps->input_channels > (unsigned int) in_dev->maxInputChannels) {
+				ps->input_channels = in_dev->maxInputChannels ? (unsigned int) in_dev->maxInputChannels : 1;
+				input_params.channelCount = ps->input_channels;
+			}
+		}
+
 		res = Pa_OpenStream(&ps->stream, &input_params, &output_params, AST_RADIO_PA_SAMPLE_RATE, AST_RADIO_PA_FRAMES_PER_BUFFER,
 			paNoFlag, NULL, NULL);
 	}


### PR DESCRIPTION
## Summary
- Add shared PortAudio lifecycle and stream helpers in `res_usbradio`
- Add ALSA card-index fallback for `audiodev=hw:N` binding
- Add `ast_radio_init_mixer_limits()` fail-fast mixer lookup (no CM108 default guess)

Standalone piece 1/3 for OSS → PortAudio migration. No channel driver changes in this PR.

## Test plan
- [ ] CI passes (ubuntu build, clang-format, codespell)
- [ ] `res_usbradio.so` links against `-lportaudio`
- [ ] Merge before opening/reviewing simpleusb PR (2/3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PortAudio-based USB radio audio streaming, including open/start/stop/read/write and audio availability support.
  * Added helper APIs to query ALSA mixer maximums for mic capture and playback, speaker playback (with alternate control fallback).
  * Added PortAudio 48kHz audio checks for RX and stereo monitoring.
* **Bug Fixes**
  * Improved ALSA mixer element info/error handling with safer failure behavior and cleanup.
  * Hardened USB audio device path resolution (correct readlink handling) and improved USB device list construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->