### PR TITLE
chan_simpleusb: Migrate to shared PortAudio API (2/3)

### DIFF
--- a/channels/Makefile.diff
+++ b/channels/Makefile.diff
@@ -1,12 +1,10 @@
-diff --git a/channels/Makefile b/channels/Makefile
-index 0f8d1328c5..c9523f6d69 100644
 --- a/channels/Makefile
 +++ b/channels/Makefile
-@@ -22,6 +22,9 @@ include $(ASTTOPDIR)/Makefile.moddir_rules
+@@ -22,6 +22,9 @@
  $(call MOD_ADD_C,chan_iax2,$(wildcard iax2/*.c))
  iax2/parser.o: _ASTCFLAGS+=$(call get_menuselect_cflags,MALLOC_DEBUG)
  
-+chan_simpleusb.so: LIBS+=-lusb -lasound -lportaudio
++chan_simpleusb.so: LIBS+=-lusb -lasound
 +chan_usbradio.so: LIBS+=-lusb -lasound
 +
  $(call MOD_ADD_C,chan_pjsip,$(wildcard pjsip/*.c))

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1647,17 +1647,7 @@ static int soundcard_writeframe(struct chan_simpleusb_pvt *o, short *data)
 	 */
 
 	res = ast_radio_pa_write(&o->pa, data, AST_RADIO_PA_FRAMES_PER_BUFFER);
-	if (res == paOutputUnderflowed) {
-		short null_buf[AST_RADIO_PA_FRAMES_PER_BUFFER * AST_RADIO_PA_OUTPUT_CHANNELS] = { 0 };
-
-		/*
-		 * Prime the stream with one silence frame so the USB buffer does not
-		 * stay empty (choppy TX). Same recovery as pre-PortAudio-API simpleusb;
-		 * move into ast_radio_pa_write() in PR #1113 so usbradio shares it.
-		 */
-		ast_debug(6, "PortAudio write stream underflow, writing a 0 frame");
-		ast_radio_pa_write(&o->pa, null_buf, AST_RADIO_PA_FRAMES_PER_BUFFER);
-	} else if (res < 0) {
+	if (res < 0 && res != paOutputUnderflowed) {
 		ast_debug(2, "Pa_WriteStream Error %s", Pa_GetErrorText(res));
 	}
 

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1942,7 +1942,6 @@ static int simpleusb_call(struct ast_channel *c, const char *dest, int timeout)
 {
 	struct chan_simpleusb_pvt *o = ast_channel_tech_pvt(c);
 	int res;
-	int hid_started_here = 0;
 
 	o->stophidthread = 0;
 	o->stopaudiothread = 0;
@@ -1950,24 +1949,19 @@ static int simpleusb_call(struct ast_channel *c, const char *dest, int timeout)
 
 	ast_radio_time(&o->lasthidtime);
 
-	if (o->hidthread == AST_PTHREADT_NULL) {
-		res = ast_pthread_create(&o->hidthread, NULL, hidthread, o);
-		if (res) {
-			ast_log(LOG_ERROR, "Channel %s: Failed to create HID thread: %s\n", o->name, strerror(res));
-			return -1;
-		}
-		hid_started_here = 1;
+	res = ast_pthread_create(&o->hidthread, NULL, hidthread, o);
+	if (res) {
+		ast_log(LOG_ERROR, "Channel %s: Failed to create HID thread: %s\n", o->name, strerror(res));
+		return -1;
 	}
 
 	res = ast_pthread_create(&o->audiothread, NULL, simpleusb_audio_thread, o);
 	if (res) {
 		ast_log(LOG_ERROR, "Channel %s: Failed to create audio thread: %s\n", o->name, strerror(res));
-		if (hid_started_here) {
-			o->stophidthread = 1;
-			if (o->hidthread != AST_PTHREADT_NULL) {
-				pthread_join(o->hidthread, NULL);
-				o->hidthread = AST_PTHREADT_NULL;
-			}
+		o->stophidthread = 1;
+		if (o->hidthread != AST_PTHREADT_NULL) {
+			pthread_join(o->hidthread, NULL);
+			o->hidthread = AST_PTHREADT_NULL;
 		}
 		return -1;
 	}
@@ -1997,13 +1991,18 @@ static int simpleusb_hangup(struct ast_channel *c)
 	struct chan_simpleusb_pvt *o = ast_channel_tech_pvt(c);
 
 	o->stopaudiothread = 1;
-	/* Wake HID's poll so PTT drops promptly instead of waiting for HID_POLL_RATE. */
+	o->stophidthread = 1;
+	/* Wake HID's poll so it notices stophidthread / can drop PTT promptly. */
 	kickptt(o);
 	if (o->audiothread != AST_PTHREADT_NULL) {
 		pthread_join(o->audiothread, NULL);
 		o->audiothread = AST_PTHREADT_NULL;
 	}
 	ast_radio_pa_stop(&o->pa);
+	if (o->hidthread != AST_PTHREADT_NULL) {
+		pthread_join(o->hidthread, NULL);
+		o->hidthread = AST_PTHREADT_NULL;
+	}
 
 	o->owner = NULL;
 	ast_channel_tech_pvt_set(c, NULL);

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -414,6 +414,8 @@ static int start_stream(struct chan_simpleusb_pvt *pvt)
 		return -1;
 	}
 
+	ast_assert(pvt->pa.input_channels == 1);
+
 	res = ast_radio_pa_start(&pvt->pa);
 	if (res != paNoError) {
 		ast_log(LOG_WARNING, "Failed to start stream - (%d) %s\n", res, Pa_GetErrorText(res));
@@ -1637,11 +1639,11 @@ static void *hidthread(void *arg)
 
 /*!
  * \brief Write a full frame of audio data to the sound card device.
- * \note The input data must be formatted as stereo at 48000 samples per second.
- *		 FRAME_SIZE * 2 * 2 * 6 (2 bytes per sample, 2 channels, 6 for upsample to 48K)
+ * \note data is 48 kHz stereo interleaved. ast_radio_pa_write() takes frames
+ *       per channel (PA_NUM_FRAMES); the buffer holds PA_NUM_FRAMES * 2 samples.
  * \param o		Channel private data.
  * \param data	Audio data to write.
- * \returns		Number bytes written.
+ * \returns		PaError from ast_radio_pa_write().
  */
 static int soundcard_writeframe(struct chan_simpleusb_pvt *o, short *data)
 {
@@ -1661,14 +1663,7 @@ static int soundcard_writeframe(struct chan_simpleusb_pvt *o, short *data)
 		ast_debug(2, "Pa_WriteStream Error %s", Pa_GetErrorText(res));
 	}
 
-	/* Check Tx audio statistics. FRAME_SIZE define refers to 8Ksps mono which is 160 samples
-	 * per 20mS USB frame. ast_radio_check_audio() takes the write buffer (48K stereo),
-	 * extracts the mono 48K channel, checks amplitude and distortion characteristics,
-	 * and returns true if clipping was detected. If local Tx audio is clipped it might be
-	 * nice to log a warning but as this does not relate to outgoing network audio it's not
-	 * a major issue. User can check the Tx Audio Stats utility if desired.
-	 */
-	ast_radio_check_audio(data, &o->txaudiostats, 12 * FRAME_SIZE, 0);
+	ast_radio_check_audio_stereo_48k(data, &o->txaudiostats);
 
 	return res;
 }
@@ -2577,13 +2572,8 @@ static void *simpleusb_audio_thread(void *arg)
 				}
 			}
 
-			/* Check for ADC clipping and input audio statistics before any filtering is done.
-			 * FRAME_SIZE define refers to 8Ksps mono which is 160 samples per 20mS USB frame.
-			 * ast_radio_check_audio() takes the read buffer as received (48K stereo or mono),
-			 * extracts the 48K channel, checks amplitude and distortion characteristics,
-			 * and returns true if clipping was detected.
-			 */
-			if (ast_radio_check_audio(o->simpleusb_read_buf, &o->rxaudiostats, 6 * FRAME_SIZE, 1)) {
+			/* RX stats on the mono PortAudio capture buffer. */
+			if (ast_radio_check_audio_pa_rx(o->simpleusb_read_buf, &o->rxaudiostats, o->pa.input_channels)) {
 				if (o->clipledgpio) {
 					/* Set Clip LED GPIO pulsetimer if not already set */
 					if (!o->hid_gpio_pulsetimer[o->clipledgpio - 1]) {

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1954,6 +1954,7 @@ static int simpleusb_call(struct ast_channel *c, const char *dest, int timeout)
 {
 	struct chan_simpleusb_pvt *o = ast_channel_tech_pvt(c);
 	int res;
+	int hid_started_here = 0;
 
 	o->stophidthread = 0;
 	o->stopaudiothread = 0;
@@ -1961,19 +1962,24 @@ static int simpleusb_call(struct ast_channel *c, const char *dest, int timeout)
 
 	ast_radio_time(&o->lasthidtime);
 
-	res = ast_pthread_create(&o->hidthread, NULL, hidthread, o);
-	if (res) {
-		ast_log(LOG_ERROR, "Channel %s: Failed to create HID thread: %s\n", o->name, strerror(res));
-		return -1;
+	if (o->hidthread == AST_PTHREADT_NULL) {
+		res = ast_pthread_create(&o->hidthread, NULL, hidthread, o);
+		if (res) {
+			ast_log(LOG_ERROR, "Channel %s: Failed to create HID thread: %s\n", o->name, strerror(res));
+			return -1;
+		}
+		hid_started_here = 1;
 	}
 
 	res = ast_pthread_create(&o->audiothread, NULL, simpleusb_audio_thread, o);
 	if (res) {
 		ast_log(LOG_ERROR, "Channel %s: Failed to create audio thread: %s\n", o->name, strerror(res));
-		o->stophidthread = 1;
-		if (o->hidthread != AST_PTHREADT_NULL) {
-			pthread_join(o->hidthread, NULL);
-			o->hidthread = AST_PTHREADT_NULL;
+		if (hid_started_here) {
+			o->stophidthread = 1;
+			if (o->hidthread != AST_PTHREADT_NULL) {
+				pthread_join(o->hidthread, NULL);
+				o->hidthread = AST_PTHREADT_NULL;
+			}
 		}
 		return -1;
 	}
@@ -2009,13 +2015,6 @@ static int simpleusb_hangup(struct ast_channel *c)
 		o->audiothread = AST_PTHREADT_NULL;
 	}
 	stop_stream(o);
-
-	o->stophidthread = 1;
-	kickptt(o);
-	if (o->hidthread != AST_PTHREADT_NULL) {
-		pthread_join(o->hidthread, NULL);
-		o->hidthread = AST_PTHREADT_NULL;
-	}
 
 	o->owner = NULL;
 	ast_channel_tech_pvt_set(c, NULL);

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1062,18 +1062,21 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 		}
 	}
 
-	o->device_error = 0;
-	ast_radio_time(&o->lasthidtime);
 	{
 		int use_newname = 0;
 
 		if (ast_radio_init_mixer_limits(o->devicenum, &o->micmax, &o->spkrmax, &o->micplaymax, &use_newname) < 0) {
-			ast_log(LOG_ERROR, "Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
+			if (!o->device_error) {
+				ast_log(LOG_ERROR, "Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
+				o->device_error = 1;
+			}
 			ast_mutex_unlock(&usb_dev_lock);
 			return -1;
 		}
 		o->newname = use_newname;
 	}
+	o->device_error = 0;
+	ast_radio_time(&o->lasthidtime);
 	o->usbass = 1;
 	ast_mutex_unlock(&usb_dev_lock);
 	return 0;

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -98,8 +98,6 @@
 #include "asterisk/format_cache.h"
 #include "asterisk/format_compatibility.h"
 
-#define PA_NUM_FRAMES AST_RADIO_PA_FRAMES_PER_BUFFER
-
 /*! \brief Global jitterbuffer configuration - by default, jb is disabled */
 static struct ast_jb_conf default_jbconf = {
 	.flags = 0,
@@ -198,7 +196,7 @@ struct chan_simpleusb_pvt {
 	char simpleusb_write_buf[FRAME_SIZE * 2]; /* buffer used for Asterisk to PA frames in 8k mono */
 
 	int simpleusb_write_dst;
-	short simpleusb_read_buf[PA_NUM_FRAMES]; /* 1 short (2 byte) samples for PortAudio config with paInt16 * 1 channel (mono) */
+	short simpleusb_read_buf[AST_RADIO_PA_FRAMES_PER_BUFFER]; /* 1 short (2 byte) samples for PortAudio config with paInt16 * 1 channel (mono) */
 	char simpleusb_read_frame_buf[FRAME_SIZE * 2 + AST_FRIENDLY_OFFSET]; /* 2 byte samples at 8k */
 	struct ast_frame read_f;											 /* returned by simpleusb_read */
 
@@ -424,11 +422,6 @@ static int start_stream(struct chan_simpleusb_pvt *pvt)
 	}
 
 	return 0;
-}
-
-static void stop_stream(struct chan_simpleusb_pvt *pvt)
-{
-	ast_radio_pa_stop(&pvt->pa);
 }
 
 /*!
@@ -1640,7 +1633,7 @@ static void *hidthread(void *arg)
 /*!
  * \brief Write a full frame of audio data to the sound card device.
  * \note data is 48 kHz stereo interleaved. ast_radio_pa_write() takes frames
- *       per channel (PA_NUM_FRAMES); the buffer holds PA_NUM_FRAMES * 2 samples.
+ *       per channel (AST_RADIO_PA_FRAMES_PER_BUFFER); the buffer holds AST_RADIO_PA_FRAMES_PER_BUFFER * 2 samples.
  * \param o		Channel private data.
  * \param data	Audio data to write.
  * \returns		PaError from ast_radio_pa_write().
@@ -1656,7 +1649,7 @@ static int soundcard_writeframe(struct chan_simpleusb_pvt *o, short *data)
 	 * a number of failures, to restart the output chain.
 	 */
 
-	res = ast_radio_pa_write(&o->pa, data, PA_NUM_FRAMES);
+	res = ast_radio_pa_write(&o->pa, data, AST_RADIO_PA_FRAMES_PER_BUFFER);
 	if (res == paOutputUnderflowed) {
 		ast_debug(6, "PortAudio write stream underflow, writing a 0 frame");
 	} else if (res < 0) {
@@ -2009,7 +2002,7 @@ static int simpleusb_hangup(struct ast_channel *c)
 		pthread_join(o->audiothread, NULL);
 		o->audiothread = AST_PTHREADT_NULL;
 	}
-	stop_stream(o);
+	ast_radio_pa_stop(&o->pa);
 
 	o->owner = NULL;
 	ast_channel_tech_pvt_set(c, NULL);
@@ -2111,7 +2104,7 @@ static void flush_stream_buffer(struct chan_simpleusb_pvt *o)
  */
 static void stream_cleanup(struct chan_simpleusb_pvt *o)
 {
-	stop_stream(o);
+	ast_radio_pa_stop(&o->pa);
 	o->audio_thread_ready = 0;
 	flush_stream_buffer(o);
 }
@@ -2131,7 +2124,7 @@ static void *simpleusb_audio_thread(void *arg)
 	time_t now;
 	struct timeval last_frame_time;
 	short *sp, *sp1;
-	short outbuf[PA_NUM_FRAMES * 2]; /* 1 short (2 bytes) per sample on PortAudio config with paInt16 * 2 channels */
+	short outbuf[AST_RADIO_PA_FRAMES_PER_BUFFER * 2]; /* 1 short (2 bytes) per sample on PortAudio config with paInt16 * 2 channels */
 
 	ast_debug(5, "Audio thread is starting\n");
 	ast_radio_time(&o->lastaudiotime);
@@ -2282,7 +2275,7 @@ static void *simpleusb_audio_thread(void *arg)
 					last_frame_time = ast_radio_tvnow();
 				}
 
-				if (num_frames && (num_frames > 3 || (!o->txkeyed && !o->txtestkey)) && (frames_available >= PA_NUM_FRAMES)) {
+				if (num_frames && (num_frames > 3 || (!o->txkeyed && !o->txtestkey)) && (frames_available >= AST_RADIO_PA_FRAMES_PER_BUFFER)) {
 					ast_mutex_lock(&o->txqlock);
 					f1 = AST_LIST_REMOVE_HEAD(&o->txq, frame_list);
 					ast_mutex_unlock(&o->txqlock);
@@ -2430,7 +2423,7 @@ static void *simpleusb_audio_thread(void *arg)
 			 * in mono format.  We should always have 20ms frames, 40ms timeout
 			 * as a reasonable max wait time.
 			 */
-			res = ast_radio_pa_read(&o->pa, o->simpleusb_read_buf, PA_NUM_FRAMES, 40, &o->stopaudiothread);
+			res = ast_radio_pa_read(&o->pa, o->simpleusb_read_buf, AST_RADIO_PA_FRAMES_PER_BUFFER, 40, &o->stopaudiothread);
 			if (res != paNoError) {
 				/* audio data not ready */
 				if (res == paInputOverflowed) {
@@ -4430,7 +4423,7 @@ static int unload_module(void)
 			pthread_join(o->audiothread, NULL); /* wait for audio thread to end */
 			o->audiothread = AST_PTHREADT_NULL;
 		}
-		stop_stream(o);
+		ast_radio_pa_stop(&o->pa);
 		if (o->hidthread != AST_PTHREADT_NULL) {
 			pthread_join(o->hidthread, NULL);
 			o->hidthread = AST_PTHREADT_NULL;
@@ -4439,10 +4432,14 @@ static int unload_module(void)
 			ast_dsp_free(o->dsp);
 		}
 		for (i = 0; i < GPIO_PINCOUNT; i++) {
-			ast_free(o->gpios[i]);
+			if (o->gpios[i]) {
+				ast_free(o->gpios[i]);
+			}
 		}
 		for (i = 0; i < ARRAY_LEN(o->pps); i++) {
-			ast_free(o->pps[i]);
+			if (o->pps[i]) {
+				ast_free(o->pps[i]);
+			}
 		}
 		ast_free(o->name);
 		ast_free(o);

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -873,6 +873,7 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 	struct chan_simpleusb_pvt *ao;
 	int i;
 	int subdev;
+	int use_newname = 0;
 
 	ast_radio_time(&o->lasthidtime);
 	ast_mutex_lock(&usb_dev_lock);
@@ -1057,19 +1058,15 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 		}
 	}
 
-	{
-		int use_newname = 0;
-
-		if (ast_radio_init_mixer_limits(o->devicenum, &o->micmax, &o->spkrmax, &o->micplaymax, &use_newname) < 0) {
-			if (!o->device_error) {
-				ast_log(LOG_ERROR, "Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
-				o->device_error = 1;
-			}
-			ast_mutex_unlock(&usb_dev_lock);
-			return -1;
+	if (ast_radio_init_mixer_limits(o->devicenum, &o->micmax, &o->spkrmax, &o->micplaymax, &use_newname) < 0) {
+		if (!o->device_error) {
+			ast_log(LOG_ERROR, "Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
+			o->device_error = 1;
 		}
-		o->newname = use_newname;
+		ast_mutex_unlock(&usb_dev_lock);
+		return -1;
 	}
+	o->newname = use_newname;
 	o->device_error = 0;
 	ast_radio_time(&o->lasthidtime);
 	o->usbass = 1;

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1648,7 +1648,15 @@ static int soundcard_writeframe(struct chan_simpleusb_pvt *o, short *data)
 
 	res = ast_radio_pa_write(&o->pa, data, AST_RADIO_PA_FRAMES_PER_BUFFER);
 	if (res == paOutputUnderflowed) {
+		short null_buf[AST_RADIO_PA_FRAMES_PER_BUFFER * AST_RADIO_PA_OUTPUT_CHANNELS] = { 0 };
+
+		/*
+		 * Prime the stream with one silence frame so the USB buffer does not
+		 * stay empty (choppy TX). Same recovery as pre-PortAudio-API simpleusb;
+		 * move into ast_radio_pa_write() in PR #1113 so usbradio shares it.
+		 */
 		ast_debug(6, "PortAudio write stream underflow, writing a 0 frame");
+		ast_radio_pa_write(&o->pa, null_buf, AST_RADIO_PA_FRAMES_PER_BUFFER);
 	} else if (res < 0) {
 		ast_debug(2, "Pa_WriteStream Error %s", Pa_GetErrorText(res));
 	}

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1997,6 +1997,7 @@ static int simpleusb_hangup(struct ast_channel *c)
 	struct chan_simpleusb_pvt *o = ast_channel_tech_pvt(c);
 
 	o->stopaudiothread = 1;
+	/* Wake HID's poll so PTT drops promptly instead of waiting for HID_POLL_RATE. */
 	kickptt(o);
 	if (o->audiothread != AST_PTHREADT_NULL) {
 		pthread_join(o->audiothread, NULL);

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -894,7 +894,7 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 			ast_log(LOG_ERROR, "audiodev=default is not supported for SimpleUSB until HID-less startup is implemented\n");
 			ast_mutex_unlock(&usb_dev_lock);
 			return -1;
-		} else if (ast_radio_parse_hw_anywhere(o->hw_device, &o->devicenum, &subdev)) {
+		} else if (ast_radio_parse_alsa_hw_device(o->hw_device, &o->devicenum, &subdev)) {
 			ast_debug(5, "audiodev is defined: %s, Device %d", o->hw_device, o->devicenum);
 			o->usb_dev = ast_radio_usb_device_from_alsa_card(o->devicenum);
 			if (!o->usb_dev) {
@@ -1663,7 +1663,7 @@ static int soundcard_writeframe(struct chan_simpleusb_pvt *o, short *data)
 		ast_debug(2, "Pa_WriteStream Error %s", Pa_GetErrorText(res));
 	}
 
-	ast_radio_check_audio_stereo_48k(data, &o->txaudiostats);
+	ast_radio_check_audio(data, &o->txaudiostats, AST_RADIO_PA_48K_STEREO_SAMPLES, 0);
 
 	return res;
 }
@@ -2573,7 +2573,7 @@ static void *simpleusb_audio_thread(void *arg)
 			}
 
 			/* RX stats on the mono PortAudio capture buffer. */
-			if (ast_radio_check_audio_pa_rx(o->simpleusb_read_buf, &o->rxaudiostats, o->pa.input_channels)) {
+			if (ast_radio_check_audio(o->simpleusb_read_buf, &o->rxaudiostats, AST_RADIO_PA_48K_MONO_SAMPLES, 1)) {
 				if (o->clipledgpio) {
 					/* Set Clip LED GPIO pulsetimer if not already set */
 					if (!o->hid_gpio_pulsetimer[o->clipledgpio - 1]) {

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -29,14 +29,12 @@
 
 /*** MODULEINFO
 	<depend>alsa</depend>
-	<depend>portaudio</depend>
 	<depend>res_usbradio</depend>
 	<support_level>extended</support_level>
  ***/
 
 #include "asterisk.h"
 
-#include <portaudio.h>
 #include <alsa/asoundlib.h>
 
 #include <stdio.h>
@@ -81,13 +79,6 @@
 #define HID_POLL_RATE 50
 #define DEVICE_RETRY 500000 /* Retry time in uS when USB device is missing */
 #define MAX_FRAME_DELAY 200 /* 200ms (.2s) max time to queue audio frames before resetting usb audio */
-#ifdef __linux
-#include <linux/soundcard.h>
-#elif defined(__FreeBSD__)
-#include <sys/soundcard.h>
-#else
-#include <soundcard.h>
-#endif
 
 #include "asterisk/lock.h"
 #include "asterisk/frame.h"
@@ -107,29 +98,7 @@
 #include "asterisk/format_cache.h"
 #include "asterisk/format_compatibility.h"
 
-/*!
- * \brief The sample rate to request from PortAudio
- *
- * \todo Make this optional.  If this is only going to talk to 8 kHz endpoints,
- *       then it makes sense to use 8 kHz natively if possible.
- */
-#define PA_SAMPLE_RATE 48000 /* PortAudio Sample rate: Hardware likes 48k and is divisible by 6 for a "nice" down conversion. */
-
-/*!
- * \brief The number of samples to configure the PortAudio stream for.
- *
- * At 48kHz, 960 samples gives a 20ms frame, which aligns with Asterisk's
- * common frame size after resampling to 8kHz (160 samples @ 2 bytes per sample).
- * The number of short (2 byte) with paInt16 samples per PortAudio "frame".
- * This is 1920 bytes for stereo, or 960 bytes for mono
- */
-#define PA_NUM_FRAMES FRAME_SIZE * 6 /* Number of samples to read/write from PortAudio stream per Asterisk frame at 48k */
-
-/*! \brief Mono Input */
-#define PA_INPUT_CHANNELS 1 /* PortAudio: Mono input for Microphone / RX */
-
-/*! \brief Stereo Output */
-#define PA_OUTPUT_CHANNELS 2 /* PortAudio: Stereo output for Speaker / TX */
+#define PA_NUM_FRAMES AST_RADIO_PA_FRAMES_PER_BUFFER
 
 /*! \brief Global jitterbuffer configuration - by default, jb is disabled */
 static struct ast_jb_conf default_jbconf = {
@@ -224,7 +193,7 @@ struct chan_simpleusb_pvt {
 	struct usb_device *usb_dev;
 	struct ast_channel *owner;
 
-	PaStream *stream; /*! Current PortAudio stream for this device */
+	struct ast_radio_pa_stream pa;
 
 	char simpleusb_write_buf[FRAME_SIZE * 2]; /* buffer used for Asterisk to PA frames in 8k mono */
 
@@ -312,7 +281,6 @@ struct chan_simpleusb_pvt {
 	char had_pp_in;
 
 	/* bit fields */
-	unsigned int streamstate:1;			   /* indicator if stream is started */
 	unsigned int rxcapraw:1;			   /* indicator if receive capture is enabled */
 	unsigned int txcapraw:1;			   /* indicator if transmit capture is enabled */
 	unsigned int measure_enabled:1;		   /* indicator if measure mode is enabled */
@@ -428,267 +396,37 @@ static struct ast_channel_tech simpleusb_tech = {
 	.setoption = simpleusb_setoption,
 };
 
-static int64_t now_ms(void)
-{
-	struct timespec ts;
-	clock_gettime(CLOCK_MONOTONIC, &ts);
-	return (int64_t) ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
-}
-
-static PaError Pa_ReadStream_with_timeout(PaStream *s, short *buf, unsigned long frames, int timeout_ms, volatile sig_atomic_t *stop)
-{
-	int64_t start;
-
-	start = now_ms();
-	while (!(*stop)) {
-		long avail;
-		PaError err;
-
-		avail = Pa_GetStreamReadAvailable(s);
-		if (avail < 0) {
-			return (PaError) avail;
-		}
-
-		if ((now_ms() - start) > timeout_ms) {
-			return paTimedOut;
-		}
-
-		if (avail < frames) {
-			usleep(500); /*.5ms */
-			continue;
-		}
-
-		err = Pa_ReadStream(s, buf, frames);
-		return err;
-	}
-
-	return paTimedOut;
-}
-
-/*!
- * \brief Parse "hw:<card>" or "hw:<card>,<dev>" from anywhere in s.
- * \retval 1 if found; sets *card; sets *dev to parsed value or -1 if absent.
- */
-static int parse_hw_anywhere(const char *s, int *card, int *dev)
-{
-	const char *p = s;
-
-	if (!s || !card || !dev) {
-		return 0;
-	}
-
-	while ((p = strstr(p, "hw:")) != NULL) {
-		const char *q = p + 3; /* after "hw:" */
-		int c = 0;
-		int d = -1; /* dev absent by default */
-
-		/* card must start with digit */
-		if (!isdigit((unsigned char) *q)) {
-			p = q;
-			continue;
-		}
-
-		while (isdigit((unsigned char) *q)) {
-			if (c > 9999) {
-				/* reasonable upper bound for card numbers */
-				p = q;
-				break;
-			}
-
-			c = c * 10 + (*q - '0');
-			q++;
-		}
-
-		if (*q == ',') {
-			q++;
-			if (!isdigit((unsigned char) *q)) {
-				/* "hw:<card>," is malformed; skip this occurrence */
-				p = q;
-				continue;
-			}
-			d = 0;
-			while (isdigit((unsigned char) *q)) {
-				d = d * 10 + (*q - '0');
-				q++;
-			}
-		}
-
-		*card = c;
-		*dev = d;
-		return 1; /* first valid hw: occurrence */
-	}
-
-	return 0;
-}
-
-/*!
- * \brief Match rule:
- * - needle "hw:C" matches any "hw:C" or "hw:C,D" in haystack
- * - needle "hw:C,D" matches only "hw:C,D" in haystack
- */
-static int hw_match(const char *haystack, const char *needle)
-{
-	int haystack_c, haystack_d, needle_c, needle_d;
-	const char *p = haystack ? haystack : "";
-
-	if (!parse_hw_anywhere(needle, &needle_c, &needle_d)) {
-		return 0;
-	}
-
-	/* haystack may contain multiple hw: occurrences; scan all */
-	while ((p = strstr(p, "hw:")) != NULL) {
-		if (parse_hw_anywhere(p, &haystack_c, &haystack_d)) {
-			if (haystack_c == needle_c) {
-				if (needle_d < 0) {
-					/* needle is "hw:C" -> accept any dev (including absent) */
-					return 1;
-				} else if (haystack_d == needle_d) {
-					/* needle is "hw:C,D" -> require exact dev match */
-					return 1;
-				}
-			}
-		}
-		p += 3; /* move forward to find next occurrence */
-	}
-
-	return 0;
-}
-
-static int open_stream(struct chan_simpleusb_pvt *o)
-{
-	PaError res = paInternalError;
-	const PaStreamInfo *si;
-
-	if (!strcasecmp(o->hw_device, "default")) {
-		ast_debug(1, "Opening stream with default device\n");
-		res = Pa_OpenDefaultStream(&o->stream, PA_INPUT_CHANNELS, PA_OUTPUT_CHANNELS, paInt16, PA_SAMPLE_RATE, PA_NUM_FRAMES, NULL, NULL);
-	} else {
-		PaStreamParameters input_params = {
-			.channelCount = PA_INPUT_CHANNELS,
-			.sampleFormat = paInt16,
-			.suggestedLatency = (1.0 / 50.0), /* 20 ms */
-			.device = paNoDevice,
-		};
-		PaStreamParameters output_params = {
-			.channelCount = PA_OUTPUT_CHANNELS,
-			.sampleFormat = paInt16,
-			.suggestedLatency = (1.0 / 50.0), /* 20 ms */
-			.device = paNoDevice,
-		};
-		PaDeviceIndex idx, num_devices;
-		ast_debug(1, "Looking for device %s\n", o->hw_device);
-		ast_debug(5, "PortAudio host api count %d\n", Pa_GetHostApiCount());
-		num_devices = Pa_GetDeviceCount();
-		if (num_devices < 0) {
-			ast_debug(1, "No devices found\n");
-			return res;
-		} else {
-			ast_debug(6, "%d Devices found\n", num_devices);
-		}
-
-		for (idx = 0; idx < num_devices && (input_params.device == paNoDevice || output_params.device == paNoDevice); idx++) {
-			const PaDeviceInfo *dev = Pa_GetDeviceInfo(idx);
-			ast_debug(1, "Found device %s\n", dev->name);
-			if (dev->maxInputChannels) {
-				if (hw_match(dev->name, o->hw_device)) {
-					ast_debug(5, "Found input device %s\n", dev->name);
-					input_params.device = idx;
-				}
-			}
-
-			if (dev->maxOutputChannels) {
-				if (hw_match(dev->name, o->hw_device)) {
-					ast_debug(5, "Found output device %s\n", dev->name);
-					output_params.device = idx;
-				}
-			}
-		}
-
-		if (input_params.device == paNoDevice) {
-			ast_log(LOG_ERROR, "No input device found for simpleusb device '%s'\n", o->name);
-			return res;
-		}
-
-		if (output_params.device == paNoDevice) {
-			ast_log(LOG_ERROR, "No output device found for simpleusb device '%s'\n", o->name);
-			return res;
-		}
-		ast_debug(5, "Opening stream on device %s", o->hw_device);
-		res = Pa_OpenStream(&o->stream, &input_params, &output_params, PA_SAMPLE_RATE, PA_NUM_FRAMES, paNoFlag, NULL, NULL);
-		ast_debug(5, "Stream feedback: %s\n", Pa_GetErrorText(res));
-		if (res == paNoError) {
-			si = Pa_GetStreamInfo(o->stream);
-			if (si) {
-				ast_debug(5, "Stream output latency: %.3f ms\n", si->outputLatency * 1000.0);
-				ast_debug(5, "Stream input latency: %.3f ms\n", si->inputLatency * 1000.0);
-			}
-		}
-	}
-
-	return res;
-}
-
 static int start_stream(struct chan_simpleusb_pvt *pvt)
 {
 	PaError res;
 
 	ast_debug(5, "Starting PA Stream");
-	/* It is possible for simpleusb_hangup to be called before the
-	 * stream is started, if this is the case pvt->owner will be NULL
-	 * and start_stream should be aborted. */
-	if (pvt->streamstate || !pvt->owner)
-		return -1;
-
-	res = Pa_Initialize();
-	if (res != paNoError) {
-		ast_log(LOG_WARNING, "Failed to initialize audio system - (%d) %s\n", res, Pa_GetErrorText(res));
+	if (pvt->pa.active || !pvt->owner) {
 		return -1;
 	}
 
-	res = open_stream(pvt);
+	ast_copy_string(pvt->pa.hw_device, pvt->hw_device, sizeof(pvt->pa.hw_device));
+	pvt->pa.input_channels = 1;
+
+	res = ast_radio_pa_open(&pvt->pa);
 	if (res != paNoError) {
 		ast_log(LOG_WARNING, "Failed to open stream - (%d) %s\n", res, Pa_GetErrorText(res));
-		Pa_Terminate();
 		return -1;
 	}
 
-	res = Pa_StartStream(pvt->stream);
+	res = ast_radio_pa_start(&pvt->pa);
 	if (res != paNoError) {
 		ast_log(LOG_WARNING, "Failed to start stream - (%d) %s\n", res, Pa_GetErrorText(res));
-		Pa_CloseStream(pvt->stream);
-		pvt->stream = NULL;
-		pvt->streamstate = 0;
-		Pa_Terminate();
+		ast_radio_pa_stop(&pvt->pa);
 		return -1;
 	}
 
-	pvt->streamstate = 1;
 	return 0;
 }
 
-static int stop_stream(struct chan_simpleusb_pvt *pvt)
+static void stop_stream(struct chan_simpleusb_pvt *pvt)
 {
-	PaError err;
-
-	if (!pvt->streamstate) {
-		return 0;
-	}
-
-	/* Abort and close the stream */
-	err = Pa_AbortStream(pvt->stream);
-	if (err != paNoError) {
-		ast_log(LOG_WARNING, "Pa_AbortStream failed: %s\n", Pa_GetErrorText(err));
-	}
-
-	err = Pa_CloseStream(pvt->stream);
-	if (err != paNoError) {
-		ast_log(LOG_WARNING, "Pa_CloseStream failed: %s\n", Pa_GetErrorText(err));
-	}
-
-	pvt->stream = NULL;
-	pvt->streamstate = 0;
-	Pa_Terminate();
-	return 0;
+	ast_radio_pa_stop(&pvt->pa);
 }
 
 /*!
@@ -1078,6 +816,7 @@ static int load_tune_config(struct chan_simpleusb_pvt *o, const struct ast_confi
 	int configured = 0;
 	char devstr[sizeof(o->devstr)];
 	char serial[sizeof(o->serial)];
+	char hw_device[sizeof(o->hw_device)];
 
 	o->rxmixerset = 500;
 	o->txmixaset = 500;
@@ -1085,6 +824,7 @@ static int load_tune_config(struct chan_simpleusb_pvt *o, const struct ast_confi
 
 	devstr[0] = '\0';
 	serial[0] = '\0';
+	hw_device[0] = '\0';
 
 	if (!cfg) {
 		struct ast_flags zeroflag = { 0 };
@@ -1105,15 +845,18 @@ static int load_tune_config(struct chan_simpleusb_pvt *o, const struct ast_confi
 		CV_UINT("txmixbset", o->txmixbset);
 		CV_STR("devstr", devstr);
 		CV_STR("serial", serial);
-		if (o->devstr[0] == '\0') {
-			CV_STR("audiodev", o->hw_device); /* use audiodevice as opposed to the usb device path (devstr) */
-		}
+		CV_STR("audiodev", hw_device); /* use audiodevice as opposed to the usb device path (devstr) */
 		CV_END;
 	}
 	if (!reload) {
 		/* Using the ternary operator in CV_STR won't work, due to butchering the sizeof, so copy after if needed */
 		ast_copy_string(o->devstr, devstr, sizeof(o->devstr)); /* Safe */
 		ast_copy_string(o->serial, serial, sizeof(o->serial)); /* Safe */
+		if (ast_strlen_zero(devstr)) {
+			ast_copy_string(o->hw_device, hw_device, sizeof(o->hw_device));
+		} else {
+			o->hw_device[0] = '\0';
+		}
 	}
 	if (opened) {
 		ast_config_destroy(cfg2);
@@ -1133,7 +876,8 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 	char serial[sizeof(o->serial)] = { '\0' };
 	char *s;
 	struct chan_simpleusb_pvt *ao;
-	register int i;
+	int i;
+	int subdev;
 
 	ast_radio_time(&o->lasthidtime);
 	ast_mutex_lock(&usb_dev_lock);
@@ -1148,7 +892,7 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 			ast_log(LOG_ERROR, "audiodev=default is not supported for SimpleUSB until HID-less startup is implemented\n");
 			ast_mutex_unlock(&usb_dev_lock);
 			return -1;
-		} else if (sscanf(o->hw_device, "hw:%d", &o->devicenum) == 1) {
+		} else if (ast_radio_parse_hw_anywhere(o->hw_device, &o->devicenum, &subdev)) {
 			ast_debug(5, "audiodev is defined: %s, Device %d", o->hw_device, o->devicenum);
 			o->usb_dev = ast_radio_usb_device_from_alsa_card(o->devicenum);
 			if (!o->usb_dev) {
@@ -1156,9 +900,16 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 				ast_mutex_unlock(&usb_dev_lock);
 				return -1;
 			}
+			for (ao = simpleusb_default.next; ao && ao->name; ao = ao->next) {
+				if (ao != o && ao->usbass && ao->devicenum == o->devicenum) {
+					ast_log(LOG_ERROR, "Channel %s: Audio device %s is already assigned to channel %s\n", o->name, o->hw_device, ao->name);
+					ast_mutex_unlock(&usb_dev_lock);
+					return -1;
+				}
+			}
 
 		} else {
-			ast_log(LOG_ERROR, "Incorrect audio parameter audiodev (should be hw:0 format), found %s\n", o->hw_device);
+			ast_log(LOG_ERROR, "Incorrect audio parameter audiodev (should be hw:0 or hw:0,0 format), found %s\n", o->hw_device);
 			ast_mutex_unlock(&usb_dev_lock);
 			return -1;
 		}
@@ -1313,18 +1064,18 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 
 	o->device_error = 0;
 	ast_radio_time(&o->lasthidtime);
+	{
+		int use_newname = 0;
+
+		if (ast_radio_init_mixer_limits(o->devicenum, &o->micmax, &o->spkrmax, &o->micplaymax, &use_newname) < 0) {
+			ast_log(LOG_ERROR, "Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
+			ast_mutex_unlock(&usb_dev_lock);
+			return -1;
+		}
+		o->newname = use_newname;
+	}
 	o->usbass = 1;
 	ast_mutex_unlock(&usb_dev_lock);
-	/* set the audio mixer values */
-	o->micmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL);
-	o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL);
-	o->micplaymax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_VOL);
-
-	if (o->spkrmax == -1) {
-		o->newname = 1;
-		o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW);
-	}
-
 	return 0;
 }
 
@@ -1471,6 +1222,11 @@ static void *hidthread(void *arg)
 		}
 		if (pipe2(o->pttkick, O_NONBLOCK) == -1) {
 			ast_log(LOG_ERROR, "Channel %s: Is not able to create a pipe\n", o->name);
+			ast_mutex_lock(&usb_dev_lock);
+			o->usbass = 0;
+			o->hasusb = 0;
+			o->usb_dev = NULL;
+			ast_mutex_unlock(&usb_dev_lock);
 			usb_close(usb_handle);
 			usb_handle = NULL;
 			return NULL;
@@ -1525,6 +1281,8 @@ static void *hidthread(void *arg)
 				ast_radio_time(&audio_time_now);
 				if ((audio_time_now - o->lastaudiotime) > 1) {
 					ast_log(LOG_ERROR, "Channel %s: Audio process has died or is not responding.\n", o->name);
+					o->hasusb = 0;
+					break;
 				}
 			}
 
@@ -1893,11 +1651,9 @@ static int soundcard_writeframe(struct chan_simpleusb_pvt *o, short *data)
 	 * a number of failures, to restart the output chain.
 	 */
 
-	res = Pa_WriteStream(o->stream, data, PA_NUM_FRAMES);
+	res = ast_radio_pa_write(&o->pa, data, PA_NUM_FRAMES);
 	if (res == paOutputUnderflowed) {
-		short null_buf[PA_NUM_FRAMES * 2] = { 0 };
 		ast_debug(6, "PortAudio write stream underflow, writing a 0 frame");
-		Pa_WriteStream(o->stream, null_buf, PA_NUM_FRAMES);
 	} else if (res < 0) {
 		ast_debug(2, "Pa_WriteStream Error %s", Pa_GetErrorText(res));
 	}
@@ -2244,12 +2000,15 @@ static int simpleusb_hangup(struct ast_channel *c)
 	struct chan_simpleusb_pvt *o = ast_channel_tech_pvt(c);
 
 	o->stopaudiothread = 1;
+	kickptt(o);
 	if (o->audiothread != AST_PTHREADT_NULL) {
 		pthread_join(o->audiothread, NULL);
 		o->audiothread = AST_PTHREADT_NULL;
 	}
+	stop_stream(o);
 
 	o->stophidthread = 1;
+	kickptt(o);
 	if (o->hidthread != AST_PTHREADT_NULL) {
 		pthread_join(o->hidthread, NULL);
 		o->hidthread = AST_PTHREADT_NULL;
@@ -2391,7 +2150,7 @@ static void *simpleusb_audio_thread(void *arg)
 			continue;
 		}
 
-		if (!o->streamstate && start_stream(o) < 0) {
+		if (!o->pa.active && start_stream(o) < 0) {
 			ast_log(LOG_ERROR, "Channel %s: Failed to start audio stream %s\n", o->name, o->hw_device);
 			o->hasusb = 0;
 			usleep(DEVICE_RETRY);
@@ -2507,7 +2266,7 @@ static void *simpleusb_audio_thread(void *arg)
 				/* Check for room in the write buffer.  If the device goes unavailable or
 				 * there is not room in the buffer, Pa_WriteStream will hang.
 				 */
-				frames_available = Pa_GetStreamWriteAvailable(o->stream);
+				frames_available = ast_radio_pa_write_available(&o->pa);
 
 				if (frames_available < 0) {
 					if (frames_available != paOutputUnderflowed) {
@@ -2517,6 +2276,7 @@ static void *simpleusb_audio_thread(void *arg)
 						ast_debug(2, "Pa_GetStreamWriteAvailable error %s", Pa_GetErrorText(frames_available));
 						o->hasusb = 0;
 						stream_cleanup(o);
+						break;
 					}
 				}
 
@@ -2615,6 +2375,7 @@ static void *simpleusb_audio_thread(void *arg)
 									ast_debug(2, "Pa_WriteStream error %s", Pa_GetErrorText(res));
 									o->hasusb = 0;
 									stream_cleanup(o);
+									break;
 								}
 							}
 
@@ -2647,6 +2408,9 @@ static void *simpleusb_audio_thread(void *arg)
 						}
 					}
 					ast_frfree(f1);
+					if (!o->hasusb) {
+						break;
+					}
 					continue;
 				}
 
@@ -2660,16 +2424,23 @@ static void *simpleusb_audio_thread(void *arg)
 				break;
 			}
 
+			if (!o->hasusb || !o->pa.active) {
+				break;
+			}
+
 			/* Read audio data from the USB sound device.
 			 * Sound data will arrive at 48000 samples per second
 			 * in mono format.  We should always have 20ms frames, 40ms timeout
 			 * as a reasonable max wait time.
 			 */
-			res = Pa_ReadStream_with_timeout(o->stream, o->simpleusb_read_buf, PA_NUM_FRAMES, 40, &o->stopaudiothread);
+			res = ast_radio_pa_read(&o->pa, o->simpleusb_read_buf, PA_NUM_FRAMES, 40, &o->stopaudiothread);
 			if (res != paNoError) {
 				/* audio data not ready */
 				if (res == paInputOverflowed) {
 					ast_debug(6, "PortAudio read overflow on channel %s\n", o->name);
+				} else if (res == paTimedOut) {
+					ast_debug(6, "PortAudio read timeout on channel %s\n", o->name);
+					continue;
 				} else {
 					ast_log(LOG_ERROR, "Pa_ReadStream Error on channel %s : %s\n", o->name, Pa_GetErrorText(res));
 					o->hasusb = 0;
@@ -4650,6 +4421,7 @@ static int load_module(void)
 static int unload_module(void)
 {
 	struct chan_simpleusb_pvt *o, *no;
+	int i;
 
 	stoppulser = 1;
 
@@ -4658,11 +4430,15 @@ static int unload_module(void)
 		if (o->owner) {
 			ast_softhangup(o->owner, AST_SOFTHANGUP_APPUNLOAD);
 		}
+		o->stopaudiothread = 1;
+		o->stophidthread = 1;
+		kickptt(o);
 
 		if (o->audiothread != AST_PTHREADT_NULL) {
 			pthread_join(o->audiothread, NULL); /* wait for audio thread to end */
 			o->audiothread = AST_PTHREADT_NULL;
 		}
+		stop_stream(o);
 		if (o->hidthread != AST_PTHREADT_NULL) {
 			pthread_join(o->hidthread, NULL);
 			o->hidthread = AST_PTHREADT_NULL;
@@ -4670,9 +4446,14 @@ static int unload_module(void)
 		if (o->dsp) {
 			ast_dsp_free(o->dsp);
 		}
+		for (i = 0; i < GPIO_PINCOUNT; i++) {
+			ast_free(o->gpios[i]);
+		}
+		for (i = 0; i < ARRAY_LEN(o->pps); i++) {
+			ast_free(o->pps[i]);
+		}
+		ast_free(o->name);
 		ast_free(o);
-
-		/* XXX what about the memory allocated ? */
 	}
 
 #if DEBUG_CAPTURES == 1

--- a/configs/samples/simpleusb.conf.sample
+++ b/configs/samples/simpleusb.conf.sample
@@ -117,6 +117,8 @@ legacyaudioscaling = no     ; If yes, continue to do raw audio sample scaling an
 ;;;;; Tune settings ;;;;;
 ;devstr=
 ;serial=
+;audiodev=hw:0             ; Optional ALSA device for PortAudio audio (hw:N or hw:N,M).
+                            ; Use instead of devstr when binding audio by card number.
 ;rxmixerset=500
 ;txmixaset=500
 ;txmixbset=500

--- a/configs/samples/simpleusb.conf.sample
+++ b/configs/samples/simpleusb.conf.sample
@@ -117,7 +117,7 @@ legacyaudioscaling = no     ; If yes, continue to do raw audio sample scaling an
 ;;;;; Tune settings ;;;;;
 ;devstr=
 ;serial=
-;audiodev=hw:0             ; Optional ALSA device for PortAudio audio (hw:N or hw:N,M).
+;audiodev=hw:0              ; Optional ALSA device for PortAudio audio (hw:N or hw:N,M).
                             ; Use instead of devstr when binding audio by card number.
 ;rxmixerset=500
 ;txmixaset=500

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -1361,6 +1361,9 @@ PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned l
 
 PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, unsigned long frames)
 {
+	PaError res;
+	short null_buf[AST_RADIO_PA_FRAMES_PER_BUFFER * AST_RADIO_PA_OUTPUT_CHANNELS];
+
 	if (!ps || !ps->stream || !data) {
 		return paBadStreamPtr;
 	}
@@ -1370,7 +1373,18 @@ PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, un
 		return paBufferTooBig;
 	}
 
-	return Pa_WriteStream(ps->stream, data, frames);
+	res = Pa_WriteStream(ps->stream, data, frames);
+	if (res == paOutputUnderflowed) {
+		/*
+		 * Prime the stream with one silence frame so the USB buffer does not
+		 * stay empty (choppy TX). See #593 / #598.
+		 */
+		memset(null_buf, 0, sizeof(null_buf));
+		ast_debug(6, "PortAudio write stream underflow, writing a 0 frame");
+		Pa_WriteStream(ps->stream, null_buf, frames);
+	}
+
+	return res;
 }
 
 long ast_radio_pa_write_available(struct ast_radio_pa_stream *ps)

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -1362,8 +1362,6 @@ PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned l
 PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, unsigned long frames)
 {
 	PaError res;
-	PaError prime_res;
-	short null_buf[AST_RADIO_PA_FRAMES_PER_BUFFER * AST_RADIO_PA_OUTPUT_CHANNELS];
 
 	if (!ps || !ps->stream || !data) {
 		return paBadStreamPtr;
@@ -1376,12 +1374,14 @@ PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, un
 
 	res = Pa_WriteStream(ps->stream, data, frames);
 	if (res == paOutputUnderflowed) {
+		PaError prime_res;
+		short null_buf[AST_RADIO_PA_FRAMES_PER_BUFFER * AST_RADIO_PA_OUTPUT_CHANNELS] = { 0 };
+
 		/*
 		 * Prime the stream with one silence frame so the USB buffer does not
 		 * stay empty (choppy TX). See #593 / #598. Propagate a real failure
 		 * from the silence write so callers can restart the stream.
 		 */
-		memset(null_buf, 0, sizeof(null_buf));
 		ast_debug(6, "PortAudio write stream underflow, writing a 0 frame");
 		prime_res = Pa_WriteStream(ps->stream, null_buf, frames);
 		if (prime_res != paNoError) {

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -1362,6 +1362,7 @@ PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned l
 PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, unsigned long frames)
 {
 	PaError res;
+	PaError prime_res;
 	short null_buf[AST_RADIO_PA_FRAMES_PER_BUFFER * AST_RADIO_PA_OUTPUT_CHANNELS];
 
 	if (!ps || !ps->stream || !data) {
@@ -1377,11 +1378,15 @@ PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, un
 	if (res == paOutputUnderflowed) {
 		/*
 		 * Prime the stream with one silence frame so the USB buffer does not
-		 * stay empty (choppy TX). See #593 / #598.
+		 * stay empty (choppy TX). See #593 / #598. Propagate a real failure
+		 * from the silence write so callers can restart the stream.
 		 */
 		memset(null_buf, 0, sizeof(null_buf));
 		ast_debug(6, "PortAudio write stream underflow, writing a 0 frame");
-		Pa_WriteStream(ps->stream, null_buf, frames);
+		prime_res = Pa_WriteStream(ps->stream, null_buf, frames);
+		if (prime_res != paNoError) {
+			return prime_res;
+		}
 	}
 
 	return res;


### PR DESCRIPTION
## Summary
- Migrate `chan_simpleusb` off OSS `/dev/dsp` to shared `ast_radio_pa_*` helpers
- Fail device init when ALSA mixer limits are unavailable
- Document optional `audiodev=hw:N` in `simpleusb.conf.sample`

Standalone piece **2/3**. Depends on #1111 — merge that first, then rebase this branch onto `master` before final merge.

**Review focus:** `channels/chan_simpleusb.c`, `channels/Makefile.diff`, `configs/samples/simpleusb.conf.sample` (compare against `portaudio/1-res-usbradio` for scope-only diff).

## Test plan
- [ ] CI passes
- [ ] `chan_simpleusb.so` loads; audio via PortAudio on test node
- [ ] Mixer init fails cleanly when ALSA limits unavailable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added USB radio channel support using the shared USB audio system.
  - Added an `audiodev` configuration option for selecting audio devices by ALSA card or device number.
  - Improved USB audio device and mixer configuration.

- **Bug Fixes**
  - Improved audio stream startup, shutdown, and recovery when USB audio becomes unavailable.
  - Improved channel cleanup during hangup and module shutdown.
  - Removed the direct PortAudio dependency from the simple USB channel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->