### PR TITLE
app_rpt.c: Remove extra set of ( )

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -5608,7 +5608,7 @@ static void *rpt(void *this)
 			queue_id(myrpt);
 		}
 
-		if ((myrpt->p.idtime && totx && !myrpt->exttx && (myrpt->idtimer <= myrpt->p.politeid) && myrpt->tailtimer)) { /* ID time must be non-zero */
+		if (myrpt->p.idtime && totx && !myrpt->exttx && (myrpt->idtimer <= myrpt->p.politeid) && myrpt->tailtimer) { /* ID time must be non-zero */
 			myrpt->tailid = 1;
 		}
 


### PR DESCRIPTION
#1106 left an extra set of parenthesis. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the repeater’s polite identification behavior while clarifying the condition used to trigger it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->