### PR TITLE
chan_voter: Remove unreachable code

### DIFF
--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -4784,7 +4784,6 @@ static void *voter_reader(void *data)
 	VOTER_REC rec;
 	VOTER_STREAM stream;
 	time_t timestuff, t;
-	short silbuf[FRAME_SIZE];
 #pragma pack(push)
 #pragma pack(1)
 #ifdef ADPCM_LOOPBACK

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -6005,27 +6005,6 @@ static void *voter_reader(void *data)
 									p->testcycle = 0;
 									p->testindex = 0;
 								}
-								/*!
-								 * \todo VE7FET is this dead code? We are nested inside a
-								 * if (maxclient) already?
-								 */
-								if (!maxclient) { /* If nothing there */
-									memset(silbuf, 0, sizeof(silbuf));
-									memset(&fr, 0, sizeof(fr));
-									fr.frametype = AST_FRAME_VOICE;
-									fr.subclass.format = ast_format_slin;
-									fr.datalen = FRAME_SIZE * 2;
-									fr.samples = FRAME_SIZE;
-									fr.data.ptr = silbuf;
-									fr.src = __PRETTY_FUNCTION__;
-									p->threshold = 0;
-									p->threshcount = 0;
-									p->lingercount = 0;
-									p->winner = 0;
-									incr_drainindex(p);
-									ast_queue_frame(p->owner, &fr);
-									continue;
-								}
 								/* Figure out where in the ring buffer we are. */
 								buffer_bytes_avail = maxclient->buflen - (maxclient->drainindex + FRAME_SIZE);
 								/* Copy the audio frame from the voted client into the channel (ring) buffer. */


### PR DESCRIPTION
This code is dead/unreachable, since we are already inside `if (maxclient)`.

Resolves #1143

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voter selection processing by removing an unnecessary fallback path.
  * Prevented silent frame queuing and redundant state changes when no client is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->