### PR TITLE
app_rpt: Long queue errors on slow redial

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2557,6 +2557,8 @@ static void *attempt_reconnect(struct rpt *myrpt, struct rpt_link *l)
 	l->newkeytimer = NEWKEYTIME;
 	l->link_newkey = RADIO_KEY_NOT_ALLOWED;
 
+	/* rpt_make_call is blocking, long dns lookups result in exceptionally long queue warnings */
+	ast_autoservice_start(l->pchan);
 	l->chan = ast_request(deststr, cap, NULL, NULL, tele, NULL);
 	ao2_ref(cap, -1);
 	while ((f1 = AST_LIST_REMOVE_HEAD(&l->textq, frame_list))) {
@@ -2577,6 +2579,7 @@ static void *attempt_reconnect(struct rpt *myrpt, struct rpt_link *l)
 		l->retrytimer = RETRY_TIMER_MS;
 		rpt_mutex_unlock(&myrpt->lock);
 	}
+	ast_autoservice_stop(l->pchan);
 	ast_log(LOG_NOTICE, "Reconnect Attempt to %s in progress\n", l->name);
 	return NULL;
 }
@@ -4588,21 +4591,6 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 		if (!ms) {
 			/* No channels had activity before the timer expired,
 			 * so just continue to the next loop. */
-			continue;
-		}
-		if (l->disctime) {
-			/* We are disconnected but still need to read and discard frames */
-			if (who == l->pchan) {
-				struct ast_frame *f;
-
-				f = ast_read(l->pchan);
-				if (!f) {
-					ast_debug(1, "@@@@ rpt:Hung Up\n");
-					break;
-				}
-				ast_frfree(f);
-				continue;
-			}
 			continue;
 		}
 

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2557,8 +2557,8 @@ static void *attempt_reconnect(struct rpt *myrpt, struct rpt_link *l)
 	l->newkeytimer = NEWKEYTIME;
 	l->link_newkey = RADIO_KEY_NOT_ALLOWED;
 
-	/* rpt_make_call is blocking, long dns lookups result in exceptionally long queue warnings 
-	 * autoservice handles "eating" the frames and eliminating the warning. 
+	/* rpt_make_call is blocking, long dns lookups result in exceptionally long queue warnings
+	 * autoservice handles "eating" the frames and eliminating the warning.
 	 */
 	ast_autoservice_start(l->pchan);
 	l->chan = ast_request(deststr, cap, NULL, NULL, tele, NULL);

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2558,7 +2558,7 @@ static void *attempt_reconnect(struct rpt *myrpt, struct rpt_link *l)
 	l->link_newkey = RADIO_KEY_NOT_ALLOWED;
 
 	/* rpt_make_call is blocking, long dns lookups result in exceptionally long queue warnings 
-	 * autoservice handles "eating" the frames and elminating the warning. 
+	 * autoservice handles "eating" the frames and eliminating the warning. 
 	 */
 	ast_autoservice_start(l->pchan);
 	l->chan = ast_request(deststr, cap, NULL, NULL, tele, NULL);

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2557,7 +2557,9 @@ static void *attempt_reconnect(struct rpt *myrpt, struct rpt_link *l)
 	l->newkeytimer = NEWKEYTIME;
 	l->link_newkey = RADIO_KEY_NOT_ALLOWED;
 
-	/* rpt_make_call is blocking, long dns lookups result in exceptionally long queue warnings */
+	/* rpt_make_call is blocking, long dns lookups result in exceptionally long queue warnings 
+	 * autoservice handles "eating" the frames and elminating the warning. 
+	 */
 	ast_autoservice_start(l->pchan);
 	l->chan = ast_request(deststr, cap, NULL, NULL, tele, NULL);
 	ao2_ref(cap, -1);

--- a/apps/app_rpt/rpt_call.c
+++ b/apps/app_rpt/rpt_call.c
@@ -83,7 +83,7 @@ int rpt_disable_cdr(struct ast_channel *chan)
 	return res;
 }
 
-int rpt_setup_call(struct ast_channel *chan, const char *addr, int timeout, const char *driver, const char *data,
+void rpt_setup_call(struct ast_channel *chan, const char *addr, int timeout, const char *driver, const char *data,
 	const char *desc, const char *callerid, const char *node)
 {
 	ast_debug(1, "Requested channel %s\n", ast_channel_name(chan));
@@ -99,19 +99,12 @@ int rpt_setup_call(struct ast_channel *chan, const char *addr, int timeout, cons
 	ast_channel_exten_set(chan, node);
 
 	ast_debug(1, "rpt (%s) initiating call to %s/%s on %s\n", data, driver, addr, ast_channel_name(chan));
-	return 0;
 }
 
 int rpt_make_call(struct ast_channel *chan, const char *addr, int timeout, const char *driver, const char *data, const char *desc,
 	const char *callerid, const char *node)
 {
-	int res;
-
-	res = rpt_setup_call(chan, addr, timeout, driver, data, desc, callerid, node);
-	if (res) {
-		return res;
-	}
-
+	rpt_setup_call(chan, addr, timeout, driver, data, desc, callerid, node);
 	return ast_call(chan, addr, timeout);
 }
 

--- a/apps/app_rpt/rpt_call.c
+++ b/apps/app_rpt/rpt_call.c
@@ -83,8 +83,7 @@ int rpt_disable_cdr(struct ast_channel *chan)
 	return res;
 }
 
-void rpt_setup_call(struct ast_channel *chan, const char *addr, int timeout, const char *driver, const char *data,
-	const char *desc, const char *callerid, const char *node)
+void rpt_setup_call(struct ast_channel *chan, const char *addr, const char *driver, const char *data, const char *callerid, const char *node)
 {
 	ast_debug(1, "Requested channel %s\n", ast_channel_name(chan));
 	ast_set_read_format(chan, ast_format_slin);
@@ -104,7 +103,7 @@ void rpt_setup_call(struct ast_channel *chan, const char *addr, int timeout, con
 int rpt_make_call(struct ast_channel *chan, const char *addr, int timeout, const char *driver, const char *data, const char *desc,
 	const char *callerid, const char *node)
 {
-	rpt_setup_call(chan, addr, timeout, driver, data, desc, callerid, node);
+	rpt_setup_call(chan, addr, driver, data, callerid, node);
 	return ast_call(chan, addr, timeout);
 }
 

--- a/apps/app_rpt/rpt_call.h
+++ b/apps/app_rpt/rpt_call.h
@@ -22,9 +22,44 @@
 /*! \brief Disable CDR for a call */
 int rpt_disable_cdr(struct ast_channel *chan);
 
+/*! \brief Prepare a channel for an outbound RPT call
+ *
+ * Sets channel read/write formats, disables CDRs where appropriate,
+ * attaches the "Rpt" application and application data to the channel,
+ * and sets the connected Caller ID and displayed extension for the
+ * outgoing call so that the remote side sees the expected caller
+ * information and node/extension.
+ *
+ * \param chan Channel initiating the outbound call
+ * \param addr Destination address (driver-specific dial string or endpoint)
+ * \param timeout Call timeout in seconds (used when actually placing the call)
+ * \param driver Driver/protocol name (for logging; may be part of addr)
+ * \param data Application data to set on the channel (rpt node/type)
+ * \param desc Short description of the call purpose (for logging)
+ * \param callerid Caller ID number/string to set on the outgoing call
+ * \param node Node name or extension to set on the channel for visibility
+ * \return 0 on success, non-zero on error
+ */
 int rpt_setup_call(struct ast_channel *chan, const char *addr, int timeout, const char *driver, const char *data,
 	const char *desc, const char *callerid, const char *node);
 
+/*! \brief Setup the channel and place an outbound RPT call
+ *
+ * This is a convenience wrapper that calls rpt_setup_call() to prepare
+ * the channel and then invokes ast_call() to actually create the
+ * outbound channel to the specified address.
+ *
+ * \param chan Channel initiating the outbound call
+ * \param addr Destination address (driver-specific dial string or endpoint)
+ * \param timeout Call timeout in seconds (passed to ast_call)
+ * \param driver Driver/protocol name (for logging; may be part of addr)
+ * \param data Application data to set on the channel (rpt node/type)
+ * \param desc Short description of the call purpose (for logging)
+ * \param callerid Caller ID number/string to set on the outgoing call
+ * \param node Node name or extension to set on the channel for visibility
+ * \return 0 on success, negative on error (returns result of rpt_setup_call() or ast_call())
+ * \note Calls to this function call DNS lookup and is "blocking" up to DNS timeout time.
+ */
 int rpt_make_call(struct ast_channel *chan, const char *addr, int timeout, const char *driver, const char *data, const char *desc,
 	const char *callerid, const char *node);
 

--- a/apps/app_rpt/rpt_call.h
+++ b/apps/app_rpt/rpt_call.h
@@ -38,9 +38,8 @@ int rpt_disable_cdr(struct ast_channel *chan);
  * \param desc Short description of the call purpose (for logging)
  * \param callerid Caller ID number/string to set on the outgoing call
  * \param node Node name or extension to set on the channel for visibility
- * \return 0 on success, non-zero on error
  */
-int rpt_setup_call(struct ast_channel *chan, const char *addr, int timeout, const char *driver, const char *data,
+void rpt_setup_call(struct ast_channel *chan, const char *addr, int timeout, const char *driver, const char *data,
 	const char *desc, const char *callerid, const char *node);
 
 /*! \brief Setup the channel and place an outbound RPT call
@@ -58,7 +57,8 @@ int rpt_setup_call(struct ast_channel *chan, const char *addr, int timeout, cons
  * \param callerid Caller ID number/string to set on the outgoing call
  * \param node Node name or extension to set on the channel for visibility
  * \return 0 on success, negative on error (returns result of rpt_setup_call() or ast_call())
- * \note Calls to this function call DNS lookup and is "blocking" up to DNS timeout time.
+ * \note This function may perform a blocking DNS lookup during call setup.
+ *       The lookup can block until the DNS timeout expires.
  */
 int rpt_make_call(struct ast_channel *chan, const char *addr, int timeout, const char *driver, const char *data, const char *desc,
 	const char *callerid, const char *node);

--- a/apps/app_rpt/rpt_call.h
+++ b/apps/app_rpt/rpt_call.h
@@ -32,15 +32,12 @@ int rpt_disable_cdr(struct ast_channel *chan);
  *
  * \param chan Channel initiating the outbound call
  * \param addr Destination address (driver-specific dial string or endpoint)
- * \param timeout Call timeout in seconds (used when actually placing the call)
  * \param driver Driver/protocol name (for logging; may be part of addr)
  * \param data Application data to set on the channel (rpt node/type)
- * \param desc Short description of the call purpose (for logging)
  * \param callerid Caller ID number/string to set on the outgoing call
  * \param node Node name or extension to set on the channel for visibility
  */
-void rpt_setup_call(struct ast_channel *chan, const char *addr, int timeout, const char *driver, const char *data,
-	const char *desc, const char *callerid, const char *node);
+void rpt_setup_call(struct ast_channel *chan, const char *addr, const char *driver, const char *data, const char *callerid, const char *node);
 
 /*! \brief Setup the channel and place an outbound RPT call
  *


### PR DESCRIPTION
Adding auto_service() handles the long hang on redial when DNS is slow.
Another option would be to thread the redial function allowing the frame processing thread to continue while the redial hangs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconnection handling to keep link communication responsive during blocking call requests.
  * Prevented pending channel frames from being unnecessarily discarded when a link disconnects.

* **Documentation**
  * Added detailed API documentation describing call setup and call execution behavior, parameters, return values, and DNS-related blocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->