### PR TITLE
chan_simpleusb, chan_usbradio: Log USB radio device recovery after audio/host faults

### DIFF
--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -284,6 +284,7 @@ struct chan_simpleusb_pvt {
 	unsigned int txcapraw:1;			   /* indicator if transmit capture is enabled */
 	unsigned int measure_enabled:1;		   /* indicator if measure mode is enabled */
 	unsigned int device_error:1;		   /* indicator set when we cannot find the USB device */
+	unsigned int usb_faulted:1;			   /* set after USB/audio failure; cleared on recovery NOTICE */
 	unsigned int newname:1;				   /* indicator that we should use MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW */
 	unsigned int hasusb:1;				   /* indicator for has a USB device */
 	unsigned int usbass:1;				   /* indicator for USB device assigned */
@@ -368,6 +369,21 @@ static void tune_menusupport(int fd, struct chan_simpleusb_pvt *o, const char *c
 static void tune_write(struct chan_simpleusb_pvt *o);
 static int _send_tx_test_tone(int fd, struct chan_simpleusb_pvt *o, int ms, int intflag);
 static void *simpleusb_audio_thread(void *arg);
+
+/*!
+ * \brief Log once when USB/audio returns after a prior failure.
+ */
+static void simpleusb_log_usb_recovered(struct chan_simpleusb_pvt *o)
+{
+	const char *dev;
+
+	if (!o->usb_faulted) {
+		return;
+	}
+	dev = !ast_strlen_zero(o->devstr) ? o->devstr : o->hw_device;
+	ast_log(LOG_NOTICE, "Channel %s: USB radio device recovered (%s)\n", o->name, !ast_strlen_zero(dev) ? dev : "unknown");
+	o->usb_faulted = 0;
+}
 
 static char *simpleusb_active; /* the active device */
 
@@ -968,6 +984,7 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 					if (!o->device_error) {
 						ast_log(LOG_ERROR, "Channel %s: No USB devices are available for assignment.\n", o->name);
 						o->device_error = 1;
+						o->usb_faulted = 1;
 					}
 					usleep(DEVICE_RETRY);
 					break;
@@ -1008,6 +1025,7 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 				if (!o->device_error) {
 					ast_log(LOG_ERROR, "Channel %s: Device string %s was not found.\n", o->name, o->devstr);
 					o->device_error = 1;
+					o->usb_faulted = 1;
 				}
 				ast_mutex_unlock(&usb_dev_lock);
 				return -1;
@@ -1067,6 +1085,7 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 		if (!o->device_error) {
 			ast_log(LOG_ERROR, "Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
 			o->device_error = 1;
+			o->usb_faulted = 1;
 		}
 		ast_mutex_unlock(&usb_dev_lock);
 		return -1;
@@ -1148,6 +1167,7 @@ static void *hidthread(void *arg)
 			if (!init_audio_failed) {
 				ast_log(LOG_ERROR, "Channel %s: Failed initialize the audio device\n", o->name);
 				init_audio_failed = 1;
+				o->usb_faulted = 1;
 			}
 
 			usleep(DEVICE_RETRY);
@@ -1158,6 +1178,7 @@ static void *hidthread(void *arg)
 			if (!init_hid_failed) {
 				ast_log(LOG_ERROR, "Channel %s: Cannot initialize device %s\n", o->name, o->devstr);
 				init_hid_failed = 1;
+				o->usb_faulted = 1;
 			}
 
 			usleep(DEVICE_RETRY);
@@ -1169,6 +1190,7 @@ static void *hidthread(void *arg)
 			if (!open_device_failed) {
 				ast_log(LOG_ERROR, "Channel %s: Cannot open device %s\n", o->name, o->devstr);
 				open_device_failed = 1;
+				o->usb_faulted = 1;
 			}
 
 			usleep(DEVICE_RETRY);
@@ -1180,6 +1202,7 @@ static void *hidthread(void *arg)
 				if (!detach_failed) {
 					ast_log(LOG_ERROR, "Channel %s: Is not able to detach the USB device\n", o->name);
 					detach_failed = 1;
+					o->usb_faulted = 1;
 				}
 
 				libusb_close(usb_handle);
@@ -1191,6 +1214,7 @@ static void *hidthread(void *arg)
 				if (!claim_failed) {
 					ast_log(LOG_ERROR, "Channel %s: Is not able to claim the USB device\n", o->name);
 					claim_failed = 1;
+					o->usb_faulted = 1;
 				}
 
 				libusb_close(usb_handle);
@@ -1233,6 +1257,7 @@ static void *hidthread(void *arg)
 			libusb_close(usb_handle);
 			usb_handle = NULL;
 			/* Stay in hidthread and retry; call() only starts the thread once. */
+			o->usb_faulted = 1;
 			usleep(DEVICE_RETRY);
 			continue;
 		}
@@ -1262,6 +1287,7 @@ static void *hidthread(void *arg)
 		}
 		ast_mutex_unlock(&o->eepromlock);
 
+		simpleusb_log_usb_recovered(o);
 		o->hasusb = 1;
 		o->had_gpios_in = 0;
 		memset(&rfds, 0, sizeof(rfds));
@@ -1292,6 +1318,7 @@ static void *hidthread(void *arg)
 				ast_radio_time(&audio_time_now);
 				if ((audio_time_now - o->lastaudiotime) > 1) {
 					ast_log(LOG_ERROR, "Channel %s: Audio process has died or is not responding.\n", o->name);
+					o->usb_faulted = 1;
 					o->hasusb = 0;
 					break;
 				}
@@ -2156,6 +2183,7 @@ static void *simpleusb_audio_thread(void *arg)
 
 		if (!o->pa.active && start_stream(o) < 0) {
 			ast_log(LOG_ERROR, "Channel %s: Failed to start audio stream %s\n", o->name, o->hw_device);
+			o->usb_faulted = 1;
 			o->hasusb = 0;
 			usleep(DEVICE_RETRY);
 			continue;
@@ -2172,6 +2200,7 @@ static void *simpleusb_audio_thread(void *arg)
 				if ((now - o->lasthidtime) > 1) {
 					ast_log(LOG_ERROR, "Channel %s: HID process has died or is not responding.\n", o->name);
 					usleep(DEVICE_RETRY);
+					o->usb_faulted = 1;
 					o->hasusb = 0;
 					stream_cleanup(o);
 					break;
@@ -2274,6 +2303,7 @@ static void *simpleusb_audio_thread(void *arg)
 
 				if (frames_available < 0) {
 					ast_debug(2, "Pa_GetStreamWriteAvailable error %s", Pa_GetErrorText(frames_available));
+					o->usb_faulted = 1;
 					o->hasusb = 0;
 					stream_cleanup(o);
 					break;
@@ -2372,6 +2402,7 @@ static void *simpleusb_audio_thread(void *arg)
 										 * all other errors require restart
 										 */
 										ast_debug(2, "Pa_WriteStream error %s", Pa_GetErrorText(res));
+										o->usb_faulted = 1;
 										o->hasusb = 0;
 										stream_cleanup(o);
 										break;
@@ -2432,6 +2463,7 @@ static void *simpleusb_audio_thread(void *arg)
 
 			if (num_frames && (ast_tvdiff_ms(ast_radio_tvnow(), last_frame_time) > MAX_FRAME_DELAY)) {
 				ast_log(LOG_ERROR, "Audio thread has not processed audio for over %d ms, restarting stream.\n", MAX_FRAME_DELAY);
+				o->usb_faulted = 1;
 				o->hasusb = 0;
 				stream_cleanup(o);
 				break;
@@ -2455,7 +2487,8 @@ static void *simpleusb_audio_thread(void *arg)
 					ast_debug(6, "PortAudio read timeout on channel %s\n", o->name);
 					continue;
 				} else {
-					ast_log(LOG_ERROR, "Pa_ReadStream Error on channel %s : %s\n", o->name, Pa_GetErrorText(res));
+					ast_log(LOG_ERROR, "Channel %s: PortAudio read failed (%s); restarting audio stream\n", o->name, Pa_GetErrorText(res));
+					o->usb_faulted = 1;
 					o->hasusb = 0;
 					stream_cleanup(o);
 					break; /* Close the stream and retry */

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -46,6 +46,7 @@
 #include <sys/time.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <stdarg.h>
 #include <search.h>
 #include <linux/ppdev.h>
 #include <linux/parport.h>
@@ -297,7 +298,7 @@ struct chan_simpleusb_pvt {
 	unsigned int rx_cos_active:1;		   /* indicator if cos is active - active state after processing */
 	unsigned int rx_ctcss_active:1;		   /* indicator if ctcss is active - active state after processing */
 	/* Whole-word latch shared by HID/audio threads (not a bit-field). */
-	volatile sig_atomic_t usb_faulted;	   /* set after USB/audio failure; cleared on recovery NOTICE */
+	volatile sig_atomic_t usb_faulted;	   /* set after USB/audio failure; cleared on recovery log */
 	volatile sig_atomic_t stophidthread;   /* indicator to stop hid thread */
 	volatile sig_atomic_t stopaudiothread; /* indicator to stop audio thread */
 
@@ -372,6 +373,30 @@ static int _send_tx_test_tone(int fd, struct chan_simpleusb_pvt *o, int ms, int 
 static void *simpleusb_audio_thread(void *arg);
 
 /*!
+ * \brief Log a USB/audio fault and set the recovery latch.
+ *
+ * First occurrence (already_logged == 0) uses LOG_ERROR; repeats use DEBUG
+ * so retry loops do not spam. Returns 1 for storing into a rate-limit latch.
+ */
+static int __attribute__((format(printf, 3, 4))) simpleusb_log_fault(struct chan_simpleusb_pvt *o, int already_logged, const char *fmt, ...)
+{
+	va_list ap;
+	char buf[512];
+
+	o->usb_faulted = 1;
+	va_start(ap, fmt);
+	vsnprintf(buf, sizeof(buf), fmt, ap);
+	va_end(ap);
+
+	if (already_logged) {
+		ast_debug(1, "%s", buf);
+	} else {
+		ast_log(LOG_ERROR, "%s", buf);
+	}
+	return 1;
+}
+
+/*!
  * \brief Log once when USB/audio returns after a prior failure.
  */
 static void simpleusb_log_usb_recovered(struct chan_simpleusb_pvt *o)
@@ -385,7 +410,8 @@ static void simpleusb_log_usb_recovered(struct chan_simpleusb_pvt *o)
 		return;
 	}
 	dev = !ast_strlen_zero(o->devstr) ? o->devstr : o->hw_device;
-	ast_log(LOG_NOTICE, "Channel %s: USB radio device recovered (%s)\n", o->name, !ast_strlen_zero(dev) ? dev : "unknown");
+	/* Match fault priority so ERROR-level logs pair fault with recovery. */
+	ast_log(LOG_ERROR, "Channel %s: USB radio device recovered (%s)\n", o->name, !ast_strlen_zero(dev) ? dev : "unknown");
 }
 
 static char *simpleusb_active; /* the active device */
@@ -984,11 +1010,8 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 			for (;;) {
 				index_devstr = ast_radio_usb_get_devstr(index);
 				if (ast_strlen_zero(index_devstr)) {
-					if (!o->device_error) {
-						ast_log(LOG_ERROR, "Channel %s: No USB devices are available for assignment.\n", o->name);
-						o->device_error = 1;
-						o->usb_faulted = 1;
-					}
+					o->device_error =
+						simpleusb_log_fault(o, o->device_error, "Channel %s: No USB devices are available for assignment.\n", o->name);
 					usleep(DEVICE_RETRY);
 					break;
 				}
@@ -1025,11 +1048,8 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 			s = find_installed_usb_match();
 
 			if (ast_strlen_zero(s)) {
-				if (!o->device_error) {
-					ast_log(LOG_ERROR, "Channel %s: Device string %s was not found.\n", o->name, o->devstr);
-					o->device_error = 1;
-					o->usb_faulted = 1;
-				}
+				o->device_error =
+					simpleusb_log_fault(o, o->device_error, "Channel %s: Device string %s was not found.\n", o->name, o->devstr);
 				ast_mutex_unlock(&usb_dev_lock);
 				return -1;
 			}
@@ -1085,11 +1105,8 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 	}
 
 	if (ast_radio_init_mixer_limits(o->devicenum, &o->micmax, &o->spkrmax, &o->micplaymax, &use_newname) < 0) {
-		if (!o->device_error) {
-			ast_log(LOG_ERROR, "Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
-			o->device_error = 1;
-			o->usb_faulted = 1;
-		}
+		o->device_error = simpleusb_log_fault(o, o->device_error, "Channel %s: Cannot use audio device %s without mixer limits\n",
+			o->name, o->hw_device);
 		ast_mutex_unlock(&usb_dev_lock);
 		return -1;
 	}
@@ -1145,6 +1162,7 @@ static void *hidthread(void *arg)
 	int open_device_failed = 0;
 	int detach_failed = 0;
 	int claim_failed = 0;
+	int pipe_failed = 0;
 
 	ast_debug(2, "hidthread has started");
 	/* enable gpio_set so that we will write GPIO information upon start up */
@@ -1167,59 +1185,34 @@ static void *hidthread(void *arg)
 		/* try to initialize the usb device */
 		res = init_audio_device(o);
 		if (res < 0) {
-			if (!init_audio_failed) {
-				ast_log(LOG_ERROR, "Channel %s: Failed initialize the audio device\n", o->name);
-				init_audio_failed = 1;
-				o->usb_faulted = 1;
-			}
-
+			init_audio_failed = simpleusb_log_fault(o, init_audio_failed, "Channel %s: Failed initialize the audio device\n", o->name);
 			usleep(DEVICE_RETRY);
 			continue;
 		}
 
 		if (o->usb_dev == NULL) {
-			if (!init_hid_failed) {
-				ast_log(LOG_ERROR, "Channel %s: Cannot initialize device %s\n", o->name, o->devstr);
-				init_hid_failed = 1;
-				o->usb_faulted = 1;
-			}
-
+			init_hid_failed = simpleusb_log_fault(o, init_hid_failed, "Channel %s: Cannot initialize device %s\n", o->name, o->devstr);
 			usleep(DEVICE_RETRY);
 			continue;
 		}
 
 		/* open the usb device device */
 		if (libusb_open(o->usb_dev, &usb_handle) < 0) {
-			if (!open_device_failed) {
-				ast_log(LOG_ERROR, "Channel %s: Cannot open device %s\n", o->name, o->devstr);
-				open_device_failed = 1;
-				o->usb_faulted = 1;
-			}
-
+			open_device_failed = simpleusb_log_fault(o, open_device_failed, "Channel %s: Cannot open device %s\n", o->name, o->devstr);
 			usleep(DEVICE_RETRY);
 			continue;
 		}
 		/* attempt to claim the usb hid interface and detach from the kernel */
 		if (libusb_claim_interface(usb_handle, C108_HID_INTERFACE) < 0) {
 			if (libusb_detach_kernel_driver(usb_handle, C108_HID_INTERFACE) < 0) {
-				if (!detach_failed) {
-					ast_log(LOG_ERROR, "Channel %s: Is not able to detach the USB device\n", o->name);
-					detach_failed = 1;
-					o->usb_faulted = 1;
-				}
-
+				detach_failed = simpleusb_log_fault(o, detach_failed, "Channel %s: Is not able to detach the USB device\n", o->name);
 				libusb_close(usb_handle);
 				usb_handle = NULL;
 				usleep(DEVICE_RETRY);
 				continue;
 			}
 			if (libusb_claim_interface(usb_handle, C108_HID_INTERFACE) < 0) {
-				if (!claim_failed) {
-					ast_log(LOG_ERROR, "Channel %s: Is not able to claim the USB device\n", o->name);
-					claim_failed = 1;
-					o->usb_faulted = 1;
-				}
-
+				claim_failed = simpleusb_log_fault(o, claim_failed, "Channel %s: Is not able to claim the USB device\n", o->name);
 				libusb_close(usb_handle);
 				usb_handle = NULL;
 				usleep(DEVICE_RETRY);
@@ -1247,7 +1240,7 @@ static void *hidthread(void *arg)
 			o->pttkick[1] = -1;
 		}
 		if (pipe2(o->pttkick, O_NONBLOCK) == -1) {
-			ast_log(LOG_ERROR, "Channel %s: Is not able to create a pipe\n", o->name);
+			pipe_failed = simpleusb_log_fault(o, pipe_failed, "Channel %s: Is not able to create a pipe\n", o->name);
 			ast_mutex_lock(&usb_dev_lock);
 			o->usbass = 0;
 			o->hasusb = 0;
@@ -1260,7 +1253,6 @@ static void *hidthread(void *arg)
 			libusb_close(usb_handle);
 			usb_handle = NULL;
 			/* Stay in hidthread and retry; call() only starts the thread once. */
-			o->usb_faulted = 1;
 			usleep(DEVICE_RETRY);
 			continue;
 		}
@@ -1305,6 +1297,7 @@ static void *hidthread(void *arg)
 		open_device_failed = 0;
 		detach_failed = 0;
 		claim_failed = 0;
+		pipe_failed = 0;
 
 		/* Main processing loop for GPIO
 		 * This loop process every HID_POLL_RATE milliseconds.
@@ -1320,8 +1313,7 @@ static void *hidthread(void *arg)
 				/* HID thread monitors audio thread */
 				ast_radio_time(&audio_time_now);
 				if ((audio_time_now - o->lastaudiotime) > 1) {
-					ast_log(LOG_ERROR, "Channel %s: Audio process has died or is not responding.\n", o->name);
-					o->usb_faulted = 1;
+					simpleusb_log_fault(o, 0, "Channel %s: Audio process has died or is not responding.\n", o->name);
 					o->hasusb = 0;
 					break;
 				}
@@ -2169,6 +2161,7 @@ static void *simpleusb_audio_thread(void *arg)
 	struct timeval last_frame_time;
 	short *sp, *sp1;
 	short outbuf[AST_RADIO_PA_FRAMES_PER_BUFFER * 2]; /* 1 short (2 bytes) per sample on PortAudio config with paInt16 * 2 channels */
+	int start_stream_failed = 0;
 
 	ast_debug(5, "Audio thread is starting\n");
 	ast_radio_time(&o->lastaudiotime);
@@ -2185,12 +2178,13 @@ static void *simpleusb_audio_thread(void *arg)
 		}
 
 		if (!o->pa.active && start_stream(o) < 0) {
-			ast_log(LOG_ERROR, "Channel %s: Failed to start audio stream %s\n", o->name, o->hw_device);
-			o->usb_faulted = 1;
+			start_stream_failed =
+				simpleusb_log_fault(o, start_stream_failed, "Channel %s: Failed to start audio stream %s\n", o->name, o->hw_device);
 			o->hasusb = 0;
 			usleep(DEVICE_RETRY);
 			continue;
 		}
+		start_stream_failed = 0;
 
 		flush_stream_buffer(o);
 		o->audio_thread_ready = 1;
@@ -2201,9 +2195,8 @@ static void *simpleusb_audio_thread(void *arg)
 			if (o->lasthidtime) {
 				ast_radio_time(&now);
 				if ((now - o->lasthidtime) > 1) {
-					ast_log(LOG_ERROR, "Channel %s: HID process has died or is not responding.\n", o->name);
+					simpleusb_log_fault(o, 0, "Channel %s: HID process has died or is not responding.\n", o->name);
 					usleep(DEVICE_RETRY);
-					o->usb_faulted = 1;
 					o->hasusb = 0;
 					stream_cleanup(o);
 					break;
@@ -2465,8 +2458,7 @@ static void *simpleusb_audio_thread(void *arg)
 			}
 
 			if (num_frames && (ast_tvdiff_ms(ast_radio_tvnow(), last_frame_time) > MAX_FRAME_DELAY)) {
-				ast_log(LOG_ERROR, "Audio thread has not processed audio for over %d ms, restarting stream.\n", MAX_FRAME_DELAY);
-				o->usb_faulted = 1;
+				simpleusb_log_fault(o, 0, "Audio thread has not processed audio for over %d ms, restarting stream.\n", MAX_FRAME_DELAY);
 				o->hasusb = 0;
 				stream_cleanup(o);
 				break;
@@ -2490,8 +2482,8 @@ static void *simpleusb_audio_thread(void *arg)
 					ast_debug(6, "PortAudio read timeout on channel %s\n", o->name);
 					continue;
 				} else {
-					ast_log(LOG_ERROR, "Channel %s: PortAudio read failed (%s); restarting audio stream\n", o->name, Pa_GetErrorText(res));
-					o->usb_faulted = 1;
+					simpleusb_log_fault(o, 0, "Channel %s: PortAudio read failed (%s); restarting audio stream\n", o->name,
+						Pa_GetErrorText(res));
 					o->hasusb = 0;
 					stream_cleanup(o);
 					break; /* Close the stream and retry */

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -284,7 +284,6 @@ struct chan_simpleusb_pvt {
 	unsigned int txcapraw:1;			   /* indicator if transmit capture is enabled */
 	unsigned int measure_enabled:1;		   /* indicator if measure mode is enabled */
 	unsigned int device_error:1;		   /* indicator set when we cannot find the USB device */
-	unsigned int usb_faulted:1;			   /* set after USB/audio failure; cleared on recovery NOTICE */
 	unsigned int newname:1;				   /* indicator that we should use MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW */
 	unsigned int hasusb:1;				   /* indicator for has a USB device */
 	unsigned int usbass:1;				   /* indicator for USB device assigned */
@@ -297,6 +296,8 @@ struct chan_simpleusb_pvt {
 	unsigned int preemphasis:1;			   /* indicator if we need preemphasis filter */
 	unsigned int rx_cos_active:1;		   /* indicator if cos is active - active state after processing */
 	unsigned int rx_ctcss_active:1;		   /* indicator if ctcss is active - active state after processing */
+	/* Whole-word latch shared by HID/audio threads (not a bit-field). */
+	volatile sig_atomic_t usb_faulted;	   /* set after USB/audio failure; cleared on recovery NOTICE */
 	volatile sig_atomic_t stophidthread;   /* indicator to stop hid thread */
 	volatile sig_atomic_t stopaudiothread; /* indicator to stop audio thread */
 
@@ -376,13 +377,15 @@ static void *simpleusb_audio_thread(void *arg);
 static void simpleusb_log_usb_recovered(struct chan_simpleusb_pvt *o)
 {
 	const char *dev;
+	sig_atomic_t was_faulted;
 
-	if (!o->usb_faulted) {
+	was_faulted = o->usb_faulted;
+	o->usb_faulted = 0;
+	if (!was_faulted) {
 		return;
 	}
 	dev = !ast_strlen_zero(o->devstr) ? o->devstr : o->hw_device;
 	ast_log(LOG_NOTICE, "Channel %s: USB radio device recovered (%s)\n", o->name, !ast_strlen_zero(dev) ? dev : "unknown");
-	o->usb_faulted = 0;
 }
 
 static char *simpleusb_active; /* the active device */

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -1282,7 +1282,6 @@ static void *hidthread(void *arg)
 		}
 		ast_mutex_unlock(&o->eepromlock);
 
-		simpleusb_log_usb_recovered(o);
 		o->hasusb = 1;
 		o->had_gpios_in = 0;
 		memset(&rfds, 0, sizeof(rfds));
@@ -2188,6 +2187,8 @@ static void *simpleusb_audio_thread(void *arg)
 
 		flush_stream_buffer(o);
 		o->audio_thread_ready = 1;
+		/* Audio path is up; pair any prior fault with a single recovery log. */
+		simpleusb_log_usb_recovered(o);
 		last_frame_time = ast_radio_tvnow();
 
 		while (!o->stopaudiothread && o->hasusb) {

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -367,6 +367,7 @@ struct chan_usbradio_pvt {
 	unsigned int lsdtxpolarity:1;	/* indicator for lsd transmit polarity */
 	unsigned int radioactive:1;		/* indicator for active radio channel */
 	unsigned int device_error:1;	/* indicator set when we cannot find the USB device */
+	unsigned int usb_faulted:1;		/* set after USB/audio failure; cleared on recovery NOTICE */
 	unsigned int newname:1;			/* indicator that we should use MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW */
 	unsigned int hasusb:1;			/* indicator for has a USB device */
 	unsigned int usbass:1;			/* indicator for USB device assigned */
@@ -469,6 +470,21 @@ static int xpmr_set_tx_soft_limiter(struct chan_usbradio_pvt *o, int setpoint);
 #if DEBUG_FILETEST == 1
 static int RxTestIt(struct chan_usbradio_pvt *o);
 #endif
+
+/*!
+ * \brief Log once when USB/audio returns after a prior failure.
+ */
+static void usbradio_log_usb_recovered(struct chan_usbradio_pvt *o)
+{
+	const char *dev;
+
+	if (!o->usb_faulted) {
+		return;
+	}
+	dev = !ast_strlen_zero(o->devstr) ? o->devstr : o->hw_device;
+	ast_log(LOG_NOTICE, "Channel %s: USB radio device recovered (%s)\n", o->name, !ast_strlen_zero(dev) ? dev : "unknown");
+	o->usb_faulted = 0;
+}
 
 static char *usbradio_active; /* the active device */
 
@@ -990,6 +1006,7 @@ static void *hidthread(void *arg)
 					if (!o->device_error) {
 						ast_log(LOG_ERROR, "Channel %s: No USB device for audiodev %s\n", o->name, o->hw_device);
 						o->device_error = 1;
+						o->usb_faulted = 1;
 					}
 					ast_mutex_unlock(&usb_dev_lock);
 					usleep(500000);
@@ -1000,6 +1017,7 @@ static void *hidthread(void *arg)
 					if (!o->device_error) {
 						ast_log(LOG_ERROR, "Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
 						o->device_error = 1;
+						o->usb_faulted = 1;
 					}
 					ast_mutex_unlock(&usb_dev_lock);
 					usleep(500000);
@@ -1015,6 +1033,7 @@ static void *hidthread(void *arg)
 			if (!o->device_error) {
 				ast_log(LOG_ERROR, "Channel %s: Invalid audiodev '%s' (use hw:N or hw:N,M)\n", o->name, o->hw_device);
 				o->device_error = 1;
+				o->usb_faulted = 1;
 			}
 			ast_mutex_unlock(&usb_dev_lock);
 			usleep(500000);
@@ -1071,6 +1090,7 @@ static void *hidthread(void *arg)
 					if (!o->device_error) {
 						ast_log(LOG_ERROR, "Channel %s: No USB devices are available for assignment.\n", o->name);
 						o->device_error = 1;
+						o->usb_faulted = 1;
 					}
 					ast_mutex_unlock(&usb_dev_lock);
 					usleep(500000);
@@ -1110,6 +1130,7 @@ static void *hidthread(void *arg)
 				if (!o->device_error) {
 					ast_log(LOG_ERROR, "Channel %s: Device string %s was not found.\n", o->name, o->devstr);
 					o->device_error = 1;
+					o->usb_faulted = 1;
 				}
 				ast_mutex_unlock(&usb_dev_lock);
 				usleep(500000);
@@ -1161,6 +1182,7 @@ static void *hidthread(void *arg)
 			if (!o->device_error) {
 				ast_log(LOG_ERROR, "Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
 				o->device_error = 1;
+				o->usb_faulted = 1;
 			}
 			ast_mutex_unlock(&usb_dev_lock);
 			usleep(500000);
@@ -1175,6 +1197,7 @@ static void *hidthread(void *arg)
 		usb_dev = ast_radio_hid_device_init(o->devstr);
 		if (usb_dev == NULL) {
 			ast_log(LOG_ERROR, "Channel %s: Cannot initialize device %s\n", o->name, o->devstr);
+			o->usb_faulted = 1;
 			usleep(500000);
 			continue;
 		}
@@ -1182,6 +1205,7 @@ usb_device_ready:
 		/* open the usb device device */
 		if (libusb_open(usb_dev, &usb_handle) < 0) {
 			ast_log(LOG_ERROR, "Channel %s: Cannot open device %s\n", o->name, o->devstr);
+			o->usb_faulted = 1;
 			usleep(500000);
 			continue;
 		}
@@ -1189,11 +1213,13 @@ usb_device_ready:
 		if (libusb_claim_interface(usb_handle, C108_HID_INTERFACE) < 0) {
 			if (libusb_detach_kernel_driver(usb_handle, C108_HID_INTERFACE) < 0) {
 				ast_log(LOG_ERROR, "Channel %s: Is not able to detach the USB device\n", o->name);
+				o->usb_faulted = 1;
 				usleep(500000);
 				continue;
 			}
 			if (libusb_claim_interface(usb_handle, C108_HID_INTERFACE) < 0) {
 				ast_log(LOG_ERROR, "Channel %s: Is not able to claim the USB device\n", o->name);
+				o->usb_faulted = 1;
 				usleep(500000);
 				continue;
 			}
@@ -1225,6 +1251,7 @@ usb_device_ready:
 			o->hasusb = 0;
 			ast_mutex_unlock(&usb_dev_lock);
 			/* Stay in hidthread and retry; call() only starts the thread once. */
+			o->usb_faulted = 1;
 			usleep(500000);
 			continue;
 		}
@@ -1360,9 +1387,11 @@ usb_device_ready:
 			ast_mutex_lock(&usb_dev_lock);
 			o->usbass = 0;
 			ast_mutex_unlock(&usb_dev_lock);
+			o->usb_faulted = 1;
 			usleep(500000);
 			continue;
 		}
+		usbradio_log_usb_recovered(o);
 		o->hasusb = 1;
 		o->had_gpios_in = 0;
 
@@ -1698,7 +1727,8 @@ static int soundcard_writeframe(struct chan_usbradio_pvt *o, short *data)
 	 */
 	res = ast_radio_pa_write(&o->pa, data, AST_RADIO_PA_FRAMES_PER_BUFFER);
 	if (res < 0 && res != paOutputUnderflowed) {
-		ast_log(LOG_ERROR, "Channel %s: PortAudio write error %s\n", o->name, Pa_GetErrorText(res));
+		ast_log(LOG_ERROR, "Channel %s: PortAudio write failed (%s); restarting audio stream\n", o->name, Pa_GetErrorText(res));
+		o->usb_faulted = 1;
 		ast_radio_pa_stop(&o->pa);
 		return 0;
 	}
@@ -2119,7 +2149,8 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 			/* No RX audio available; still run PTT/TX processing with silence. */
 			memset(o->usbradio_read_buf + AST_FRIENDLY_OFFSET, 0, sizeof(o->usbradio_read_buf) - AST_FRIENDLY_OFFSET);
 		} else {
-			ast_log(LOG_ERROR, "Channel %s: PortAudio read error %s\n", o->name, Pa_GetErrorText(pa_res));
+			ast_log(LOG_ERROR, "Channel %s: PortAudio read failed (%s); restarting audio stream\n", o->name, Pa_GetErrorText(pa_res));
+			o->usb_faulted = 1;
 			o->hasusb = 0;
 			ast_radio_pa_stop(&o->pa);
 			return &ast_null_frame;

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -367,7 +367,6 @@ struct chan_usbradio_pvt {
 	unsigned int lsdtxpolarity:1;	/* indicator for lsd transmit polarity */
 	unsigned int radioactive:1;		/* indicator for active radio channel */
 	unsigned int device_error:1;	/* indicator set when we cannot find the USB device */
-	unsigned int usb_faulted:1;		/* set after USB/audio failure; cleared on recovery NOTICE */
 	unsigned int newname:1;			/* indicator that we should use MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW */
 	unsigned int hasusb:1;			/* indicator for has a USB device */
 	unsigned int usbass:1;			/* indicator for USB device assigned */
@@ -382,6 +381,8 @@ struct chan_usbradio_pvt {
 	unsigned int rxctcssoverride:1; /* indicator if receive ctcss override is enabled */
 	unsigned int rx_cos_active:1;	/* indicator if cos is active - active state after processing */
 	unsigned int rx_ctcss_active:1; /* indicator if ctcss is active - active state after processing */
+	/* Whole-word latch shared by HID/audio paths (not a bit-field). */
+	volatile sig_atomic_t usb_faulted; /* set after USB/audio failure; cleared on recovery NOTICE */
 
 	/* EEPROM access variables */
 	unsigned short eeprom[EEPROM_USER_LEN];
@@ -477,13 +478,15 @@ static int RxTestIt(struct chan_usbradio_pvt *o);
 static void usbradio_log_usb_recovered(struct chan_usbradio_pvt *o)
 {
 	const char *dev;
+	sig_atomic_t was_faulted;
 
-	if (!o->usb_faulted) {
+	was_faulted = o->usb_faulted;
+	o->usb_faulted = 0;
+	if (!was_faulted) {
 		return;
 	}
 	dev = !ast_strlen_zero(o->devstr) ? o->devstr : o->hw_device;
 	ast_log(LOG_NOTICE, "Channel %s: USB radio device recovered (%s)\n", o->name, !ast_strlen_zero(dev) ? dev : "unknown");
-	o->usb_faulted = 0;
 }
 
 static char *usbradio_active; /* the active device */
@@ -1729,6 +1732,8 @@ static int soundcard_writeframe(struct chan_usbradio_pvt *o, short *data)
 	if (res < 0 && res != paOutputUnderflowed) {
 		ast_log(LOG_ERROR, "Channel %s: PortAudio write failed (%s); restarting audio stream\n", o->name, Pa_GetErrorText(res));
 		o->usb_faulted = 1;
+		/* Force HID reinit so recovery NOTICE clears the latch. */
+		o->hasusb = 0;
 		ast_radio_pa_stop(&o->pa);
 		return 0;
 	}

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -48,6 +48,7 @@
 #include <sys/time.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <stdarg.h>
 #include <search.h>
 #include <alsa/asoundlib.h>
 #include <linux/ppdev.h>
@@ -382,7 +383,7 @@ struct chan_usbradio_pvt {
 	unsigned int rx_cos_active:1;	/* indicator if cos is active - active state after processing */
 	unsigned int rx_ctcss_active:1; /* indicator if ctcss is active - active state after processing */
 	/* Whole-word latch shared by HID/audio paths (not a bit-field). */
-	volatile sig_atomic_t usb_faulted; /* set after USB/audio failure; cleared on recovery NOTICE */
+	volatile sig_atomic_t usb_faulted; /* set after USB/audio failure; cleared on recovery log */
 
 	/* EEPROM access variables */
 	unsigned short eeprom[EEPROM_USER_LEN];
@@ -473,6 +474,30 @@ static int RxTestIt(struct chan_usbradio_pvt *o);
 #endif
 
 /*!
+ * \brief Log a USB/audio fault and set the recovery latch.
+ *
+ * First occurrence (already_logged == 0) uses LOG_ERROR; repeats use DEBUG
+ * so retry loops do not spam. Returns 1 for storing into a rate-limit latch.
+ */
+static int __attribute__((format(printf, 3, 4))) usbradio_log_fault(struct chan_usbradio_pvt *o, int already_logged, const char *fmt, ...)
+{
+	va_list ap;
+	char buf[512];
+
+	o->usb_faulted = 1;
+	va_start(ap, fmt);
+	vsnprintf(buf, sizeof(buf), fmt, ap);
+	va_end(ap);
+
+	if (already_logged) {
+		ast_debug(1, "%s", buf);
+	} else {
+		ast_log(LOG_ERROR, "%s", buf);
+	}
+	return 1;
+}
+
+/*!
  * \brief Log once when USB/audio returns after a prior failure.
  */
 static void usbradio_log_usb_recovered(struct chan_usbradio_pvt *o)
@@ -486,7 +511,8 @@ static void usbradio_log_usb_recovered(struct chan_usbradio_pvt *o)
 		return;
 	}
 	dev = !ast_strlen_zero(o->devstr) ? o->devstr : o->hw_device;
-	ast_log(LOG_NOTICE, "Channel %s: USB radio device recovered (%s)\n", o->name, !ast_strlen_zero(dev) ? dev : "unknown");
+	/* Match fault priority so ERROR-level logs pair fault with recovery. */
+	ast_log(LOG_ERROR, "Channel %s: USB radio device recovered (%s)\n", o->name, !ast_strlen_zero(dev) ? dev : "unknown");
 }
 
 static char *usbradio_active; /* the active device */
@@ -892,13 +918,13 @@ static int usbradio_start_audio(struct chan_usbradio_pvt *o)
 
 	res = ast_radio_pa_open(&o->pa);
 	if (res != paNoError) {
-		ast_log(LOG_ERROR, "Channel %s: Unable to open PortAudio stream %s\n", o->name, o->hw_device);
+		ast_log(LOG_WARNING, "Channel %s: Unable to open PortAudio stream %s (%s)\n", o->name, o->hw_device, Pa_GetErrorText(res));
 		return -1;
 	}
 
 	res = ast_radio_pa_start(&o->pa);
 	if (res != paNoError) {
-		ast_log(LOG_ERROR, "Channel %s: Unable to start PortAudio stream %s\n", o->name, o->hw_device);
+		ast_log(LOG_WARNING, "Channel %s: Unable to start PortAudio stream %s (%s)\n", o->name, o->hw_device, Pa_GetErrorText(res));
 		ast_radio_pa_stop(&o->pa);
 		return -1;
 	}
@@ -942,6 +968,12 @@ static void *hidthread(void *arg)
 	int i, j, k;
 	int res;
 	int use_newname = 0;
+	int init_hid_failed = 0;
+	int open_device_failed = 0;
+	int detach_failed = 0;
+	int claim_failed = 0;
+	int pipe_failed = 0;
+	int start_audio_failed = 0;
 	struct libusb_device *usb_dev;
 	struct libusb_device_handle *usb_handle;
 	struct chan_usbradio_pvt *o = arg, *ao;
@@ -1006,22 +1038,16 @@ static void *hidthread(void *arg)
 				}
 				usb_dev = ast_radio_usb_device_from_alsa_card(i);
 				if (!usb_dev) {
-					if (!o->device_error) {
-						ast_log(LOG_ERROR, "Channel %s: No USB device for audiodev %s\n", o->name, o->hw_device);
-						o->device_error = 1;
-						o->usb_faulted = 1;
-					}
+					o->device_error =
+						usbradio_log_fault(o, o->device_error, "Channel %s: No USB device for audiodev %s\n", o->name, o->hw_device);
 					ast_mutex_unlock(&usb_dev_lock);
 					usleep(500000);
 					continue;
 				}
 				o->devicenum = i;
 				if (ast_radio_init_mixer_limits(o->devicenum, &o->micmax, &o->spkrmax, &o->micplaymax, &use_newname) < 0) {
-					if (!o->device_error) {
-						ast_log(LOG_ERROR, "Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
-						o->device_error = 1;
-						o->usb_faulted = 1;
-					}
+					o->device_error = usbradio_log_fault(o, o->device_error,
+						"Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
 					ast_mutex_unlock(&usb_dev_lock);
 					usleep(500000);
 					continue;
@@ -1033,11 +1059,8 @@ static void *hidthread(void *arg)
 				ast_mutex_unlock(&usb_dev_lock);
 				goto usb_device_ready;
 			}
-			if (!o->device_error) {
-				ast_log(LOG_ERROR, "Channel %s: Invalid audiodev '%s' (use hw:N or hw:N,M)\n", o->name, o->hw_device);
-				o->device_error = 1;
-				o->usb_faulted = 1;
-			}
+			o->device_error =
+				usbradio_log_fault(o, o->device_error, "Channel %s: Invalid audiodev '%s' (use hw:N or hw:N,M)\n", o->name, o->hw_device);
 			ast_mutex_unlock(&usb_dev_lock);
 			usleep(500000);
 			continue;
@@ -1090,11 +1113,8 @@ static void *hidthread(void *arg)
 			for (;;) {
 				index_devstr = ast_radio_usb_get_devstr(index);
 				if (ast_strlen_zero(index_devstr)) {
-					if (!o->device_error) {
-						ast_log(LOG_ERROR, "Channel %s: No USB devices are available for assignment.\n", o->name);
-						o->device_error = 1;
-						o->usb_faulted = 1;
-					}
+					o->device_error =
+						usbradio_log_fault(o, o->device_error, "Channel %s: No USB devices are available for assignment.\n", o->name);
 					ast_mutex_unlock(&usb_dev_lock);
 					usleep(500000);
 					break;
@@ -1130,11 +1150,8 @@ static void *hidthread(void *arg)
 			 */
 			s = find_installed_usb_match();
 			if (ast_strlen_zero(s)) {
-				if (!o->device_error) {
-					ast_log(LOG_ERROR, "Channel %s: Device string %s was not found.\n", o->name, o->devstr);
-					o->device_error = 1;
-					o->usb_faulted = 1;
-				}
+				o->device_error =
+					usbradio_log_fault(o, o->device_error, "Channel %s: Device string %s was not found.\n", o->name, o->devstr);
 				ast_mutex_unlock(&usb_dev_lock);
 				usleep(500000);
 				continue;
@@ -1182,11 +1199,8 @@ static void *hidthread(void *arg)
 		o->devicenum = i;
 		snprintf(o->hw_device, sizeof(o->hw_device), "hw:%d", i);
 		if (ast_radio_init_mixer_limits(o->devicenum, &o->micmax, &o->spkrmax, &o->micplaymax, &use_newname) < 0) {
-			if (!o->device_error) {
-				ast_log(LOG_ERROR, "Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
-				o->device_error = 1;
-				o->usb_faulted = 1;
-			}
+			o->device_error = usbradio_log_fault(o, o->device_error,
+				"Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
 			ast_mutex_unlock(&usb_dev_lock);
 			usleep(500000);
 			continue;
@@ -1199,30 +1213,26 @@ static void *hidthread(void *arg)
 		/* initialize the usb device */
 		usb_dev = ast_radio_hid_device_init(o->devstr);
 		if (usb_dev == NULL) {
-			ast_log(LOG_ERROR, "Channel %s: Cannot initialize device %s\n", o->name, o->devstr);
-			o->usb_faulted = 1;
+			init_hid_failed = usbradio_log_fault(o, init_hid_failed, "Channel %s: Cannot initialize device %s\n", o->name, o->devstr);
 			usleep(500000);
 			continue;
 		}
 usb_device_ready:
 		/* open the usb device device */
 		if (libusb_open(usb_dev, &usb_handle) < 0) {
-			ast_log(LOG_ERROR, "Channel %s: Cannot open device %s\n", o->name, o->devstr);
-			o->usb_faulted = 1;
+			open_device_failed = usbradio_log_fault(o, open_device_failed, "Channel %s: Cannot open device %s\n", o->name, o->devstr);
 			usleep(500000);
 			continue;
 		}
 		/* attempt to claim the usb hid interface and detach from the kernel */
 		if (libusb_claim_interface(usb_handle, C108_HID_INTERFACE) < 0) {
 			if (libusb_detach_kernel_driver(usb_handle, C108_HID_INTERFACE) < 0) {
-				ast_log(LOG_ERROR, "Channel %s: Is not able to detach the USB device\n", o->name);
-				o->usb_faulted = 1;
+				detach_failed = usbradio_log_fault(o, detach_failed, "Channel %s: Is not able to detach the USB device\n", o->name);
 				usleep(500000);
 				continue;
 			}
 			if (libusb_claim_interface(usb_handle, C108_HID_INTERFACE) < 0) {
-				ast_log(LOG_ERROR, "Channel %s: Is not able to claim the USB device\n", o->name);
-				o->usb_faulted = 1;
+				claim_failed = usbradio_log_fault(o, claim_failed, "Channel %s: Is not able to claim the USB device\n", o->name);
 				usleep(500000);
 				continue;
 			}
@@ -1246,7 +1256,7 @@ usb_device_ready:
 			o->pttkick[1] = -1;
 		}
 		if (pipe2(o->pttkick, O_NONBLOCK) == -1) {
-			ast_log(LOG_ERROR, "Channel %s: Is not able to create a pipe\n", o->name);
+			pipe_failed = usbradio_log_fault(o, pipe_failed, "Channel %s: Is not able to create a pipe\n", o->name);
 			libusb_close(usb_handle);
 			usb_handle = NULL;
 			ast_mutex_lock(&usb_dev_lock);
@@ -1254,7 +1264,6 @@ usb_device_ready:
 			o->hasusb = 0;
 			ast_mutex_unlock(&usb_dev_lock);
 			/* Stay in hidthread and retry; call() only starts the thread once. */
-			o->usb_faulted = 1;
 			usleep(500000);
 			continue;
 		}
@@ -1386,14 +1395,21 @@ usb_device_ready:
 		ast_mutex_unlock(&o->eepromlock);
 
 		if (usbradio_start_audio(o) < 0) {
-			ast_log(LOG_ERROR, "Channel %s: Unable to start audio for %s\n", o->name, o->hw_device);
+			start_audio_failed =
+				usbradio_log_fault(o, start_audio_failed, "Channel %s: Unable to start audio for %s\n", o->name, o->hw_device);
 			ast_mutex_lock(&usb_dev_lock);
 			o->usbass = 0;
 			ast_mutex_unlock(&usb_dev_lock);
-			o->usb_faulted = 1;
 			usleep(500000);
 			continue;
 		}
+		/* Reset the failure flags, we succeeded */
+		init_hid_failed = 0;
+		open_device_failed = 0;
+		detach_failed = 0;
+		claim_failed = 0;
+		pipe_failed = 0;
+		start_audio_failed = 0;
 		usbradio_log_usb_recovered(o);
 		o->hasusb = 1;
 		o->had_gpios_in = 0;
@@ -1730,9 +1746,8 @@ static int soundcard_writeframe(struct chan_usbradio_pvt *o, short *data)
 	 */
 	res = ast_radio_pa_write(&o->pa, data, AST_RADIO_PA_FRAMES_PER_BUFFER);
 	if (res < 0 && res != paOutputUnderflowed) {
-		ast_log(LOG_ERROR, "Channel %s: PortAudio write failed (%s); restarting audio stream\n", o->name, Pa_GetErrorText(res));
-		o->usb_faulted = 1;
-		/* Force HID reinit so recovery NOTICE clears the latch. */
+		usbradio_log_fault(o, 0, "Channel %s: PortAudio write failed (%s); restarting audio stream\n", o->name, Pa_GetErrorText(res));
+		/* Force HID reinit so recovery log clears the latch. */
 		o->hasusb = 0;
 		ast_radio_pa_stop(&o->pa);
 		return 0;
@@ -2069,7 +2084,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 	if (o->lasthidtime) {
 		ast_radio_time(&now);
 		if ((now - o->lasthidtime) > 3) {
-			ast_log(LOG_ERROR, "Channel %s: HID process has died or is not responding.\n", o->name);
+			usbradio_log_fault(o, 0, "Channel %s: HID process has died or is not responding.\n", o->name);
 			return NULL;
 		}
 	}
@@ -2154,8 +2169,7 @@ static struct ast_frame *usbradio_read(struct ast_channel *c)
 			/* No RX audio available; still run PTT/TX processing with silence. */
 			memset(o->usbradio_read_buf + AST_FRIENDLY_OFFSET, 0, sizeof(o->usbradio_read_buf) - AST_FRIENDLY_OFFSET);
 		} else {
-			ast_log(LOG_ERROR, "Channel %s: PortAudio read failed (%s); restarting audio stream\n", o->name, Pa_GetErrorText(pa_res));
-			o->usb_faulted = 1;
+			usbradio_log_fault(o, 0, "Channel %s: PortAudio read failed (%s); restarting audio stream\n", o->name, Pa_GetErrorText(pa_res));
 			o->hasusb = 0;
 			ast_radio_pa_stop(&o->pa);
 			return &ast_null_frame;

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -1372,13 +1372,14 @@ void ast_radio_pa_stop(struct ast_radio_pa_stream *ps)
 	if (ps->active) {
 		err = Pa_AbortStream(ps->stream);
 		if (err != paNoError) {
-			ast_log(LOG_WARNING, "Pa_AbortStream failed: %s\n", Pa_GetErrorText(err));
+			/* Common after USB yank; Abort/Close often fail once the host device is gone. */
+			ast_debug(3, "Pa_AbortStream failed: %s\n", Pa_GetErrorText(err));
 		}
 	}
 
 	err = Pa_CloseStream(ps->stream);
 	if (err != paNoError) {
-		ast_log(LOG_WARNING, "Pa_CloseStream failed: %s\n", Pa_GetErrorText(err));
+		ast_debug(3, "Pa_CloseStream failed: %s\n", Pa_GetErrorText(err));
 	}
 
 	ps->stream = NULL;


### PR DESCRIPTION
## Summary
- Emit a single `NOTICE` when simpleusb/usbradio recover from a USB/audio fault (URI unplug/replug), so logs show the failed→OK transition Allan noted was missing.
- Downgrade expected `Pa_AbortStream` / `Pa_CloseStream` failures during teardown after a yank from `WARNING` to `DEBUG`.
- Clarify PortAudio read/write hard-error messages as restart-oriented wording.

## Test plan
- [ ] On a simpleusb node, unplug the URI and confirm one clear read/start failure (no Abort/Close WARNING spam).
- [ ] Replug the URI and confirm a `USB radio device recovered (...)` NOTICE appears once.
- [ ] Confirm first boot / clean start does not emit a recovery NOTICE.
- [ ] Repeat briefly on a usbradio channel if available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of USB device and audio failures across USB audio and radio channels.
  - Added clear recovery notifications when USB/audio connectivity returns after an interruption.
  - Reduced noisy warning messages for expected stream cleanup failures after a USB device is disconnected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->