### PR TITLE
chan_voter: fix VoterStatus to use correct selected transmit client

### DIFF
--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -1665,8 +1665,8 @@ static int manager_voter_status(struct mansession *ses, const struct message *m)
 		}
 		rpt_manager_success(ses, m);
 		astman_append(ses, "Node: %d\r\n", p->nodenum);
-		if (p->lastwon) {
-			astman_append(ses, "Voted: %s\r\n", p->lastwon->name);
+		if (p->winner) {
+			astman_append(ses, "Voted: %s\r\n", p->winner->name);
 		}
 		for (client = clients; client; client = client->next) {
 			if (client->nodenum != p->nodenum) {


### PR DESCRIPTION
VoterStatus was using `p->lastwon` which only reported the selected voting client for transmit (not mix clients), as `p->lastwon` is only set for voting clients.

Changed to use `p->winner`, as that is set for both mix and voting clients.

Resolves #1122