### PR TITLE
app_gps: improve NMEA parsing, APRStt offsets, and serial recovery

### DIFF
--- a/apps/app_gps.c
+++ b/apps/app_gps.c
@@ -445,12 +445,15 @@ static int getnmea_line(int fd, char *buf, size_t buflen)
 		}
 		if (c == '$') {
 			/* Resync to the start of the next NMEA sentence. */
+			buf[0] = c;
 			break;
 		}
 		ast_debug(5, "Waiting for start of NMEA sentence, ignoring 0x%02x\n", (unsigned char) c);
 	}
+	if (!run_forever) {
+		return -1;
+	}
 
-	buf[0] = c;
 	for (i = 1; (i < (int) buflen - 1) && run_forever; i++) {
 		c = getserialchar(fd);
 		if (c < 1) {

--- a/apps/app_gps.c
+++ b/apps/app_gps.c
@@ -454,7 +454,10 @@ static int getnmea_line(int fd, char *buf, size_t buflen)
 		return -1;
 	}
 
-	for (i = 1; (i < (int) buflen - 1) && run_forever; i++) {
+	for (i = 1; i < (int) buflen - 1; i++) {
+		if (!run_forever) {
+			return -1;
+		}
 		ch = getserialchar(fd);
 		if (ch < 1) {
 			buf[i] = '\0';
@@ -464,6 +467,9 @@ static int getnmea_line(int fd, char *buf, size_t buflen)
 			break;
 		}
 		buf[i] = (char) ch;
+	}
+	if (!run_forever) {
+		return -1;
 	}
 	buf[i] = '\0';
 

--- a/apps/app_gps.c
+++ b/apps/app_gps.c
@@ -424,45 +424,45 @@ static int getserialchar(int fd)
  * deliver data mid-stream.
  *
  * \param fd		File descriptor to read.
- * \param str		Pointer to string buffer.
- * \param max		Maximum characters to read (including NUL terminator).
+ * \param buf		Buffer for the NMEA sentence.
+ * \param buflen	Buffer size (including NUL terminator).
  *
  * \retval 			Number of characters read, 0 for time out or -1 for error.
  */
-static int getnmea_line(int fd, char *str, int max)
+static int getnmea_line(int fd, char *buf, size_t buflen)
 {
 	int i;
 	char c;
 
-	if (max < 2) {
+	if (buflen < 2) {
 		return -1;
 	}
 
-	/* Resync to the start of the next NMEA sentence. */
 	while (run_forever) {
 		c = getserialchar(fd);
 		if (c < 1) {
 			return c;
 		}
 		if (c == '$') {
+			/* Resync to the start of the next NMEA sentence. */
 			break;
 		}
-		ast_debug(5, "GPS discarding byte 0x%02x while resyncing to NMEA sentence\n", (unsigned char) c);
+		ast_debug(5, "Waiting for start of NMEA sentence, ignoring 0x%02x\n", (unsigned char) c);
 	}
 
-	str[0] = '$';
-	for (i = 1; (i < max - 1) && run_forever; i++) {
+	buf[0] = c;
+	for (i = 1; (i < (int) buflen - 1) && run_forever; i++) {
 		c = getserialchar(fd);
 		if (c < 1) {
-			str[i] = '\0';
+			buf[i] = '\0';
 			return c;
 		}
 		if (c < ' ') {
 			break;
 		}
-		str[i] = c;
+		buf[i] = c;
 	}
-	str[i] = '\0';
+	buf[i] = '\0';
 
 	return i;
 }
@@ -943,7 +943,7 @@ static int is_gga_sentence(const char *sentence)
  */
 static int aprs_lat_apply_offset(const char *in_lat, int minute_offset, char *out_lat, size_t out_len)
 {
-	char work[25];
+	char latbuf[25]; /* scratch copy of DDMM.mmN/S before parsing */
 	char dir;
 	int deg;
 	double minutes, decimal;
@@ -952,15 +952,15 @@ static int aprs_lat_apply_offset(const char *in_lat, int minute_offset, char *ou
 		return 0;
 	}
 
-	ast_copy_string(work, in_lat, sizeof(work));
-	dir = work[strlen(work) - 1];
+	ast_copy_string(latbuf, in_lat, sizeof(latbuf));
+	dir = latbuf[strlen(latbuf) - 1];
 	if (dir != 'N' && dir != 'S') {
 		return 0;
 	}
-	work[strlen(work) - 1] = '\0';
+	latbuf[strlen(latbuf) - 1] = '\0';
 
-	deg = (work[0] - '0') * 10 + (work[1] - '0');
-	minutes = strtod(work + 2, NULL);
+	deg = (latbuf[0] - '0') * 10 + (latbuf[1] - '0');
+	minutes = strtod(latbuf + 2, NULL);
 	if (minutes < 0.0 || minutes >= 60.0) {
 		return 0;
 	}
@@ -1007,16 +1007,7 @@ static int gps_serial_open(void)
 		close(fd);
 		return -1;
 	}
-#ifndef SOLARIS
 	cfmakeraw(&mode);
-#else
-	mode.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON);
-	mode.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
-	mode.c_cflag &= ~(CSIZE | PARENB | CRTSCTS);
-	mode.c_cflag |= CS8;
-	mode.c_cc[VTIME] = 3;
-	mode.c_cc[VMIN] = 1;
-#endif
 
 	cfsetispeed(&mode, baudrate);
 	cfsetospeed(&mode, baudrate);
@@ -1552,6 +1543,8 @@ static void *aprstt_sender_thread(void *data)
 				if ((selected_position.last_updated + GPS_VALID_SECS) >= now) {
 					report_aprstt(ctg, lat, selected_position.longitude, theircall, overlay);
 				}
+			} else {
+				ast_debug(2, "APRS_SENDTT: unable to apply latitude offset to '%s'\n", selected_position.latitude);
 			}
 		}
 	}
@@ -1863,7 +1856,7 @@ static int load_module(void)
 			baudrate = B57600;
 			break;
 		default:
-			ast_log(LOG_ERROR, "%s is not valid baud rate, using %d\n", val, 4800);
+			ast_log(LOG_ERROR, "%s is not a supported baud rate, using %d\n", val, 4800);
 			baudrate = GPS_DEFAULT_BAUDRATE;
 			break;
 		}

--- a/apps/app_gps.c
+++ b/apps/app_gps.c
@@ -417,39 +417,52 @@ static int getserialchar(int fd)
 }
 
 /*!
- * \brief Get a line of characters from serial device.
+ * \brief Read one complete NMEA sentence from serial device.
  *
- * Get one line of characters from the serial device.  Timeout after SERIAL_MAXMS.
+ * Discards bytes until a '$' start-of-sentence marker is found, then reads
+ * until end-of-line.  This keeps the reader aligned when pseudo-serial bridges
+ * deliver data mid-stream.
  *
  * \param fd		File descriptor to read.
  * \param str		Pointer to string buffer.
- * \param max		Maximum characters to read.
+ * \param max		Maximum characters to read (including NUL terminator).
  *
  * \retval 			Number of characters read, 0 for time out or -1 for error.
  */
-
-static int getserialline(int fd, char *str, int max)
+static int getnmea_line(int fd, char *str, int max)
 {
 	int i;
 	char c;
 
-	for (i = 0; (i < max) && run_forever; i++) {
+	if (max < 2) {
+		return -1;
+	}
+
+	/* Resync to the start of the next NMEA sentence. */
+	while (run_forever) {
 		c = getserialchar(fd);
-		/* See if we timed out or received an error */
 		if (c < 1) {
 			return c;
 		}
-		if ((i == 0) && (c < ' ')) {
-			i--;
-			continue;
+		if (c == '$') {
+			break;
 		}
-		/* Any character < ' ' indicates the end of line */
+		ast_debug(5, "GPS discarding byte 0x%02x while resyncing to NMEA sentence\n", (unsigned char) c);
+	}
+
+	str[0] = '$';
+	for (i = 1; (i < max - 1) && run_forever; i++) {
+		c = getserialchar(fd);
+		if (c < 1) {
+			str[i] = '\0';
+			return c;
+		}
 		if (c < ' ') {
 			break;
 		}
 		str[i] = c;
 	}
-	str[i] = 0;
+	str[i] = '\0';
 
 	return i;
 }
@@ -894,11 +907,10 @@ static void lon_decimal_to_DMS(float dec, char *value, int len)
 static void format_def_elevation(const char *defelev, char *elevation, size_t elen)
 {
 	if (defelev) {
-		float eleva, elevd;
+		float eleva;
 
 		eleva = strtof(defelev, NULL);
-		elevd = (eleva - floor(eleva)) * 10 + 0.5;
-		snprintf(elevation, elen, "%03d.%1dM", (int) eleva, (int) elevd);
+		snprintf(elevation, elen, "%.1fM", eleva);
 	} else {
 		ast_copy_string(elevation, "000.0M", elen);
 	}
@@ -916,11 +928,11 @@ static int is_gga_sentence(const char *sentence)
 	}
 
 	len = strlen(sentence);
-	if (len < 6) {
+	if (len != 6 || strcasecmp(sentence + 3, "GGA")) {
 		return 0;
 	}
 
-	return !strcasecmp(sentence + len - 3, "GGA");
+	return 1;
 }
 
 /*!
@@ -1048,8 +1060,8 @@ static void *gps_reader(void *data)
 			}
 		}
 
-		/* Read a line from the serial port */
-		res = getserialline(fd, buf, sizeof(buf) - 1);
+		/* Read a complete NMEA sentence from the serial port */
+		res = getnmea_line(fd, buf, sizeof(buf));
 		if (res < 0) {
 			ast_log(LOG_WARNING, "GPS serial read error on %s, reconnecting\n", comport);
 			close(fd);
@@ -1087,7 +1099,7 @@ static void *gps_reader(void *data)
 			}
 			/* Validate the GPS data */
 			if (buf[0] != '$') {
-				ast_log(LOG_WARNING, "GPS Invalid data format (no '$' at beginning)\n");
+				ast_debug(1, "GPS reader lost NMEA framing on %s\n", comport);
 				continue;
 			}
 			/* Calculate the check sum */
@@ -1100,11 +1112,11 @@ static void *gps_reader(void *data)
 			}
 			star_idx = i;
 			if ((!buf[star_idx]) || (strlen(buf) < (star_idx + 3))) {
-				ast_log(LOG_WARNING, "GPS Invalid data format (checksum format)\n");
+				ast_debug(1, "GPS ignoring truncated NMEA sentence: %s\n", buf);
 				continue;
 			}
 			if ((sscanf(buf + star_idx + 1, "%x", &rx_checksum) != 1) || (c != rx_checksum)) {
-				ast_log(LOG_WARNING, "GPS Invalid checksum\n");
+				ast_debug(1, "GPS ignoring NMEA sentence with bad checksum: %s\n", buf);
 				continue;
 			}
 
@@ -1424,6 +1436,7 @@ static void *aprstt_sender_thread(void *data)
 		memset(&ttempty, 0, sizeof(ttempty));
 		if (fseek(mfp, 0, SEEK_END)) {
 			ast_log(LOG_ERROR, "Can not seek aprstt common block file %s: %s\n", fname, strerror(errno));
+			fclose(mfp);
 			return NULL;
 		}
 		for (i = mystat.st_size; i < (sizeof(struct ttentry) * ttlist); i += sizeof(struct ttentry)) {

--- a/apps/app_gps.c
+++ b/apps/app_gps.c
@@ -949,6 +949,7 @@ static int aprs_lat_apply_offset(const char *in_lat, int hundredth_minute_offset
 	char latbuf[25]; /* scratch copy of DDMM.mmN/S before parsing */
 	char dir;
 	int deg;
+	size_t len;
 	double minutes, decimal;
 
 	if (ast_strlen_zero(in_lat) || strlen(in_lat) < 4) {
@@ -956,11 +957,12 @@ static int aprs_lat_apply_offset(const char *in_lat, int hundredth_minute_offset
 	}
 
 	ast_copy_string(latbuf, in_lat, sizeof(latbuf));
-	dir = latbuf[strlen(latbuf) - 1];
+	len = strlen(latbuf);
+	dir = latbuf[len - 1];
 	if (dir != 'N' && dir != 'S') {
 		return 0;
 	}
-	latbuf[strlen(latbuf) - 1] = '\0';
+	latbuf[len - 1] = '\0';
 
 	deg = (latbuf[0] - '0') * 10 + (latbuf[1] - '0');
 	minutes = strtod(latbuf + 2, NULL);

--- a/apps/app_gps.c
+++ b/apps/app_gps.c
@@ -431,7 +431,7 @@ static int getserialchar(int fd)
  */
 static int getnmea_line(int fd, char *buf, size_t buflen)
 {
-	int i;
+	size_t i;
 	int ch;
 
 	if (buflen < 2) {
@@ -454,7 +454,7 @@ static int getnmea_line(int fd, char *buf, size_t buflen)
 		return -1;
 	}
 
-	for (i = 1; i < (int) buflen - 1; i++) {
+	for (i = 1; i < buflen - 1; i++) {
 		if (!run_forever) {
 			return -1;
 		}
@@ -473,7 +473,7 @@ static int getnmea_line(int fd, char *buf, size_t buflen)
 	}
 	buf[i] = '\0';
 
-	return i;
+	return (int) i;
 }
 
 /*!

--- a/apps/app_gps.c
+++ b/apps/app_gps.c
@@ -41,13 +41,14 @@
  *
  * app_gps can connect to a serial GPS receiver to get position information.
  * If a GPS receiver is not configured, it can provide default position information
- * entered in the gps.conf file.  It decodes the NEMA-0183 $GPGGA sentence.
+ * entered in the gps.conf file.  It decodes NMEA-0183 GGA sentences ($GPGGA,
+ * $GNGGA, etc.).
  *
  * The $GPGGA sentence looks like the following:
  * $GPGGA,011530.00,3255.21780,N,08556.91695,W,2,06,3.45,217.4,M,-30.3,M,,0000*63
  *
  * Name	                  Example Data        Description
- * Sentence Identifier	  $GPGGA              Global Positioning System Fix Data
+ * Sentence Identifier	  $xxGGA              Global Positioning System Fix Data
  * Time                   011530.00           01:15:30 UTC
  * Latitude               3255.21780          32.920297°N or 32° 55' 13.0692"N
  * Latitude direction	  N                   N = North or S = South
@@ -478,7 +479,7 @@ static void *aprs_connection_thread(void *data)
 
 	if (!(cfg = ast_config_load(config, zeroflag))) {
 		ast_log(LOG_NOTICE, "Unable to load config %s\n", config);
-		pthread_exit(NULL);
+		return NULL;
 	}
 	val = ast_variable_retrieve(cfg, "general", "call");
 	if (val) {
@@ -497,7 +498,7 @@ static void *aprs_connection_thread(void *data)
 	/* Verify that we have a callsign and password */
 	if ((!call) || (!password)) {
 		ast_log(LOG_ERROR, "You must specify call and password\n");
-		pthread_exit(NULL);
+		return NULL;
 	}
 
 	while (run_forever) {
@@ -709,8 +710,7 @@ static int report_aprs(const char *ctg, char *lat, char *lon, const char *elev)
 
 	/* Setup optional elevation */
 	elev_f = 0;
-	sscanf(elev, "%f", &elev_f);
-	if (elev_f > 0) {
+	if (sscanf(elev, "%f", &elev_f) == 1) {
 		snprintf(elev_str, sizeof(elev_str), "/A=%06.0f", elev_f * 3.28);
 	} else {
 		elev_str[0] = '\0';
@@ -889,6 +889,136 @@ static void lon_decimal_to_DMS(float dec, char *value, int len)
 }
 
 /*!
+ * \brief Format a default elevation string with a meters unit suffix.
+ */
+static void format_def_elevation(const char *defelev, char *elevation, size_t elen)
+{
+	if (defelev) {
+		float eleva, elevd;
+
+		eleva = strtof(defelev, NULL);
+		elevd = (eleva - floor(eleva)) * 10 + 0.5;
+		snprintf(elevation, elen, "%03d.%1dM", (int) eleva, (int) elevd);
+	} else {
+		ast_copy_string(elevation, "000.0M", elen);
+	}
+}
+
+/*!
+ * \brief Test whether a sentence is an NMEA GGA fix record.
+ */
+static int is_gga_sentence(const char *sentence)
+{
+	size_t len;
+
+	if (ast_strlen_zero(sentence) || sentence[0] != '$') {
+		return 0;
+	}
+
+	len = strlen(sentence);
+	if (len < 6) {
+		return 0;
+	}
+
+	return !strcasecmp(sentence + len - 3, "GGA");
+}
+
+/*!
+ * \brief Apply a minute offset to an APRS-format latitude string.
+ *
+ * \retval 1 on success
+ * \retval 0 on parse failure
+ */
+static int aprs_lat_apply_offset(const char *in_lat, int minute_offset, char *out_lat, size_t out_len)
+{
+	char work[25];
+	char dir;
+	int deg;
+	double minutes, decimal;
+
+	if (ast_strlen_zero(in_lat) || strlen(in_lat) < 4) {
+		return 0;
+	}
+
+	ast_copy_string(work, in_lat, sizeof(work));
+	dir = work[strlen(work) - 1];
+	if (dir != 'N' && dir != 'S') {
+		return 0;
+	}
+	work[strlen(work) - 1] = '\0';
+
+	deg = (work[0] - '0') * 10 + (work[1] - '0');
+	minutes = strtod(work + 2, NULL);
+	if (minutes < 0.0 || minutes >= 60.0) {
+		return 0;
+	}
+
+	decimal = (double) deg + minutes / 60.0;
+	if (dir == 'S') {
+		decimal = -decimal;
+	}
+	decimal += minute_offset / 60.0;
+
+	if (decimal >= 0.0) {
+		dir = 'N';
+	} else {
+		dir = 'S';
+		decimal = -decimal;
+	}
+
+	deg = (int) decimal;
+	minutes = (decimal - deg) * 60.0;
+	snprintf(out_lat, out_len, "%02d%05.2f%c", deg, minutes, dir);
+	return 1;
+}
+
+/*!
+ * \brief Open and configure the GPS serial port.
+ *
+ * \retval fd on success
+ * \retval -1 on failure
+ */
+static int gps_serial_open(void)
+{
+	int fd;
+	struct termios mode;
+
+	fd = open(comport, O_RDWR);
+	if (fd == -1) {
+		ast_log(LOG_WARNING, "Cannot open serial port %s: %s\n", comport, strerror(errno));
+		return -1;
+	}
+
+	memset(&mode, 0, sizeof(mode));
+	if (tcgetattr(fd, &mode)) {
+		ast_log(LOG_WARNING, "Unable to get serial parameters on %s: %s\n", comport, strerror(errno));
+		close(fd);
+		return -1;
+	}
+#ifndef SOLARIS
+	cfmakeraw(&mode);
+#else
+	mode.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON);
+	mode.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
+	mode.c_cflag &= ~(CSIZE | PARENB | CRTSCTS);
+	mode.c_cflag |= CS8;
+	mode.c_cc[VTIME] = 3;
+	mode.c_cc[VMIN] = 1;
+#endif
+
+	cfsetispeed(&mode, baudrate);
+	cfsetospeed(&mode, baudrate);
+	if (tcsetattr(fd, TCSANOW, &mode)) {
+		ast_log(LOG_WARNING, "Unable to set serial parameters on %s: %s\n", comport, strerror(errno));
+		close(fd);
+		return -1;
+	}
+
+	usleep(100000);
+	return fd;
+}
+
+/*!
  * \brief GPS device processing thread.
  * This routine continuously reads and parses the serial GPS data.
  *
@@ -900,61 +1030,34 @@ static void lon_decimal_to_DMS(float dec, char *value, int len)
 static void *gps_reader(void *data)
 {
 	char buf[300], c, *strs[100];
-	int res, i, n, fd, has_comport = 0;
-	struct termios mode;
+	int res, i, n, fd, star_idx, rx_checksum;
 	struct position_info *selected_info;
 	time_t now_mono;
 
-	if (comport) {
-		has_comport = 1;
-	} else {
-		comport = "/dev/null";
-	}
-
-	/* Open the serial port configured for the GPS device */
-	fd = open(comport, O_RDWR);
-	if (fd == -1) {
-		ast_log(LOG_WARNING, "Cannot open serial port %s: %s\n", comport, strerror(errno));
-		goto err;
-	}
-
-	if (has_comport) {
-		memset(&mode, 0, sizeof(mode));
-		if (tcgetattr(fd, &mode)) {
-			ast_log(LOG_WARNING, "Unable to get serial parameters on %s: %s\n", comport, strerror(errno));
-			close(fd);
-			goto err;
-		}
-#ifndef SOLARIS
-		cfmakeraw(&mode);
-#else
-		mode.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON);
-		mode.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
-		mode.c_cflag &= ~(CSIZE | PARENB | CRTSCTS);
-		mode.c_cflag |= CS8;
-		mode.c_cc[VTIME] = 3;
-		mode.c_cc[VMIN] = 1;
-#endif
-
-		cfsetispeed(&mode, baudrate);
-		cfsetospeed(&mode, baudrate);
-		if (tcsetattr(fd, TCSANOW, &mode)) {
-			ast_log(LOG_WARNING, "Unable to set serial parameters on %s: %s\n", comport, strerror(errno));
-			close(fd);
-			goto err;
-		}
-	}
-
-	/* Give the device a few milliseconds to come on-line */
-	usleep(100000);
-
-	/*! \todo we need to deal with someone unplugging the device */
+	fd = -1;
 
 	while (run_forever) {
+		if (fd < 0) {
+			fd = gps_serial_open();
+			if (fd < 0) {
+				ast_mutex_lock(&position_update_lock);
+				current_gps_position.is_valid = 0;
+				ast_mutex_unlock(&position_update_lock);
+				sleep(2);
+				continue;
+			}
+		}
+
 		/* Read a line from the serial port */
 		res = getserialline(fd, buf, sizeof(buf) - 1);
 		if (res < 0) {
-			ast_log(LOG_ERROR, "GPS fatal error!\n");
+			ast_log(LOG_WARNING, "GPS serial read error on %s, reconnecting\n", comport);
+			close(fd);
+			fd = -1;
+			ast_mutex_lock(&position_update_lock);
+			current_gps_position.is_valid = 0;
+			ast_mutex_unlock(&position_update_lock);
+			sleep(1);
 			continue;
 		}
 		if (!res) {
@@ -995,11 +1098,12 @@ static void *gps_reader(void *data)
 				}
 				c ^= buf[i];
 			}
-			if ((!buf[i]) || (strlen(buf) < (i + 3))) {
+			star_idx = i;
+			if ((!buf[star_idx]) || (strlen(buf) < (star_idx + 3))) {
 				ast_log(LOG_WARNING, "GPS Invalid data format (checksum format)\n");
 				continue;
 			}
-			if ((sscanf(buf + i + 1, "%x", &i) != 1) || (c != i)) {
+			if ((sscanf(buf + star_idx + 1, "%x", &rx_checksum) != 1) || (c != rx_checksum)) {
 				ast_log(LOG_WARNING, "GPS Invalid checksum\n");
 				continue;
 			}
@@ -1009,8 +1113,8 @@ static void *gps_reader(void *data)
 				ast_log(LOG_WARNING, "GPS Invalid data format (no data)\n");
 				continue;
 			}
-			/* We only process the $GPGGA sentence */
-			if (strcasecmp(strs[0], "$GPGGA")) {
+			/* Process NMEA GGA sentences ($GPGGA, $GNGGA, etc.) */
+			if (!is_gga_sentence(strs[0])) {
 				continue;
 			}
 			if (n != 15) {
@@ -1052,7 +1156,6 @@ static void *gps_reader(void *data)
 		close(fd);
 	}
 
-err:
 	ast_debug(2, "%s has exited\n", __FUNCTION__);
 	return NULL;
 }
@@ -1087,7 +1190,7 @@ static void *aprs_sender_thread(void *data)
 
 	if (!(cfg = ast_config_load(config, zeroflag))) {
 		ast_log(LOG_NOTICE, "Unable to load config %s\n", config);
-		pthread_exit(NULL);
+		return NULL;
 	}
 	val = ast_variable_retrieve(cfg, ctg, "lat");
 	if (val) {
@@ -1133,15 +1236,7 @@ static void *aprs_sender_thread(void *data)
 		this_def_position.is_valid = 1;
 		lat_decimal_to_DMS(strtof(deflat, NULL), this_def_position.latitude, sizeof(this_def_position.latitude));
 		lon_decimal_to_DMS(strtof(deflon, NULL), this_def_position.longitude, sizeof(this_def_position.longitude));
-		/* See if we have a default elevation */
-		if (defelev) {
-			float eleva, elevd;
-			eleva = strtof(defelev, NULL);
-			elevd = (eleva - floor(eleva)) * 10 + 0.5;
-			snprintf(this_def_position.elevation, sizeof(this_def_position.elevation), "%03d.%1d", (int) eleva, (int) elevd);
-		} else {
-			strcpy(this_def_position.elevation, "000.0");
-		}
+		format_def_elevation(defelev, this_def_position.elevation, sizeof(this_def_position.elevation));
 	}
 
 	memset(&selected_position, 0, sizeof(selected_position));
@@ -1195,8 +1290,8 @@ static void *aprstt_sender_thread(void *data)
 {
 	struct ast_config *cfg = NULL;
 	struct ast_flags zeroflag = { 0 };
-	int i, j, ttlist, ttoffset, ttslot, myoffset;
-	char *ctg, c;
+	int i, ttlist, ttoffset, ttslot, myoffset;
+	char *ctg;
 	char *deflat, *deflon, *defelev, ttsplit, *ttlat, *ttlon;
 	const char *val, *resolved_lat, *resolved_lon;
 	char fname[200], lat[25], theircall[20], overlay;
@@ -1216,7 +1311,7 @@ static void *aprstt_sender_thread(void *data)
 	/* Load our configuration */
 	if (!(cfg = ast_config_load(config, zeroflag))) {
 		ast_log(LOG_NOTICE, "Unable to load config %s\n", config);
-		pthread_exit(NULL);
+		return NULL;
 	}
 	val = ast_variable_retrieve(cfg, ctg, "lat");
 	if (val) {
@@ -1287,15 +1382,7 @@ static void *aprstt_sender_thread(void *data)
 		this_def_position.is_valid = 1;
 		lat_decimal_to_DMS(strtof(resolved_lat, NULL), this_def_position.latitude, sizeof(this_def_position.latitude));
 		lon_decimal_to_DMS(strtof(resolved_lon, NULL), this_def_position.longitude, sizeof(this_def_position.longitude));
-		/* See if we have a default elevation */
-		if (defelev) {
-			float eleva, elevd;
-			eleva = strtof(defelev, NULL);
-			elevd = (eleva - floor(eleva)) * 10 + 0.5;
-			snprintf(this_def_position.elevation, sizeof(this_def_position.elevation), "%03d.%1d", (int) eleva, (int) elevd);
-		} else {
-			strcpy(this_def_position.elevation, "000.0");
-		}
+		format_def_elevation(defelev, this_def_position.elevation, sizeof(this_def_position.elevation));
 	}
 
 	/*
@@ -1312,55 +1399,56 @@ static void *aprstt_sender_thread(void *data)
 		mfp = fopen(fname, "w");
 		if (!mfp) {
 			ast_log(LOG_ERROR, "Can not create aprstt common block file %s: %s\n", fname, strerror(errno));
-			pthread_exit(NULL);
+			return NULL;
 		}
 		memset(&ttempty, 0, sizeof(ttempty));
 		for (i = 0; i < ttlist; i++) {
 			if (fwrite(&ttempty, 1, sizeof(ttempty), mfp) != sizeof(ttempty)) {
 				ast_log(LOG_ERROR, "Error initializing aprtss common block file %s: %s\n", fname, strerror(errno));
 				fclose(mfp);
-				pthread_exit(NULL);
+				return NULL;
 			}
 		}
 		fclose(mfp);
 		if (stat(fname, &mystat) == -1) {
 			ast_log(LOG_ERROR, "Unable to stat new aprstt common block file %s: %s\n", fname, strerror(errno));
-			pthread_exit(NULL);
+			return NULL;
 		}
 	}
 	if (mystat.st_size < (sizeof(struct ttentry) * ttlist)) {
 		mfp = fopen(fname, "r+");
 		if (!mfp) {
 			ast_log(LOG_ERROR, "Can not open aprstt common block file %s: %s\n", fname, strerror(errno));
-			pthread_exit(NULL);
+			return NULL;
 		}
 		memset(&ttempty, 0, sizeof(ttempty));
 		if (fseek(mfp, 0, SEEK_END)) {
 			ast_log(LOG_ERROR, "Can not seek aprstt common block file %s: %s\n", fname, strerror(errno));
-			pthread_exit(NULL);
+			return NULL;
 		}
 		for (i = mystat.st_size; i < (sizeof(struct ttentry) * ttlist); i += sizeof(struct ttentry)) {
 			if (fwrite(&ttempty, 1, sizeof(ttempty), mfp) != sizeof(ttempty)) {
 				ast_log(LOG_ERROR, "Error growing aprtss common block file %s: %s\n", fname, strerror(errno));
 				fclose(mfp);
-				pthread_exit(NULL);
+				return NULL;
 			}
 		}
 		fclose(mfp);
 		if (stat(fname, &mystat) == -1) {
 			ast_log(LOG_ERROR, "Unable to stat updated aprstt common block file %s: %s\n", fname, strerror(errno));
-			pthread_exit(NULL);
+			return NULL;
 		}
 	}
 	mfp = fopen(fname, "r+");
 	if (!mfp) {
 		ast_log(LOG_ERROR, "Can not open aprstt common block file %s: %s\n", fname, strerror(errno));
-		pthread_exit(NULL);
+		return NULL;
 	}
 	ttentries = mmap(NULL, mystat.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, fileno(mfp), 0);
-	if (ttentries == NULL) {
+	if (ttentries == MAP_FAILED) {
 		ast_log(LOG_ERROR, "Cannot map aprtss common file %s: %s\n", fname, strerror(errno));
-		pthread_exit(NULL);
+		fclose(mfp);
+		return NULL;
 	}
 
 	while (run_forever) {
@@ -1446,22 +1534,7 @@ static void *aprstt_sender_thread(void *data)
 		ast_mutex_unlock(&position_update_lock);
 
 		if (selected_position.is_valid) {
-			if (sscanf(selected_position.latitude, "%d.%d%c", &i, &j, &c) == 3) {
-				/* Adjust the latitude for the offset */
-				if (c == 'S') {
-					i = -i;
-				}
-				if (i >= 0) {
-					j -= myoffset;
-				} else {
-					j += myoffset;
-				}
-				i += (j / 60);
-				if (j < 0) {
-					snprintf(lat, sizeof(lat), "%04d.%02d%c", (i >= 0) ? i : -i, -j % 60, (i >= 0) ? 'N' : 'S');
-				} else {
-					snprintf(lat, sizeof(lat), "%04d.%02d%c", (i >= 0) ? i : -i, j % 60, (i >= 0) ? 'N' : 'S');
-				}
+			if (aprs_lat_apply_offset(selected_position.latitude, myoffset, lat, sizeof(lat))) {
 				/* If our last position update is good, send an update */
 				if ((selected_position.last_updated + GPS_VALID_SECS) >= now) {
 					report_aprstt(ctg, lat, selected_position.longitude, theircall, overlay);
@@ -1777,7 +1850,8 @@ static int load_module(void)
 			baudrate = B57600;
 			break;
 		default:
-			ast_log(LOG_ERROR, "%s is not valid baud rate for iospeed\n", val);
+			ast_log(LOG_ERROR, "%s is not valid baud rate, using %d\n", val, 4800);
+			baudrate = GPS_DEFAULT_BAUDRATE;
 			break;
 		}
 	} else {
@@ -1792,15 +1866,7 @@ static int load_module(void)
 		general_def_position.is_valid = 1;
 		lat_decimal_to_DMS(strtof(def_lat, NULL), general_def_position.latitude, sizeof(general_def_position.latitude));
 		lon_decimal_to_DMS(strtof(def_lon, NULL), general_def_position.longitude, sizeof(general_def_position.longitude));
-		/* See if we have a default elevation */
-		if (def_elev) {
-			float eleva, elevd;
-			eleva = strtof(def_elev, NULL);
-			elevd = (eleva - floor(eleva)) * 10 + 0.5;
-			snprintf(general_def_position.elevation, sizeof(general_def_position.elevation), "%03d.%1dM", (int) eleva, (int) elevd);
-		} else {
-			strcpy(general_def_position.elevation, "000.0M");
-		}
+		format_def_elevation(def_elev, general_def_position.elevation, sizeof(general_def_position.elevation));
 	}
 
 	/* Create the aprs connection thread */

--- a/apps/app_gps.c
+++ b/apps/app_gps.c
@@ -432,38 +432,38 @@ static int getserialchar(int fd)
 static int getnmea_line(int fd, char *buf, size_t buflen)
 {
 	int i;
-	char c;
+	int ch;
 
 	if (buflen < 2) {
 		return -1;
 	}
 
 	while (run_forever) {
-		c = getserialchar(fd);
-		if (c < 1) {
-			return c;
+		ch = getserialchar(fd);
+		if (ch < 1) {
+			return ch;
 		}
-		if (c == '$') {
+		if (ch == '$') {
 			/* Resync to the start of the next NMEA sentence. */
-			buf[0] = c;
+			buf[0] = (char) ch;
 			break;
 		}
-		ast_debug(5, "Waiting for start of NMEA sentence, ignoring 0x%02x\n", (unsigned char) c);
+		ast_debug(5, "Waiting for start of NMEA sentence, ignoring 0x%02x\n", (unsigned char) ch);
 	}
 	if (!run_forever) {
 		return -1;
 	}
 
 	for (i = 1; (i < (int) buflen - 1) && run_forever; i++) {
-		c = getserialchar(fd);
-		if (c < 1) {
+		ch = getserialchar(fd);
+		if (ch < 1) {
 			buf[i] = '\0';
-			return c;
+			return ch;
 		}
-		if (c < ' ') {
+		if (ch < ' ') {
 			break;
 		}
-		buf[i] = c;
+		buf[i] = (char) ch;
 	}
 	buf[i] = '\0';
 
@@ -939,12 +939,12 @@ static int is_gga_sentence(const char *sentence)
 }
 
 /*!
- * \brief Apply a minute offset to an APRS-format latitude string.
+ * \brief Apply a hundredths-of-minute offset to an APRS-format latitude string.
  *
  * \retval 1 on success
  * \retval 0 on parse failure
  */
-static int aprs_lat_apply_offset(const char *in_lat, int minute_offset, char *out_lat, size_t out_len)
+static int aprs_lat_apply_offset(const char *in_lat, int hundredth_minute_offset, char *out_lat, size_t out_len)
 {
 	char latbuf[25]; /* scratch copy of DDMM.mmN/S before parsing */
 	char dir;
@@ -972,7 +972,7 @@ static int aprs_lat_apply_offset(const char *in_lat, int minute_offset, char *ou
 	if (dir == 'S') {
 		decimal = -decimal;
 	}
-	decimal += minute_offset / 60.0;
+	decimal += hundredth_minute_offset / 6000.0;
 
 	if (decimal >= 0.0) {
 		dir = 'N';
@@ -1395,6 +1395,11 @@ static void *aprstt_sender_thread(void *data)
 	 * Open the common block file for this section.
 	 * We will store the callsign and last update time.
 	 */
+	if (ttlist <= 0) {
+		ast_log(LOG_ERROR, "APRStt ttlist must be greater than zero\n");
+		return NULL;
+	}
+
 	mfp = NULL;
 	if (!strcmp(sender_entry->section, "general")) {
 		strcpy(fname, TT_COMMON);


### PR DESCRIPTION
Replaces #1110 (GitHub cannot reopen after branch force-push).

## Summary
- Accept all NMEA GGA sentences (`$GPGGA`, `$GNGGA`, etc.) so modern GNSS receivers work
- Fix APRStt latitude offset math for real DDMM.mmN/S position strings
- Reconnect the serial GPS port after read errors or unplug events
- Normalize default elevation strings to include the `M` unit suffix for STATS_GPS telemetry
- Replace `pthread_exit()` with `return NULL`, check `mmap()` against `MAP_FAILED`, and fall back to 4800 baud on invalid config

**Scope:** `apps/app_gps.c` only — no PortAudio or native gpsd changes.

## Allan review (`0c30310`)
- Renamed `getnmea_line()` params to `buf`/`buflen`
- Allan's resync log wording, `buf[0] = c`, comment inside `$` branch
- Dropped SOLARIS termios fallback
- APRStt offset parse failure logged at debug
- `latbuf` naming with comment; baud rate log wording

Elevation format (`%.1fM` vs old `%03d.%1d`) — follow-up posted on #1110; awaiting Allan's preference on fixed-width output.

## Test plan
- [ ] Build `app_gps.so` on Trixie amd64
- [ ] Verify `$GNGGA` sentences update `GPS_READ()` on a modern USB GPS
- [ ] Trigger APRStt DTMF report and confirm offset positions are sensible
- [ ] Unplug/replug GPS serial device and confirm reconnect without module reload
- [ ] Run `*4` / STATS_GPS telemetry with section default coordinates and confirm elevation is announced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of GPS/NMEA ingestion by resynchronizing to complete sentences mid-stream, tolerating framing glitches, and validating checksums before updating position.
  * Enhanced GPS parsing to accept GGA sentences across supported talker prefixes and to better determine when position data is valid.
  * Improved APRS/APRStt message formatting reliability, including safer elevation inclusion and more accurate latitude offset handling.
  * Improved reliability during startup and error scenarios, with safer handling for early failures and clearer messaging for unsupported GPS baud rates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->