### PR TITLE
chan_usbradio: PortAudio migration and install/docs (3/3)

### DIFF
--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1224,7 +1224,9 @@ static void *hidthread(void *arg)
 			ast_mutex_unlock(&usb_dev_lock);
 			usb_close(usb_handle);
 			usb_handle = NULL;
-			return NULL;
+			/* Stay in hidthread and retry; call() only starts the thread once. */
+			usleep(DEVICE_RETRY);
+			continue;
 		}
 
 		if ((o->usb_dev->descriptor.idProduct & 0xfffc) == C108_PRODUCT_ID) {

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -1890,7 +1890,12 @@ static int usbradio_call(struct ast_channel *c, const char *dest, int timeout)
 
 	o->stophid = 0;
 	ast_radio_time(&o->lasthidtime);
-	ast_pthread_create(&o->hidthread, NULL, hidthread, o);
+	if (o->hidthread == AST_PTHREADT_NULL) {
+		if (ast_pthread_create(&o->hidthread, NULL, hidthread, o)) {
+			ast_log(LOG_ERROR, "Channel %s: Failed to create HID thread\n", o->name);
+			return -1;
+		}
+	}
 	ast_setstate(c, AST_STATE_UP);
 	return 0;
 }
@@ -1918,12 +1923,7 @@ static int usbradio_hangup(struct ast_channel *c)
 	ast_channel_tech_pvt_set(c, NULL);
 	o->owner = NULL;
 	ast_module_unref(ast_module_info->self);
-	o->stophid = 1;
 	kickptt(o);
-	if (o->hidthread != AST_PTHREADT_NULL) {
-		pthread_join(o->hidthread, NULL);
-		o->hidthread = AST_PTHREADT_NULL;
-	}
 	if (o->hookstate) {
 		o->hookstate = 0;
 	}

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -939,13 +939,19 @@ static void *hidthread(void *arg)
 			int subdev;
 
 			if (ast_radio_parse_hw_anywhere(o->hw_device, &i, &subdev)) {
+				int card_in_use = 0;
+
 				for (ao = usbradio_default.next; ao && ao->name; ao = ao->next) {
 					if (ao != o && ao->usbass && ao->devicenum == i) {
 						ast_log(LOG_ERROR, "Channel %s: Audio device %s is already assigned to channel %s\n", o->name, o->hw_device, ao->name);
-						ast_mutex_unlock(&usb_dev_lock);
-						usleep(500000);
-						continue;
+						card_in_use = 1;
+						break;
 					}
+				}
+				if (card_in_use) {
+					ast_mutex_unlock(&usb_dev_lock);
+					usleep(500000);
+					continue;
 				}
 				usb_dev = ast_radio_usb_device_from_alsa_card(i);
 				if (!usb_dev) {
@@ -1647,7 +1653,7 @@ static int used_blocks(struct chan_usbradio_pvt *o)
 	}
 
 	if (avail < AST_RADIO_PA_FRAMES_PER_BUFFER) {
-		return o->total_blocks;
+		return o->total_blocks + 1;
 	}
 
 	return 0;
@@ -1692,6 +1698,7 @@ static int soundcard_writeframe(struct chan_usbradio_pvt *o, short *data)
 	res = ast_radio_pa_write(&o->pa, data, AST_RADIO_PA_FRAMES_PER_BUFFER);
 	if (res < 0 && res != paOutputUnderflowed) {
 		ast_log(LOG_ERROR, "Channel %s: PortAudio write error %s\n", o->name, Pa_GetErrorText(res));
+		usbradio_stop_audio(o);
 		return 0;
 	}
 
@@ -1913,7 +1920,10 @@ static int usbradio_hangup(struct ast_channel *c)
 	ast_module_unref(ast_module_info->self);
 	o->stophid = 1;
 	kickptt(o);
-	pthread_join(o->hidthread, NULL);
+	if (o->hidthread != AST_PTHREADT_NULL) {
+		pthread_join(o->hidthread, NULL);
+		o->hidthread = AST_PTHREADT_NULL;
+	}
 	if (o->hookstate) {
 		o->hookstate = 0;
 	}
@@ -2066,6 +2076,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 		}
 		ast_log(LOG_ERROR, "Channel %s: PortAudio read error %s\n", o->name, Pa_GetErrorText(pa_res));
 		o->hasusb = 0;
+		usbradio_stop_audio(o);
 		return &ast_null_frame;
 	}
 
@@ -2599,11 +2610,6 @@ static struct ast_channel *usbradio_new(struct chan_usbradio_pvt *o, char *ext, 
 		return NULL;
 	}
 	ast_channel_tech_set(c, &usbradio_tech);
-	if (!o->pa.active && o->hasusb) {
-		if (usbradio_start_audio(o) < 0) {
-			return NULL;
-		}
-	}
 	ast_channel_nativeformats_set(c, usbradio_tech.capabilities);
 	ast_channel_set_readformat(c, ast_format_slin);
 	ast_channel_set_writeformat(c, ast_format_slin);
@@ -2612,6 +2618,12 @@ static struct ast_channel *usbradio_new(struct chan_usbradio_pvt *o, char *ext, 
 
 	o->owner = c;
 	ast_module_ref(ast_module_info->self);
+	if (!o->pa.active && o->hasusb) {
+		if (usbradio_start_audio(o) < 0) {
+			ast_hangup(c);
+			return NULL;
+		}
+	}
 	ast_jb_configure(c, &global_jbconf);
 	if (state != AST_STATE_DOWN) {
 		if (ast_pbx_start(c)) {
@@ -4886,6 +4898,7 @@ static struct chan_usbradio_pvt *store_config(struct ast_config *cfg, const char
 			o->name = ast_strdup(ctg);
 			o->pttkick[0] = -1;
 			o->pttkick[1] = -1;
+			o->hidthread = AST_PTHREADT_NULL;
 			o->hw_device[0] = '\0';
 			if (!usbradio_active) {
 				usbradio_active = o->name;
@@ -5513,10 +5526,6 @@ static int unload_module(void)
 	ast_cli_unregister_multiple(cli_usbradio, sizeof(cli_usbradio) / sizeof(struct ast_cli_entry));
 
 	for (o = usbradio_default.next; o; o = o->next) {
-		if (o->pmrChan) {
-			destroyPmrChannel(o->pmrChan);
-		}
-
 #if DEBUG_CAPTURES == 1
 		if (frxcapraw) {
 			fclose(frxcapraw);
@@ -5549,8 +5558,15 @@ static int unload_module(void)
 		}
 		o->stophid = 1;
 		kickptt(o);
-		pthread_join(o->hidthread, NULL);
+		if (o->hidthread != AST_PTHREADT_NULL) {
+			pthread_join(o->hidthread, NULL);
+			o->hidthread = AST_PTHREADT_NULL;
+		}
 		usbradio_stop_audio(o);
+		if (o->pmrChan) {
+			destroyPmrChannel(o->pmrChan);
+			o->pmrChan = NULL;
+		}
 		if (o->dsp) {
 			ast_dsp_free(o->dsp);
 		}

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -96,6 +96,8 @@
 #define MS_PER_FRAME 20						   /* 20 ms frames */
 #define MS_TO_FRAMES(ms) ((ms) / MS_PER_FRAME) /* convert ms to frames */
 
+#define USBRADIO_48K_STEREO_BYTES (FRAME_SIZE * 2 * 2 * 6)
+
 #include "./xpmr/xpmr.h"
 #ifdef HAVE_XPMRX
 #include "./xpmrx/xpmrx.h"
@@ -211,12 +213,12 @@ struct chan_usbradio_pvt {
 	struct ast_channel *owner;
 
 	/* buffer used in usbradio_write, 2 per int by 2 channels by 6 times oversampling (48KS/s) */
-	char usbradio_write_buf[FRAME_SIZE * 2 * 2 * 6];
+	char usbradio_write_buf[USBRADIO_48K_STEREO_BYTES];
 
 	/* buffers used in usbradio_read - AST_FRIENDLY_OFFSET space for headers
-	 * plus enough room for a full frame
+	 * plus enough room for a full 48 kHz stereo PortAudio frame
 	 */
-	char usbradio_read_buf[FRAME_SIZE * (2 * 12) + AST_FRIENDLY_OFFSET]; /* 2 bytes * 2 channels * 6 for 48K */
+	char usbradio_read_buf[AST_RADIO_PA_48K_STEREO_SAMPLES * (int) sizeof(short) + AST_FRIENDLY_OFFSET];
 	char usbradio_read_buf_8k[FRAME_SIZE * 2 + AST_FRIENDLY_OFFSET];
 	int readpos;			 /* read position above */
 	struct ast_frame read_f; /* returned by usbradio_read */
@@ -447,6 +449,7 @@ static int hidhdwconfig(struct chan_usbradio_pvt *o);
 static void mixer_write(struct chan_usbradio_pvt *o);
 static int usbradio_start_audio(struct chan_usbradio_pvt *o);
 static void usbradio_stop_audio(struct chan_usbradio_pvt *o);
+static PaError usbradio_read_pa_stereo(struct chan_usbradio_pvt *o);
 static struct ast_channel *usbradio_request(const char *type, struct ast_format_cap *cap,
 	const struct ast_assigned_ids *assignedids, const struct ast_channel *requestor, const char *data, int *cause);
 static int usbradio_digit_begin(struct ast_channel *c, char digit);
@@ -1694,11 +1697,11 @@ usb_device_ready:
 
 /*!
  * \brief Write a full frame of audio data to the sound card device.
- * \note The input data must be formatted as stereo at 48000 samples per second.
- *		 FRAME_SIZE * 2 * 2 * 6 (2 bytes per sample, 2 channels, 6 for upsample to 48K)
+ * \note data is 48 kHz stereo interleaved. ast_radio_pa_write() takes frames
+ *       per channel (AST_RADIO_PA_FRAMES_PER_BUFFER).
  * \param o		chan_usbradio_pvt.
  * \param data	Audio data to write.
- * \returns		Number bytes written.
+ * \returns		Byte count written on success, 0 on failure.
  */
 static int soundcard_writeframe(struct chan_usbradio_pvt *o, short *data)
 {
@@ -1726,7 +1729,35 @@ static int soundcard_writeframe(struct chan_usbradio_pvt *o, short *data)
 		return 0;
 	}
 
-	return FRAME_SIZE * 2 * 2 * 6;
+	return USBRADIO_48K_STEREO_BYTES;
+}
+
+/*!
+ * \brief Read one PortAudio frame into the 48 kHz stereo workspace.
+ *
+ * When hardware opened with one input channel, duplicate mono samples to both
+ * channels so downstream PmrRx and stats code always see stereo layout.
+ */
+static PaError usbradio_read_pa_stereo(struct chan_usbradio_pvt *o)
+{
+	short *stereo = (short *) (o->usbradio_read_buf + AST_FRIENDLY_OFFSET);
+	PaError pa_res;
+
+	if (o->pa.input_channels == 1) {
+		short mono_buf[AST_RADIO_PA_FRAMES_PER_BUFFER];
+		int i;
+
+		pa_res = ast_radio_pa_read(&o->pa, mono_buf, AST_RADIO_PA_FRAMES_PER_BUFFER, 40, NULL);
+		if (pa_res == paNoError) {
+			for (i = AST_RADIO_PA_FRAMES_PER_BUFFER - 1; i >= 0; i--) {
+				stereo[i * 2] = mono_buf[i];
+				stereo[i * 2 + 1] = mono_buf[i];
+			}
+		}
+		return pa_res;
+	}
+
+	return ast_radio_pa_read(&o->pa, stereo, AST_RADIO_PA_FRAMES_PER_BUFFER, 40, NULL);
 }
 
 /*!
@@ -2108,21 +2139,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 		}
 	}
 
-	if (o->pa.input_channels == 1) {
-		short mono_buf[AST_RADIO_PA_FRAMES_PER_BUFFER];
-		short *stereo = (short *) (o->usbradio_read_buf + AST_FRIENDLY_OFFSET);
-		int i;
-
-		pa_res = ast_radio_pa_read(&o->pa, mono_buf, AST_RADIO_PA_FRAMES_PER_BUFFER, 40, NULL);
-		if (pa_res == paNoError) {
-			for (i = AST_RADIO_PA_FRAMES_PER_BUFFER - 1; i >= 0; i--) {
-				stereo[i * 2] = mono_buf[i];
-				stereo[i * 2 + 1] = mono_buf[i];
-			}
-		}
-	} else {
-		pa_res = ast_radio_pa_read(&o->pa, (short *) (o->usbradio_read_buf + AST_FRIENDLY_OFFSET), AST_RADIO_PA_FRAMES_PER_BUFFER, 40, NULL);
-	}
+	pa_res = usbradio_read_pa_stereo(o);
 	if (pa_res != paNoError) {
 		if (pa_res == paTimedOut || pa_res == paInputOverflowed) {
 			/* No RX audio available; still run PTT/TX processing with silence. */
@@ -2137,20 +2154,15 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 
 #if DEBUG_CAPTURES == 1
 	if (o->rxcapraw && frxcapraw) {
-		fwrite(o->usbradio_read_buf + AST_FRIENDLY_OFFSET, 1, FRAME_SIZE * 2 * 2 * 6, frxcapraw);
+		fwrite(o->usbradio_read_buf + AST_FRIENDLY_OFFSET, 1, USBRADIO_48K_STEREO_BYTES, frxcapraw);
 	}
 #endif
 
 	o->readerrs = 0;
 	o->readpos = sizeof(o->usbradio_read_buf);
 
-	/* Check for ADC clipping and input audio statistics before any filtering is done.
-	 * FRAME_SIZE define refers to 8Ksps mono which is 160 samples per 20mS USB frame.
-	 * ast_radio_check_audio() takes the read buffer as received (48K stereo),
-	 * extracts the mono 48K channel, checks amplitude and distortion characteristics,
-	 * and returns true if clipping was detected.
-	 */
-	if (ast_radio_check_audio((short *) (o->usbradio_read_buf + AST_FRIENDLY_OFFSET), &o->rxaudiostats, 12 * FRAME_SIZE, 0)) {
+	/* RX stats on the normalized 48 kHz stereo workspace. */
+	if (ast_radio_check_audio_stereo_48k((short *) (o->usbradio_read_buf + AST_FRIENDLY_OFFSET), &o->rxaudiostats)) {
 		if (o->clipledgpio) {
 			/* Set Clip LED GPIO pulsetimer if not already set */
 			if (!o->hid_gpio_pulsetimer[o->clipledgpio - 1]) {
@@ -2174,7 +2186,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 		register float v;
 		register int i;
 
-		for (i = 0; i < FRAME_SIZE * 2 * 6; i++) {
+		for (i = 0; i < AST_RADIO_PA_48K_STEREO_SAMPLES; i++) {
 			v = ((float) *sp) * 0.800;
 			*sp++ = (int) v;
 		}
@@ -2245,14 +2257,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	/* Write the received audio to the sound card */
 	soundcard_writeframe(o, (short *) o->usbradio_write_buf);
 
-	/* Check Tx audio statistics. FRAME_SIZE define refers to 8Ksps mono which is 160 samples
-	 * per 20mS USB frame. ast_radio_check_audio() takes the write buffer (48K stereo),
-	 * extracts the mono 48K channel, checks amplitude and distortion characteristics,
-	 * and returns true if clipping was detected. If local Tx audio is clipped it might be
-	 * nice to log a warning but as this does not relate to outgoing network audio it's not
-	 * a major issue. User can check the Tx Audio Stats utility if desired.
-	 */
-	ast_radio_check_audio((short *) o->usbradio_write_buf, &o->txaudiostats, 12 * FRAME_SIZE, 0);
+	ast_radio_check_audio_stereo_48k((short *) o->usbradio_write_buf, &o->txaudiostats);
 
 #if DEBUG_CAPTURES == 1 && XPMR_DEBUG0 == 1
 	if (frxcaptrace && o->rxcap2 && o->pmrChan->b.radioactive) {

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -102,14 +102,6 @@
 #include "./xpmrx/bitweight.h"
 #endif
 
-#ifdef __linux
-#include <linux/soundcard.h>
-#elif defined(__FreeBSD__)
-#include <sys/soundcard.h>
-#else
-#include <soundcard.h>
-#endif
-
 #include "asterisk/lock.h"
 #include "asterisk/frame.h"
 #include "asterisk/logger.h"
@@ -182,11 +174,12 @@ static const char *const mixer_type[] = { "no", "voice", "tone", "composite", "a
 struct chan_usbradio_pvt {
 	struct chan_usbradio_pvt *next;
 
-	char *name;		  /* the internal name of our channel */
-	int devtype;	  /* actual type of device */
-	int pttkick[2];	  /* ptt kick pipe */
-	int total_blocks; /* total blocks in the output device */
-	int sounddev;
+	char *name;			 /* the internal name of our channel */
+	char hw_device[100]; /* ALSA/PortAudio device (hw:N or hw:N,M) */
+	int devtype;		 /* actual type of device */
+	int pttkick[2];		 /* ptt kick pipe */
+	int total_blocks;	 /* legacy queue depth hint for TX buffering */
+	struct ast_radio_pa_stream pa;
 	enum {
 		M_UNSET,
 		M_FULL,
@@ -426,7 +419,6 @@ struct chan_usbradio_pvt {
  * \brief Default channel descriptor
  */
 static struct chan_usbradio_pvt usbradio_default = {
-	.sounddev = -1,
 	.duplex = M_UNSET,
 	.queuesize = QUEUE_SIZE,
 	.frags = FRAGS,
@@ -450,7 +442,8 @@ static struct chan_usbradio_pvt usbradio_default = {
 
 static int hidhdwconfig(struct chan_usbradio_pvt *o);
 static void mixer_write(struct chan_usbradio_pvt *o);
-static int setformat(struct chan_usbradio_pvt *o, int mode);
+static int usbradio_start_audio(struct chan_usbradio_pvt *o);
+static void usbradio_stop_audio(struct chan_usbradio_pvt *o);
 static struct ast_channel *usbradio_request(const char *type, struct ast_format_cap *cap,
 	const struct ast_assigned_ids *assignedids, const struct ast_channel *requestor, const char *data, int *cause);
 static int usbradio_digit_begin(struct ast_channel *c, char digit);
@@ -764,6 +757,7 @@ static int load_tune_config(struct chan_usbradio_pvt *o, const struct ast_config
 	int configured = 0;
 	char devstr[sizeof(o->devstr)];
 	char serial[sizeof(o->serial)];
+	char hw_device[sizeof(o->hw_device)];
 
 	/* No load defaults */
 	o->rxmixerset = 500;
@@ -777,9 +771,11 @@ static int load_tune_config(struct chan_usbradio_pvt *o, const struct ast_config
 
 	devstr[0] = '\0';
 	serial[0] = '\0';
+	hw_device[0] = '\0';
 	if (!reload) {
 		o->devstr[0] = 0;
 		o->serial[0] = 0;
+		o->hw_device[0] = '\0';
 	}
 
 	if (!cfg) {
@@ -807,12 +803,18 @@ static int load_tune_config(struct chan_usbradio_pvt *o, const struct ast_config
 		CV_UINT("fever", o->fever);
 		CV_STR("devstr", devstr);
 		CV_STR("serial", serial);
+		CV_STR("audiodev", hw_device);
 		CV_END;
 	}
 	if (!reload) {
 		/* Using the ternary operator in CV_STR won't work, due to butchering the sizeof, so copy after if needed */
 		ast_copy_string(o->devstr, devstr, sizeof(o->devstr));
 		ast_copy_string(o->serial, serial, sizeof(o->serial));
+		if (ast_strlen_zero(devstr)) {
+			ast_copy_string(o->hw_device, hw_device, sizeof(o->hw_device));
+		} else {
+			o->hw_device[0] = '\0';
+		}
 	}
 	if (opened) {
 		ast_config_destroy(cfg2);
@@ -822,6 +824,42 @@ static int load_tune_config(struct chan_usbradio_pvt *o, const struct ast_config
 		return -1;
 	}
 	return 0;
+}
+
+static int usbradio_start_audio(struct chan_usbradio_pvt *o)
+{
+	PaError res;
+
+	if (o->pa.active) {
+		return 0;
+	}
+
+	if (!o->hw_device[0]) {
+		snprintf(o->hw_device, sizeof(o->hw_device), "hw:%d", (int) (unsigned char) o->devicenum);
+	}
+
+	ast_copy_string(o->pa.hw_device, o->hw_device, sizeof(o->pa.hw_device));
+	o->pa.input_channels = 2;
+
+	res = ast_radio_pa_open(&o->pa);
+	if (res != paNoError) {
+		ast_log(LOG_ERROR, "Channel %s: Unable to open PortAudio stream %s\n", o->name, o->hw_device);
+		return -1;
+	}
+
+	res = ast_radio_pa_start(&o->pa);
+	if (res != paNoError) {
+		ast_log(LOG_ERROR, "Channel %s: Unable to start PortAudio stream %s\n", o->name, o->hw_device);
+		ast_radio_pa_stop(&o->pa);
+		return -1;
+	}
+
+	return 0;
+}
+
+static void usbradio_stop_audio(struct chan_usbradio_pvt *o)
+{
+	ast_radio_pa_stop(&o->pa);
 }
 
 /*!
@@ -857,7 +895,7 @@ static void *hidthread(void *arg)
 {
 	unsigned char buf[4], bufsave[4], keyed, ctcssed;
 	char *s, lasttxtmp;
-	register int i, j, k;
+	int i, j, k;
 	int res;
 	struct usb_device *usb_dev;
 	struct usb_dev_handle *usb_handle;
@@ -895,6 +933,59 @@ static void *hidthread(void *arg)
 		usb_handle = NULL;
 		usb_dev = NULL;
 		ast_radio_hid_device_mklist();
+
+		/* audiodev without devstr: bind HID to ALSA card number */
+		if (o->hw_device[0] && ast_strlen_zero(o->devstr)) {
+			int subdev;
+
+			if (ast_radio_parse_hw_anywhere(o->hw_device, &i, &subdev)) {
+				for (ao = usbradio_default.next; ao && ao->name; ao = ao->next) {
+					if (ao != o && ao->usbass && ao->devicenum == i) {
+						ast_log(LOG_ERROR, "Channel %s: Audio device %s is already assigned to channel %s\n", o->name, o->hw_device, ao->name);
+						ast_mutex_unlock(&usb_dev_lock);
+						usleep(500000);
+						continue;
+					}
+				}
+				usb_dev = ast_radio_usb_device_from_alsa_card(i);
+				if (!usb_dev) {
+					if (!o->device_error) {
+						ast_log(LOG_ERROR, "Channel %s: No USB device for audiodev %s\n", o->name, o->hw_device);
+						o->device_error = 1;
+					}
+					ast_mutex_unlock(&usb_dev_lock);
+					usleep(500000);
+					continue;
+				}
+				o->devicenum = i;
+				{
+					int use_newname = 0;
+
+					if (ast_radio_init_mixer_limits(o->devicenum, &o->micmax, &o->spkrmax, &o->micplaymax, &use_newname) < 0) {
+						if (!o->device_error) {
+							ast_log(LOG_ERROR, "Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
+							o->device_error = 1;
+						}
+						ast_mutex_unlock(&usb_dev_lock);
+						usleep(500000);
+						continue;
+					}
+					o->newname = use_newname;
+				}
+				o->device_error = 0;
+				ast_radio_time(&o->lasthidtime);
+				o->usbass = 1;
+				ast_mutex_unlock(&usb_dev_lock);
+				goto usb_device_ready;
+			}
+			if (!o->device_error) {
+				ast_log(LOG_ERROR, "Channel %s: Invalid audiodev '%s' (use hw:N or hw:N,M)\n", o->name, o->hw_device);
+				o->device_error = 1;
+			}
+			ast_mutex_unlock(&usb_dev_lock);
+			usleep(500000);
+			continue;
+		}
 
 		/* Check to see if our specified device string
 		 * matches to a device that is attached to this system, or exists
@@ -1031,17 +1122,25 @@ static void *hidthread(void *arg)
 			continue;
 		}
 		o->devicenum = i;
+		snprintf(o->hw_device, sizeof(o->hw_device), "hw:%d", i);
+		{
+			int use_newname = 0;
+
+			if (ast_radio_init_mixer_limits(o->devicenum, &o->micmax, &o->spkrmax, &o->micplaymax, &use_newname) < 0) {
+				if (!o->device_error) {
+					ast_log(LOG_ERROR, "Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
+					o->device_error = 1;
+				}
+				ast_mutex_unlock(&usb_dev_lock);
+				usleep(500000);
+				continue;
+			}
+			o->newname = use_newname;
+		}
 		o->device_error = 0;
 		ast_radio_time(&o->lasthidtime);
 		o->usbass = 1;
 		ast_mutex_unlock(&usb_dev_lock);
-		/* set the audio mixer values */
-		o->micmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL);
-		o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL);
-		if (o->spkrmax == -1) {
-			o->newname = 1;
-			o->spkrmax = ast_radio_amixer_max(o->devicenum, MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW);
-		}
 		/* initialize the usb device */
 		usb_dev = ast_radio_hid_device_init(o->devstr);
 		if (usb_dev == NULL) {
@@ -1049,6 +1148,7 @@ static void *hidthread(void *arg)
 			usleep(500000);
 			continue;
 		}
+usb_device_ready:
 		/* open the usb device device */
 		usb_handle = usb_open(usb_dev);
 		if (usb_handle == NULL) {
@@ -1089,6 +1189,12 @@ static void *hidthread(void *arg)
 		}
 		if (pipe2(o->pttkick, O_NONBLOCK) == -1) {
 			ast_log(LOG_ERROR, "Channel %s: Is not able to create a pipe\n", o->name);
+			usb_close(usb_handle);
+			usb_handle = NULL;
+			ast_mutex_lock(&usb_dev_lock);
+			o->usbass = 0;
+			o->hasusb = 0;
+			ast_mutex_unlock(&usb_dev_lock);
 			pthread_exit(NULL);
 		}
 		if ((usb_dev->descriptor.idProduct & 0xfffc) == C108_PRODUCT_ID) {
@@ -1209,7 +1315,14 @@ static void *hidthread(void *arg)
 		}
 		ast_mutex_unlock(&o->eepromlock);
 
-		setformat(o, O_RDWR);
+		if (usbradio_start_audio(o) < 0) {
+			ast_log(LOG_ERROR, "Channel %s: Unable to start audio for %s\n", o->name, o->hw_device);
+			ast_mutex_lock(&usb_dev_lock);
+			o->usbass = 0;
+			ast_mutex_unlock(&usb_dev_lock);
+			usleep(500000);
+			continue;
+		}
 		o->hasusb = 1;
 		o->had_gpios_in = 0;
 
@@ -1514,32 +1627,30 @@ static void *hidthread(void *arg)
  */
 static int used_blocks(struct chan_usbradio_pvt *o)
 {
-	struct audio_buf_info info;
+	long avail;
 
-	if (ioctl(o->sounddev, SNDCTL_DSP_GETOSPACE, &info)) {
+	if (!o->pa.active) {
+		return 0;
+	}
+
+	avail = ast_radio_pa_write_available(&o->pa);
+	if (avail < 0) {
 		if (!(o->warned & WARN_used_blocks)) {
-			ast_log(LOG_WARNING, "Channel %s: Error reading output space.\n", o->name);
+			ast_log(LOG_WARNING, "Channel %s: Error reading PortAudio output space.\n", o->name);
 			o->warned |= WARN_used_blocks;
 		}
-		return 1;
+		return o->queuesize + 1;
 	}
 
-	/* Set the total blocks */
 	if (o->total_blocks == 0) {
-		ast_debug(1, "Channel %s: fragment total %d, size %d, available %d, bytes %d\n", o->name, info.fragstotal, info.fragsize,
-			info.fragments, info.bytes);
-		o->total_blocks = info.fragments;
-		/* Check the queue size, it cannot exceed the total fragments */
-		if (o->queuesize >= info.fragstotal) {
-			o->queuesize = info.fragstotal - 1;
-			if (o->queuesize < 2) {
-				o->queuesize = QUEUE_SIZE;
-			}
-			ast_debug(1, "Channel %s: Queue size reset to %d\n", o->name, o->queuesize);
-		}
+		o->total_blocks = o->queuesize ? o->queuesize : QUEUE_SIZE;
 	}
 
-	return o->total_blocks - info.fragments;
+	if (avail < AST_RADIO_PA_FRAMES_PER_BUFFER) {
+		return o->total_blocks;
+	}
+
+	return 0;
 }
 
 /*!
@@ -1552,161 +1663,39 @@ static int used_blocks(struct chan_usbradio_pvt *o)
  */
 static int soundcard_writeframe(struct chan_usbradio_pvt *o, short *data)
 {
-	int res;
+	PaError res;
 	short outbuf[FRAME_SIZE * 2 * 6];
 
-	/* If the sound device is not open, setformat will open the device */
-	if (o->sounddev < 0) {
-		setformat(o, O_RDWR);
+	if (!o->pa.active) {
+		if (usbradio_start_audio(o) < 0) {
+			return 0;
+		}
 	}
-	if (o->sounddev < 0) {
-		return 0; /* not fatal */
-	}
-	/*  This may or may not be a good thing
-	 *  drop the frame if not transmitting, this keeps from gradually
-	 *  filling the buffer when asterisk clock > usb sound clock
-	 */
+
 	if (!o->pmrChan->txPttIn && !o->pmrChan->txPttOut) {
 		return 0;
 	}
-	/*
-	 * Nothing complex to manage the audio device queue.
-	 * If the buffer is full just drop the extra, otherwise write.
-	 * In some cases it might be useful to write anyways after
-	 * a number of failures, to restart the output chain.
-	 */
-	res = used_blocks(o);
-	if (res > o->queuesize) { /* no room to write a block */
-		/* Only report a buffer overflow when we are transmitting */
+
+	if (used_blocks(o) > o->queuesize) {
 		if (o->pmrChan->txPttIn || o->pmrChan->txPttOut) {
-			ast_log(LOG_WARNING, "Channel %s: Sound device write buffer overflow - used %d blocks\n", o->name, res);
+			ast_log(LOG_WARNING, "Channel %s: Sound device write buffer overflow\n", o->name);
 		}
 		return 0;
 	}
-	if (res == 0) { /* We are not keeping the buffer full, add 1 frame */
+
+	if (used_blocks(o) == 0) {
 		memset(outbuf, 0, sizeof(outbuf));
-		res = write(o->sounddev, ((void *) outbuf), sizeof(outbuf));
-		if (res < 0) {
-			ast_log(LOG_ERROR, "Channel %s: Sound card write error %s\n", o->name, strerror(errno));
-		}
+		ast_radio_pa_write(&o->pa, outbuf, AST_RADIO_PA_FRAMES_PER_BUFFER);
 		ast_debug(7, "A null frame has been added");
 	}
-	res = write(o->sounddev, ((void *) data), FRAME_SIZE * 2 * 2 * 6);
-	if (res < 0) {
-		ast_log(LOG_ERROR, "Channel %s: Sound card write error %s\n", o->name, strerror(errno));
-	} else if (res != FRAME_SIZE * 2 * 2 * 6) {
-		ast_log(LOG_ERROR, "Channel %s: Sound card wrote %d bytes of %d\n", o->name, res, (FRAME_SIZE * 2 * 2 * 6));
-	}
 
-	return res;
-}
-
-/*!
- * \brief Open the sound card device.
- * If the device is already open, this will close the device
- * and open it again.
- * It initializes the device based on our requirements and triggers
- * reads and writes.
- * \param o		Channel private data.
- * \param mode	The mode to open the file.  This is the flags argument to open.
- * \retval 0	Success.
- * \retval -1	Failed.
- */
-static int setformat(struct chan_usbradio_pvt *o, int mode)
-{
-	int fmt, desired, res, fd;
-	char device[100];
-
-	/* If the device is open, close it */
-	if (o->sounddev >= 0) {
-		ioctl(o->sounddev, SNDCTL_DSP_RESET, 0);
-		close(o->sounddev);
-		o->duplex = M_UNSET;
-		o->sounddev = -1;
-	}
-	if (mode == O_CLOSE) { /* we are done */
+	res = ast_radio_pa_write(&o->pa, data, AST_RADIO_PA_FRAMES_PER_BUFFER);
+	if (res < 0 && res != paOutputUnderflowed) {
+		ast_log(LOG_ERROR, "Channel %s: PortAudio write error %s\n", o->name, Pa_GetErrorText(res));
 		return 0;
 	}
 
-	ast_copy_string(device, "/dev/dsp", sizeof(device));
-	if (o->devicenum) {
-		snprintf(device, sizeof(device), "/dev/dsp%d", o->devicenum);
-	}
-	/* open the device */
-	fd = o->sounddev = open(device, mode | O_NONBLOCK);
-	if (fd < 0) {
-		ast_log(LOG_ERROR, "Channel %s: Unable to open DSP device %d: %s.\n", o->name, o->devicenum, strerror(errno));
-		return -1;
-	}
-	if (o->owner) {
-		ast_channel_internal_fd_set(o->owner, 0, fd);
-	}
-
-#if __BYTE_ORDER == __LITTLE_ENDIAN
-	fmt = AFMT_S16_LE;
-#else
-	fmt = AFMT_S16_BE;
-#endif
-	res = ioctl(fd, SNDCTL_DSP_SETFMT, &fmt);
-	if (res < 0) {
-		ast_log(LOG_WARNING, "Channel %s: Unable to set format to 16-bit signed\n", o->name);
-		return -1;
-	}
-	/* set our duplex mode based on the way we opened the device. */
-	switch (mode) {
-	case O_RDWR:
-		res = ioctl(fd, SNDCTL_DSP_SETDUPLEX, 0);
-		/* Check to see if duplex set (FreeBSD Bug) */
-		res = ioctl(fd, SNDCTL_DSP_GETCAPS, &fmt);
-		if (res == 0 && (fmt & DSP_CAP_DUPLEX)) {
-			o->duplex = M_FULL;
-		};
-		break;
-	case O_WRONLY:
-		o->duplex = M_WRITE;
-		break;
-	case O_RDONLY:
-		o->duplex = M_READ;
-		break;
-	}
-
-	fmt = 1;
-	res = ioctl(fd, SNDCTL_DSP_STEREO, &fmt);
-	if (res < 0) {
-		ast_log(LOG_WARNING, "Channel %s: Failed to set audio device to stereo\n", o->name);
-		return -1;
-	}
-	fmt = desired = 48000; /* 48000 Hz desired */
-	res = ioctl(fd, SNDCTL_DSP_SPEED, &fmt);
-	if (res < 0) {
-		ast_log(LOG_WARNING, "Channel %s: Failed to set audio device sample rate.\n", o->name);
-		return -1;
-	}
-	if (fmt != desired) {
-		if (!(o->warned & WARN_speed)) {
-			ast_log(LOG_WARNING, "Channel %s: Requested %d Hz, got %d Hz -- sound may be choppy.\n", o->name, desired, fmt);
-			o->warned |= WARN_speed;
-		}
-	}
-	/*
-	 * on Freebsd, SETFRAGMENT does not work very well on some cards.
-	 * Default to use 256 bytes, let the user override
-	 */
-	if (o->frags) {
-		fmt = o->frags;
-		res = ioctl(fd, SNDCTL_DSP_SETFRAGMENT, &fmt);
-		if (res < 0) {
-			if (!(o->warned & WARN_frag)) {
-				ast_log(LOG_WARNING, "Channel %s: Unable to set fragment size -- sound may be choppy.\n", o->name);
-				o->warned |= WARN_frag;
-			}
-		}
-	}
-	/* on some cards, we need SNDCTL_DSP_SETTRIGGER to start outputting */
-	res = PCM_ENABLE_INPUT | PCM_ENABLE_OUTPUT;
-	res = ioctl(fd, SNDCTL_DSP_SETTRIGGER, &res);
-	/* it may fail if we are in half duplex, never mind */
-	return 0;
+	return FRAME_SIZE * 2 * 2 * 6;
 }
 
 /*!
@@ -1922,12 +1911,13 @@ static int usbradio_hangup(struct ast_channel *c)
 	ast_channel_tech_pvt_set(c, NULL);
 	o->owner = NULL;
 	ast_module_unref(ast_module_info->self);
+	o->stophid = 1;
+	kickptt(o);
+	pthread_join(o->hidthread, NULL);
 	if (o->hookstate) {
 		o->hookstate = 0;
-		setformat(o, O_CLOSE);
 	}
-	o->stophid = 1;
-	pthread_join(o->hidthread, NULL);
+	usbradio_stop_audio(o);
 	return 0;
 }
 
@@ -1945,11 +1935,10 @@ static int usbradio_write(struct ast_channel *c, struct ast_frame *f)
 	if (!o->hasusb) {
 		return 0;
 	}
-	if (o->sounddev < 0) {
-		setformat(o, O_RDWR);
-	}
-	if (o->sounddev < 0) {
-		return 0; /* not fatal */
+	if (!o->pa.active) {
+		if (usbradio_start_audio(o) < 0) {
+			return 0;
+		}
 	}
 	/*
 	 * we could receive a block which is not a multiple of our
@@ -1988,7 +1977,8 @@ static int usbradio_write(struct ast_channel *c, struct ast_frame *f)
  */
 static struct ast_frame *usbradio_read(struct ast_channel *c)
 {
-	int res, oldpttout;
+	PaError pa_res;
+	int oldpttout;
 	int cd, sd;
 	struct chan_usbradio_pvt *o = ast_channel_tech_pvt(c);
 	struct ast_frame *f = &o->read_f, *f1;
@@ -2062,44 +2052,31 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 		ast_mutex_unlock(&o->echolock);
 	}
 
-	/* Read audio data from the USB sound device.
-	 * Sound data will arrive at 48000 samples per second
-	 * in stereo format.
-	 */
-	res = read(o->sounddev, o->usbradio_read_buf + o->readpos, sizeof(o->usbradio_read_buf) - o->readpos);
-	if (res < 0) { /* Audio data not ready, return a NULL frame */
-		if (errno != EAGAIN) {
-			o->readerrs = 0;
-			o->hasusb = 0;
+	/* Read audio data from the USB sound device (48 kHz stereo via PortAudio). */
+	if (!o->pa.active) {
+		if (usbradio_start_audio(o) < 0) {
 			return &ast_null_frame;
 		}
-		if (o->readerrs++ > READERR_THRESHOLD) {
-			ast_log(LOG_ERROR, "Stuck USB read channel [%s], un-sticking it!\n", o->name);
-			o->readerrs = 0;
-			o->hasusb = 0;
+	}
+
+	pa_res = ast_radio_pa_read(&o->pa, (short *) (o->usbradio_read_buf + AST_FRIENDLY_OFFSET), AST_RADIO_PA_FRAMES_PER_BUFFER, 40, NULL);
+	if (pa_res != paNoError) {
+		if (pa_res == paTimedOut || pa_res == paInputOverflowed) {
 			return &ast_null_frame;
 		}
-		if (o->readerrs == 1) {
-			ast_log(LOG_WARNING, "Possibly stuck USB read channel. [%s]\n", o->name);
-		}
+		ast_log(LOG_ERROR, "Channel %s: PortAudio read error %s\n", o->name, Pa_GetErrorText(pa_res));
+		o->hasusb = 0;
 		return &ast_null_frame;
 	}
 
 #if DEBUG_CAPTURES == 1
 	if (o->rxcapraw && frxcapraw) {
-		fwrite(o->usbradio_read_buf + o->readpos, 1, res, frxcapraw);
+		fwrite(o->usbradio_read_buf + AST_FRIENDLY_OFFSET, 1, FRAME_SIZE * 2 * 2 * 6, frxcapraw);
 	}
 #endif
 
-	if (o->readerrs) {
-		ast_log(LOG_WARNING, "USB read channel [%s] was not stuck.\n", o->name);
-	}
-
 	o->readerrs = 0;
-	o->readpos += res;
-	if (o->readpos < sizeof(o->usbradio_read_buf)) { /* not enough samples */
-		return &ast_null_frame;
-	}
+	o->readpos = sizeof(o->usbradio_read_buf);
 
 	/* Check for ADC clipping and input audio statistics before any filtering is done.
 	 * FRAME_SIZE define refers to 8Ksps mono which is 160 samples per 20mS USB frame.
@@ -2107,7 +2084,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	 * extracts the mono 48K channel, checks amplitude and distortion characteristics,
 	 * and returns true if clipping was detected.
 	 */
-	if (ast_radio_check_audio((short *) o->usbradio_read_buf, &o->rxaudiostats, 12 * FRAME_SIZE, 0)) {
+	if (ast_radio_check_audio((short *) (o->usbradio_read_buf + AST_FRIENDLY_OFFSET), &o->rxaudiostats, 12 * FRAME_SIZE, 0)) {
 		if (o->clipledgpio) {
 			/* Set Clip LED GPIO pulsetimer if not already set */
 			if (!o->hid_gpio_pulsetimer[o->clipledgpio - 1]) {
@@ -2127,13 +2104,11 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	 */
 	/* Decrease the audio level for CM119 A/B devices */
 	if (o->legacyaudioscaling && o->devtype != C108_PRODUCT_ID) {
-		/* Subtract res from o->readpos in below assignment (o->readpos was incremented
-		   above prior to check of if enough samples were received) */
-		register short *sp = (short *) (o->usbradio_read_buf + (o->readpos - res));
+		register short *sp = (short *) (o->usbradio_read_buf + AST_FRIENDLY_OFFSET);
 		register float v;
 		register int i;
 
-		for (i = 0; i < res / 2; i++) {
+		for (i = 0; i < FRAME_SIZE * 2 * 6; i++) {
 			v = ((float) *sp) * 0.800;
 			*sp++ = (int) v;
 		}
@@ -2624,10 +2599,11 @@ static struct ast_channel *usbradio_new(struct chan_usbradio_pvt *o, char *ext, 
 		return NULL;
 	}
 	ast_channel_tech_set(c, &usbradio_tech);
-	if ((o->sounddev < 0) && o->hasusb) {
-		setformat(o, O_RDWR);
+	if (!o->pa.active && o->hasusb) {
+		if (usbradio_start_audio(o) < 0) {
+			return NULL;
+		}
 	}
-	ast_channel_internal_fd_set(c, 0, o->sounddev); /* -1 if device closed, override later */
 	ast_channel_nativeformats_set(c, usbradio_tech.capabilities);
 	ast_channel_set_readformat(c, ast_format_slin);
 	ast_channel_set_writeformat(c, ast_format_slin);
@@ -4910,6 +4886,7 @@ static struct chan_usbradio_pvt *store_config(struct ast_config *cfg, const char
 			o->name = ast_strdup(ctg);
 			o->pttkick[0] = -1;
 			o->pttkick[1] = -1;
+			o->hw_device[0] = '\0';
 			if (!usbradio_active) {
 				usbradio_active = o->name;
 			}
@@ -5567,21 +5544,16 @@ static int unload_module(void)
 		}
 #endif
 
-		if (o->sounddev >= 0) {
-			close(o->sounddev);
-			o->sounddev = -1;
-		}
-		if (o->dsp) {
-			ast_dsp_free(o->dsp);
-		}
 		if (o->owner) {
 			ast_softhangup(o->owner, AST_SOFTHANGUP_APPUNLOAD);
 		}
-		if (o->owner) { /* XXX how ??? */
-			return -1;
+		o->stophid = 1;
+		kickptt(o);
+		pthread_join(o->hidthread, NULL);
+		usbradio_stop_audio(o);
+		if (o->dsp) {
+			ast_dsp_free(o->dsp);
 		}
-		/* XXX what about the thread ? */
-		/* XXX what about the memory allocated ? */
 	}
 
 	ao2_cleanup(usbradio_tech.capabilities);

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -1007,7 +1007,7 @@ static void *hidthread(void *arg)
 		if (o->hw_device[0] && ast_strlen_zero(o->devstr)) {
 			int subdev;
 
-			if (ast_radio_parse_hw_anywhere(o->hw_device, &i, &subdev)) {
+			if (ast_radio_parse_alsa_hw_device(o->hw_device, &i, &subdev)) {
 				int card_in_use = 0;
 
 				for (ao = usbradio_default.next; ao && ao->name; ao = ao->next) {
@@ -2162,7 +2162,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	o->readpos = sizeof(o->usbradio_read_buf);
 
 	/* RX stats on the normalized 48 kHz stereo workspace. */
-	if (ast_radio_check_audio_stereo_48k((short *) (o->usbradio_read_buf + AST_FRIENDLY_OFFSET), &o->rxaudiostats)) {
+	if (ast_radio_check_audio((short *) (o->usbradio_read_buf + AST_FRIENDLY_OFFSET), &o->rxaudiostats, AST_RADIO_PA_48K_STEREO_SAMPLES, 0)) {
 		if (o->clipledgpio) {
 			/* Set Clip LED GPIO pulsetimer if not already set */
 			if (!o->hid_gpio_pulsetimer[o->clipledgpio - 1]) {
@@ -2257,7 +2257,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	/* Write the received audio to the sound card */
 	soundcard_writeframe(o, (short *) o->usbradio_write_buf);
 
-	ast_radio_check_audio_stereo_48k((short *) o->usbradio_write_buf, &o->txaudiostats);
+	ast_radio_check_audio((short *) o->usbradio_write_buf, &o->txaudiostats, AST_RADIO_PA_48K_STEREO_SAMPLES, 0);
 
 #if DEBUG_CAPTURES == 1 && XPMR_DEBUG0 == 1
 	if (frxcaptrace && o->rxcap2 && o->pmrChan->b.radioactive) {

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -178,6 +178,9 @@ struct chan_usbradio_pvt {
 	char hw_device[100]; /* ALSA/PortAudio device (hw:N or hw:N,M) */
 	int devtype;		 /* actual type of device */
 	int pttkick[2];		 /* ptt kick pipe */
+	int tickpipe[2];	 /* read loop wakeup pipe */
+	pthread_t tickthread;
+	int stoptick;
 	int total_blocks;	 /* legacy queue depth hint for TX buffering */
 	struct ast_radio_pa_stream pa;
 	enum {
@@ -627,6 +630,69 @@ static void kickptt(const struct chan_usbradio_pvt *o)
 	} else if (res == 0) {
 		ast_log(LOG_ERROR, "Channel %s: Write returned 0 bytes unexpectedly\n", o->name);
 	}
+}
+
+static void usbradio_stop_tick(struct chan_usbradio_pvt *o)
+{
+	char c = 0;
+
+	if (!o) {
+		return;
+	}
+	if (o->stoptick) {
+		return;
+	}
+	o->stoptick = 1;
+	if (o->tickpipe[1] >= 0) {
+		(void) write(o->tickpipe[1], &c, 1);
+	}
+	if (o->tickthread != AST_PTHREADT_NULL) {
+		pthread_join(o->tickthread, NULL);
+		o->tickthread = AST_PTHREADT_NULL;
+	}
+	if (o->tickpipe[0] >= 0) {
+		close(o->tickpipe[0]);
+		o->tickpipe[0] = -1;
+	}
+	if (o->tickpipe[1] >= 0) {
+		close(o->tickpipe[1]);
+		o->tickpipe[1] = -1;
+	}
+}
+
+static void *usbradio_tick_thread(void *arg)
+{
+	struct chan_usbradio_pvt *o = arg;
+	char c = 0;
+
+	while (!o->stoptick) {
+		if (o->tickpipe[1] >= 0) {
+			(void) write(o->tickpipe[1], &c, 1);
+		}
+		usleep(20000);
+	}
+	return NULL;
+}
+
+static int usbradio_start_tick(struct chan_usbradio_pvt *o, struct ast_channel *c)
+{
+	if (o->tickpipe[0] >= 0) {
+		return 0;
+	}
+	o->tickpipe[0] = -1;
+	o->tickpipe[1] = -1;
+	o->stoptick = 0;
+	if (pipe2(o->tickpipe, O_NONBLOCK) == -1) {
+		ast_log(LOG_ERROR, "Channel %s: tick pipe failed: %s\n", o->name, strerror(errno));
+		return -1;
+	}
+	ast_channel_internal_fd_set(c, 0, o->tickpipe[0]);
+	if (ast_pthread_create(&o->tickthread, NULL, usbradio_tick_thread, o)) {
+		ast_log(LOG_ERROR, "Channel %s: Failed to create tick thread\n", o->name);
+		usbradio_stop_tick(o);
+		return -1;
+	}
+	return 0;
 }
 
 /*!
@@ -1627,39 +1693,6 @@ usb_device_ready:
 }
 
 /*!
- * \brief Get the number of blocks used in the audio output channel.
- * \param o		Channel private data.
- * \returns		Number of blocks that have been used.
- */
-static int used_blocks(struct chan_usbradio_pvt *o)
-{
-	long avail;
-
-	if (!o->pa.active) {
-		return 0;
-	}
-
-	avail = ast_radio_pa_write_available(&o->pa);
-	if (avail < 0) {
-		if (!(o->warned & WARN_used_blocks)) {
-			ast_log(LOG_WARNING, "Channel %s: Error reading PortAudio output space.\n", o->name);
-			o->warned |= WARN_used_blocks;
-		}
-		return o->queuesize + 1;
-	}
-
-	if (o->total_blocks == 0) {
-		o->total_blocks = o->queuesize ? o->queuesize : QUEUE_SIZE;
-	}
-
-	if (avail < AST_RADIO_PA_FRAMES_PER_BUFFER) {
-		return o->total_blocks + 1;
-	}
-
-	return 0;
-}
-
-/*!
  * \brief Write a full frame of audio data to the sound card device.
  * \note The input data must be formatted as stereo at 48000 samples per second.
  *		 FRAME_SIZE * 2 * 2 * 6 (2 bytes per sample, 2 channels, 6 for upsample to 48K)
@@ -1670,7 +1703,6 @@ static int used_blocks(struct chan_usbradio_pvt *o)
 static int soundcard_writeframe(struct chan_usbradio_pvt *o, short *data)
 {
 	PaError res;
-	short outbuf[FRAME_SIZE * 2 * 6];
 
 	if (!o->pa.active) {
 		if (usbradio_start_audio(o) < 0) {
@@ -1682,21 +1714,13 @@ static int soundcard_writeframe(struct chan_usbradio_pvt *o, short *data)
 		return 0;
 	}
 
-	if (used_blocks(o) > o->queuesize) {
-		if (o->pmrChan->txPttIn || o->pmrChan->txPttOut) {
-			ast_log(LOG_WARNING, "Channel %s: Sound device write buffer overflow\n", o->name);
-		}
-		return 0;
-	}
-
-	if (used_blocks(o) == 0) {
-		memset(outbuf, 0, sizeof(outbuf));
-		ast_radio_pa_write(&o->pa, outbuf, AST_RADIO_PA_FRAMES_PER_BUFFER);
-		ast_debug(7, "A null frame has been added");
-	}
-
 	res = ast_radio_pa_write(&o->pa, data, AST_RADIO_PA_FRAMES_PER_BUFFER);
-	if (res < 0 && res != paOutputUnderflowed) {
+	if (res == paOutputUnderflowed) {
+		short null_buf[AST_RADIO_PA_FRAMES_PER_BUFFER * AST_RADIO_PA_OUTPUT_CHANNELS] = { 0 };
+
+		ast_debug(6, "Channel %s: PortAudio write underflow, priming with silence\n", o->name);
+		ast_radio_pa_write(&o->pa, null_buf, AST_RADIO_PA_FRAMES_PER_BUFFER);
+	} else if (res != paNoError) {
 		ast_log(LOG_ERROR, "Channel %s: PortAudio write error %s\n", o->name, Pa_GetErrorText(res));
 		usbradio_stop_audio(o);
 		return 0;
@@ -1920,10 +1944,16 @@ static int usbradio_hangup(struct ast_channel *c)
 {
 	struct chan_usbradio_pvt *o = ast_channel_tech_pvt(c);
 
+	usbradio_stop_tick(o);
+	o->stophid = 1;
+	kickptt(o);
+	if (o->hidthread != AST_PTHREADT_NULL) {
+		pthread_join(o->hidthread, NULL);
+		o->hidthread = AST_PTHREADT_NULL;
+	}
 	ast_channel_tech_pvt_set(c, NULL);
 	o->owner = NULL;
 	ast_module_unref(ast_module_info->self);
-	kickptt(o);
 	if (o->hookstate) {
 		o->hookstate = 0;
 	}
@@ -2002,6 +2032,15 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 			return NULL;
 		}
 	}
+	/* Drain tick pipe wakeups. */
+	if (o->tickpipe[0] >= 0) {
+		char drain[32];
+
+		while (read(o->tickpipe[0], drain, sizeof(drain)) > 0) {
+			;
+		}
+	}
+
 	/* Set frame defaults */
 	memset(f, 0, sizeof(struct ast_frame));
 	f->frametype = AST_FRAME_NULL;
@@ -2069,15 +2108,31 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 		}
 	}
 
-	pa_res = ast_radio_pa_read(&o->pa, (short *) (o->usbradio_read_buf + AST_FRIENDLY_OFFSET), AST_RADIO_PA_FRAMES_PER_BUFFER, 40, NULL);
+	if (o->pa.input_channels == 1) {
+		short mono_buf[AST_RADIO_PA_FRAMES_PER_BUFFER];
+		short *stereo = (short *) (o->usbradio_read_buf + AST_FRIENDLY_OFFSET);
+		int i;
+
+		pa_res = ast_radio_pa_read(&o->pa, mono_buf, AST_RADIO_PA_FRAMES_PER_BUFFER, 40, NULL);
+		if (pa_res == paNoError) {
+			for (i = AST_RADIO_PA_FRAMES_PER_BUFFER - 1; i >= 0; i--) {
+				stereo[i * 2] = mono_buf[i];
+				stereo[i * 2 + 1] = mono_buf[i];
+			}
+		}
+	} else {
+		pa_res = ast_radio_pa_read(&o->pa, (short *) (o->usbradio_read_buf + AST_FRIENDLY_OFFSET), AST_RADIO_PA_FRAMES_PER_BUFFER, 40, NULL);
+	}
 	if (pa_res != paNoError) {
 		if (pa_res == paTimedOut || pa_res == paInputOverflowed) {
+			/* No RX audio available; still run PTT/TX processing with silence. */
+			memset(o->usbradio_read_buf + AST_FRIENDLY_OFFSET, 0, sizeof(o->usbradio_read_buf) - AST_FRIENDLY_OFFSET);
+		} else {
+			ast_log(LOG_ERROR, "Channel %s: PortAudio read error %s\n", o->name, Pa_GetErrorText(pa_res));
+			o->hasusb = 0;
+			usbradio_stop_audio(o);
 			return &ast_null_frame;
 		}
-		ast_log(LOG_ERROR, "Channel %s: PortAudio read error %s\n", o->name, Pa_GetErrorText(pa_res));
-		o->hasusb = 0;
-		usbradio_stop_audio(o);
-		return &ast_null_frame;
 	}
 
 #if DEBUG_CAPTURES == 1
@@ -2614,9 +2669,17 @@ static struct ast_channel *usbradio_new(struct chan_usbradio_pvt *o, char *ext, 
 	ast_channel_set_readformat(c, ast_format_slin);
 	ast_channel_set_writeformat(c, ast_format_slin);
 	ast_channel_tech_pvt_set(c, o);
-	ast_channel_unlock(c);
-
 	o->owner = c;
+	o->tickpipe[0] = -1;
+	o->tickpipe[1] = -1;
+	o->tickthread = AST_PTHREADT_NULL;
+	o->stoptick = 0;
+	if (usbradio_start_tick(o, c) < 0) {
+		ast_channel_unlock(c);
+		ast_hangup(c);
+		return NULL;
+	}
+	ast_channel_unlock(c);
 	ast_module_ref(ast_module_info->self);
 	if (!o->pa.active && o->hasusb) {
 		if (usbradio_start_audio(o) < 0) {
@@ -4898,6 +4961,10 @@ static struct chan_usbradio_pvt *store_config(struct ast_config *cfg, const char
 			o->name = ast_strdup(ctg);
 			o->pttkick[0] = -1;
 			o->pttkick[1] = -1;
+			o->tickpipe[0] = -1;
+			o->tickpipe[1] = -1;
+			o->tickthread = AST_PTHREADT_NULL;
+			o->stoptick = 0;
 			o->hidthread = AST_PTHREADT_NULL;
 			o->hw_device[0] = '\0';
 			if (!usbradio_active) {
@@ -5556,6 +5623,7 @@ static int unload_module(void)
 		if (o->owner) {
 			ast_softhangup(o->owner, AST_SOFTHANGUP_APPUNLOAD);
 		}
+		usbradio_stop_tick(o);
 		o->stophid = 1;
 		kickptt(o);
 		if (o->hidthread != AST_PTHREADT_NULL) {

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -181,7 +181,7 @@ struct chan_usbradio_pvt {
 	int tickpipe[2];	 /* read loop wakeup pipe */
 	pthread_t tickthread;
 	int stoptick;
-	int total_blocks;	 /* legacy queue depth hint for TX buffering */
+	int total_blocks; /* legacy queue depth hint for TX buffering */
 	struct ast_radio_pa_stream pa;
 	enum {
 		M_UNSET,

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -1654,7 +1654,8 @@ usb_device_ready:
 /*!
  * \brief Write a full frame of audio data to the sound card device.
  * \note data is 48 kHz stereo interleaved. ast_radio_pa_write() takes frames
- *       per channel (AST_RADIO_PA_FRAMES_PER_BUFFER).
+ *       per channel (AST_RADIO_PA_FRAMES_PER_BUFFER); interleaved sample count
+ *       is frames * AST_RADIO_PA_OUTPUT_CHANNELS (== AST_RADIO_PA_48K_STEREO_SAMPLES).
  * \param o		chan_usbradio_pvt.
  * \param data	Audio data to write.
  * \returns		Byte count written on success, 0 on failure.
@@ -1684,7 +1685,7 @@ static int soundcard_writeframe(struct chan_usbradio_pvt *o, short *data)
 		return 0;
 	}
 
-	return AST_RADIO_PA_48K_STEREO_SAMPLES * (int) sizeof(short);
+	return AST_RADIO_PA_FRAMES_PER_BUFFER * AST_RADIO_PA_OUTPUT_CHANNELS * (int) sizeof(short);
 }
 
 /*!
@@ -2108,7 +2109,8 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 
 #if DEBUG_CAPTURES == 1
 	if (o->rxcapraw && frxcapraw) {
-		fwrite(o->usbradio_read_buf + AST_FRIENDLY_OFFSET, 1, AST_RADIO_PA_48K_STEREO_SAMPLES * sizeof(short), frxcapraw);
+		fwrite(o->usbradio_read_buf + AST_FRIENDLY_OFFSET, 1,
+			AST_RADIO_PA_FRAMES_PER_BUFFER * AST_RADIO_PA_OUTPUT_CHANNELS * sizeof(short), frxcapraw);
 	}
 #endif
 

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -180,7 +180,6 @@ struct chan_usbradio_pvt {
 	int devtype;			 /* actual type of device */
 	int pttkick[2];			 /* ptt kick pipe */
 	struct ast_timer *timer; /* 20 ms channel wakeup (PTT / DSP tick) */
-	int total_blocks;		 /* legacy queue depth hint for TX buffering */
 	struct ast_radio_pa_stream pa;
 	enum {
 		M_UNSET,
@@ -191,11 +190,6 @@ struct chan_usbradio_pvt {
 	int hookstate;
 	unsigned int queuesize; /* max fragments in queue */
 	unsigned int frags;		/* parameter for SETFRAGMENT */
-
-	int warned; /* various flags used for warnings */
-#define WARN_used_blocks 1
-#define WARN_speed 2
-#define WARN_frag 4
 
 	char devicenum;
 	char devstr[128];
@@ -1647,6 +1641,9 @@ usb_device_ready:
 		buf[o->hid_gpio_ctl_loc] = o->hid_gpio_ctl;
 		ast_radio_hid_set_outputs(usb_handle, buf);
 		ast_mutex_unlock(&o->usblock);
+		/* Hangup joins this thread; release HID so the next call can reopen it. */
+		usb_close(usb_handle);
+		usb_handle = NULL;
 	}
 	return NULL;
 }

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -1220,7 +1220,9 @@ usb_device_ready:
 			o->usbass = 0;
 			o->hasusb = 0;
 			ast_mutex_unlock(&usb_dev_lock);
-			return NULL;
+			/* Stay in hidthread and retry; call() only starts the thread once. */
+			usleep(500000);
+			continue;
 		}
 		if ((usb_dev->descriptor.idProduct & 0xfffc) == C108_PRODUCT_ID) {
 			o->devtype = C108_PRODUCT_ID;

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -448,7 +448,6 @@ static struct chan_usbradio_pvt usbradio_default = {
 static int hidhdwconfig(struct chan_usbradio_pvt *o);
 static void mixer_write(struct chan_usbradio_pvt *o);
 static int usbradio_start_audio(struct chan_usbradio_pvt *o);
-static void usbradio_stop_audio(struct chan_usbradio_pvt *o);
 static PaError usbradio_read_pa_stereo(struct chan_usbradio_pvt *o);
 static struct ast_channel *usbradio_request(const char *type, struct ast_format_cap *cap,
 	const struct ast_assigned_ids *assignedids, const struct ast_channel *requestor, const char *data, int *cause);
@@ -926,11 +925,6 @@ static int usbradio_start_audio(struct chan_usbradio_pvt *o)
 	return 0;
 }
 
-static void usbradio_stop_audio(struct chan_usbradio_pvt *o)
-{
-	ast_radio_pa_stop(&o->pa);
-}
-
 /*!
  * \brief USB sound device GPIO processing thread
  * This thread is responsible for finding and associating the node with the
@@ -966,6 +960,7 @@ static void *hidthread(void *arg)
 	char *s, lasttxtmp;
 	int i, j, k;
 	int res;
+	int use_newname = 0;
 	struct usb_device *usb_dev;
 	struct usb_dev_handle *usb_handle;
 	struct chan_usbradio_pvt *o = arg, *ao;
@@ -1033,20 +1028,16 @@ static void *hidthread(void *arg)
 					continue;
 				}
 				o->devicenum = i;
-				{
-					int use_newname = 0;
-
-					if (ast_radio_init_mixer_limits(o->devicenum, &o->micmax, &o->spkrmax, &o->micplaymax, &use_newname) < 0) {
-						if (!o->device_error) {
-							ast_log(LOG_ERROR, "Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
-							o->device_error = 1;
-						}
-						ast_mutex_unlock(&usb_dev_lock);
-						usleep(500000);
-						continue;
+				if (ast_radio_init_mixer_limits(o->devicenum, &o->micmax, &o->spkrmax, &o->micplaymax, &use_newname) < 0) {
+					if (!o->device_error) {
+						ast_log(LOG_ERROR, "Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
+						o->device_error = 1;
 					}
-					o->newname = use_newname;
+					ast_mutex_unlock(&usb_dev_lock);
+					usleep(500000);
+					continue;
 				}
+				o->newname = use_newname;
 				o->device_error = 0;
 				ast_radio_time(&o->lasthidtime);
 				o->usbass = 1;
@@ -1198,20 +1189,16 @@ static void *hidthread(void *arg)
 		}
 		o->devicenum = i;
 		snprintf(o->hw_device, sizeof(o->hw_device), "hw:%d", i);
-		{
-			int use_newname = 0;
-
-			if (ast_radio_init_mixer_limits(o->devicenum, &o->micmax, &o->spkrmax, &o->micplaymax, &use_newname) < 0) {
-				if (!o->device_error) {
-					ast_log(LOG_ERROR, "Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
-					o->device_error = 1;
-				}
-				ast_mutex_unlock(&usb_dev_lock);
-				usleep(500000);
-				continue;
+		if (ast_radio_init_mixer_limits(o->devicenum, &o->micmax, &o->spkrmax, &o->micplaymax, &use_newname) < 0) {
+			if (!o->device_error) {
+				ast_log(LOG_ERROR, "Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
+				o->device_error = 1;
 			}
-			o->newname = use_newname;
+			ast_mutex_unlock(&usb_dev_lock);
+			usleep(500000);
+			continue;
 		}
+		o->newname = use_newname;
 		o->device_error = 0;
 		ast_radio_time(&o->lasthidtime);
 		o->usbass = 1;
@@ -1717,15 +1704,14 @@ static int soundcard_writeframe(struct chan_usbradio_pvt *o, short *data)
 		return 0;
 	}
 
+	/*
+	 * ast_radio_pa_write() already primes one silence frame on
+	 * paOutputUnderflowed (#593 / #598). Treat that as success here.
+	 */
 	res = ast_radio_pa_write(&o->pa, data, AST_RADIO_PA_FRAMES_PER_BUFFER);
-	if (res == paOutputUnderflowed) {
-		short null_buf[AST_RADIO_PA_FRAMES_PER_BUFFER * AST_RADIO_PA_OUTPUT_CHANNELS] = { 0 };
-
-		ast_debug(6, "Channel %s: PortAudio write underflow, priming with silence\n", o->name);
-		ast_radio_pa_write(&o->pa, null_buf, AST_RADIO_PA_FRAMES_PER_BUFFER);
-	} else if (res != paNoError) {
+	if (res < 0 && res != paOutputUnderflowed) {
 		ast_log(LOG_ERROR, "Channel %s: PortAudio write error %s\n", o->name, Pa_GetErrorText(res));
-		usbradio_stop_audio(o);
+		ast_radio_pa_stop(&o->pa);
 		return 0;
 	}
 
@@ -1988,7 +1974,7 @@ static int usbradio_hangup(struct ast_channel *c)
 	if (o->hookstate) {
 		o->hookstate = 0;
 	}
-	usbradio_stop_audio(o);
+	ast_radio_pa_stop(&o->pa);
 	return 0;
 }
 
@@ -2147,7 +2133,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 		} else {
 			ast_log(LOG_ERROR, "Channel %s: PortAudio read error %s\n", o->name, Pa_GetErrorText(pa_res));
 			o->hasusb = 0;
-			usbradio_stop_audio(o);
+			ast_radio_pa_stop(&o->pa);
 			return &ast_null_frame;
 		}
 	}
@@ -5591,6 +5577,7 @@ static int load_module(void)
 static int unload_module(void)
 {
 	struct chan_usbradio_pvt *o;
+	int i;
 
 	stoppulser = 1;
 
@@ -5635,13 +5622,23 @@ static int unload_module(void)
 			pthread_join(o->hidthread, NULL);
 			o->hidthread = AST_PTHREADT_NULL;
 		}
-		usbradio_stop_audio(o);
+		ast_radio_pa_stop(&o->pa);
 		if (o->pmrChan) {
 			destroyPmrChannel(o->pmrChan);
 			o->pmrChan = NULL;
 		}
 		if (o->dsp) {
 			ast_dsp_free(o->dsp);
+		}
+		for (i = 0; i < GPIO_PINCOUNT; i++) {
+			if (o->gpios[i]) {
+				ast_free(o->gpios[i]);
+			}
+		}
+		for (i = 0; i < ARRAY_LEN(o->pps); i++) {
+			if (o->pps[i]) {
+				ast_free(o->pps[i]);
+			}
 		}
 	}
 

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -96,8 +96,6 @@
 #define MS_PER_FRAME 20						   /* 20 ms frames */
 #define MS_TO_FRAMES(ms) ((ms) / MS_PER_FRAME) /* convert ms to frames */
 
-#define USBRADIO_48K_STEREO_BYTES (FRAME_SIZE * 2 * 2 * 6)
-
 #include "./xpmr/xpmr.h"
 #ifdef HAVE_XPMRX
 #include "./xpmrx/xpmrx.h"
@@ -121,6 +119,7 @@
 #include "asterisk/format.h"
 #include "asterisk/format_cache.h"
 #include "asterisk/format_compatibility.h"
+#include "asterisk/timing.h"
 
 /*! \brief Global jitterbuffer configuration - by default, jb is disabled */
 static struct ast_jb_conf default_jbconf = {
@@ -180,9 +179,7 @@ struct chan_usbradio_pvt {
 	char hw_device[100]; /* ALSA/PortAudio device (hw:N or hw:N,M) */
 	int devtype;		 /* actual type of device */
 	int pttkick[2];		 /* ptt kick pipe */
-	int tickpipe[2];	 /* read loop wakeup pipe */
-	pthread_t tickthread;
-	int stoptick;
+	struct ast_timer *timer; /* 20 ms channel wakeup (PTT / DSP tick) */
 	int total_blocks; /* legacy queue depth hint for TX buffering */
 	struct ast_radio_pa_stream pa;
 	enum {
@@ -212,8 +209,8 @@ struct chan_usbradio_pvt {
 
 	struct ast_channel *owner;
 
-	/* buffer used in usbradio_write, 2 per int by 2 channels by 6 times oversampling (48KS/s) */
-	char usbradio_write_buf[USBRADIO_48K_STEREO_BYTES];
+	/* TX workspace: 48 kHz stereo interleaved samples (PortAudio / PmrTx) */
+	short usbradio_write_buf[AST_RADIO_PA_48K_STEREO_SAMPLES];
 
 	/* buffers used in usbradio_read - AST_FRIENDLY_OFFSET space for headers
 	 * plus enough room for a full 48 kHz stereo PortAudio frame
@@ -636,64 +633,36 @@ static void kickptt(const struct chan_usbradio_pvt *o)
 
 static void usbradio_stop_tick(struct chan_usbradio_pvt *o)
 {
-	char c = 0;
-
-	if (!o) {
+	if (!o || !o->timer) {
 		return;
 	}
-	if (o->stoptick) {
-		return;
+	if (o->owner) {
+		ast_channel_set_fd(o->owner, 0, -1);
 	}
-	o->stoptick = 1;
-	if (o->tickpipe[1] >= 0) {
-		(void) write(o->tickpipe[1], &c, 1);
-	}
-	if (o->tickthread != AST_PTHREADT_NULL) {
-		pthread_join(o->tickthread, NULL);
-		o->tickthread = AST_PTHREADT_NULL;
-	}
-	if (o->tickpipe[0] >= 0) {
-		close(o->tickpipe[0]);
-		o->tickpipe[0] = -1;
-	}
-	if (o->tickpipe[1] >= 0) {
-		close(o->tickpipe[1]);
-		o->tickpipe[1] = -1;
-	}
-}
-
-static void *usbradio_tick_thread(void *arg)
-{
-	struct chan_usbradio_pvt *o = arg;
-	char c = 0;
-
-	while (!o->stoptick) {
-		if (o->tickpipe[1] >= 0) {
-			(void) write(o->tickpipe[1], &c, 1);
-		}
-		usleep(20000);
-	}
-	return NULL;
+	ast_timer_close(o->timer);
+	o->timer = NULL;
 }
 
 static int usbradio_start_tick(struct chan_usbradio_pvt *o, struct ast_channel *c)
 {
-	if (o->tickpipe[0] >= 0) {
+	int rate;
+
+	if (o->timer) {
 		return 0;
 	}
-	o->tickpipe[0] = -1;
-	o->tickpipe[1] = -1;
-	o->stoptick = 0;
-	if (pipe2(o->tickpipe, O_NONBLOCK) == -1) {
-		ast_log(LOG_ERROR, "Channel %s: tick pipe failed: %s\n", o->name, strerror(errno));
+	o->timer = ast_timer_open();
+	if (!o->timer) {
+		ast_log(LOG_ERROR, "Channel %s: Unable to create timer.\n", o->name);
 		return -1;
 	}
-	ast_channel_internal_fd_set(c, 0, o->tickpipe[0]);
-	if (ast_pthread_create(&o->tickthread, NULL, usbradio_tick_thread, o)) {
-		ast_log(LOG_ERROR, "Channel %s: Failed to create tick thread\n", o->name);
-		usbradio_stop_tick(o);
+	rate = 1000 / MS_PER_FRAME;
+	if (ast_timer_set_rate(o->timer, rate)) {
+		ast_log(LOG_ERROR, "Channel %s: Unable to set timer rate to %d Hz.\n", o->name, rate);
+		ast_timer_close(o->timer);
+		o->timer = NULL;
 		return -1;
 	}
+	ast_channel_set_fd(c, 0, ast_timer_fd(o->timer));
 	return 0;
 }
 
@@ -1715,7 +1684,7 @@ static int soundcard_writeframe(struct chan_usbradio_pvt *o, short *data)
 		return 0;
 	}
 
-	return USBRADIO_48K_STEREO_BYTES;
+	return AST_RADIO_PA_48K_STEREO_SAMPLES * (int) sizeof(short);
 }
 
 /*!
@@ -2049,12 +2018,11 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 			return NULL;
 		}
 	}
-	/* Drain tick pipe wakeups. */
-	if (o->tickpipe[0] >= 0) {
-		char drain[32];
-
-		while (read(o->tickpipe[0], drain, sizeof(drain)) > 0) {
-			;
+	/* Ack 20 ms timer wakeup (replaces OSS sound-device FD). */
+	if (o->timer && ast_timer_get_event(o->timer) == AST_TIMING_EVENT_EXPIRED) {
+		if (ast_timer_ack(o->timer, 1) < 0) {
+			ast_log(LOG_WARNING, "Channel %s: Timer ack failed.\n", o->name);
+			return NULL;
 		}
 	}
 
@@ -2140,7 +2108,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 
 #if DEBUG_CAPTURES == 1
 	if (o->rxcapraw && frxcapraw) {
-		fwrite(o->usbradio_read_buf + AST_FRIENDLY_OFFSET, 1, USBRADIO_48K_STEREO_BYTES, frxcapraw);
+		fwrite(o->usbradio_read_buf + AST_FRIENDLY_OFFSET, 1, AST_RADIO_PA_48K_STEREO_SAMPLES * sizeof(short), frxcapraw);
 	}
 #endif
 
@@ -2192,7 +2160,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	if (oldpttout && (!o->didpmrtx)) {
 		if (o->notxcnt > 1) {
 			memset(o->usbradio_write_buf, 0, sizeof(o->usbradio_write_buf));
-			PmrTx(o->pmrChan, (i16 *) o->usbradio_write_buf);
+			PmrTx(o->pmrChan, o->usbradio_write_buf);
 		} else {
 			o->notxcnt++;
 		}
@@ -2202,7 +2170,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	o->didpmrtx = 0;
 
 	PmrRx(o->pmrChan, (i16 *) (o->usbradio_read_buf + AST_FRIENDLY_OFFSET),
-		(i16 *) (o->usbradio_read_buf_8k + AST_FRIENDLY_OFFSET), (i16 *) (o->usbradio_write_buf));
+		(i16 *) (o->usbradio_read_buf_8k + AST_FRIENDLY_OFFSET), o->usbradio_write_buf);
 
 	if (oldpttout != o->pmrChan->txPttOut) {
 		ast_debug(3, "Channel %s: txPttOut = %i.\n", o->name, o->pmrChan->txPttOut);
@@ -2225,11 +2193,11 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	 */
 	/* For the CM108 adjust the audio level */
 	if (o->legacyaudioscaling && o->devtype != C108_PRODUCT_ID) {
-		register short *sp = (short *) o->usbradio_write_buf;
+		register short *sp = o->usbradio_write_buf;
 		register float v;
 		register int i;
 
-		for (i = 0; i < sizeof(o->usbradio_write_buf) / 2; i++) {
+		for (i = 0; i < AST_RADIO_PA_48K_STEREO_SAMPLES; i++) {
 			v = ((float) *sp) * 1.10;
 			if (v > 32765.0) {
 				v = 32765.0;
@@ -2241,9 +2209,9 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	}
 
 	/* Write the received audio to the sound card */
-	soundcard_writeframe(o, (short *) o->usbradio_write_buf);
+	soundcard_writeframe(o, o->usbradio_write_buf);
 
-	ast_radio_check_audio((short *) o->usbradio_write_buf, &o->txaudiostats, AST_RADIO_PA_48K_STEREO_SAMPLES, 0);
+	ast_radio_check_audio(o->usbradio_write_buf, &o->txaudiostats, AST_RADIO_PA_48K_STEREO_SAMPLES, 0);
 
 #if DEBUG_CAPTURES == 1 && XPMR_DEBUG0 == 1
 	if (frxcaptrace && o->rxcap2 && o->pmrChan->b.radioactive) {
@@ -2661,10 +2629,7 @@ static struct ast_channel *usbradio_new(struct chan_usbradio_pvt *o, char *ext, 
 	ast_channel_set_writeformat(c, ast_format_slin);
 	ast_channel_tech_pvt_set(c, o);
 	o->owner = c;
-	o->tickpipe[0] = -1;
-	o->tickpipe[1] = -1;
-	o->tickthread = AST_PTHREADT_NULL;
-	o->stoptick = 0;
+	o->timer = NULL;
 	if (usbradio_start_tick(o, c) < 0) {
 		ast_channel_unlock(c);
 		ast_hangup(c);
@@ -4952,10 +4917,7 @@ static struct chan_usbradio_pvt *store_config(struct ast_config *cfg, const char
 			o->name = ast_strdup(ctg);
 			o->pttkick[0] = -1;
 			o->pttkick[1] = -1;
-			o->tickpipe[0] = -1;
-			o->tickpipe[1] = -1;
-			o->tickthread = AST_PTHREADT_NULL;
-			o->stoptick = 0;
+			o->timer = NULL;
 			o->hidthread = AST_PTHREADT_NULL;
 			o->hw_device[0] = '\0';
 			if (!usbradio_active) {

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -777,7 +777,7 @@ static void *pulserthread(void *arg)
 		}
 		ast_mutex_unlock(&pp_lock);
 	}
-	pthread_exit(0);
+	return NULL;
 }
 
 /*!
@@ -1226,7 +1226,7 @@ usb_device_ready:
 			o->usbass = 0;
 			o->hasusb = 0;
 			ast_mutex_unlock(&usb_dev_lock);
-			pthread_exit(NULL);
+			return NULL;
 		}
 		if ((usb_dev->descriptor.idProduct & 0xfffc) == C108_PRODUCT_ID) {
 			o->devtype = C108_PRODUCT_ID;
@@ -1648,7 +1648,7 @@ usb_device_ready:
 		ast_radio_hid_set_outputs(usb_handle, buf);
 		ast_mutex_unlock(&o->usblock);
 	}
-	pthread_exit(0);
+	return NULL;
 }
 
 /*!
@@ -2005,7 +2005,7 @@ static int usbradio_write(struct ast_channel *c, struct ast_frame *f)
 static struct ast_frame *usbradio_read(struct ast_channel *c)
 {
 	PaError pa_res;
-	int oldpttout;
+	int lastpttout;
 	int cd, sd;
 	struct chan_usbradio_pvt *o = ast_channel_tech_pvt(c);
 	struct ast_frame *f = &o->read_f, *f1;
@@ -2157,9 +2157,9 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 		o->pmrChan->txPttIn = 0;
 		ast_debug(3, "Channel %s: txPttIn = %i.\n", o->name, o->pmrChan->txPttIn);
 	}
-	oldpttout = o->pmrChan->txPttOut;
+	lastpttout = o->pmrChan->txPttOut;
 
-	if (oldpttout && (!o->didpmrtx)) {
+	if (lastpttout && (!o->didpmrtx)) {
 		if (o->notxcnt > 1) {
 			memset(o->usbradio_write_buf, 0, sizeof(o->usbradio_write_buf));
 			PmrTx(o->pmrChan, o->usbradio_write_buf);
@@ -2174,7 +2174,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	PmrRx(o->pmrChan, (i16 *) (o->usbradio_read_buf + AST_FRIENDLY_OFFSET),
 		(i16 *) (o->usbradio_read_buf_8k + AST_FRIENDLY_OFFSET), o->usbradio_write_buf);
 
-	if (oldpttout != o->pmrChan->txPttOut) {
+	if (lastpttout != o->pmrChan->txPttOut) {
 		ast_debug(3, "Channel %s: txPttOut = %i.\n", o->name, o->pmrChan->txPttOut);
 		kickptt(o);
 	}

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -175,12 +175,12 @@ static const char *const mixer_type[] = { "no", "voice", "tone", "composite", "a
 struct chan_usbradio_pvt {
 	struct chan_usbradio_pvt *next;
 
-	char *name;			 /* the internal name of our channel */
-	char hw_device[100]; /* ALSA/PortAudio device (hw:N or hw:N,M) */
-	int devtype;		 /* actual type of device */
-	int pttkick[2];		 /* ptt kick pipe */
+	char *name;				 /* the internal name of our channel */
+	char hw_device[100];	 /* ALSA/PortAudio device (hw:N or hw:N,M) */
+	int devtype;			 /* actual type of device */
+	int pttkick[2];			 /* ptt kick pipe */
 	struct ast_timer *timer; /* 20 ms channel wakeup (PTT / DSP tick) */
-	int total_blocks; /* legacy queue depth hint for TX buffering */
+	int total_blocks;		 /* legacy queue depth hint for TX buffering */
 	struct ast_radio_pa_stream pa;
 	enum {
 		M_UNSET,

--- a/channels/xpmr/xpmr.c
+++ b/channels/xpmr/xpmr.c
@@ -2850,7 +2850,7 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 			} else {
 				f = pChan->txctcssdefault_value;
 			}
-			if (f && pChan->spsSigGen0->freq != f * 10) {
+			if (f && pChan->spsSigGen0->freq != f * 10 && !pChan->b.txCtcssHangMuted) {
 				pChan->spsSigGen0->freq = f * 10;
 				pChan->spsSigGen0->option = 1;
 			}
@@ -2871,6 +2871,8 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 				pChan->rxCtcssMap[pChan->rxCtcss->decode]);
 			pChan->dd.b.doitnow = 1;
 			pChan->spsSigGen0->freq = 0;
+			pChan->b.txHadRxCarrier = 0;
+			pChan->b.txCtcssHangMuted = 0;
 			if (pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit) {
 				if (pChan->rxCtcss->decode > CTCSS_NULL) {
 					if (pChan->rxCtcssMap[pChan->rxCtcss->decode] != CTCSS_RXONLY) {
@@ -2934,10 +2936,33 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 			TRACEC(1, "PmrRx() TxOn\n");
 		} else if (pChan->txPttIn && pChan->txState == CHAN_TXSTATE_ACTIVE) {
 			pChan->smodetimer = pChan->smodetime;
+
+			/*
+			 * Full duplex: app_rpt hangtime keeps txPttIn asserted after the user
+			 * unkeys, so classic TOC (which waits for txPttIn to drop) never runs
+			 * until hangtime ends. Start notone/phase turn-off when local COS drops
+			 * so CTCSS ends at the start of hang instead of riding until PTT drops.
+			 * Half duplex blanks RX while keyed, so COS cannot be used that way.
+			 */
+			if (pChan->radioDuplex && pChan->rxCarrierDetect) {
+				pChan->b.txHadRxCarrier = 1;
+			}
+			if (pChan->radioDuplex && pChan->b.txHadRxCarrier && !pChan->rxCarrierDetect && !pChan->b.txCtcssHangMuted &&
+				pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit && pChan->b.ctcssTxEnable && pChan->txTocType != TOC_NONE) {
+				pChan->b.txCtcssHangMuted = 1;
+				if (pChan->txTocType == TOC_NOTONE) {
+					pChan->spsSigGen0->option = 3;
+					TRACEC(1, "Tx CTCSS off on COS drop (notone).\n");
+				} else {
+					pChan->spsSigGen0->option = 2;
+					TRACEC(1, "Tx CTCSS phase turn-off on COS drop.\n");
+				}
+			}
 		} else if (!pChan->txPttIn && pChan->txState == CHAN_TXSTATE_ACTIVE) {
 			TRACEC(1, "txPttIn==0 from CHAN_TXSTATE_ACTIVE\n");
 			if (pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit) {
-				if (pChan->txTocType == TOC_NONE || !pChan->b.ctcssTxEnable) {
+				if (pChan->txTocType == TOC_NONE || !pChan->b.ctcssTxEnable || pChan->b.txCtcssHangMuted) {
+					/* Immediate off, or tone already dropped at COS for duplex hang. */
 					TRACEC(1, "Tx Off Immediate.\n");
 					pChan->spsSigGen0->option = 3;
 					pChan->txBufferClear = 3;
@@ -2962,6 +2987,7 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 			if (pChan->txPttIn && pChan->smode == SMODE_CTCSS) {
 				TRACEC(1, "Tx Key During HangTime\n");
 				pChan->txState = CHAN_TXSTATE_ACTIVE;
+				pChan->b.txCtcssHangMuted = 0;
 				pChan->spsSigGen0->option = 1;
 				pChan->spsSigGen0->enabled = 1;
 				pChan->spsSigGen0->discounterl = 0;
@@ -2988,6 +3014,8 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 		pChan->txPttOut = 0;
 		pChan->spsSigGen0->option = 3;
 		pChan->txrxblankingtimer = pChan->txrxblankingtime;
+		pChan->b.txHadRxCarrier = 0;
+		pChan->b.txCtcssHangMuted = 0;
 		TRACEC(1, "PmrRx() txrxblankingtimer=%i\n", pChan->txrxblankingtimer);
 		pChan->txState = CHAN_TXSTATE_IDLE;
 		if (pChan->spsTxLsdLpf) {

--- a/channels/xpmr/xpmr.c
+++ b/channels/xpmr/xpmr.c
@@ -2942,10 +2942,19 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 			 * unkeys, so classic TOC (which waits for txPttIn to drop) never runs
 			 * until hangtime ends. Start notone/phase turn-off when local COS drops
 			 * so CTCSS ends at the start of hang instead of riding until PTT drops.
+			 * If COS returns while hangtime still holds PTT, restore CTCSS so the
+			 * next keyed period is not left muted until PTT finally drops.
 			 * Half duplex blanks RX while keyed, so COS cannot be used that way.
 			 */
 			if (pChan->radioDuplex && pChan->rxCarrierDetect) {
 				pChan->b.txHadRxCarrier = 1;
+				if (pChan->b.txCtcssHangMuted && pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit && pChan->b.ctcssTxEnable) {
+					pChan->b.txCtcssHangMuted = 0;
+					pChan->spsSigGen0->option = 1;
+					pChan->spsSigGen0->enabled = 1;
+					pChan->spsSigGen0->discounterl = 0;
+					TRACEC(1, "Tx CTCSS restore on COS reassert during hang.\n");
+				}
 			}
 			if (pChan->radioDuplex && pChan->b.txHadRxCarrier && !pChan->rxCarrierDetect && !pChan->b.txCtcssHangMuted &&
 				pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit && pChan->b.ctcssTxEnable && pChan->txTocType != TOC_NONE) {

--- a/channels/xpmr/xpmr.h
+++ b/channels/xpmr/xpmr.h
@@ -843,6 +843,8 @@ typedef struct t_pmr_chan {
 		unsigned txCtcssInhibit:1;
 		unsigned txCtcssReady:1;
 		unsigned txCtcssOff:1;
+		unsigned txHadRxCarrier:1;	 /*!< Saw local RX carrier during this TX cycle */
+		unsigned txCtcssHangMuted:1; /*!< CTCSS already turned off on COS drop (duplex hang) */
 
 		unsigned rxkeyed:1;
 		unsigned rxhalted:1;

--- a/configs/samples/usbradio.conf.sample
+++ b/configs/samples/usbradio.conf.sample
@@ -185,6 +185,8 @@ legacyaudioscaling = no     ; If yes, continue to do raw audio sample scaling an
 ;;;;; Tune settings ;;;;;
 ;devstr=
 ;serial=
+;audiodev=hw:0             ; Optional ALSA device for PortAudio audio (hw:N or hw:N,M).
+                            ; Use instead of devstr when binding audio by card number.
 ;rxmixerset=500
 ;txmixaset=500
 ;txmixbset=500

--- a/configs/samples/usbradio.conf.sample
+++ b/configs/samples/usbradio.conf.sample
@@ -120,6 +120,9 @@
                             ; AKA ("reverse burst") before unkeying TX
                             ; notone - encode CTCSS and stop sending tone before unkeying TX
                             ; AKA ("chicken burst")
+                            ; With duplex=1 (full duplex), notone/phase begin when local
+                            ; COS drops so CTCSS does not ride app_rpt hangtime. Half duplex
+                            ; still applies the burst when PTT is released (fixed ~600ms).
 
 ;txmixa = composite         ; Left channel output: no,voice,tone,composite,auxvoice
                             ; no - Do not output anything

--- a/configs/samples/usbradio.conf.sample
+++ b/configs/samples/usbradio.conf.sample
@@ -188,7 +188,7 @@ legacyaudioscaling = no     ; If yes, continue to do raw audio sample scaling an
 ;;;;; Tune settings ;;;;;
 ;devstr=
 ;serial=
-;audiodev=hw:0             ; Optional ALSA device for PortAudio audio (hw:N or hw:N,M).
+;audiodev=hw:0              ; Optional ALSA device for PortAudio audio (hw:N or hw:N,M).
                             ; Use instead of devstr when binding audio by card number.
 ;rxmixerset=500
 ;txmixaset=500

--- a/rpt_install.sh
+++ b/rpt_install.sh
@@ -34,20 +34,29 @@ printf "Script is now the latest version\n"
 ls -d -v */ | grep "^asterisk" | tail -1
 cd $( ls -d -v */ | grep "^asterisk" | tail -1 )
 
-apt-get install -y libusb-dev # chan_simpleusb and chan_usbradio require libusb-dev on Debian
-modprobe snd-pcm-oss # /dev/dsp1 needs to exist for chan_simpleusb and chan_usbradio to work
-echo "snd-pcm-oss" >> /etc/modules # load module at startup for USB
+apt-get install -y libusb-dev libasound2-dev libportaudio2 portaudio19-dev # USB radio drivers and PortAudio
 
-cp ../$MYDIR/apps/Makefile.diff /tmp/app_Makefile.diff
-git apply /tmp/app_Makefile.diff
+apply_diff() {
+	src="$1"
+	tmpdiff="$(mktemp)" || exit 1
 
-cp ../$MYDIR/channels/Makefile.diff /tmp/channels_Makefile.diff
-git apply /tmp/channels_Makefile.diff
+	cp "$src" "$tmpdiff" || {
+		rm -f "$tmpdiff"
+		exit 1
+	}
+	if ! git apply "$tmpdiff"; then
+		patch -p1 < "$tmpdiff" || {
+			rm -f "$tmpdiff"
+			exit 1
+		}
+	fi
+	rm -f "$tmpdiff"
+}
 
-cp ../$MYDIR/utils/Makefile.diff /tmp/utils_makefile.diff
-git apply /tmp/utils_makefile.diff
-
-git apply ../$MYDIR/res/Makefile.diff
+apply_diff "../$MYDIR/apps/Makefile.diff"
+apply_diff "../$MYDIR/channels/Makefile.diff"
+apply_diff "../$MYDIR/utils/Makefile.diff"
+apply_diff "../$MYDIR/res/Makefile.diff"
 
 echoerr() {
 	printf "\e[31;1m%s\e[0m\n" "$*" >&2;

--- a/rpt_install.sh
+++ b/rpt_install.sh
@@ -45,7 +45,7 @@ apply_diff() {
 		exit 1
 	}
 	if ! git apply "$tmpdiff"; then
-		patch -p1 < "$tmpdiff" || {
+		patch --batch --forward -p1 < "$tmpdiff" || {
 			rm -f "$tmpdiff"
 			exit 1
 		}


### PR DESCRIPTION
## Summary
- Migrate `chan_usbradio` off OSS `/dev/dsp` to shared `ast_radio_pa_*` helpers
- Document optional `audiodev=hw:N` in `usbradio.conf.sample`
- Update `rpt_install.sh`: drop `snd-pcm-oss`, add PortAudio deps, `mktemp` for Makefile diffs
- Fix `txtoctype=notone` / `phase` so CTCSS turn-off starts on local COS drop when full duplex (does not ride `app_rpt` hangtime). Fixes #1024.

Standalone piece **3/3**. Depends on #1111 and #1112 (both merged); rebased onto current `master`.

**Review focus:** `channels/chan_usbradio.c`, `channels/xpmr/xpmr.c`, `configs/samples/usbradio.conf.sample`, `rpt_install.sh`.

## Test plan
- [x] CI passes
- [x] `chan_usbradio.so` loads; audio via PortAudio on test node (crazytrain / node 546050)
- [ ] `rpt_install.sh` on dev tree: no `snd-pcm-oss`, PortAudio packages installed
- [ ] With `duplex=1`, `txtoctype=notone` (or `phase`), and TX CTCSS encode: tone drops when local COS drops, before hangtime/PTT drop (service monitor or CTCSS RX)
- [ ] Half duplex still applies ~600ms burst when PTT is released

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * USB radio audio now streams via PortAudio for improved ALSA device selection and more reliable audio handling.
  * Added an `audiodev` option to target a specific ALSA audio device (instead of `devstr`).
  * Installation now includes USB radio and PortAudio development/runtime support.
* **Bug Fixes**
  * Enhanced PortAudio handling for underflow, timeout, and overflow scenarios.
  * Improved shutdown/teardown to stop streaming reliably and recover cleanly.
  * Fixed CTCSS transmit/TOC behavior during duplex carrier loss (“hang-muted” handling).
* **Documentation**
  * Updated the sample configuration with `audiodev` guidance and clearer tone burst behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->