### PR TITLE
chan_simpleusb: address null buffer write thread blocks

### DIFF
--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -2255,15 +2255,10 @@ static void *simpleusb_audio_thread(void *arg)
 				frames_available = ast_radio_pa_write_available(&o->pa);
 
 				if (frames_available < 0) {
-					if (frames_available != paOutputUnderflowed) {
-						/* Underflow handled in soundcard_writeframe
-						 * all other errors require restart
-						 */
-						ast_debug(2, "Pa_GetStreamWriteAvailable error %s", Pa_GetErrorText(frames_available));
-						o->hasusb = 0;
-						stream_cleanup(o);
-						break;
-					}
+					ast_debug(2, "Pa_GetStreamWriteAvailable error %s", Pa_GetErrorText(frames_available));
+					o->hasusb = 0;
+					stream_cleanup(o);
+					break;
 				}
 
 				if ((num_frames <= 3) && (o->txkeyed || o->txtestkey)) {

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -1654,6 +1654,7 @@ usb_device_ready:
  * \note data is 48 kHz stereo interleaved. ast_radio_pa_write() takes frames
  *       per channel (AST_RADIO_PA_FRAMES_PER_BUFFER); interleaved sample count
  *       is frames * AST_RADIO_PA_OUTPUT_CHANNELS (== AST_RADIO_PA_48K_STEREO_SAMPLES).
+ * 		 pa frames are a single sample per frame, while asterisk frames are 160 samples per frame.
  * \param o		chan_usbradio_pvt.
  * \param data	Audio data to write.
  * \returns		Byte count written on success, 0 on failure.

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -156,7 +156,7 @@
  *		(otherwise it will never be full).
  */
 
-#define FRAME_SIZE 160
+#define FRAME_SIZE 160 /* Samples per Asterisk Frame */
 
 #if defined(__FreeBSD__)
 #define FRAGS 0x8

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -1368,7 +1368,7 @@ PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, un
 	}
 
 	if (frames > AST_RADIO_PA_FRAMES_PER_BUFFER) {
-		ast_log(LOG_WARNING, "ast_radio_pa_write: frames %lu exceeds buffer capacity\n", frames);
+		ast_log(LOG_WARNING, "ast_radio_pa_write: PortAudio frames %lu exceeds buffer capacity\n", frames);
 		return paBufferTooBig;
 	}
 

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -1359,7 +1359,7 @@ PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned l
 	return paTimedOut;
 }
 
-PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, unsigned long frames)
+PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, unsigned long pa_frames)
 {
 	PaError res;
 
@@ -1367,12 +1367,12 @@ PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, un
 		return paBadStreamPtr;
 	}
 
-	if (frames > AST_RADIO_PA_FRAMES_PER_BUFFER) {
-		ast_log(LOG_WARNING, "ast_radio_pa_write: PortAudio frames %lu exceeds buffer capacity\n", frames);
+	if (pa_frames > AST_RADIO_PA_FRAMES_PER_BUFFER) {
+		ast_log(LOG_WARNING, "ast_radio_pa_write: PortAudio frames %lu exceeds buffer capacity\n", pa_frames);
 		return paBufferTooBig;
 	}
 
-	res = Pa_WriteStream(ps->stream, data, frames);
+	res = Pa_WriteStream(ps->stream, data, pa_frames);
 	if (res == paOutputUnderflowed) {
 		PaError prime_res;
 		/* The data size depends on how many channels are set up in a frame.  We have a max of 2 channels
@@ -1388,15 +1388,15 @@ PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, un
 		 */
 		frames_available = ast_radio_pa_write_available(ps);
 
-		if ((frames_available > 0) && (frames_available >= frames)) {
-			ast_debug(6, "PortAudio write stream underflow, priming with %ld silence frames\n", frames);
-			prime_res = Pa_WriteStream(ps->stream, null_buf, frames);
+		if ((frames_available > 0) && (frames_available >= pa_frames)) {
+			ast_debug(6, "PortAudio write stream underflow, priming with %ld silence frames\n", pa_frames);
+			prime_res = Pa_WriteStream(ps->stream, null_buf, pa_frames);
 			if (prime_res != paNoError) {
 				return prime_res;
 			}
 		} else {
 			ast_debug(6, "PortAudio write stream underflow, Unable to prime with %ld silence frames, only %ld available\n",
-				frames, frames_available);
+				pa_frames, frames_available);
 		}
 	}
 

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -1388,7 +1388,7 @@ PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, un
 		 */
 		frames_available = ast_radio_pa_write_available(ps);
 
-		if (frames_available >= frames) {
+		if ((frames_available > 0) && (frames_available >= frames)) {
 			ast_debug(6, "PortAudio write stream underflow, priming with %ld silence frames\n", frames);
 			prime_res = Pa_WriteStream(ps->stream, null_buf, frames);
 			if (prime_res != paNoError) {

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -1375,17 +1375,28 @@ PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, un
 	res = Pa_WriteStream(ps->stream, data, frames);
 	if (res == paOutputUnderflowed) {
 		PaError prime_res;
+		/* The data size depends on how many channels are set up in a frame.  We have a max of 2 channels
+		 * If only channel, the buffer is 2x what is needed
+		 */
 		short null_buf[AST_RADIO_PA_FRAMES_PER_BUFFER * AST_RADIO_PA_OUTPUT_CHANNELS] = { 0 };
+		long frames_available;
 
 		/*
 		 * Prime the stream with one silence frame so the USB buffer does not
 		 * stay empty (choppy TX). See #593 / #598. Propagate a real failure
 		 * from the silence write so callers can restart the stream.
 		 */
-		ast_debug(6, "PortAudio write stream underflow, writing a 0 frame");
-		prime_res = Pa_WriteStream(ps->stream, null_buf, frames);
-		if (prime_res != paNoError) {
-			return prime_res;
+		frames_available = ast_radio_pa_write_available(ps);
+
+		if (frames_available >= frames) {
+			ast_debug(6, "PortAudio write stream underflow, priming with %ld silence frames\n", frames);
+			prime_res = Pa_WriteStream(ps->stream, null_buf, frames);
+			if (prime_res != paNoError) {
+				return prime_res;
+			}
+		} else {
+			ast_debug(6, "PortAudio write stream underflow, Unable to prime with %ld silence frames, only %ld available\n",
+				frames, frames_available);
 		}
 	}
 


### PR DESCRIPTION
Unfortunately, `ast_radio_pa_write_available();` never returns `paOutputUnderflowed` - remove "dead" code.
Additionally, there is a condition where `Pa_WriteStream` returns `paOutputUnderflowed` yet there is not enough room for the additional null frame. 
Adding a check to confirm room in the buffer before attempting to add the null frame.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USB radio stream error handling so output failures are detected consistently.
  * Prevented transmission attempts when insufficient audio capacity is available.
  * Improved stream cleanup and device availability handling after output errors.
  * Added clearer logging when audio output cannot be safely initialized.
* **Documentation**
  * Clarified audio frame and sample sizing to improve maintainability and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->