### PR TITLE
app_rpt.c: add ast_assert to hung rpt thread

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -6260,6 +6260,7 @@ static void *rpt_master(void *ignore)
 			if (current_loop_time > RPT_THREAD_TIMEOUT && !thread_hung[i]) {
 				thread_hung[i] = rpt_true;
 				ast_log(LOG_WARNING, "RPT thread on %s is hung for %ld seconds.\n", rpt_vars[i].name, current_loop_time);
+				ast_assert(0); /* Why are we hung coredump */
 			}
 
 			if (!rpt_vars[i].rpt_thread || rpt_vars[i].rpt_thread == AST_PTHREADT_NULL) {


### PR DESCRIPTION
Attempt to capture "why" the thread is hung

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repeater thread hangs now trigger an immediate failure with diagnostic information, improving detection and troubleshooting of stalled operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->