### PR TITLE
first-pass at funcchars / multiple DTMFs (#1049)

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -1862,24 +1862,50 @@ static inline void handle_callmode_dialing(struct rpt *myrpt, char c)
 }
 
 /*!
- * \brief Determine whether a character is one of the configured function (lead-in) characters.
+ * \brief Feed a character through the funcchars lead-in sequence matcher.
+ *
+ * The configured funcchars directive is a sequence (e.g. "*123") that must be entered in full,
+ * in order, to trigger the function lead-in. Each independent DTMF stream (e.g. the local/remote-base
+ * stream vs. the link/phone stream) must track its own progress through the sequence, so idx/last
+ * are owned by the caller (myrpt->funcidx/functime or myrpt->rem_funcidx/rem_functime) and must be
+ * fed every character of that stream exactly once, in order, or match progress will be corrupted.
+ *
  * \param myrpt pointer to repeater struct.
- * \param c character to check.
- * \return 1 if c is a configured function character, 0 otherwise.
+ * \param c character to process.
+ * \param idx pointer to this stream's sequence-match progress index.
+ * \param last pointer to this stream's last-progress timestamp.
+ * \return 1 if c completed the configured funcchars sequence, 0 otherwise.
  */
-static int rpt_is_funcchar(struct rpt *myrpt, char c)
+static int rpt_funcchars_match(struct rpt *myrpt, char c, int *idx, time_t *last)
 {
-	return c && strchr(myrpt->p.funcchars, c) != NULL;
+	time_t now;
+
+	time(&now);
+	if (*idx && ((now - *last) > MAXXLATTIME)) {
+		*idx = 0;
+	}
+	if (c && (c == myrpt->p.funcchars[*idx])) {
+		*last = now;
+		(*idx)++;
+		if (!myrpt->p.funcchars[*idx]) {
+			*idx = 0;
+			return 1;
+		}
+	} else {
+		*idx = 0;
+	}
+	return 0;
 }
 
 /*!
  * \brief Handle the function character. Must be called locked.
  * \param myrpt pointer to repeater struct.
  * \param c character to process.
+ * \param funcmatch 1 if c just completed the funcchars lead-in sequence for this stream, 0 otherwise.
  * \return 1 if the character was processed, 0 otherwise.
  */
 
-static int funcchar_common(struct rpt *myrpt, char c)
+static int funcchar_common(struct rpt *myrpt, char c, int funcmatch)
 {
 	if (myrpt->callmode == CALLMODE_DIALING) {
 		handle_callmode_dialing(myrpt, c);
@@ -1893,7 +1919,7 @@ static int funcchar_common(struct rpt *myrpt, char c)
 			time(&myrpt->dtmf_time);
 			return 1;
 		}
-		if (rpt_is_funcchar(myrpt, c)) {
+		if (funcmatch) {
 			myrpt->rem_dtmfidx = 0;
 			myrpt->rem_dtmfbuf[myrpt->rem_dtmfidx] = 0;
 			time(&myrpt->rem_dtmf_time);
@@ -1909,7 +1935,7 @@ static void handle_link_data(struct rpt *myrpt, struct rpt_link *mylink, char *s
 	 * Is this a typo here?  Why would dest be any bigger than src?
 	 */
 	char tmp1[RPT_TMP_SZ + 1], cmd[RPT_CMD_SZ + 1] = "", dest[RPT_DEST_SZ + 1], src[RPT_SRC_SZ + 1], c;
-	int i, seq, res, ts, rest;
+	int i, seq, res, ts, rest, funcmatch = 0;
 	struct ast_frame wf = {
 		.frametype = AST_FRAME_TEXT,
 		.data.ptr = str,
@@ -2136,9 +2162,12 @@ static void handle_link_data(struct rpt *myrpt, struct rpt_link *mylink, char *s
 		return;
 	}
 	donodelog_fmt(myrpt, "DTMF,%s,%c", mylink->name, c);
-	c = func_xlat(myrpt, c, &myrpt->p.outxlat);
+	c = func_xlat(myrpt, c, &myrpt->p.outxlat, &funcmatch);
 	if (!c) {
 		return;
+	}
+	if (!funcmatch) {
+		funcmatch = rpt_funcchars_match(myrpt, c, &myrpt->rem_funcidx, &myrpt->rem_functime);
 	}
 	rpt_mutex_lock(&myrpt->lock);
 	if ((iswebtransceiver(mylink)) || CHAN_TECH(mylink->chan, "tlb")) {
@@ -2160,7 +2189,7 @@ static void handle_link_data(struct rpt *myrpt, struct rpt_link *mylink, char *s
 	if (c == myrpt->p.endchar) {
 		myrpt->stopgen = 1;
 	}
-	if (funcchar_common(myrpt, c)) {
+	if (funcchar_common(myrpt, c, funcmatch)) {
 		rpt_mutex_unlock(&myrpt->lock);
 		return;
 	}
@@ -2206,7 +2235,7 @@ static inline void cmdnode_helper(struct rpt *myrpt, char *cmd)
 static void handle_link_phone_dtmf(struct rpt *myrpt, struct rpt_link *mylink, char c)
 {
 	char cmd[300];
-	int res;
+	int res, funcmatch;
 
 	donodelog_fmt(myrpt, "DTMF(P),%s,%c", mylink->name, c);
 	if (mylink->phonemonitor) {
@@ -2214,6 +2243,7 @@ static void handle_link_phone_dtmf(struct rpt *myrpt, struct rpt_link *mylink, c
 	}
 
 	rpt_mutex_lock(&myrpt->lock);
+	funcmatch = rpt_funcchars_match(myrpt, c, &myrpt->rem_funcidx, &myrpt->rem_functime);
 
 	if (mylink->phonemode == RPT_PHONE_MODE_DUMB_SIMPLEX) { /*If in simplex dumb phone mode */
 		if (c == myrpt->p.endchar) {						/* If end char */
@@ -2222,7 +2252,7 @@ static void handle_link_phone_dtmf(struct rpt *myrpt, struct rpt_link *mylink, c
 			return;
 		}
 
-		if (rpt_is_funcchar(myrpt, c)) {				  /* If lead-in char */
+		if (funcmatch) {				  /* If lead-in sequence complete */
 			mylink->lastrealrx = !mylink->lastrealrx; /* Toggle keying state */
 			rpt_mutex_unlock(&myrpt->lock);
 			return;
@@ -2248,7 +2278,7 @@ static void handle_link_phone_dtmf(struct rpt *myrpt, struct rpt_link *mylink, c
 		send_link_dtmf(myrpt, c);
 		return;
 	}
-	if (funcchar_common(myrpt, c)) {
+	if (funcchar_common(myrpt, c, funcmatch)) {
 		rpt_mutex_unlock(&myrpt->lock);
 		return;
 	}
@@ -2281,7 +2311,7 @@ static void handle_link_phone_dtmf(struct rpt *myrpt, struct rpt_link *mylink, c
 	rpt_mutex_unlock(&myrpt->lock);
 }
 
-static int handle_remote_dtmf_digit(struct rpt *myrpt, char c, char *keyed, enum rpt_phone_mode phonemode)
+static int handle_remote_dtmf_digit(struct rpt *myrpt, char c, char *keyed, enum rpt_phone_mode phonemode, int funcmatch)
 {
 	time_t now;
 	int res = 0, src;
@@ -2304,8 +2334,8 @@ static int handle_remote_dtmf_digit(struct rpt *myrpt, char c, char *keyed, enum
 	}
 	/* if decode not active */
 	if (myrpt->dtmfidx == -1) {
-		/* if not lead-in digit, dont worry */
-		if (!rpt_is_funcchar(myrpt, c)) {
+		/* if lead-in sequence not complete, dont worry */
+		if (!funcmatch) {
 			if (!myrpt->p.propagate_dtmf) {
 				rpt_mutex_lock(&myrpt->lock);
 				do_dtmf_local(myrpt, c);
@@ -2323,15 +2353,6 @@ static int handle_remote_dtmf_digit(struct rpt *myrpt, char c, char *keyed, enum
 		myrpt->dtmfidx = 0;
 		myrpt->dtmfbuf[0] = 0;
 		myrpt->dtmf_time_rem = now;
-	}
-	if (rpt_is_funcchar(myrpt, c)) {
-		/* if star at beginning, or 2 together, erase buffer */
-		if ((myrpt->dtmfidx < 1) || rpt_is_funcchar(myrpt, myrpt->dtmfbuf[myrpt->dtmfidx - 1])) {
-			myrpt->dtmfidx = 0;
-			myrpt->dtmfbuf[0] = 0;
-			myrpt->dtmf_time_rem = now;
-			return 0;
-		}
 	}
 	myrpt->dtmfbuf[myrpt->dtmfidx++] = c;
 	myrpt->dtmfbuf[myrpt->dtmfidx] = 0;
@@ -2390,7 +2411,7 @@ static int handle_remote_data(struct rpt *myrpt, const char *str)
 {
 	/* Should src[300] be src[30] as in handle_link_data?*/
 	char cmd[RPT_CMD_SZ + 1], dest[RPT_DEST_SZ + 1], src[RPT_SRC_SZ + 1], c;
-	int seq, res;
+	int seq, res, funcmatch = 0;
 
 	/* put string in our buffer */
 	if (!strcmp(str, DISCSTR)) {
@@ -2443,10 +2464,13 @@ static int handle_remote_data(struct rpt *myrpt, const char *str)
 	if (strcmp(dest, myrpt->name))
 		return 0;
 	donodelog_fmt(myrpt, "DTMF,%c", c);
-	c = func_xlat(myrpt, c, &myrpt->p.outxlat);
+	c = func_xlat(myrpt, c, &myrpt->p.outxlat, &funcmatch);
 	if (!c)
 		return 0;
-	res = handle_remote_dtmf_digit(myrpt, c, NULL, RPT_PHONE_MODE_NONE);
+	if (!funcmatch) {
+		funcmatch = rpt_funcchars_match(myrpt, c, &myrpt->funcidx, &myrpt->functime);
+	}
+	res = handle_remote_dtmf_digit(myrpt, c, NULL, RPT_PHONE_MODE_NONE, funcmatch);
 	if (res != 1)
 		return res;
 	if ((!strcmp(myrpt->remoterig, REMOTE_RIG_TM271)) || (!strcmp(myrpt->remoterig, REMOTE_RIG_KENWOOD)))
@@ -2458,13 +2482,14 @@ static int handle_remote_data(struct rpt *myrpt, const char *str)
 
 static int handle_remote_phone_dtmf(struct rpt *myrpt, char c, char *restrict keyed, enum rpt_phone_mode phonemode)
 {
-	int res;
+	int res, funcmatch;
 
+	funcmatch = rpt_funcchars_match(myrpt, c, &myrpt->funcidx, &myrpt->functime);
 	if (phonemode == RPT_PHONE_MODE_DUMB_SIMPLEX) { /* simplex phonemode, funcchars key/unkey toggle */
-		if (keyed && *keyed && (rpt_is_funcchar(myrpt, c) || (c == myrpt->p.endchar))) {
+		if (keyed && *keyed && (funcmatch || (c == myrpt->p.endchar))) {
 			*keyed = 0; /* UNKEY */
 			return 0;
-		} else if (keyed && !*keyed && rpt_is_funcchar(myrpt, c)) {
+		} else if (keyed && !*keyed && funcmatch) {
 			*keyed = 1; /* KEY */
 			return 0;
 		}
@@ -2475,7 +2500,7 @@ static int handle_remote_phone_dtmf(struct rpt *myrpt, char c, char *restrict ke
 		}
 	}
 	donodelog_fmt(myrpt, "DTMF(P),%c", c);
-	res = handle_remote_dtmf_digit(myrpt, c, keyed, phonemode);
+	res = handle_remote_dtmf_digit(myrpt, c, keyed, phonemode, funcmatch);
 	if (res != 1)
 		return res;
 	if ((!strcmp(myrpt->remoterig, REMOTE_RIG_TM271)) || (!strcmp(myrpt->remoterig, REMOTE_RIG_KENWOOD)))
@@ -2598,7 +2623,7 @@ static void *attempt_reconnect(struct rpt *myrpt, struct rpt_link *l)
 }
 
 /* 0 return=continue, 1 return = break, -1 return = error */
-static void local_dtmf_helper(struct rpt *myrpt, char c_in)
+static void local_dtmf_helper(struct rpt *myrpt, char c_in, int funcmatch)
 {
 	enum rpt_function_response res;
 	char cmd[MAXDTMF + 1] = "", c, tone[10];
@@ -2671,7 +2696,7 @@ static void local_dtmf_helper(struct rpt *myrpt, char c_in)
 			time(&myrpt->dtmf_time);
 			return;
 		}
-		if ((!myrpt->inpadtest) && rpt_is_funcchar(myrpt, c)) {
+		if ((!myrpt->inpadtest) && funcmatch) {
 			if (myrpt->p.dopfxtone && (myrpt->dtmfidx == -1))
 				rpt_telemetry(myrpt, PFXTONE, NULL);
 			myrpt->dtmfidx = 0;
@@ -2730,7 +2755,7 @@ static void local_dtmf_helper(struct rpt *myrpt, char c_in)
 			}
 		}
 	} else { /* if simple */
-		if ((myrpt->callmode == CALLMODE_DOWN) && rpt_is_funcchar(myrpt, c)) {
+		if ((myrpt->callmode == CALLMODE_DOWN) && funcmatch) {
 			myrpt->callmode = CALLMODE_DIALING;
 			myrpt->patchnoct = 0;
 			myrpt->patchquiet = 0;
@@ -4169,7 +4194,7 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 		dtmfed = 1;
 		myrpt->lastdtmftime = rpt_tvnow();
 	} else if (f->frametype == AST_FRAME_DTMF) {
-		int x;
+		int x, funcmatch = 0;
 		char c = (char) f->subclass.integer; /* get DTMF char */
 		ast_frfree(f);
 		x = ast_tvdiff_ms(rpt_tvnow(), myrpt->lastdtmftime);
@@ -4185,9 +4210,13 @@ static inline int rxchannel_read(struct rpt *myrpt, const int lasttx)
 				local_dtmfkey_helper(myrpt, c);
 			return 0;
 		}
-		c = func_xlat(myrpt, c, &myrpt->p.inxlat);
-		if (c)
-			local_dtmf_helper(myrpt, c);
+		c = func_xlat(myrpt, c, &myrpt->p.inxlat, &funcmatch);
+		if (c) {
+			if (!funcmatch) {
+				funcmatch = rpt_funcchars_match(myrpt, c, &myrpt->funcidx, &myrpt->functime);
+			}
+			local_dtmf_helper(myrpt, c, funcmatch);
+		}
 		return 0;
 	} else if (f->frametype == AST_FRAME_CONTROL) {
 		if (f->subclass.integer == AST_CONTROL_HANGUP) {
@@ -5826,7 +5855,7 @@ static void *rpt(void *this)
 			}
 			rpt_mutex_unlock(&myrpt->lock);
 			donodelog_fmt(myrpt, "DTMF(M),MAIN,%c", cin);
-			local_dtmf_helper(myrpt, c);
+			local_dtmf_helper(myrpt, c, rpt_funcchars_match(myrpt, cin, &myrpt->funcidx, &myrpt->functime));
 		} else {
 			rpt_mutex_unlock(&myrpt->lock);
 		}
@@ -7868,7 +7897,8 @@ static int rpt_exec(struct ast_channel *chan, const char *data)
 				myrpt->macrotimer = MACROPTIME;
 			rpt_mutex_unlock(&myrpt->lock);
 			donodelog_fmt(myrpt, "DTMF(M),%c", c);
-			if (handle_remote_dtmf_digit(myrpt, c, &keyed, RPT_PHONE_MODE_NONE) == -1)
+			if (handle_remote_dtmf_digit(myrpt, c, &keyed, RPT_PHONE_MODE_NONE,
+				rpt_funcchars_match(myrpt, c, &myrpt->funcidx, &myrpt->functime)) == -1)
 				break;
 			continue;
 		} else {

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -377,7 +377,7 @@
 					</option>
 					<option name="S">
 						<para>Simplex Dumb Phone Control mode. This allows a regular phone user audio-only access to the radio
- system. In this mode, the transmitter is toggled on and off when the phone user presses the funcchar (*) key on the telephone
+ system. In this mode, the transmitter is toggled on and off when the phone user presses one of the funcchars (*) keys on the telephone
  set. In addition, the transmitter will turn off if the endchar (#) key is pressed. When a user first calls in, the transmitter
  will be off, and the user can listen for radio traffic. When the user wants to transmit, they press the * key, start talking,
  then press the * key again or the # key to turn the transmitter off.  No other functions can be executed by the user on the phone
@@ -1862,6 +1862,17 @@ static inline void handle_callmode_dialing(struct rpt *myrpt, char c)
 }
 
 /*!
+ * \brief Determine whether a character is one of the configured function (lead-in) characters.
+ * \param myrpt pointer to repeater struct.
+ * \param c character to check.
+ * \return 1 if c is a configured function character, 0 otherwise.
+ */
+static int rpt_is_funcchar(struct rpt *myrpt, char c)
+{
+	return c && strchr(myrpt->p.funcchars, c) != NULL;
+}
+
+/*!
  * \brief Handle the function character. Must be called locked.
  * \param myrpt pointer to repeater struct.
  * \param c character to process.
@@ -1882,7 +1893,7 @@ static int funcchar_common(struct rpt *myrpt, char c)
 			time(&myrpt->dtmf_time);
 			return 1;
 		}
-		if (c == myrpt->p.funcchar) {
+		if (rpt_is_funcchar(myrpt, c)) {
 			myrpt->rem_dtmfidx = 0;
 			myrpt->rem_dtmfbuf[myrpt->rem_dtmfidx] = 0;
 			time(&myrpt->rem_dtmf_time);
@@ -2211,7 +2222,7 @@ static void handle_link_phone_dtmf(struct rpt *myrpt, struct rpt_link *mylink, c
 			return;
 		}
 
-		if (c == myrpt->p.funcchar) {				  /* If lead-in char */
+		if (rpt_is_funcchar(myrpt, c)) {				  /* If lead-in char */
 			mylink->lastrealrx = !mylink->lastrealrx; /* Toggle keying state */
 			rpt_mutex_unlock(&myrpt->lock);
 			return;
@@ -2294,7 +2305,7 @@ static int handle_remote_dtmf_digit(struct rpt *myrpt, char c, char *keyed, enum
 	/* if decode not active */
 	if (myrpt->dtmfidx == -1) {
 		/* if not lead-in digit, dont worry */
-		if (c != myrpt->p.funcchar) {
+		if (!rpt_is_funcchar(myrpt, c)) {
 			if (!myrpt->p.propagate_dtmf) {
 				rpt_mutex_lock(&myrpt->lock);
 				do_dtmf_local(myrpt, c);
@@ -2313,9 +2324,9 @@ static int handle_remote_dtmf_digit(struct rpt *myrpt, char c, char *keyed, enum
 		myrpt->dtmfbuf[0] = 0;
 		myrpt->dtmf_time_rem = now;
 	}
-	if (c == myrpt->p.funcchar) {
+	if (rpt_is_funcchar(myrpt, c)) {
 		/* if star at beginning, or 2 together, erase buffer */
-		if ((myrpt->dtmfidx < 1) || (myrpt->dtmfbuf[myrpt->dtmfidx - 1] == myrpt->p.funcchar)) {
+		if ((myrpt->dtmfidx < 1) || rpt_is_funcchar(myrpt, myrpt->dtmfbuf[myrpt->dtmfidx - 1])) {
 			myrpt->dtmfidx = 0;
 			myrpt->dtmfbuf[0] = 0;
 			myrpt->dtmf_time_rem = now;
@@ -2449,11 +2460,11 @@ static int handle_remote_phone_dtmf(struct rpt *myrpt, char c, char *restrict ke
 {
 	int res;
 
-	if (phonemode == RPT_PHONE_MODE_DUMB_SIMPLEX) { /* simplex phonemode, funcchar key/unkey toggle */
-		if (keyed && *keyed && ((c == myrpt->p.funcchar) || (c == myrpt->p.endchar))) {
+	if (phonemode == RPT_PHONE_MODE_DUMB_SIMPLEX) { /* simplex phonemode, funcchars key/unkey toggle */
+		if (keyed && *keyed && (rpt_is_funcchar(myrpt, c) || (c == myrpt->p.endchar))) {
 			*keyed = 0; /* UNKEY */
 			return 0;
-		} else if (keyed && !*keyed && (c == myrpt->p.funcchar)) {
+		} else if (keyed && !*keyed && rpt_is_funcchar(myrpt, c)) {
 			*keyed = 1; /* KEY */
 			return 0;
 		}
@@ -2660,7 +2671,7 @@ static void local_dtmf_helper(struct rpt *myrpt, char c_in)
 			time(&myrpt->dtmf_time);
 			return;
 		}
-		if ((!myrpt->inpadtest) && (c == myrpt->p.funcchar)) {
+		if ((!myrpt->inpadtest) && rpt_is_funcchar(myrpt, c)) {
 			if (myrpt->p.dopfxtone && (myrpt->dtmfidx == -1))
 				rpt_telemetry(myrpt, PFXTONE, NULL);
 			myrpt->dtmfidx = 0;
@@ -2719,7 +2730,7 @@ static void local_dtmf_helper(struct rpt *myrpt, char c_in)
 			}
 		}
 	} else { /* if simple */
-		if ((myrpt->callmode == CALLMODE_DOWN) && (c == myrpt->p.funcchar)) {
+		if ((myrpt->callmode == CALLMODE_DOWN) && rpt_is_funcchar(myrpt, c)) {
 			myrpt->callmode = CALLMODE_DIALING;
 			myrpt->patchnoct = 0;
 			myrpt->patchquiet = 0;

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -990,6 +990,7 @@ struct rpt {
 	struct rpt_conf rptconf;
 	pthread_t rpt_call_thread, rpt_thread;
 	time_t dtmf_time, rem_dtmf_time, dtmf_time_rem;
+	time_t functime, rem_functime; /*!< \brief last progress timestamp for the funcchars sequence matcher */
 	int calldigittimer;
 	int tailtimer, totimer, idtimer, cidx, scantimer, tmsgtimer, skedtimer, linkactivitytimer, elketimer;
 	int remote_time_out_reset_unkey_interval_timer, time_out_reset_unkey_interval_timer;
@@ -1001,6 +1002,7 @@ struct rpt {
 	int first_keyup_inactivity_timer;
 	int tailevent;
 	int dtmfidx, rem_dtmfidx;
+	int funcidx, rem_funcidx; /*!< \brief funcchars sequence match progress: funcidx for the local/remote-base stream, rem_funcidx for the link/phone stream */
 	int dailytxtime, dailykerchunks, totalkerchunks, dailykeyups, totalkeyups, timeouts;
 	int totalexecdcommands, dailyexecdcommands;
 	int retxtimer;

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -157,7 +157,8 @@ typedef struct {
 #define TONEMACRO "tonemacro"
 #define MDCMACRO "mdcmacro"
 #define DTMFKEYS "dtmfkeys"
-#define FUNCCHAR '*'
+#define FUNCCHARS "*"
+#define MAXFUNCCHARS 16
 #define ENDCHAR '#'
 #define EXTNODEFILE "/var/lib/asterisk/rpt_extnodes"
 #define NODENAMES "rpt/nodenames"
@@ -833,7 +834,7 @@ struct rpt {
 		int iobase;
 		const char *ioport;
 		int iospeed;
-		char funcchar;
+		char funcchars[MAXFUNCCHARS];
 		char endchar;
 		rpt_bool simple:1;
 		rpt_bool archiveaudio:1;

--- a/apps/app_rpt/rpt_config.c
+++ b/apps/app_rpt/rpt_config.c
@@ -922,8 +922,18 @@ void load_rpt_vars(int n, int init)
 	RPT_CONFIG_VAR_COND_DEFAULT(phone_functions, "phone_functions", 0, rpt_vars[n].p.functions);
 	RPT_CONFIG_VAR_COND_DEFAULT(dphone_functions, "dphone_functions", 0, rpt_vars[n].p.functions);
 	RPT_CONFIG_VAR(alt_functions, "alt_functions");
-	RPT_CONFIG_VAR_CHAR_DEFAULT(funcchar, "funcchar", FUNCCHAR);
+	val = ast_variable_retrieve(cfg, cat, "funcchars");
+	if (!val) {
+		val = ast_variable_retrieve(cfg, cat, "funcchar"); /* accepted as a compatibility alias for funcchars */
+	}
+	ast_copy_string(rpt_vars[n].p.funcchars, val ? val : FUNCCHARS, sizeof(rpt_vars[n].p.funcchars));
 	RPT_CONFIG_VAR_CHAR_DEFAULT(endchar, "endchar", ENDCHAR);
+	if (strchr(rpt_vars[n].p.funcchars, rpt_vars[n].p.endchar)) {
+		ast_mutex_unlock(&rpt_vars[n].lock);
+		ast_log(LOG_ERROR, "endchar '%c' must not also appear in funcchars '%s' for node %s.  Radio Repeater disabled.\n",
+			rpt_vars[n].p.endchar, rpt_vars[n].p.funcchars, cat);
+		pthread_exit(NULL);
+	}
 	RPT_CONFIG_VAR_BOOL(nobusyout, "nobusyout");
 	RPT_CONFIG_VAR_BOOL(notelemtx, "notelemtx");
 	RPT_CONFIG_VAR_BOOL(propagate_dtmf, "propagate_dtmf");

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -1100,7 +1100,7 @@ enum rpt_function_response function_autopatchup(struct rpt *myrpt, char *param, 
 
 	if ((myrpt->callmode == CALLMODE_CONNECTING) || (myrpt->callmode == CALLMODE_UP)) {
 		if (!nostar) {
-			myrpt->mydtmf = myrpt->p.funcchar;
+			myrpt->mydtmf = myrpt->p.funcchars[0];
 		}
 	}
 	if (myrpt->callmode != CALLMODE_DOWN) {
@@ -2043,7 +2043,7 @@ enum rpt_function_response function_cmd(struct rpt *myrpt, char *param, char *di
  *   "s" — status:                no trailing digits expected
  *   "l" — logout:                no trailing digits expected
  *
- * Example rpt.conf entries (assuming funcchar='*'):
+ * Example rpt.conf entries (assuming funcchars='*'):
  *   A1 = auth,a    ; *A1<10 digits>   login
  *   A2 = auth,s    ; *A2              status query
  *   A3 = auth,l    ; *A3              logout

--- a/apps/app_rpt/rpt_translate.c
+++ b/apps/app_rpt/rpt_translate.c
@@ -12,11 +12,12 @@
 #include "app_rpt.h"
 #include "rpt_translate.h"
 
-char func_xlat(struct rpt *myrpt, char c, struct rpt_xlat *xlat)
+char func_xlat(struct rpt *myrpt, char c, struct rpt_xlat *xlat, int *funcmatch)
 {
 	time_t now;
 	int gotone;
 
+	*funcmatch = 0;
 	time(&now);
 	gotone = 0;
 	/* if too much time, reset the state machine */
@@ -30,6 +31,7 @@ char func_xlat(struct rpt *myrpt, char c, struct rpt_xlat *xlat)
 		if (!xlat->funccharseq[xlat->funcindex]) {
 			xlat->funcindex = 0;
 			xlat->endindex = 0;
+			*funcmatch = 1;
 			return myrpt->p.funcchars[0];
 		}
 	} else {

--- a/apps/app_rpt/rpt_translate.c
+++ b/apps/app_rpt/rpt_translate.c
@@ -30,7 +30,7 @@ char func_xlat(struct rpt *myrpt, char c, struct rpt_xlat *xlat)
 		if (!xlat->funccharseq[xlat->funcindex]) {
 			xlat->funcindex = 0;
 			xlat->endindex = 0;
-			return myrpt->p.funcchar;
+			return myrpt->p.funcchars[0];
 		}
 	} else {
 		xlat->funcindex = 0;

--- a/apps/app_rpt/rpt_translate.h
+++ b/apps/app_rpt/rpt_translate.h
@@ -1,6 +1,14 @@
 
-/*! \brief Translate function */
-char func_xlat(struct rpt *myrpt, char c, struct rpt_xlat *xlat);
+/*!
+ * \brief Translate function
+ * \param myrpt pointer to repeater struct.
+ * \param c character to process.
+ * \param xlat translation state to advance.
+ * \param[out] funcmatch set to 1 if c completed the funccharseq alternate sequence (the returned
+ *                        character is a synthesized funcchars trigger, not a raw passthrough digit),
+ *                        0 otherwise.
+ */
+char func_xlat(struct rpt *myrpt, char c, struct rpt_xlat *xlat, int *funcmatch);
 
 /*! \brief Translate APRStt DTMF to a callsign */
 char aprstt_xlat(const char *instr, char *outstr);


### PR DESCRIPTION
The goal of this PR is to implement `funcchars` and support multiple DTMF characters as the function input character. Also make sure that `endchar` doesn't appear in `funcchars`. The current `funcchar` is an acceptable alias for `funcchars`.