### PR TITLE
chan_voter: Refactor Portions of reload(), Add Comments, Resolve Identified Bugs

### DIFF
--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -4328,8 +4328,9 @@ static int reload(void)
 		 * we need to recreate the PMR channel.
 		 */
 		if (strcmp(oldctcss, p->txctcssfreq) || (oldtoctype != p->txtoctype) || (oldlevel != p->txctcsslevel)) {
-			ast_debug(1, "VOTER %i: CTCSS frequency, level, or turn off code type changed, recreating PMR channel\n", p->nodenum);
 			t_pmr_chan tChan;
+			
+			ast_debug(1, "VOTER %i: CTCSS frequency, level, or turn off code type changed, recreating PMR channel\n", p->nodenum);
 
 			if (p->pmrChan) {
 				destroyPmrChannel(p->pmrChan);

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -3788,7 +3788,7 @@ static struct ast_channel *voter_request(const char *type, struct ast_format_cap
 {
 	int i, j;
 	struct voter_pvt *p, *p1;
-	struct ast_channel *astchanptr = NULL;
+	struct ast_channel *chan = NULL;
 	char *cp, *cp1, *cp2, *strs[MAXTHRESHOLDS], *ctg;
 	const char *val;
 	struct ast_config *cfg = NULL;
@@ -3866,9 +3866,8 @@ static struct ast_channel *voter_request(const char *type, struct ast_format_cap
 	 * endpoint: channel prefix "voter/%s" (where %s is the node number)
 	 * __FILE__: source file name (set to to the node identifier string, aka node number, for debugging)
 	 */
-	astchanptr =
-		ast_channel_alloc(1, AST_STATE_DOWN, 0, 0, "", (char *) data, context, assignedids, requestor, 0, "voter/%s", (char *) data);
-	if (!astchanptr) {
+	chan = ast_channel_alloc(1, AST_STATE_DOWN, 0, 0, "", (char *) data, context, assignedids, requestor, 0, "voter/%s", (char *) data);
+	if (!chan) {
 		ast_log(LOG_ERROR, "VOTER %i: Cannot alloc new Asterisk channel\n", p->nodenum);
 		ast_free(p);
 		return NULL;
@@ -3881,17 +3880,17 @@ static struct ast_channel *voter_request(const char *type, struct ast_format_cap
 	}
 	pvts = p;
 	ast_mutex_unlock(&voter_lock);
-	ast_channel_tech_set(astchanptr, &voter_tech);
-	ast_channel_set_rawwriteformat(astchanptr, ast_format_slin);
-	ast_channel_set_writeformat(astchanptr, ast_format_slin);
-	ast_channel_set_rawreadformat(astchanptr, ast_format_slin);
-	ast_channel_set_readformat(astchanptr, ast_format_slin);
-	ast_channel_nativeformats_set(astchanptr, voter_tech.capabilities);
-	ast_channel_tech_pvt_set(astchanptr, p);
-	ast_channel_unlock(astchanptr);
-	ast_channel_language_set(astchanptr, "");
-	p->owner = astchanptr;
-	p->u = ast_module_user_add(astchanptr);
+	ast_channel_tech_set(chan, &voter_tech);
+	ast_channel_set_rawwriteformat(chan, ast_format_slin);
+	ast_channel_set_writeformat(chan, ast_format_slin);
+	ast_channel_set_rawreadformat(chan, ast_format_slin);
+	ast_channel_set_readformat(chan, ast_format_slin);
+	ast_channel_nativeformats_set(chan, voter_tech.capabilities);
+	ast_channel_tech_pvt_set(chan, p);
+	ast_channel_unlock(chan);
+	ast_channel_language_set(chan, "");
+	p->owner = chan;
+	p->u = ast_module_user_add(chan);
 	/* Load the configuration for this node. Note that not all variables are loaded here,
 	 * some are loaded in the reload function, which is also executed on initial start.
 	 */
@@ -3955,7 +3954,7 @@ static struct ast_channel *voter_request(const char *type, struct ast_format_cap
 			}
 			j = finddelim(cp, strs, ARRAY_LEN(strs));
 			if (j < 2) {
-				ast_log(LOG_ERROR, "Channel %s: primary config not specified properly in %s\n", ast_channel_name(astchanptr), config);
+				ast_log(LOG_ERROR, "Channel %s: primary config not specified properly in %s\n", ast_channel_name(chan), config);
 			} else {
 				cp1 = strchr(strs[0], ':');
 				if (cp1) {
@@ -3963,8 +3962,7 @@ static struct ast_channel *voter_request(const char *type, struct ast_format_cap
 					j = atoi(cp1 + 1);
 				} else {
 					j = listen_port;
-					ast_log(LOG_NOTICE, "Channel %s: Primary UDP port not configured, using default port %i\n",
-						ast_channel_name(astchanptr), j);
+					ast_log(LOG_NOTICE, "Channel %s: Primary UDP port not configured, using default port %i\n", ast_channel_name(chan), j);
 				}
 				p->primary.sin_family = AF_INET;
 				p->primary.sin_addr.s_addr = inet_addr(strs[0]);
@@ -3976,8 +3974,7 @@ static struct ast_channel *voter_request(const char *type, struct ast_format_cap
 		val = ast_variable_retrieve(cfg, (char *) data, "isprimary");
 		if (val) {
 			p->isprimary = ast_true(val);
-			ast_log(LOG_NOTICE, "Channel %s: Found isprimary directive, this instance will be the primary server\n",
-				ast_channel_name(astchanptr));
+			ast_log(LOG_NOTICE, "Channel %s: Found isprimary directive, this instance will be the primary server\n", ast_channel_name(chan));
 		} else {
 			p->isprimary = 0;
 		}
@@ -4071,7 +4068,7 @@ static struct ast_channel *voter_request(const char *type, struct ast_format_cap
 	if (SEND_PRIMARY(p)) {
 		ast_pthread_create(&p->primary_thread, NULL, voter_primary_client, p);
 	}
-	return astchanptr;
+	return chan;
 }
 
 /*!

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -4075,6 +4075,35 @@ static struct ast_channel *voter_request(const char *type, struct ast_format_cap
 }
 
 /*!
+ * \brief Helper function to free memory allocations when clients are removed.
+ *
+ * \param client       Pointer to the voter_client structure to be freed.
+ */
+static void voter_client_free(struct voter_client *client)
+{
+	struct voter_client **target;
+
+	for (target = &clients; *target && *target != client; target = &(*target)->next) {
+		;
+	}
+	if (!*target) {
+		return;
+	}
+
+	*target = client->next;
+	if (client->audio) {
+		ast_free(client->audio);
+	}
+	if (client->rssi) {
+		ast_free(client->rssi);
+	}
+	if (client->gpsid) {
+		ast_free(client->gpsid);
+	}
+	ast_free(client);
+}
+
+/*!
  * \brief Reload VOTER driver configuration from disk and apply changes.
  *
  * Parses the configured voter.conf, updates per-instance (pvts) and per-client
@@ -4626,6 +4655,7 @@ static int reload(void)
 		if (client->digest == 0) {
 			ast_log(LOG_ERROR, "Can not load chan_voter -- VOTER client %s has invalid authentication digest (can not be 0)!!!\n",
 				client->name);
+			voter_client_free(client);
 			return AST_MODULE_LOAD_FAILURE;
 		}
 		for (client1 = clients; client1; client1 = client1->next) {
@@ -4638,6 +4668,8 @@ static int reload(void)
 			if (client->digest == client1->digest) {
 				ast_log(LOG_ERROR, "Can not load chan_voter -- VOTER clients %s and %s have same authentication digest!!!\n",
 					client->name, client1->name);
+				voter_client_free(client);
+				voter_client_free(client1);
 				return AST_MODULE_LOAD_FAILURE;
 			}
 		}
@@ -4650,15 +4682,7 @@ static int reload(void)
 		if (client->reload) {
 			continue;
 		}
-		if (client->audio) {
-			ast_free(client->audio);
-		}
-		if (client->rssi) {
-			ast_free(client->rssi);
-		}
-		if (client->gpsid) {
-			ast_free(client->gpsid);
-		}
+		voter_client_free(client);
 		for (client1 = clients; client1; client1 = client1->next) {
 			if (client1->next == client) {
 				ast_debug(1, "Checking if VOTER client %s should be removed from VOTER instance %i\n", client->name, client->nodenum);
@@ -4672,7 +4696,7 @@ static int reload(void)
 			clients = next;
 		}
 		ast_debug(1, "Removing outdated VOTER client %s from VOTER instance %i\n", client->name, client->nodenum);
-		ast_free(client);
+		voter_client_free(client);
 		/* Continue from saved next without dereferencing freed client */
 		client = next;
 	}
@@ -6760,12 +6784,8 @@ static int load_module(void)
 	ast_mutex_lock(&voter_lock);
 	if (reload()) {
 		ast_log(LOG_ERROR, "Failed to reload configuration\n");
-		ast_timer_close(voter_thread_timer);
-		voter_thread_timer = NULL;
-		close(udp_socket);
-		udp_socket = -1;
 		ast_mutex_unlock(&voter_lock);
-		return AST_MODULE_LOAD_DECLINE;
+		return AST_MODULE_LOAD_FAILURE;
 	}
 	ast_mutex_unlock(&voter_lock);
 
@@ -6805,9 +6825,11 @@ static int load_module(void)
  *
  * This function is called when the module is reloaded. It locks the voter_lock mutex,
  * calls the reload() function to reload the configuration, and unlocks the mutex.
- * If reload() fails, it logs an error and preserves the existing socket and running configuration.
+ * If reload() fails, it logs an error and returns AST_MODULE_LOAD_FAILURE back to Asterisk,
+ * otherwise, it returns AST_MODULE_LOAD_SUCCESS.
  *
- *	 \return 				0 on success; non-zero on failure (typically -1 if the configuration could not be reloaded).
+ *	 \return 			AST_MODULE_LOAD_SUCCESS (0) on success
+ *         				AST_MODULE_LOAD_FAILURE (-1) on failure if the configuration could not be reloaded
  */
 static int reload_module(void)
 {
@@ -6817,9 +6839,11 @@ static int reload_module(void)
 	res = reload();
 	if (res) {
 		ast_log(LOG_ERROR, "Failed to reload configuration\n");
+		ast_mutex_unlock(&voter_lock);
+		return AST_MODULE_LOAD_FAILURE;
 	}
 	ast_mutex_unlock(&voter_lock);
-	return res; /* Return the result of the reload operation back to Asterisk*/
+	return AST_MODULE_LOAD_SUCCESS;
 }
 
 AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_DEFAULT, "Voter Radio Channel Driver",

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -4329,7 +4329,6 @@ static int reload(void)
 		 */
 		if (strcmp(oldctcss, p->txctcssfreq) || (oldtoctype != p->txtoctype) || (oldlevel != p->txctcsslevel)) {
 			t_pmr_chan tChan;
-			
 			ast_debug(1, "VOTER %i: CTCSS frequency, level, or turn off code type changed, recreating PMR channel\n", p->nodenum);
 
 			if (p->pmrChan) {

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -4088,9 +4088,9 @@ static struct ast_channel *voter_request(const char *type, struct ast_format_cap
  * Also note that reload() is called with voter_lock locked, so client and instance
  * list traversal and modifications are safe.
  *
- * \retval  			0 Success — configuration loaded and applied.
- * \retval 				-1 Failure — configuration load or allocation error;
- *						existing state is left unchanged where possible.
+ * \retval  			AST_MODULE_LOAD_SUCCESS (0) — configuration loaded and applied.
+ * \retval 				AST_MODULE_LOAD_FAILURE (-1) — configuration, validation,
+ *						authentication, or allocation error.
  */
 static int reload(void)
 {
@@ -4115,7 +4115,7 @@ static int reload(void)
 	/* Attempt to load/reload voter.conf. */
 	if (!(cfg = ast_config_load(config, zeroflag))) {
 		ast_log(LOG_ERROR, "Unable to load/reload config %s\n", config);
-		return -1;
+		return AST_MODULE_LOAD_FAILURE;
 	} else {
 		ast_log(LOG_NOTICE, "Config load/reload from %s\n", config);
 	}
@@ -4449,7 +4449,7 @@ static int reload(void)
 			cp = ast_strdup(v->value);
 			if (!cp) {
 				ast_config_destroy(cfg);
-				return -1;
+				return AST_MODULE_LOAD_FAILURE;
 			}
 			n = finddelim(cp, strs, ARRAY_LEN(strs));
 			if (n < 1) {
@@ -4482,7 +4482,7 @@ static int reload(void)
 				if (!client) {
 					ast_free(cp);
 					ast_config_destroy(cfg);
-					return -1;
+					return AST_MODULE_LOAD_FAILURE;
 				}
 				ast_debug(1, "New VOTER client %s is being allocated space\n", v->name);
 				/* When initializing a client, set the CLI priority override to PRIO_DEFAULT (-2). */
@@ -4568,7 +4568,7 @@ static int reload(void)
 				client->audio = ast_realloc(client->audio, client->buflen);
 				if (!client->audio) {
 					ast_config_destroy(cfg);
-					return -1;
+					return AST_MODULE_LOAD_FAILURE;
 				}
 				/* Fill the new buffer with silence. */
 				memset(client->audio, ULAW_SILENCE, client->buflen);
@@ -4577,7 +4577,7 @@ static int reload(void)
 				client->audio = ast_malloc(client->buflen);
 				if (!client->audio) {
 					ast_config_destroy(cfg);
-					return -1;
+					return AST_MODULE_LOAD_FAILURE;
 				}
 				/* Fill the new buffer with silence. */
 				memset(client->audio, ULAW_SILENCE, client->buflen);
@@ -4587,7 +4587,7 @@ static int reload(void)
 				client->rssi = ast_realloc(client->rssi, client->buflen);
 				if (!client->rssi) {
 					ast_config_destroy(cfg);
-					return -1;
+					return AST_MODULE_LOAD_FAILURE;
 				}
 				/* Fill the new RSSI buffer with zeros. */
 				memset(client->rssi, 0, client->buflen);
@@ -4598,7 +4598,7 @@ static int reload(void)
 				client->rssi = ast_calloc(1, client->buflen);
 				if (!client->rssi) {
 					ast_config_destroy(cfg);
-					return -1;
+					return AST_MODULE_LOAD_FAILURE;
 				}
 			}
 			/* If this is a new client, add it into list. */
@@ -4626,7 +4626,7 @@ static int reload(void)
 		if (client->digest == 0) {
 			ast_log(LOG_ERROR, "Can not load chan_voter -- VOTER client %s has invalid authentication digest (can not be 0)!!!\n",
 				client->name);
-			return -1;
+			return AST_MODULE_LOAD_FAILURE;
 		}
 		for (client1 = clients; client1; client1 = client1->next) {
 			if (!client1->reload) {
@@ -4638,7 +4638,7 @@ static int reload(void)
 			if (client->digest == client1->digest) {
 				ast_log(LOG_ERROR, "Can not load chan_voter -- VOTER clients %s and %s have same authentication digest!!!\n",
 					client->name, client1->name);
-				return -1;
+				return AST_MODULE_LOAD_FAILURE;
 			}
 		}
 	}
@@ -4672,7 +4672,7 @@ static int reload(void)
 		ast_free(client);
 		client = clients;
 	}
-	return 0;
+	return AST_MODULE_LOAD_SUCCESS;
 }
 
 /*!
@@ -6655,9 +6655,9 @@ static int unload_module(void)
  * reader and timer threads, allocates channel format capabilities, and registers
  * the channel driver so the Voter channel becomes available to Asterisk.
  *
- * \return 				0 on success; non-zero on failure (typically AST_MODULE_LOAD_DECLINE for
- *         				module load errors, or
- *						1 if the configuration could not be loaded).
+ * \return 				AST_MODULE_LOAD_SUCCESS (0) on success
+ *         				AST_MODULE_LOAD_DECLINE (1) for module load errors, or if
+ *						the configuration could not be loaded).
  */
 static int load_module(void)
 {

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -4261,7 +4261,6 @@ static int reload(void)
 		/* Backup the old CTCSS frequency, so we can tell if it changed when
 		 * we read in the txctcss variable.
 		 */
-		oldctcss[0] = 0;
 		ast_copy_string(oldctcss, p->txctcssfreq, sizeof(oldctcss));
 		val = ast_variable_retrieve(cfg, (char *) data, "txctcss");
 		if (val) {
@@ -4373,19 +4372,15 @@ static int reload(void)
 	/* Reset the hasmaster and masterconnected flags, so they can be re-evaluated later. */
 	hasmaster = 0;
 	masterconnected = 0;
-	/* Reset the config file category pointer. */
-	ctg = NULL;
+
 	/* Passing ast_category_browse a second arg of NULL tells it to start from the
 	 * first category, and pass the current category on subsequent loop iterations.
 	 *
 	 * This is going to go through the instances again, this time looking for client
 	 * definitions, and loading them (and their options) into the clients list.
 	 */
+	ctg = NULL;
 	while ((ctg = ast_category_browse(cfg, ctg)) != NULL) {
-		/* If there are no more categories (instances), skip. */
-		if (ctg == NULL) {
-			continue;
-		}
 		/* If the category is [general], skip it. strcmp returns 0 on a match. */
 		if (!strcmp(ctg, "general")) {
 			continue;

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -4501,7 +4501,8 @@ static int reload(void)
 					ast_debug(1, "Existing client %s found, attached to VOTER instance %s\n", client->name, ctg);
 					/* If has moved to another instance, free this one, and treat as new. */
 					if (client->nodenum != strtoul(ctg, NULL, 0)) {
-						ast_debug(1, "Existing client %s has moved from VOTER instance %i to %s, freeing to treat as new\n", client->name, client->nodenum, ctg);
+						ast_debug(1, "Existing client %s has moved from VOTER instance %i to %s, freeing to treat as new\n",
+							client->name, client->nodenum, ctg);
 						client->reload = 0;
 						client = NULL;
 					}

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -4079,12 +4079,22 @@ static struct ast_channel *voter_request(const char *type, struct ast_format_cap
 static void voter_client_free(struct voter_client *client)
 {
 	struct voter_client **target;
+	struct voter_pvt *p;
 
 	for (target = &clients; *target && *target != client; target = &(*target)->next) {
 		;
 	}
 	if (!*target) {
 		return;
+	}
+
+	for (p = pvts; p; p = p->next) {
+		if (p->lastwon == client) {
+			p->lastwon = NULL;
+			p->threshold = 0;
+			p->threshcount = 0;
+			p->lingercount = 0;
+		}
 	}
 
 	*target = client->next;

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -4586,10 +4586,13 @@ static int reload(void)
 			client->digest = crc32_bufs(challenge, strs[0]);
 			ast_copy_string(client->pswd, strs[0], sizeof(client->pswd));
 			ast_free(cp);
-			/* Check to see if the buflen has changed. If it has, reset the drain index. */
+			/* Check to see if the buflen has changed. If it has, reset the drain index.
+			 * Note we have to divide by 8 to convert back from bytes to match what is in
+			 * voter.conf.
+			 */
 			if (client->old_buflen && (client->buflen != client->old_buflen)) {
 				ast_debug(1, "VOTER client %s buflen changed from %i to %i, resetting drain index\n", client->name,
-					client->old_buflen, client->buflen);
+					client->old_buflen / 8, client->buflen / 8);
 				client->drainindex = 0;
 			}
 			/* If the audio buffer exists and the buflen has changed, reallocate it. */

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -4074,6 +4074,9 @@ static struct ast_channel *voter_request(const char *type, struct ast_format_cap
 /*!
  * \brief Helper function to free memory allocations when clients are removed.
  *
+ * Must be called with voter_lock locked, as it modifies the global clients list
+ * and per-instance state.
+ *
  * \param client       Pointer to the voter_client structure to be freed.
  */
 static void voter_client_free(struct voter_client *client)
@@ -4116,7 +4119,29 @@ static void voter_client_free(struct voter_client *client)
 	if (client->gpsid) {
 		ast_free(client->gpsid);
 	}
+	ast_debug(1, "Freeing client %s from the client list\n", client->name);
 	ast_free(client);
+}
+
+/*!
+ * \brief Helper function to free memory allocations of all clients in the
+ * client list when called.
+ *
+ * Must be called with voter_lock locked, as it modifies the global clients list.
+ *
+ */
+
+static void voter_client_free_all(void)
+{
+	struct voter_client *client, *next;
+
+	ast_debug(1, "Freeing all clients in the client list\n");
+	/* Traverse the client list, freeing each client and its associated memory. */
+	for (client = clients; client; client = next) {
+		next = client->next;
+		voter_client_free(client);
+	}
+	clients = NULL;
 }
 
 /*!
@@ -4141,6 +4166,7 @@ static int reload(void)
 {
 	struct ast_flags zeroflag = { 0 };
 	int i, n, instance_buflen, buflen, oldtoctype, oldlevel;
+	uint8_t *tempbuf;
 	char *ctg, *cp, *cp1, *cp2, *strs[40], newclient, data[100], oldctcss[100];
 	const char *val;
 	struct voter_pvt *p;
@@ -4493,6 +4519,7 @@ static int reload(void)
 			cp = ast_strdup(v->value);
 			if (!cp) {
 				ast_config_destroy(cfg);
+				voter_client_free_all();
 				return AST_MODULE_LOAD_FAILURE;
 			}
 			n = finddelim(cp, strs, ARRAY_LEN(strs));
@@ -4527,6 +4554,7 @@ static int reload(void)
 				if (!client) {
 					ast_free(cp);
 					ast_config_destroy(cfg);
+					voter_client_free_all();
 					return AST_MODULE_LOAD_FAILURE;
 				}
 				ast_debug(1, "New VOTER client %s is being allocated space\n", v->name);
@@ -4615,13 +4643,19 @@ static int reload(void)
 					client->old_buflen / 8, client->buflen / 8);
 				client->drainindex = 0;
 			}
-			/* If the audio buffer exists and the buflen has changed, reallocate it. */
+			/* If the audio buffer exists and the buflen has changed, reallocate it.
+			 * We use a temporary buffer for the reallocation to preserve the original buffer
+			 * if re-allocation fails (which would return a null pointer, while leaving the
+			 * original buffer intact).
+			 */
 			if (client->audio && client->old_buflen && (client->buflen != client->old_buflen)) {
-				client->audio = ast_realloc(client->audio, client->buflen);
-				if (!client->audio) {
+				tempbuf = ast_realloc(client->audio, client->buflen);
+				if (!tempbuf) {
 					ast_config_destroy(cfg);
+					voter_client_free_all();
 					return AST_MODULE_LOAD_FAILURE;
 				}
+				client->audio = tempbuf;
 				/* Fill the new buffer with silence. */
 				memset(client->audio, ULAW_SILENCE, client->buflen);
 				/* If the audio buffer doesn't exist, allocate it. */
@@ -4629,18 +4663,31 @@ static int reload(void)
 				client->audio = ast_malloc(client->buflen);
 				if (!client->audio) {
 					ast_config_destroy(cfg);
+					/* If we fail to allocate the audio buffer, free the new client,
+					 * since it doesn't exist in the clients list, yet. Then free all
+					 * other clients */
+					if (newclient) {
+						voter_client_free(client);
+					}
+					voter_client_free_all();
 					return AST_MODULE_LOAD_FAILURE;
 				}
 				/* Fill the new buffer with silence. */
 				memset(client->audio, ULAW_SILENCE, client->buflen);
 			}
-			/* If the RSSI buffer exists and the buflen has changed, reallocate it. */
+			/* If the RSSI buffer exists and the buflen has changed, reallocate it.
+			 * We use a temporary buffer for the reallocation to preserve the original buffer
+			 * if re-allocation fails (which would return a null pointer, while leaving the
+			 * original buffer intact).
+			 */
 			if (client->rssi && client->old_buflen && (client->buflen != client->old_buflen)) {
-				client->rssi = ast_realloc(client->rssi, client->buflen);
-				if (!client->rssi) {
+				tempbuf = ast_realloc(client->rssi, client->buflen);
+				if (!tempbuf) {
 					ast_config_destroy(cfg);
+					voter_client_free_all();
 					return AST_MODULE_LOAD_FAILURE;
 				}
+				client->rssi = tempbuf;
 				/* Fill the new RSSI buffer with zeros. */
 				memset(client->rssi, 0, client->buflen);
 				/* If the RSSI buffer doesn't exist, allocate it. Note that ast_calloc will
@@ -4650,6 +4697,13 @@ static int reload(void)
 				client->rssi = ast_calloc(1, client->buflen);
 				if (!client->rssi) {
 					ast_config_destroy(cfg);
+					/* If we fail to allocate the RSSI buffer, free the new client,
+					 * since it doesn't exist in the clients list, yet. Then free all
+					 * other clients */
+					if (newclient) {
+						voter_client_free(client);
+					}
+					voter_client_free_all();
 					return AST_MODULE_LOAD_FAILURE;
 				}
 			}
@@ -4678,7 +4732,8 @@ static int reload(void)
 		if (client->digest == 0) {
 			ast_log(LOG_ERROR, "Can not load chan_voter -- VOTER client %s has invalid authentication digest (can not be 0)!!!\n",
 				client->name);
-			voter_client_free(client);
+			// voter_client_free(client);
+			voter_client_free_all();
 			return AST_MODULE_LOAD_FAILURE;
 		}
 		for (client1 = clients; client1; client1 = client1->next) {
@@ -4691,8 +4746,9 @@ static int reload(void)
 			if (client->digest == client1->digest) {
 				ast_log(LOG_ERROR, "Can not load chan_voter -- VOTER clients %s and %s have same authentication digest!!!\n",
 					client->name, client1->name);
-				voter_client_free(client);
-				voter_client_free(client1);
+				// voter_client_free(client);
+				// voter_client_free(client1);
+				voter_client_free_all();
 				return AST_MODULE_LOAD_FAILURE;
 			}
 		}

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -4645,6 +4645,8 @@ static int reload(void)
 	/* Remove all the clients that are no longer in the config and free their memory. */
 	ast_debug(1, "Removing outdated VOTER clients (moved or removed)\n");
 	for (client = clients; client; client = client->next) {
+		/* Save client->next before unlinking so iteration can continue safely */
+		struct voter_client *next = client->next;
 		if (client->reload) {
 			continue;
 		}
@@ -4664,13 +4666,15 @@ static int reload(void)
 			}
 		}
 		if (client1) {
-			client1->next = client->next;
+			client1->next = next;
 		} else {
-			clients = NULL;
+			/* Removed head; set list head to saved next */
+			clients = next;
 		}
 		ast_debug(1, "Removing outdated VOTER client %s from VOTER instance %i\n", client->name, client->nodenum);
 		ast_free(client);
-		client = clients;
+		/* Continue from saved next without dereferencing freed client */
+		client = next;
 	}
 	return AST_MODULE_LOAD_SUCCESS;
 }

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -4695,28 +4695,12 @@ static int reload(void)
 	}
 	/* Remove all the clients that are no longer in the config and free their memory. */
 	ast_debug(1, "Removing outdated VOTER clients (moved or removed)\n");
-	for (client = clients; client; client = client->next) {
-		/* Save client->next before unlinking so iteration can continue safely */
+	for (client = clients; client;) {
 		struct voter_client *next = client->next;
-		if (client->reload) {
-			continue;
+		if (!client->reload) {
+			ast_debug(1, "Removing outdated VOTER client %s from VOTER instance %i\n", client->name, client->nodenum);
+			voter_client_free(client);
 		}
-		voter_client_free(client);
-		for (client1 = clients; client1; client1 = client1->next) {
-			if (client1->next == client) {
-				ast_debug(1, "Checking if VOTER client %s should be removed from VOTER instance %i\n", client->name, client->nodenum);
-				break;
-			}
-		}
-		if (client1) {
-			client1->next = next;
-		} else {
-			/* Removed head; set list head to saved next */
-			clients = next;
-		}
-		ast_debug(1, "Removing outdated VOTER client %s from VOTER instance %i\n", client->name, client->nodenum);
-		voter_client_free(client);
-		/* Continue from saved next without dereferencing freed client */
 		client = next;
 	}
 	return AST_MODULE_LOAD_SUCCESS;

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -1444,10 +1444,10 @@ static int rad_rxwait(int fd, int ms)
 {
 	struct pollfd fds[1];
 	int res, timeout;
-	fds[0].fd = fd;			// Asterisk CLI file descriptor
-	fds[0].events = POLLIN; // Monitor for incoming data
+	fds[0].fd = fd;			/* Asterisk CLI file descriptor */
+	fds[0].events = POLLIN; /* Monitor for incoming data */
 
-	timeout = ms; // Timeout in milliseconds
+	timeout = ms; /* Timeout in milliseconds */
 
 	/* Poll the fd. Wait for a keypress to exit. */
 	res = ast_poll(fds, 1, timeout);
@@ -4594,7 +4594,7 @@ static int reload(void)
 				} else if (!strcasecmp(strs[i], "master")) {
 					client->ismaster = 1;
 					hasmaster = 1;
-					client->mix = 0; // Reset the mix flag if the config changed to now be a voting client
+					client->mix = 0; /* Reset the mix flag if the config changed to now be a voting client */
 				} else if (!strcasecmp(strs[i], "adpcm")) {
 					client->doadpcm = 1;
 				} else if (!strcasecmp(strs[i], "nodeemp")) {
@@ -4732,7 +4732,6 @@ static int reload(void)
 		if (client->digest == 0) {
 			ast_log(LOG_ERROR, "Can not load chan_voter -- VOTER client %s has invalid authentication digest (can not be 0)!!!\n",
 				client->name);
-			// voter_client_free(client);
 			voter_client_free_all();
 			return AST_MODULE_LOAD_FAILURE;
 		}
@@ -4746,8 +4745,6 @@ static int reload(void)
 			if (client->digest == client1->digest) {
 				ast_log(LOG_ERROR, "Can not load chan_voter -- VOTER clients %s and %s have same authentication digest!!!\n",
 					client->name, client1->name);
-				// voter_client_free(client);
-				// voter_client_free(client1);
 				voter_client_free_all();
 				return AST_MODULE_LOAD_FAILURE;
 			}

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -4078,16 +4078,25 @@ static struct ast_channel *voter_request(const char *type, struct ast_format_cap
  */
 static void voter_client_free(struct voter_client *client)
 {
-	struct voter_client **target;
+	struct voter_client *prev;
 	struct voter_pvt *p;
 
-	for (target = &clients; *target && *target != client; target = &(*target)->next) {
-		;
-	}
-	if (!*target) {
-		return;
+	if (client == clients) {
+		/* If we are removing the client at the start of the list */
+		clients = client->next;
+	} else {
+		for (prev = clients; prev; prev = prev->next) {
+			if (prev->next == client) {
+				/* Remove the client from the middle of the list */
+				prev->next = client->next;
+				break;
+			}
+		}
 	}
 
+	/* Reset some variables in the instance that the client we are removing
+	 * was attached to, to prevent stale data.
+	 */
 	for (p = pvts; p; p = p->next) {
 		if (p->lastwon == client) {
 			p->lastwon = NULL;
@@ -4097,7 +4106,7 @@ static void voter_client_free(struct voter_client *client)
 		}
 	}
 
-	*target = client->next;
+	/* Free the client's audio, RSSI, and GPS ID buffers. */
 	if (client->audio) {
 		ast_free(client->audio);
 	}

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -4127,6 +4127,7 @@ static int reload(void)
 	 * in the load_module() function, and are immutable after the module
 	 * is loaded.
 	 */
+	ast_debug(1, "Loading [general] options from voter.conf\n");
 	val = ast_variable_retrieve(cfg, "general", "password");
 	if (val) {
 		ast_copy_string(password, val, sizeof(password));
@@ -4168,10 +4169,8 @@ static int reload(void)
 	 * linger, plfilter, hostdeemp, mixminus, streams, txctcss, txctcsslevel,
 	 * txtoctype, thresholds, gtxgain
 	 */
+	ast_debug(1, "Loading per-instance options for each VOTER instance from voter.conf\n");
 	for (p = pvts; p; p = p->next) {
-		/* Reset dmwdiag to disabled for the instance upon reload. */
-		p->dmwdiag = 0;
-
 		/* The name of the instance must be the channel node number,
 		 * use that as the key to look up the instance in the config.
 		 * If we can't find the instance in the config, skip.
@@ -4182,6 +4181,9 @@ static int reload(void)
 		if (ast_variable_browse(cfg, data) == NULL) {
 			continue;
 		}
+		ast_debug(1, "Loading instance options for VOTER instance %i\n", p->nodenum);
+		/* Reset dmwdiag to disabled for the instance upon reload. */
+		p->dmwdiag = 0;
 		/* Load the linger value, or set it to default if it is unset. */
 		val = ast_variable_retrieve(cfg, (char *) data, "linger");
 		if (val) {
@@ -4297,6 +4299,7 @@ static int reload(void)
 		 * we need to recreate the PMR channel.
 		 */
 		if (strcmp(oldctcss, p->txctcssfreq) || (oldtoctype != p->txtoctype) || (oldlevel != p->txctcsslevel)) {
+			ast_debug(1, "VOTER %i: CTCSS frequency, level, or turn off code type changed, recreating PMR channel\n", p->nodenum);
 			t_pmr_chan tChan;
 
 			if (p->pmrChan) {
@@ -4462,8 +4465,10 @@ static int reload(void)
 				 * treat it as a new client.
 				 */
 				if (client->digest == crc32_bufs(challenge, strs[0])) {
+					ast_debug(1, "Existing client %s found, attached to VOTER instance %s\n", client->name, ctg);
 					/* If has moved to another instance, free this one, and treat as new. */
 					if (client->nodenum != strtoul(ctg, NULL, 0)) {
+						ast_debug(1, "Existing client %s has moved from VOTER instance %i to %s, freeing to treat as new\n", client->name, client->nodenum, ctg);
 						client->reload = 0;
 						client = NULL;
 					}
@@ -4479,6 +4484,7 @@ static int reload(void)
 					ast_config_destroy(cfg);
 					return -1;
 				}
+				ast_debug(1, "New VOTER client %s is being allocated space\n", v->name);
 				/* When initializing a client, set the CLI priority override to PRIO_DEFAULT (-2). */
 				client->prio_override = PRIO_DEFAULT;
 				/* This is a new client, so v->name is the client name, copy that into client->name. */
@@ -4490,6 +4496,7 @@ static int reload(void)
 			client->reload = 1;
 			client->buflen = instance_buflen;
 			client->nodenum = strtoul(ctg, NULL, 0); /* The category name is the node number */
+			/* Reset the per-client variables. */
 			client->totransmit = 0;
 			client->doadpcm = 0;
 			client->nodeemp = 0;
@@ -4501,6 +4508,7 @@ static int reload(void)
 			/* n from above was the number of strings (variables) we parsed out of the client options.
 			 * Now, we will iterate through them all, and set the corresponding client array variables.
 			 */
+			ast_debug(1, "Loading options for VOTER client %s, %i options found\n", client->name, n);
 			for (i = 1; i < n; i++) {
 				if (!strcasecmp(strs[i], "transmit")) {
 					client->totransmit = 1;
@@ -4551,6 +4559,8 @@ static int reload(void)
 			ast_free(cp);
 			/* Check to see if the buflen has changed. If it has, reset the drain index. */
 			if (client->old_buflen && (client->buflen != client->old_buflen)) {
+				ast_debug(1, "VOTER client %s buflen changed from %i to %i, resetting drain index\n", client->name,
+					client->old_buflen, client->buflen);
 				client->drainindex = 0;
 			}
 			/* If the audio buffer exists and the buflen has changed, reallocate it. */
@@ -4593,6 +4603,7 @@ static int reload(void)
 			}
 			/* If this is a new client, add it into list. */
 			if (newclient) {
+				ast_debug(1, "Adding new VOTER client %s to client list\n", client->name);
 				if (clients == NULL) {
 					clients = client;
 				} else {
@@ -4607,6 +4618,7 @@ static int reload(void)
 	}
 	ast_config_destroy(cfg);
 	/* Traverse the client list and perform validation checks. */
+	ast_debug(1, "Performing validation checks on VOTER clients\n");
 	for (client = clients; client; client = client->next) {
 		if (!client->reload) {
 			continue;
@@ -4631,6 +4643,7 @@ static int reload(void)
 		}
 	}
 	/* Remove all the clients that are no longer in the config and free their memory. */
+	ast_debug(1, "Removing outdated VOTER clients (moved or removed)\n");
 	for (client = clients; client; client = client->next) {
 		if (client->reload) {
 			continue;
@@ -4646,6 +4659,7 @@ static int reload(void)
 		}
 		for (client1 = clients; client1; client1 = client1->next) {
 			if (client1->next == client) {
+				ast_debug(1, "Checking if VOTER client %s should be removed from VOTER instance %i\n", client->name, client->nodenum);
 				break;
 			}
 		}
@@ -4654,6 +4668,7 @@ static int reload(void)
 		} else {
 			clients = NULL;
 		}
+		ast_debug(1, "Removing outdated VOTER client %s from VOTER instance %i\n", client->name, client->nodenum);
 		ast_free(client);
 		client = clients;
 	}

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -4383,17 +4383,21 @@ static int reload(void)
 		if (!strcmp(ctg, "general")) {
 			continue;
 		}
-		/*! \todo VE7FET Shouldn't the instance buflen be loaded above with the other
-		 * instance options?  It is not a client option, it is an instance option.
+		/* This loads the buflen for the instance. This is here on purpose, and not
+		 * loaded above with the rest of the instance variables so that we can apply
+		 * it to all the clients associated with the instance. If we load it above,
+		 * the value gets overwritten on every loop iteration, and could also result
+		 * in an undefined value being set.
 		 */
-		/* This loads the buflen for the instance. */
 		val = ast_variable_retrieve(cfg, ctg, "buflen");
 		if (val) {
+			/* Multiply by 8 to convert from frames to bytes. */
 			instance_buflen = strtoul(val, NULL, 0) * 8;
 		} else {
-			ast_debug(1, "Per-instance buflen not specified, using global buflen\n");
+			ast_debug(1, "Per-instance buflen not specified, using global buflen for instance %s\n", ctg);
 			instance_buflen = buflen;
 		}
+		/* Ensure buflen is at least 320 (voter.conf buflen = 40), or two "frames" of ulaw audio.*/
 		if (instance_buflen < (FRAME_SIZE * 2)) {
 			instance_buflen = FRAME_SIZE * 2;
 		}
@@ -4523,8 +4527,14 @@ static int reload(void)
 			}
 			/* Reset a number of variables, so they can be reloaded. */
 			client->reload = 1;
+			/* Assign the instance buflen to each client associated to the instance. If
+			 * a per-instance buflen wasn't specified, the global one gets used.
+			 */
 			client->buflen = instance_buflen;
-			client->nodenum = strtoul(ctg, NULL, 0); /* The category name is the node number */
+			/* This effectively turns buflen into 40ms resolution "steps". */
+			client->buflen -= client->buflen % (FRAME_SIZE * 2);
+			/* The category name is the node number, assign the client to the correct node. */
+			client->nodenum = strtoul(ctg, NULL, 0);
 			/* Reset the per-client variables. */
 			client->totransmit = 0;
 			client->doadpcm = 0;
@@ -4577,8 +4587,6 @@ static int reload(void)
 					}
 				}
 			}
-			/* This effectively turns buflen into 40ms resolution "steps". */
-			client->buflen -= client->buflen % (FRAME_SIZE * 2);
 			/* Remember, the first element in the strs array is the client secret. Use
 			 * that to create a unique digest for the client, and store it in the client
 			 * array. Also, copy the client secret into the client->pswd.

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -352,7 +352,7 @@ struct ast_flags zeroflag = { 0 };
 #define VOTER_NAME_LEN 50
 char challenge[VOTER_CHALLENGE_LEN];
 char password[VOTER_PASSWORD_LEN];
-char context[100];
+static char context[AST_MAX_EXTENSION] = "default";
 
 /* Timeout definitions in ms */
 #define RX_TIMEOUT_MS 200
@@ -3788,7 +3788,7 @@ static struct ast_channel *voter_request(const char *type, struct ast_format_cap
 {
 	int i, j;
 	struct voter_pvt *p, *p1;
-	struct ast_channel *tmp = NULL;
+	struct ast_channel *astchanptr = NULL;
 	char *cp, *cp1, *cp2, *strs[MAXTHRESHOLDS], *ctg;
 	const char *val;
 	struct ast_config *cfg = NULL;
@@ -3851,8 +3851,24 @@ static struct ast_channel *voter_request(const char *type, struct ast_format_cap
 		ast_free(p);
 		return NULL;
 	}
-	tmp = ast_channel_alloc(1, AST_STATE_DOWN, 0, 0, "", (char *) data, context, assignedids, requestor, 0, "voter/%s", (char *) data);
-	if (!tmp) {
+	/* Allocate a new Asterisk channel for this voter instance and get the assigned pointer. The channel request
+	 * we send includes the following:
+	 * needqueue: 1
+	 * (initial) state: AST_STATE_DOWN
+	 * CID number: 0
+	 * CID name: 0
+	 * acctcode: ""
+	 * extension: (starting extension) node identifier string (aka node number)
+	 * context: (starting context in extensions.conf) (defaults to unset)
+	 * assignedids: assignedids
+	 * requestor: requestor
+	 * amaflag: 0 (unset/default)
+	 * endpoint: channel prefix "voter/%s" (where %s is the node number)
+	 * __FILE__: source file name (set to to the node identifier string, aka node number, for debugging)
+	 */
+	astchanptr =
+		ast_channel_alloc(1, AST_STATE_DOWN, 0, 0, "", (char *) data, context, assignedids, requestor, 0, "voter/%s", (char *) data);
+	if (!astchanptr) {
 		ast_log(LOG_ERROR, "VOTER %i: Cannot alloc new Asterisk channel\n", p->nodenum);
 		ast_free(p);
 		return NULL;
@@ -3865,17 +3881,17 @@ static struct ast_channel *voter_request(const char *type, struct ast_format_cap
 	}
 	pvts = p;
 	ast_mutex_unlock(&voter_lock);
-	ast_channel_tech_set(tmp, &voter_tech);
-	ast_channel_set_rawwriteformat(tmp, ast_format_slin);
-	ast_channel_set_writeformat(tmp, ast_format_slin);
-	ast_channel_set_rawreadformat(tmp, ast_format_slin);
-	ast_channel_set_readformat(tmp, ast_format_slin);
-	ast_channel_nativeformats_set(tmp, voter_tech.capabilities);
-	ast_channel_tech_pvt_set(tmp, p);
-	ast_channel_unlock(tmp);
-	ast_channel_language_set(tmp, "");
-	p->owner = tmp;
-	p->u = ast_module_user_add(tmp);
+	ast_channel_tech_set(astchanptr, &voter_tech);
+	ast_channel_set_rawwriteformat(astchanptr, ast_format_slin);
+	ast_channel_set_writeformat(astchanptr, ast_format_slin);
+	ast_channel_set_rawreadformat(astchanptr, ast_format_slin);
+	ast_channel_set_readformat(astchanptr, ast_format_slin);
+	ast_channel_nativeformats_set(astchanptr, voter_tech.capabilities);
+	ast_channel_tech_pvt_set(astchanptr, p);
+	ast_channel_unlock(astchanptr);
+	ast_channel_language_set(astchanptr, "");
+	p->owner = astchanptr;
+	p->u = ast_module_user_add(astchanptr);
 	/* Load the configuration for this node. Note that not all variables are loaded here,
 	 * some are loaded in the reload function, which is also executed on initial start.
 	 */
@@ -3939,7 +3955,7 @@ static struct ast_channel *voter_request(const char *type, struct ast_format_cap
 			}
 			j = finddelim(cp, strs, ARRAY_LEN(strs));
 			if (j < 2) {
-				ast_log(LOG_ERROR, "Channel %s: primary config not specified properly in %s\n", ast_channel_name(tmp), config);
+				ast_log(LOG_ERROR, "Channel %s: primary config not specified properly in %s\n", ast_channel_name(astchanptr), config);
 			} else {
 				cp1 = strchr(strs[0], ':');
 				if (cp1) {
@@ -3947,7 +3963,8 @@ static struct ast_channel *voter_request(const char *type, struct ast_format_cap
 					j = atoi(cp1 + 1);
 				} else {
 					j = listen_port;
-					ast_log(LOG_NOTICE, "Channel %s: Primary UDP port not configured, using default port %i\n", ast_channel_name(tmp), j);
+					ast_log(LOG_NOTICE, "Channel %s: Primary UDP port not configured, using default port %i\n",
+						ast_channel_name(astchanptr), j);
 				}
 				p->primary.sin_family = AF_INET;
 				p->primary.sin_addr.s_addr = inet_addr(strs[0]);
@@ -3959,7 +3976,8 @@ static struct ast_channel *voter_request(const char *type, struct ast_format_cap
 		val = ast_variable_retrieve(cfg, (char *) data, "isprimary");
 		if (val) {
 			p->isprimary = ast_true(val);
-			ast_log(LOG_NOTICE, "Channel %s: Found isprimary directive, this instance will be the primary server\n", ast_channel_name(tmp));
+			ast_log(LOG_NOTICE, "Channel %s: Found isprimary directive, this instance will be the primary server\n",
+				ast_channel_name(astchanptr));
 		} else {
 			p->isprimary = 0;
 		}
@@ -4053,7 +4071,7 @@ static struct ast_channel *voter_request(const char *type, struct ast_format_cap
 	if (SEND_PRIMARY(p)) {
 		ast_pthread_create(&p->primary_thread, NULL, voter_primary_client, p);
 	}
-	return tmp;
+	return astchanptr;
 }
 
 /*!
@@ -4066,6 +4084,9 @@ static struct ast_channel *voter_request(const char *type, struct ast_format_cap
  *
  * Note that on initial start, load_module runs this one time, before voter_request
  * loads the rest of the config file.
+ *
+ * Also note that reload() is called with voter_lock locked, so client and instance
+ * list traversal and modifications are safe.
  *
  * \retval  			0 Success — configuration loaded and applied.
  * \retval 				-1 Failure — configuration load or allocation error;
@@ -4082,11 +4103,16 @@ static int reload(void)
 	struct ast_config *cfg = NULL;
 	struct ast_variable *v;
 
+	/* Traverse the client list, resetting client->reload to 0 for each of them,
+	 * and copying the current client->buflen to client->old_buflen, so we can
+	 * detect changes in buffer length.
+	 */
 	for (client = clients; client; client = client->next) {
 		client->reload = 0;
 		client->old_buflen = client->buflen;
 	}
 
+	/* Attempt to load/reload voter.conf. */
 	if (!(cfg = ast_config_load(config, zeroflag))) {
 		ast_log(LOG_ERROR, "Unable to load/reload config %s\n", config);
 		return -1;
@@ -4094,6 +4120,13 @@ static int reload(void)
 		ast_log(LOG_NOTICE, "Config load/reload from %s\n", config);
 	}
 
+	/* We only load/reload the following [general] options in this function:
+	 * password, buflen, sanity, puckit
+	 *
+	 * The other [general] options, bindaddr, port, and utos are loaded
+	 * in the load_module() function, and are immutable after the module
+	 * is loaded.
+	 */
 	val = ast_variable_retrieve(cfg, "general", "password");
 	if (val) {
 		ast_copy_string(password, val, sizeof(password));
@@ -4101,12 +4134,6 @@ static int reload(void)
 		password[0] = 0;
 	}
 
-	val = ast_variable_retrieve(cfg, "general", "context");
-	if (val) {
-		ast_copy_string(context, val, sizeof(context));
-	} else {
-		context[0] = 0;
-	}
 	/* We read in buflen from the config file, and * 8 to convert it to bytes. See the
 	 * notes at the top of the source for more information on how/why buflen relates to time.
 	 */
@@ -4136,15 +4163,26 @@ static int reload(void)
 		puckit = 0;
 	}
 
+	/* Load/reload the following options that are associated with each defined
+	 * VOTER instance from voter.conf:
+	 * linger, plfilter, hostdeemp, mixminus, streams, txctcss, txctcsslevel,
+	 * txtoctype, thresholds, gtxgain
+	 */
 	for (p = pvts; p; p = p->next) {
-		/* Reset dmwdiag to disabled upon reload */
+		/* Reset dmwdiag to disabled for the instance upon reload. */
 		p->dmwdiag = 0;
-		oldctcss[0] = 0;
-		ast_copy_string(oldctcss, p->txctcssfreq, sizeof(oldctcss));
+
+		/* The name of the instance must be the channel node number,
+		 * use that as the key to look up the instance in the config.
+		 * If we can't find the instance in the config, skip.
+		 * This will load the node number into the "config group", so
+		 * we can load the instance-specific variables from the config group.
+		 */
 		snprintf(data, sizeof(data), "%d", p->nodenum);
 		if (ast_variable_browse(cfg, data) == NULL) {
 			continue;
 		}
+		/* Load the linger value, or set it to default if it is unset. */
 		val = ast_variable_retrieve(cfg, (char *) data, "linger");
 		if (val) {
 			p->linger = atoi(val);
@@ -4152,18 +4190,21 @@ static int reload(void)
 			ast_debug(1, "linger not specified, using default linger = %i\n", DEFAULT_LINGER);
 			p->linger = DEFAULT_LINGER;
 		}
+		/* Check if the plfilter is to be enabled, it is disabled by default. */
 		val = ast_variable_retrieve(cfg, (char *) data, "plfilter");
 		if (val) {
 			p->plfilter = ast_true(val);
 		} else {
 			p->plfilter = 0;
 		}
+		/* Check if hostdeemp is to be enabled, it is disabled by default. */
 		val = ast_variable_retrieve(cfg, (char *) data, "hostdeemp");
 		if (val) {
 			p->hostdeemp = ast_true(val);
 		} else {
 			p->hostdeemp = 0;
 		}
+		/* Check if mixminus is to be enabled, it is disabled by default. */
 		val = ast_variable_retrieve(cfg, (char *) data, "mixminus");
 		if (val) {
 			p->mixminus = ast_true(val);
@@ -4179,13 +4220,24 @@ static int reload(void)
 			cp = ast_strdup(val);
 			p->nstreams = finddelim(cp, p->streams, ARRAY_LEN(p->streams));
 		}
+		/* Backup the old CTCSS frequency, so we can tell if it changed when
+		 * we read in the txctcss variable.
+		 */
+		oldctcss[0] = 0;
+		ast_copy_string(oldctcss, p->txctcssfreq, sizeof(oldctcss));
 		val = ast_variable_retrieve(cfg, (char *) data, "txctcss");
 		if (val) {
 			ast_copy_string(p->txctcssfreq, val, sizeof(p->txctcssfreq));
 		} else {
 			p->txctcssfreq[0] = 0;
 		}
+		/* Backup the old CTCSS level, so we can tell if it changed when
+		 * we read in the txctcsslevel variable.
+		 */
 		oldlevel = p->txctcsslevel;
+		/* Load the txctcsslevel value, or set it to a default level of 62.
+		 * Why 62?
+		 */
 		val = ast_variable_retrieve(cfg, (char *) data, "txctcsslevel");
 		if (val) {
 			p->txctcsslevel = atoi(val);
@@ -4193,7 +4245,13 @@ static int reload(void)
 			p->txctcsslevel = 62;
 		}
 		p->txctcsslevelset = p->txctcsslevel;
+		/* Backup the old CTCSS turn off code type, so we can tell if it changed when
+		 * we read in the txtoctype variable.
+		 */
 		oldtoctype = p->txtoctype;
+		/* Set the default CTCSS turn off code type to NONE, and overwrite it
+		 * with PHASE or NOTONE, if either of the respective options are set.
+		 */
 		p->txtoctype = TOC_NONE;
 		val = ast_variable_retrieve(cfg, (char *) data, "txtoctype");
 		if (val) {
@@ -4203,6 +4261,7 @@ static int reload(void)
 				p->txtoctype = TOC_NOTONE;
 			}
 		}
+		/* Reset thresholds to 0 before we read in and parse any thresholds values. */
 		p->nthresholds = 0;
 		val = ast_variable_retrieve(cfg, (char *) data, "thresholds");
 		if (val) {
@@ -4228,12 +4287,15 @@ static int reload(void)
 			}
 			ast_free(cp);
 		}
+		/* Load the gtxgain value, or set it to a default if it is unset. */
 		val = ast_variable_retrieve(cfg, (char *) data, "gtxgain");
 		if (!val) {
 			val = DEFAULT_GTXGAIN;
 		}
 		p->gtxgain = pow(10.0, atof(val) / 20.0);
-		/* If new CTCSS frequency */
+		/* If new CTCSS frequency, CTCSS turn off code, or CTCSS level were specified,
+		 * we need to recreate the PMR channel.
+		 */
 		if (strcmp(oldctcss, p->txctcssfreq) || (oldtoctype != p->txtoctype) || (oldlevel != p->txctcsslevel)) {
 			t_pmr_chan tChan;
 
@@ -4269,16 +4331,30 @@ static int reload(void)
 			}
 		}
 	}
+	/* Reset the hasmaster and masterconnected flags, so they can be re-evaluated later. */
 	hasmaster = 0;
 	masterconnected = 0;
+	/* Reset the config file category pointer. */
 	ctg = NULL;
+	/* Passing ast_category_browse a second arg of NULL tells it to start from the
+	 * first category, and pass the current category on subsequent loop iterations.
+	 *
+	 * This is going to go through the instances again, this time looking for client
+	 * definitions, and loading them (and their options) into the clients list.
+	 */
 	while ((ctg = ast_category_browse(cfg, ctg)) != NULL) {
+		/* If there are no more categories (instances), skip. */
 		if (ctg == NULL) {
 			continue;
 		}
+		/* If the category is [general], skip it. strcmp returns 0 on a match. */
 		if (!strcmp(ctg, "general")) {
 			continue;
 		}
+		/*! \todo VE7FET Shouldn't the instance buflen be loaded above with the other
+		 * instance options?  It is not a client option, it is an instance option.
+		 */
+		/* This loads the buflen for the instance. */
 		val = ast_variable_retrieve(cfg, ctg, "buflen");
 		if (val) {
 			instance_buflen = strtoul(val, NULL, 0) * 8;
@@ -4289,7 +4365,13 @@ static int reload(void)
 		if (instance_buflen < (FRAME_SIZE * 2)) {
 			instance_buflen = FRAME_SIZE * 2;
 		}
+		/* Load all the variables for the instance, and iterate on them. */
 		for (v = ast_variable_browse(cfg, ctg); v; v = v->next) {
+			/* Now things get fun... we are going to skip every time we find
+			 * any valid instance or client variable name. In the end, this should
+			 * leave us with something that isn't a client or instance variable,
+			 * which would be the client name (since it can be "anything").
+			 */
 			if (!strcmp(v->name, "txctcsslevel")) {
 				continue;
 			}
@@ -4353,6 +4435,14 @@ static int reload(void)
 			if (!strncasecmp(v->name, "prio", 4)) {
 				continue;
 			}
+			/* At this point, v->name should be the client name, and
+			 * v->value should be the client's options.
+			 *
+			 * We'll make a copy of the options (and abort if that fails),
+			 * then use the copy and split it on the "," delimiter into the
+			 * strs array, and n will be the number of elements found in the array.
+			 * If n < 1, we skip this client and continue to the next one.
+			 */
 			cp = ast_strdup(v->value);
 			if (!cp) {
 				ast_config_destroy(cfg);
@@ -4362,9 +4452,15 @@ static int reload(void)
 			if (n < 1) {
 				continue;
 			}
-			/* See if we "know" this client already. */
+			/* See if we "know" this client already. The first element in the strs array is the
+			 * client secret (password). We can feed that into crc32_bufs to get a digest, and see
+			 * if it matches any existing client.
+			 */
 			for (client = clients; client; client = client->next) {
-				/* If this is the one whose digest matches one currently being looked at. */
+				/* Stop if we find a matching client that we know. Or if we have seen it before,
+				 * but it doesn't belong to this node number any more, reset the client array to
+				 * treat it as a new client.
+				 */
 				if (client->digest == crc32_bufs(challenge, strs[0])) {
 					/* If has moved to another instance, free this one, and treat as new. */
 					if (client->nodenum != strtoul(ctg, NULL, 0)) {
@@ -4375,7 +4471,7 @@ static int reload(void)
 				}
 			}
 			newclient = 0;
-			/* If a new one, alloc its space. */
+			/* If we don't know this client, treat it as new, and alloc its space. Abort if that fails. */
 			if (!client) {
 				client = ast_calloc(1, sizeof(struct voter_client));
 				if (!client) {
@@ -4385,12 +4481,15 @@ static int reload(void)
 				}
 				/* When initializing a client, set the CLI priority override to PRIO_DEFAULT (-2). */
 				client->prio_override = PRIO_DEFAULT;
+				/* This is a new client, so v->name is the client name, copy that into client->name. */
 				ast_copy_string(client->name, v->name, sizeof(client->name));
+				/* Set a flag indicating this is a new client. */
 				newclient = 1;
 			}
+			/* Reset a number of variables, so they can be reloaded. */
 			client->reload = 1;
 			client->buflen = instance_buflen;
-			client->nodenum = strtoul(ctg, NULL, 0);
+			client->nodenum = strtoul(ctg, NULL, 0); /* The category name is the node number */
 			client->totransmit = 0;
 			client->doadpcm = 0;
 			client->nodeemp = 0;
@@ -4399,6 +4498,9 @@ static int reload(void)
 			client->noplfilter = 0;
 			client->prio = PRIO_NORMAL; /* Default "normal" priority is 0 */
 			client->gpsid = 0;
+			/* n from above was the number of strings (variables) we parsed out of the client options.
+			 * Now, we will iterate through them all, and set the corresponding client array variables.
+			 */
 			for (i = 1; i < n; i++) {
 				if (!strcasecmp(strs[i], "transmit")) {
 					client->totransmit = 1;
@@ -4440,34 +4542,48 @@ static int reload(void)
 			}
 			/* This effectively turns buflen into 40ms resolution "steps". */
 			client->buflen -= client->buflen % (FRAME_SIZE * 2);
+			/* Remember, the first element in the strs array is the client secret. Use
+			 * that to create a unique digest for the client, and store it in the client
+			 * array. Also, copy the client secret into the client->pswd.
+			 */
 			client->digest = crc32_bufs(challenge, strs[0]);
 			ast_copy_string(client->pswd, strs[0], sizeof(client->pswd));
 			ast_free(cp);
+			/* Check to see if the buflen has changed. If it has, reset the drain index. */
 			if (client->old_buflen && (client->buflen != client->old_buflen)) {
 				client->drainindex = 0;
 			}
+			/* If the audio buffer exists and the buflen has changed, reallocate it. */
 			if (client->audio && client->old_buflen && (client->buflen != client->old_buflen)) {
 				client->audio = ast_realloc(client->audio, client->buflen);
 				if (!client->audio) {
 					ast_config_destroy(cfg);
 					return -1;
 				}
+				/* Fill the new buffer with silence. */
 				memset(client->audio, ULAW_SILENCE, client->buflen);
+				/* If the audio buffer doesn't exist, allocate it. */
 			} else if (!client->audio) {
 				client->audio = ast_malloc(client->buflen);
 				if (!client->audio) {
 					ast_config_destroy(cfg);
 					return -1;
 				}
+				/* Fill the new buffer with silence. */
 				memset(client->audio, ULAW_SILENCE, client->buflen);
 			}
+			/* If the RSSI buffer exists and the buflen has changed, reallocate it. */
 			if (client->rssi && client->old_buflen && (client->buflen != client->old_buflen)) {
 				client->rssi = ast_realloc(client->rssi, client->buflen);
 				if (!client->rssi) {
 					ast_config_destroy(cfg);
 					return -1;
 				}
+				/* Fill the new RSSI buffer with zeros. */
 				memset(client->rssi, 0, client->buflen);
+				/* If the RSSI buffer doesn't exist, allocate it. Note that ast_calloc will
+				 * automatically initialize the memory to zero.
+				 */
 			} else if (!client->rssi) {
 				client->rssi = ast_calloc(1, client->buflen);
 				if (!client->rssi) {
@@ -4475,7 +4591,7 @@ static int reload(void)
 					return -1;
 				}
 			}
-			/* If a new client, add it into list. */
+			/* If this is a new client, add it into list. */
 			if (newclient) {
 				if (clients == NULL) {
 					clients = client;
@@ -4490,6 +4606,7 @@ static int reload(void)
 		}
 	}
 	ast_config_destroy(cfg);
+	/* Traverse the client list and perform validation checks. */
 	for (client = clients; client; client = client->next) {
 		if (!client->reload) {
 			continue;
@@ -4513,7 +4630,7 @@ static int reload(void)
 			}
 		}
 	}
-	/* Remove all the clients that are no longer in the config. */
+	/* Remove all the clients that are no longer in the config and free their memory. */
 	for (client = clients; client; client = client->next) {
 		if (client->reload) {
 			continue;
@@ -6561,6 +6678,13 @@ static int load_module(void)
 
 	memset(&sin, 0, sizeof(sin));
 	sin.sin_family = AF_INET;
+
+	/* Load the [general] options bindaddr, port, and utos here one time. They are immutable
+	 * and cannot be changed without restarting the module.
+	 *
+	 * The other [general] options, buflen, password, sanity, and puckit are
+	 * loaded in reload() so they can be changed at runtime with a reload.
+	 */
 	val = ast_variable_retrieve(cfg, "general", "port");
 	if (val) {
 		listen_port = (uint16_t) strtoul(val, NULL, 0);

--- a/configs/rpt/voter.conf
+++ b/configs/rpt/voter.conf
@@ -5,7 +5,7 @@ buflen = 480                    ; specifies the receive buffer length in millise
                                 ; This parameter should be set to the maximum expected network latency,
                                 ; plus a little padding (100 milliseconds of padding is a good amount).
                                 ; The default is 480 milliseconds, the minimum is 320 milliseconds.
-                                ; Buffer length may be specified on a per-stanza and per-client basis, see below.
+                                ; Buffer length may be specified on a global or per-instance basis, see below.
 
 password = secret_password      ; password common to all clients (Main Menu Item 6 - Host Password, on RTCM/VOTER)
 utos = y                        ; Turn on IP TOS for Ubiquiti (ToS is enable by default on the RTCM/VOTER) from the host TO the clients
@@ -14,7 +14,7 @@ utos = y                        ; Turn on IP TOS for Ubiquiti (ToS is enable by 
 ;puckit = 1                     ; KLUDGE to try and fix random Garmin LVC-18 pucks that may or may not be 1 second off (defaults to 0 if not specified or set to 1)
 
 [1999]                          ; define the 1999 instance stanza
-Main = secret,transmit,master   ; master,transmit,adpcm,nodeemp,noplfilter,buflen=value,gpsid[=value],prio=value
+Main = secret,transmit,master   ; master,transmit,adpcm,nodeemp,noplfilter,gpsid[=value],prio=value
                                 ; 
                                 ; master - this client is the Master Timing source (the RTCM client that is on the same LAN as the Asterisk server.)
                                 ; There can only be 1 Master Timing source per ENTIRE Asterisk server.
@@ -25,7 +25,6 @@ Main = secret,transmit,master   ; master,transmit,adpcm,nodeemp,noplfilter,bufle
                                 ; nodeemp - this client is not to perform de-emphasis of the receiver audio  (This is only to be used with non-voting clients). Switches 
                                 ; the hardware de-emphasis filter OUT on the client
                                 ; noplfilter - this client is to not to perform hardware pl filtering of the audio. Switches the hardware PL filter OUT on the client.
-                                ; buflen=value - receive buffer length override for this client only.
                                 ; gpsid[=value] - This specifies a gps identity to associate with the specified client (as referred in the /etc/asterisk/gps.conf file).
                                 ; prio=value - define a specific priority for this client when voting. Lower numbers are higher priority. Default is 0 if nothing specified.
 
@@ -42,6 +41,7 @@ plfilter = y                    ; use DSP IIR 6 pole High pass filter, 300 Hz co
 ;gtxgain = 3.0                  ; adjust the audio gain to all transmitters (in db voltage gain)
 ;hostdeemp = 1                  ; force the use of the DSP FIR Integrator providing de-emphasis at 8000 samples/sec. Used with Duplex Mode 3 setting in RTCM/VOTER
 
+;buflen = 480                   ; specifies the receive buffer length for this instance. Overrides the global buflen setting if specified here.
 thresholds = 255,110=5          ;
 ; linger=6                      ; linger default is 6 if no other value specified
 ; streams = 67.215.233.178:1667 ; location to send voter data stream for this instance (used only with votemond Java program, which is deprecated)


### PR DESCRIPTION
Add comments in `reload()`.

Add comments about Asterisk channel request in `ast_channel()`.

Use friendly variable name for the Asterisk channel pointer that is returned when a new Asterisk VOTER channel is created.

Remove the un-documented `voter.conf` option `context` that can override the initial context the channel driver uses (none of our other channel drivers do that).

Remove documentation in sample `voter.conf` for un-supported per-client `buflen` variable. We only support global (in `[general]`) and per-instance (per-node) `buflen` variables.

Add additional comments and debug messages to reload function.

Use Asterisk module status constants in `reload()`.

Preserve the next client before removing the current client to prevent crash. When the outdated client is the list head, the existing else branch sets `clients = NULL` and discards the remaining clients. Line 4674 then assigns `client = clients`. The `for` increment dereferences `client->next` with `client == NULL`. Save `client->next` before unlinking. Set clients to that saved pointer for head removal, then advance without dereferencing the freed or NULL client.

Add `voter_client_free` helper function to free memory allocations when clients are removed.

Revise failure path when `reload()` fails to leave resources alone and just return AST_MODULE_LOAD_FAILURE back to Asterisk (was causing a coredump/crash with the original code when we tried to execute it on a failure).

Update debug message to match `voter.conf` settings.

Add comments in reload() around per-instance buflen variable loading.


Resolves #1157

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring buffer length globally or per channel instance.
  * Improved channel reload handling, including configuration validation and stale-client cleanup.

* **Bug Fixes**
  * Improved client resource cleanup and connection lifecycle handling.
  * Enhanced CTCSS configuration updates and diagnostic reporting during reloads.

* **Documentation**
  * Updated configuration guidance to reflect instance-level buffer-length overrides.
  * Removed the deprecated per-client buffer-length option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->