### PR TITLE
app_rpt: Earlier autoservice

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -267,6 +267,7 @@
 
 #include "asterisk.h"
 
+#include <signal.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <string.h>

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -267,7 +267,6 @@
 
 #include "asterisk.h"
 
-#include <signal.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <string.h>

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2509,6 +2509,11 @@ static void *attempt_reconnect(struct rpt *myrpt, struct rpt_link *l)
 	struct ast_format_cap *cap;
 
 	ast_debug(1, "Attempting Reconnect");
+	/* rpt_make_call is blocking, long dns lookups result in exceptionally long queue warnings
+	 * autoservice handles "eating" the frames and eliminating the warning.
+	 */
+	ast_autoservice_start(l->pchan);
+
 	if (node_lookup(myrpt, l->name, tmp, sizeof(tmp), 1)) {
 		ast_log(LOG_WARNING, "attempt_reconnect: cannot find node %s\n", l->name);
 		rpt_mutex_lock(&myrpt->lock);
@@ -2557,10 +2562,6 @@ static void *attempt_reconnect(struct rpt *myrpt, struct rpt_link *l)
 	l->newkeytimer = NEWKEYTIME;
 	l->link_newkey = RADIO_KEY_NOT_ALLOWED;
 
-	/* rpt_make_call is blocking, long dns lookups result in exceptionally long queue warnings
-	 * autoservice handles "eating" the frames and eliminating the warning.
-	 */
-	ast_autoservice_start(l->pchan);
 	l->chan = ast_request(deststr, cap, NULL, NULL, tele, NULL);
 	ao2_ref(cap, -1);
 	while ((f1 = AST_LIST_REMOVE_HEAD(&l->textq, frame_list))) {

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -1,7 +1,7 @@
 #define VERSION_MAJOR 3
 #define VERSION_MINOR 10
 #define VERSION_PATCH 1
-
+#include <signal.h>
 #include "asterisk/audiohook.h"
 
 /* 99% of the DSP code in app_rpt exists in dsp.c as private functions. This code can mostly be

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -1,6 +1,7 @@
 #define VERSION_MAJOR 3
 #define VERSION_MINOR 10
 #define VERSION_PATCH 1
+
 #include "asterisk/audiohook.h"
 
 /* 99% of the DSP code in app_rpt exists in dsp.c as private functions. This code can mostly be

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -1,7 +1,6 @@
 #define VERSION_MAJOR 3
 #define VERSION_MINOR 10
 #define VERSION_PATCH 1
-#include <signal.h>
 #include "asterisk/audiohook.h"
 
 /* 99% of the DSP code in app_rpt exists in dsp.c as private functions. This code can mostly be

--- a/channels/Makefile.diff
+++ b/channels/Makefile.diff
@@ -4,8 +4,8 @@
  $(call MOD_ADD_C,chan_iax2,$(wildcard iax2/*.c))
  iax2/parser.o: _ASTCFLAGS+=$(call get_menuselect_cflags,MALLOC_DEBUG)
  
-+chan_simpleusb.so: LIBS+=-lusb -lasound
-+chan_usbradio.so: LIBS+=-lusb -lasound
++chan_simpleusb.so: LIBS+=-lusb-1.0 -lasound
++chan_usbradio.so: LIBS+=-lusb-1.0 -lasound
 +
  $(call MOD_ADD_C,chan_pjsip,$(wildcard pjsip/*.c))
  $(call MOD_ADD_C,chan_dahdi,$(wildcard dahdi/*.c) sig_analog.c sig_pri.c sig_ss7.c)

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -879,6 +879,10 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 	o->hasusb = 0;
 	o->usbass = 0;
 	o->devicenum = 0;
+
+	if (o->usb_dev) {
+		libusb_unref_device(o->usb_dev);
+	}
 	o->usb_dev = NULL;
 
 	if (o->hw_device[0]) {
@@ -1218,6 +1222,9 @@ static void *hidthread(void *arg)
 			ast_mutex_lock(&usb_dev_lock);
 			o->usbass = 0;
 			o->hasusb = 0;
+			if (o->usb_dev) {
+				libusb_unref_device(o->usb_dev);
+			}
 			o->usb_dev = NULL;
 			ast_mutex_unlock(&usb_dev_lock);
 			libusb_close(usb_handle);
@@ -2004,7 +2011,9 @@ static int simpleusb_hangup(struct ast_channel *c)
 		pthread_join(o->hidthread, NULL);
 		o->hidthread = AST_PTHREADT_NULL;
 	}
-
+	if (o->usb_dev) {
+		libusb_unref_device(o->usb_dev);
+	}
 	o->owner = NULL;
 	ast_channel_tech_pvt_set(c, NULL);
 	ast_module_unref(ast_module_info->self);
@@ -4355,6 +4364,10 @@ static int load_module(void)
 		return AST_MODULE_LOAD_DECLINE;
 	}
 	ast_format_cap_append(simpleusb_tech.capabilities, ast_format_slin, 0);
+
+	if (ast_radio_libusb_init() < 0) {
+		return AST_MODULE_LOAD_DECLINE;
+	}
 
 	if (ast_radio_hid_device_mklist()) {
 		ast_log(LOG_ERROR, "Unable to make hid list\n");

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -4453,7 +4453,7 @@ static int unload_module(void)
 		ast_free(o->name);
 		if (o->usb_dev) {
 			libusb_unref_device(o->usb_dev);
-			o->usbdev = NULL;
+			o->usb_dev = NULL;
 		}
 		ast_free(o);
 	}

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -882,9 +882,9 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 
 	if (o->usb_dev) {
 		libusb_unref_device(o->usb_dev);
+		o->usb_dev = NULL;
 	}
 
-	o->usb_dev = NULL;
 	if (o->hw_device[0]) {
 		/* already configured device, extract the device number and usb_dev */
 		if (!strcasecmp(o->hw_device, "default")) {
@@ -1224,8 +1224,9 @@ static void *hidthread(void *arg)
 			o->hasusb = 0;
 			if (o->usb_dev) {
 				libusb_unref_device(o->usb_dev);
+				o->usb_dev = NULL;
 			}
-			o->usb_dev = NULL;
+
 			ast_mutex_unlock(&usb_dev_lock);
 			libusb_close(usb_handle);
 			usb_handle = NULL;

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -187,7 +187,7 @@ struct chan_simpleusb_pvt {
 	pthread_t audiothread;
 	pthread_t hidthread;
 
-	struct usb_device *usb_dev;
+	struct libusb_device *usb_dev;
 	struct ast_channel *owner;
 
 	struct ast_radio_pa_stream pa;
@@ -302,7 +302,7 @@ struct chan_simpleusb_pvt {
 	char eepromctl;
 	ast_mutex_t eepromlock;
 
-	struct usb_dev_handle *usb_handle;
+	struct libusb_device_handle *usb_handle;
 	struct timeval tonetime;
 	int toneflag;
 	int duplex3;
@@ -1108,7 +1108,7 @@ static void *hidthread(void *arg)
 	char lasttxtmp;
 	int i, j, k;
 	int res;
-	struct usb_dev_handle *usb_handle = NULL;
+	struct libusb_device_handle *usb_handle = NULL;
 	struct chan_simpleusb_pvt *o = arg;
 	struct timeval then;
 	struct pollfd rfds[1];
@@ -1159,8 +1159,7 @@ static void *hidthread(void *arg)
 		}
 
 		/* open the usb device device */
-		usb_handle = usb_open(o->usb_dev);
-		if (usb_handle == NULL) {
+		if (libusb_open(o->usb_dev, &usb_handle) < 0) {
 			if (!open_device_failed) {
 				ast_log(LOG_ERROR, "Channel %s: Cannot open device %s\n", o->name, o->devstr);
 				open_device_failed = 1;
@@ -1170,25 +1169,25 @@ static void *hidthread(void *arg)
 			continue;
 		}
 		/* attempt to claim the usb hid interface and detach from the kernel */
-		if (usb_claim_interface(usb_handle, C108_HID_INTERFACE) < 0) {
-			if (usb_detach_kernel_driver_np(usb_handle, C108_HID_INTERFACE) < 0) {
+		if (libusb_claim_interface(usb_handle, C108_HID_INTERFACE) < 0) {
+			if (libusb_detach_kernel_driver(usb_handle, C108_HID_INTERFACE) < 0) {
 				if (!detach_failed) {
 					ast_log(LOG_ERROR, "Channel %s: Is not able to detach the USB device\n", o->name);
 					detach_failed = 1;
 				}
 
-				usb_close(usb_handle);
+				libusb_close(usb_handle);
 				usb_handle = NULL;
 				usleep(DEVICE_RETRY);
 				continue;
 			}
-			if (usb_claim_interface(usb_handle, C108_HID_INTERFACE) < 0) {
+			if (libusb_claim_interface(usb_handle, C108_HID_INTERFACE) < 0) {
 				if (!claim_failed) {
 					ast_log(LOG_ERROR, "Channel %s: Is not able to claim the USB device\n", o->name);
 					claim_failed = 1;
 				}
 
-				usb_close(usb_handle);
+				libusb_close(usb_handle);
 				usb_handle = NULL;
 				usleep(DEVICE_RETRY);
 				continue;
@@ -1221,19 +1220,25 @@ static void *hidthread(void *arg)
 			o->hasusb = 0;
 			o->usb_dev = NULL;
 			ast_mutex_unlock(&usb_dev_lock);
-			usb_close(usb_handle);
+			libusb_close(usb_handle);
 			usb_handle = NULL;
 			/* Stay in hidthread and retry; call() only starts the thread once. */
 			usleep(DEVICE_RETRY);
 			continue;
 		}
 
-		if ((o->usb_dev->descriptor.idProduct & 0xfffc) == C108_PRODUCT_ID) {
-			o->devtype = C108_PRODUCT_ID;
-		} else {
-			o->devtype = o->usb_dev->descriptor.idProduct;
-		}
+		{
+			struct libusb_device_descriptor desc;
 
+			if (libusb_get_device_descriptor(o->usb_dev, &desc) < 0) {
+				ast_log(LOG_ERROR, "Channel %s: Unable to read USB device descriptor\n", o->name);
+				o->devtype = 0;
+			} else if ((desc.idProduct & 0xfffc) == C108_PRODUCT_ID) {
+				o->devtype = C108_PRODUCT_ID;
+			} else {
+				o->devtype = desc.idProduct;
+			}
+		}
 		ast_debug(5, "Channel %s: Starting normally.\n", o->name);
 		ast_debug(5, "Channel %s: Attached to usb device %s.\n", o->name, o->devstr);
 
@@ -1604,7 +1609,7 @@ static void *hidthread(void *arg)
 		ast_radio_hid_set_outputs(usb_handle, buf);
 
 		if (usb_handle) {
-			usb_close(usb_handle);
+			libusb_close(usb_handle);
 			usb_handle = NULL;
 		}
 	}
@@ -1620,7 +1625,7 @@ static void *hidthread(void *arg)
 		buf[o->hid_gpio_ctl_loc] = o->hid_gpio_ctl;
 		ast_radio_hid_set_outputs(usb_handle, buf);
 		ast_mutex_unlock(&o->usblock);
-		usb_close(usb_handle);
+		libusb_close(usb_handle);
 		usb_handle = NULL;
 	}
 

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -883,8 +883,8 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 	if (o->usb_dev) {
 		libusb_unref_device(o->usb_dev);
 	}
-	o->usb_dev = NULL;
 
+	o->usb_dev = NULL;
 	if (o->hw_device[0]) {
 		/* already configured device, extract the device number and usb_dev */
 		if (!strcasecmp(o->hw_device, "default")) {
@@ -2013,6 +2013,7 @@ static int simpleusb_hangup(struct ast_channel *c)
 	}
 	if (o->usb_dev) {
 		libusb_unref_device(o->usb_dev);
+		o->usb_dev = NULL;
 	}
 	o->owner = NULL;
 	ast_channel_tech_pvt_set(c, NULL);
@@ -4366,9 +4367,11 @@ static int load_module(void)
 	ast_format_cap_append(simpleusb_tech.capabilities, ast_format_slin, 0);
 
 	if (ast_radio_libusb_init() < 0) {
+		ast_log(LOG_ERROR, "Unable to initialize libusb\n");
+		ao2_cleanup(simpleusb_tech.capabilities);
+		simpleusb_tech.capabilities = NULL;
 		return AST_MODULE_LOAD_DECLINE;
 	}
-
 	if (ast_radio_hid_device_mklist()) {
 		ast_log(LOG_ERROR, "Unable to make hid list\n");
 		return AST_MODULE_LOAD_DECLINE;

--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -4451,6 +4451,10 @@ static int unload_module(void)
 			}
 		}
 		ast_free(o->name);
+		if (o->usb_dev) {
+			libusb_unref_device(o->usb_dev);
+			o->usbdev = NULL;
+		}
 		ast_free(o);
 	}
 

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -956,8 +956,7 @@ static void *hidthread(void *arg)
 		if (usb_handle) {
 			libusb_close(usb_handle);
 		}
-		usb_handle = NULL;
-		usb_dev = NULL;
+
 		ast_radio_hid_device_mklist();
 
 		/* audiodev without devstr: bind HID to ALSA card number */
@@ -1654,6 +1653,11 @@ usb_device_ready:
 		libusb_close(usb_handle);
 		usb_handle = NULL;
 	}
+
+	if (usb_dev) {
+		libusb_unref_device(usb_dev);
+	}
+
 	return NULL;
 }
 
@@ -1952,6 +1956,7 @@ static int usbradio_hangup(struct ast_channel *c)
 		o->hookstate = 0;
 	}
 	ast_radio_pa_stop(&o->pa);
+
 	return 0;
 }
 
@@ -5505,6 +5510,10 @@ static int load_module(void)
 		return AST_MODULE_LOAD_DECLINE;
 	}
 	ast_format_cap_append(usbradio_tech.capabilities, ast_format_slin, 0);
+
+	if (ast_radio_libusb_init() < 0) {
+		return AST_MODULE_LOAD_DECLINE;
+	}
 
 	if (ast_radio_hid_device_mklist()) {
 		ast_log(LOG_ERROR, "Unable to make hid list\n");

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -387,7 +387,7 @@ struct chan_usbradio_pvt {
 	char eepromctl;
 	ast_mutex_t eepromlock;
 
-	struct usb_dev_handle *usb_handle;
+	struct libusb_device_handle *usb_handle;
 	int readerrs;
 	struct timeval tonetime;
 	int toneflag;
@@ -923,8 +923,8 @@ static void *hidthread(void *arg)
 	int i, j, k;
 	int res;
 	int use_newname = 0;
-	struct usb_device *usb_dev;
-	struct usb_dev_handle *usb_handle;
+	struct libusb_device *usb_dev;
+	struct libusb_device_handle *usb_handle;
 	struct chan_usbradio_pvt *o = arg, *ao;
 	struct timeval then;
 	struct pollfd rfds[1];
@@ -954,7 +954,7 @@ static void *hidthread(void *arg)
 		o->usbass = 0;
 		o->devicenum = 0;
 		if (usb_handle) {
-			usb_close(usb_handle);
+			libusb_close(usb_handle);
 		}
 		usb_handle = NULL;
 		usb_dev = NULL;
@@ -1174,20 +1174,19 @@ static void *hidthread(void *arg)
 		}
 usb_device_ready:
 		/* open the usb device device */
-		usb_handle = usb_open(usb_dev);
-		if (usb_handle == NULL) {
+		if (libusb_open(usb_dev, &usb_handle) < 0) {
 			ast_log(LOG_ERROR, "Channel %s: Cannot open device %s\n", o->name, o->devstr);
 			usleep(500000);
 			continue;
 		}
 		/* attempt to claim the usb hid interface and detach from the kernel */
-		if (usb_claim_interface(usb_handle, C108_HID_INTERFACE) < 0) {
-			if (usb_detach_kernel_driver_np(usb_handle, C108_HID_INTERFACE) < 0) {
+		if (libusb_claim_interface(usb_handle, C108_HID_INTERFACE) < 0) {
+			if (libusb_detach_kernel_driver(usb_handle, C108_HID_INTERFACE) < 0) {
 				ast_log(LOG_ERROR, "Channel %s: Is not able to detach the USB device\n", o->name);
 				usleep(500000);
 				continue;
 			}
-			if (usb_claim_interface(usb_handle, C108_HID_INTERFACE) < 0) {
+			if (libusb_claim_interface(usb_handle, C108_HID_INTERFACE) < 0) {
 				ast_log(LOG_ERROR, "Channel %s: Is not able to claim the USB device\n", o->name);
 				usleep(500000);
 				continue;
@@ -1213,7 +1212,7 @@ usb_device_ready:
 		}
 		if (pipe2(o->pttkick, O_NONBLOCK) == -1) {
 			ast_log(LOG_ERROR, "Channel %s: Is not able to create a pipe\n", o->name);
-			usb_close(usb_handle);
+			libusb_close(usb_handle);
 			usb_handle = NULL;
 			ast_mutex_lock(&usb_dev_lock);
 			o->usbass = 0;
@@ -1223,12 +1222,21 @@ usb_device_ready:
 			usleep(500000);
 			continue;
 		}
-		if ((usb_dev->descriptor.idProduct & 0xfffc) == C108_PRODUCT_ID) {
-			o->devtype = C108_PRODUCT_ID;
-		} else {
-			o->devtype = usb_dev->descriptor.idProduct;
+
+		{
+			struct libusb_device_descriptor desc;
+
+			if (libusb_get_device_descriptor(usb_dev, &desc) < 0) {
+				ast_log(LOG_ERROR, "Channel %s: Unable to read USB device descriptor\n", o->name);
+				o->devtype = 0;
+			} else if ((desc.idProduct & 0xfffc) == C108_PRODUCT_ID) {
+				o->devtype = C108_PRODUCT_ID;
+			} else {
+				o->devtype = desc.idProduct;
+			}
 		}
 		ast_debug(5, "Channel %s: Starting normally.\n", o->name);
+
 		ast_debug(5, "Channel %s: Attached to usb device %s.\n", o->name, o->devstr);
 		/* setup the xmpr subsystem */
 		if (o->pmrChan == NULL) {
@@ -1643,7 +1651,7 @@ usb_device_ready:
 		ast_radio_hid_set_outputs(usb_handle, buf);
 		ast_mutex_unlock(&o->usblock);
 		/* Hangup joins this thread; release HID so the next call can reopen it. */
-		usb_close(usb_handle);
+		libusb_close(usb_handle);
 		usb_handle = NULL;
 	}
 	return NULL;

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -953,8 +953,15 @@ static void *hidthread(void *arg)
 		o->hasusb = 0;
 		o->usbass = 0;
 		o->devicenum = 0;
+
 		if (usb_handle) {
 			libusb_close(usb_handle);
+			usb_handle = NULL;
+		}
+
+		if (usb_dev) {
+			libusb_unref_device(usb_dev);
+			usb_dev = NULL;
 		}
 
 		ast_radio_hid_device_mklist();
@@ -5512,6 +5519,7 @@ static int load_module(void)
 	ast_format_cap_append(usbradio_tech.capabilities, ast_format_slin, 0);
 
 	if (ast_radio_libusb_init() < 0) {
+		ast_log(LOG_ERROR, "Unable to initialize libusb\n");
 		return AST_MODULE_LOAD_DECLINE;
 	}
 

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -355,7 +355,8 @@ int ast_radio_hid_device_mklist(void);
  * \note It will only evaluate USB devices known to work with this application.
  *
  * \param desired_device	Pointer to a string that contains the device string to find.
- * \retval 					Returns a usb_device structure with the found device.
+ * \retval 					Returns a libusb_device structure with the found device.
+ * 							This device has a libusb_ref_device and must be freed with libusb_unref_device by the caller.
  *							If the device was not found, it returns null.
  */
 struct libusb_device *ast_radio_hid_device_init(const char *desired_device);

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -589,6 +589,6 @@ long ast_radio_pa_write_available(struct ast_radio_pa_stream *ps);
 
 /*!
  * \brief initialize the usb_ctx register for access to usb devices.
- * \retval 0 on success, -1 on failure.
+ * \retval libusb_init status 0 on success, negative on failure.
  */
 int ast_radio_libusb_init(void);

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -28,8 +28,9 @@
 #define HAVE_SYS_IO
 #endif
 
-#include <usb.h>
+#include <libusb-1.0/libusb.h>
 #include <portaudio.h>
+#include <signal.h>
 
 /*!
  * \brief Defines for interacting with ALSA controls.
@@ -286,8 +287,9 @@ int ast_radio_setamixer(int devnum, char *param, int v1, int v2);
  *
  * \param handle		Pointer to usb_dev_handle associated with the HID.
  * \param outputs		Pointer to buffer that contains the data to send to the HID.
+ * \retval bytes >= 0 Success, LIBUSB_ERROR* if error
  */
-void ast_radio_hid_set_outputs(struct usb_dev_handle *handle, unsigned char *outputs);
+int ast_radio_hid_set_outputs(struct libusb_device_handle *handle, unsigned char *outputs);
 
 /*!
  * \brief Get USB HID inputs
@@ -297,8 +299,9 @@ void ast_radio_hid_set_outputs(struct usb_dev_handle *handle, unsigned char *out
  *
  * \param handle		Pointer to usb_dev_handle associated with the HID.
  * \param inputs		Pointer to buffer that will contain the data received from the HID.
+ * \retval bytes >= 0 Success, LIBUSB_ERROR* if error
  */
-void ast_radio_hid_get_inputs(struct usb_dev_handle *handle, unsigned char *inputs);
+int ast_radio_hid_get_inputs(struct libusb_device_handle *handle, unsigned char *inputs);
 
 /*!
  * \brief Read user memory segment from the CM-XXX EEPROM.
@@ -315,7 +318,7 @@ void ast_radio_hid_get_inputs(struct usb_dev_handle *handle, unsigned char *inpu
  *						the calculated checksum will be zero.  This indicates valid data..
  *						Any	other value indicates bad EEPROM data.
  */
-unsigned short ast_radio_get_eeprom(struct usb_dev_handle *handle, unsigned short *buf);
+unsigned short ast_radio_get_eeprom(struct libusb_device_handle *handle, unsigned short *buf);
 
 /*!
  * \brief Write user memory segment to the CM-XXX EEPROM.
@@ -330,7 +333,7 @@ unsigned short ast_radio_get_eeprom(struct usb_dev_handle *handle, unsigned shor
  * \param buf			Pointer to buffer that contains the the EEPROM data.
  *						The buffer must be an array of 13 unsigned shorts.
  */
-void ast_radio_put_eeprom(struct usb_dev_handle *handle, unsigned short *buf);
+void ast_radio_put_eeprom(struct libusb_device_handle *handle, unsigned short *buf);
 
 /*!
  * \brief Make a list of HID devices.
@@ -355,7 +358,7 @@ int ast_radio_hid_device_mklist(void);
  * \retval 					Returns a usb_device structure with the found device.
  *							If the device was not found, it returns null.
  */
-struct usb_device *ast_radio_hid_device_init(const char *desired_device);
+struct libusb_device *ast_radio_hid_device_init(const char *desired_device);
 
 /*!
  * \brief Get USB device number from device string
@@ -548,7 +551,7 @@ void ast_radio_print_audio_stats(int fd, struct audiostatistics *o, const char *
  * - The returned pointer is owned by libusb's internal device list.
  * \param cardno The ALSA card number as found in HW:<cardno>
  */
-struct usb_device *ast_radio_usb_device_from_alsa_card(int cardno);
+struct libusb_device *ast_radio_usb_device_from_alsa_card(int cardno);
 
 #define AST_RADIO_PA_SAMPLE_RATE 48000
 #define AST_RADIO_PA_FRAMES_PER_BUFFER (FRAME_SIZE * 6)

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -586,3 +586,9 @@ void ast_radio_pa_stop(struct ast_radio_pa_stream *ps);
 PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned long frames, int timeout_ms, volatile sig_atomic_t *stop);
 PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, unsigned long frames);
 long ast_radio_pa_write_available(struct ast_radio_pa_stream *ps);
+
+/*!
+ * \brief initialize the usb_ctx register for access to usb devices.
+ * \retval 0 on success, -1 on failure.
+ */
+int ast_radio_libusb_init(void);

--- a/res/Makefile.diff
+++ b/res/Makefile.diff
@@ -5,7 +5,7 @@
  snmp/agent.o: _ASTCFLAGS+=-fPIC
  res_snmp.o: _ASTCFLAGS+=-fPIC
  
-+res_usbradio.so: LIBS+=-lusb -lasound -lportaudio
++res_usbradio.so: LIBS+=-lusb-1.0 -lasound -lportaudio
 +
  MODULE_EXCLUDE=ENABLE_SRTP_AES_192 ENABLE_SRTP_AES_256 ENABLE_SRTP_AES_GCM
  

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -44,7 +44,7 @@
 #include <sys/time.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <usb.h>
+#include <libusb-1.0/libusb.h>
 #include <linux/ppdev.h>
 #include <linux/parport.h>
 #include <linux/version.h>
@@ -83,6 +83,8 @@ AST_MUTEX_DEFINE_STATIC(usb_list_lock);
  */
 static char *usb_device_list = NULL;
 static int usb_device_list_size = 0;
+static struct libusb_context *usb_ctx = NULL;
+struct libusb_device *usb_dev;
 
 /*!
  * \brief Structure for defined usb devices.
@@ -111,6 +113,15 @@ const struct usb_device_entry known_devices[] = {
  * \brief Linked list of user defined usb devices.
  */
 static AST_RWLIST_HEAD_STATIC(user_devices, usb_device_entry);
+
+static int ast_radio_libusb_init(void)
+{
+	if (usb_ctx) {
+		return 0;
+	}
+
+	return libusb_init(&usb_ctx);
+}
 
 long ast_radio_lround(double x)
 {
@@ -264,24 +275,24 @@ int ast_radio_setamixer(int devnum, char *param, int v1, int v2)
 	return 0;
 }
 
-void ast_radio_hid_set_outputs(struct usb_dev_handle *handle, unsigned char *outputs)
+int ast_radio_hid_set_outputs(struct libusb_device_handle *handle, unsigned char *outputs)
 {
 	/* This appears to prevent issues with the CM-109 chipset when switching modes too fast
 	 * Originally 1500, Issues with Uno-Q and Pi5? Adjusted to 3000
 	 */
 	usleep(3000);
-	usb_control_msg(handle, USB_ENDPOINT_OUT + USB_TYPE_CLASS + USB_RECIP_INTERFACE, HID_REPORT_SET, 0 + (HID_RT_OUTPUT << 8),
-		C108_HID_INTERFACE, (char *) outputs, 4, 5000);
+	return libusb_control_transfer(handle, LIBUSB_ENDPOINT_OUT | LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_INTERFACE,
+		HID_REPORT_SET, 0 + (HID_RT_OUTPUT << 8), C108_HID_INTERFACE, outputs, 4, 20);
 }
 
-void ast_radio_hid_get_inputs(struct usb_dev_handle *handle, unsigned char *inputs)
+int ast_radio_hid_get_inputs(struct libusb_device_handle *handle, unsigned char *inputs)
 {
 	/* This appears to prevent issues with the CM-109 chipset when switching modes too fast
 	 * Originally 1500, Issues with Uno-Q and Pi5? Adjusted to 3000
 	 */
 	usleep(3000);
-	usb_control_msg(handle, USB_ENDPOINT_IN + USB_TYPE_CLASS + USB_RECIP_INTERFACE, HID_REPORT_GET, 0 + (HID_RT_INPUT << 8),
-		C108_HID_INTERFACE, (char *) inputs, 4, 5000);
+	return libusb_control_transfer(handle, LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_INTERFACE,
+		HID_REPORT_GET, 0 + (HID_RT_INPUT << 8), C108_HID_INTERFACE, inputs, 4, 20);
 }
 
 /*!
@@ -300,7 +311,7 @@ void ast_radio_hid_get_inputs(struct usb_dev_handle *handle, unsigned char *inpu
  * \param addr			Integer address to read from the EEPROM.  The valid
  *						range is 0 to 63.
  */
-static unsigned short read_eeprom(struct usb_dev_handle *handle, int addr)
+static unsigned short read_eeprom(struct libusb_device_handle *handle, int addr)
 {
 	unsigned char buf[4];
 
@@ -336,7 +347,7 @@ static unsigned short read_eeprom(struct usb_dev_handle *handle, int addr)
  *						range is 0 to 63.
  * \param data			Unsigned short data to store.
  */
-static void write_eeprom(struct usb_dev_handle *handle, int addr, unsigned short data)
+static void write_eeprom(struct libusb_device_handle *handle, int addr, unsigned short data)
 {
 	unsigned char buf[4];
 
@@ -349,7 +360,7 @@ static void write_eeprom(struct usb_dev_handle *handle, int addr, unsigned short
 	ast_radio_hid_set_outputs(handle, buf);
 }
 
-unsigned short ast_radio_get_eeprom(struct usb_dev_handle *handle, unsigned short *buf)
+unsigned short ast_radio_get_eeprom(struct libusb_device_handle *handle, unsigned short *buf)
 {
 	int i;
 	unsigned short cs;
@@ -363,7 +374,7 @@ unsigned short ast_radio_get_eeprom(struct usb_dev_handle *handle, unsigned shor
 	return cs;
 }
 
-void ast_radio_put_eeprom(struct usb_dev_handle *handle, unsigned short *buf)
+void ast_radio_put_eeprom(struct libusb_device_handle *handle, unsigned short *buf)
 {
 	int i;
 	unsigned short cs;
@@ -387,14 +398,19 @@ void ast_radio_put_eeprom(struct usb_dev_handle *handle, unsigned short *buf)
  * \return 0	does not matches
  * \return 1	matches
  */
-static int is_known_device(struct usb_device *dev)
+static int is_known_device(struct libusb_device *dev)
 {
 	int index;
 	int matched_entry = 0;
+	struct libusb_device_descriptor desc;
+
+	if (libusb_get_device_descriptor(dev, &desc) < 0) {
+		return 0;
+	}
 
 	for (index = 0; index < ARRAY_LEN(known_devices); index++) {
-		if (known_devices[index].idVendor == dev->descriptor.idVendor &&
-			known_devices[index].idProduct == (dev->descriptor.idProduct & known_devices[index].idMask)) {
+		if (known_devices[index].idVendor == desc.idVendor &&
+			known_devices[index].idProduct == (desc.idProduct & known_devices[index].idMask)) {
 			matched_entry = 1;
 			break;
 		};
@@ -410,13 +426,18 @@ static int is_known_device(struct usb_device *dev)
  * \return 0	does not matches
  * \return 1	matches
  */
-static int is_user_device(struct usb_device *dev)
+static int is_user_device(struct libusb_device *dev)
 {
 	struct usb_device_entry *device;
+	struct libusb_device_descriptor desc;
+
+	if (libusb_get_device_descriptor(dev, &desc) < 0) {
+		return 0;
+	}
 
 	AST_RWLIST_RDLOCK(&user_devices);
 	AST_LIST_TRAVERSE(&user_devices, device, entry) {
-		if (dev->descriptor.idVendor == device->idVendor && dev->descriptor.idProduct == device->idProduct) {
+		if (desc.idVendor == device->idVendor && desc.idProduct == device->idProduct) {
 			break;
 		};
 	}
@@ -461,12 +482,16 @@ static int read_card_usbbus(int cardno, char *out, int outsz)
 
 int ast_radio_hid_device_mklist(void)
 {
-	struct usb_bus *usb_bus;
-	struct usb_device *dev;
+	struct libusb_device *dev;
 	char devstr[10000], str[200], desdev[200], *cp;
 	ssize_t linklen;
 	size_t cplen;
 	int i;
+	struct libusb_device **list = NULL;
+	ssize_t count;
+	size_t dev_index;
+	unsigned int busnum;
+	unsigned int devaddr;
 
 	ast_mutex_lock(&usb_list_lock);
 
@@ -482,40 +507,49 @@ int ast_radio_hid_device_mklist(void)
 		return -1;
 	}
 
-	usb_init();
-	usb_find_busses();
-	usb_find_devices();
-	for (usb_bus = usb_busses; usb_bus; usb_bus = usb_bus->next) {
-		for (dev = usb_bus->devices; dev; dev = dev->next) {
-			char *new_list;
+	if (ast_radio_libusb_init() < 0) {
+		ast_mutex_unlock(&usb_list_lock);
+		return -1;
+	}
 
-			if (!(is_known_device(dev) || is_user_device(dev))) {
+	count = libusb_get_device_list(usb_ctx, &list);
+	if (count < 0) {
+		ast_mutex_unlock(&usb_list_lock);
+		return -1;
+	}
+
+	for (dev_index = 0; dev_index < count; dev_index++) {
+		char *new_list;
+
+		dev = list[dev_index];
+		if (!(is_known_device(dev) || is_user_device(dev))) {
+			continue;
+		}
+
+		busnum = libusb_get_bus_number(dev);
+		devaddr = libusb_get_device_address(dev);
+		snprintf(devstr, sizeof(devstr), "%03u/%03u", busnum, devaddr);
+		for (i = 0; i < 32; i++) {
+			if (read_card_usbbus(i, desdev, sizeof(desdev))) {
 				continue;
 			}
 
-			snprintf(devstr, sizeof(devstr), "%s/%s", usb_bus->dirname, dev->filename);
-			for (i = 0; i < 32; i++) {
-				if (read_card_usbbus(i, desdev, sizeof(desdev))) {
-					continue;
-				}
-
-				if (strcasecmp(desdev, devstr)) {
-					continue;
-				}
-
-				snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
-				linklen = readlink(str, desdev, sizeof(desdev) - 1);
-				if (linklen == -1) {
-					continue;
-				}
-				desdev[linklen] = '\0';
-				cp = strrchr(desdev, '/');
-				if (!cp) {
-					continue;
-				}
-				cp++;
-				break;
+			if (strcasecmp(desdev, devstr)) {
+				continue;
 			}
+
+			snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
+			linklen = readlink(str, desdev, sizeof(desdev) - 1);
+			if (linklen == -1) {
+				continue;
+			}
+			desdev[linklen] = '\0';
+			cp = strrchr(desdev, '/');
+			if (!cp) {
+				continue;
+			}
+			cp++;
+			break;
 
 			if (i >= 32) {
 				continue;
@@ -540,59 +574,72 @@ int ast_radio_hid_device_mklist(void)
 			usb_device_list[i + cplen + 1] = 0;
 		}
 	}
+
+	libusb_free_device_list(list, 1);
 	ast_mutex_unlock(&usb_list_lock);
 	return 0;
 }
 
-struct usb_device *ast_radio_hid_device_init(const char *desired_device)
+struct libusb_device *ast_radio_hid_device_init(const char *desired_device)
 {
-	struct usb_bus *usb_bus;
-	struct usb_device *dev;
+	struct libusb_device *dev;
 	char devstr[10000], str[200], desdev[200], *cp;
 	ssize_t linklen;
 	int i;
+	struct libusb_device **list = NULL;
+	ssize_t count;
+	size_t dev_index;
+	unsigned int busnum;
+	unsigned int devaddr;
 
-	usb_init();
-	usb_find_busses();
-	usb_find_devices();
-	for (usb_bus = usb_busses; usb_bus; usb_bus = usb_bus->next) {
-		for (dev = usb_bus->devices; dev; dev = dev->next) {
-			if (!(is_known_device(dev) || is_user_device(dev))) {
+	if (ast_radio_libusb_init() < 0) {
+		return NULL;
+	}
+
+	count = libusb_get_device_list(usb_ctx, &list);
+	if (count < 0) {
+		return NULL;
+	}
+
+	for (dev_index = 0; dev_index < count; dev_index++) {
+		dev = list[dev_index];
+		if (!(is_known_device(dev) || is_user_device(dev))) {
+			continue;
+		}
+
+		busnum = libusb_get_bus_number(dev);
+		devaddr = libusb_get_device_address(dev);
+		snprintf(devstr, sizeof(devstr), "%03u/%03u", busnum, devaddr);
+
+		for (i = 0; i < 32; i++) {
+			if (read_card_usbbus(i, desdev, sizeof(desdev))) {
 				continue;
 			}
 
-			snprintf(devstr, sizeof(devstr), "%s/%s", usb_bus->dirname, dev->filename);
-
-			for (i = 0; i < 32; i++) {
-				if (read_card_usbbus(i, desdev, sizeof(desdev))) {
-					continue;
-				}
-
-				if (strcasecmp(desdev, devstr)) {
-					continue;
-				}
-
-				snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
-				linklen = readlink(str, desdev, sizeof(desdev) - 1);
-				if (linklen == -1) {
-					continue;
-				}
-				desdev[linklen] = '\0';
-				cp = strrchr(desdev, '/');
-				if (!cp) {
-					continue;
-				}
-				cp++;
-				break;
-			}
-			if (i >= 32) {
+			if (strcasecmp(desdev, devstr)) {
 				continue;
 			}
-			if (!strcmp(cp, desired_device)) {
-				return dev;
+			snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
+			linklen = readlink(str, desdev, sizeof(desdev) - 1);
+			if (linklen == -1) {
+				continue;
 			}
+			desdev[linklen] = '\0';
+			cp = strrchr(desdev, '/');
+			if (!cp) {
+				continue;
+			}
+			cp++;
+			break;
+		}
+		if (i >= 32) {
+			continue;
+		}
+		if (!strcmp(cp, desired_device)) {
+			return dev;
 		}
 	}
+	libusb_free_device_list(list, 1);
 	return NULL;
 }
 
@@ -633,22 +680,29 @@ int ast_radio_usb_get_usbdev(const char *devstr)
  */
 int ast_radio_usb_get_serial(const char *devstr, char *buf, size_t buflen)
 {
-	struct usb_device *usb_dev;
-	struct usb_dev_handle *usb_handle;
+	struct libusb_device *usb_dev;
+	struct libusb_device_handle *usb_handle;
+	struct libusb_device_descriptor desc;
 	int length = 0;
 
+	if (ast_radio_libusb_init() < 0) {
+		return 0;
+	}
 	usb_dev = ast_radio_hid_device_init(devstr);
 	if (!usb_dev) {
 		return 0;
 	}
 
-	if (usb_dev->descriptor.iSerialNumber) {
-		usb_handle = usb_open(usb_dev);
-		if (!usb_handle) {
+	if (libusb_get_device_descriptor(usb_dev, &desc) < 0) {
+		return 0;
+	}
+
+	if (desc.iSerialNumber) {
+		if (libusb_open(usb_dev, &usb_handle) < 0) {
 			return 0;
 		}
-		length = usb_get_string_simple(usb_handle, usb_dev->descriptor.iSerialNumber, buf, buflen);
-		usb_close(usb_handle);
+		length = libusb_get_string_descriptor_ascii(usb_handle, desc.iSerialNumber, (unsigned char *) buf, buflen);
+		libusb_close(usb_handle);
 	}
 
 	return length;
@@ -1418,44 +1472,61 @@ long ast_radio_pa_write_available(struct ast_radio_pa_stream *ps)
  * On failure: returns NULL.
  *
  * Notes:
- * - Uses libusb-0.1 enumeration (usb_init/usb_find_busses/usb_find_devices).
+ * - Uses libusb-1.0 enumeration (libusb_init/libusb_get_device_list).
  * - The returned pointer is owned by libusb's internal device list.
  */
-struct usb_device *ast_radio_usb_device_from_alsa_card(int cardno)
+struct libusb_device *ast_radio_usb_device_from_alsa_card(int cardno)
 {
 	char target[64]; /* usually "001/005" fits easily */
-	struct usb_bus *bus;
-	struct usb_device *dev;
+	struct libusb_device *dev;
 
 	if (read_card_usbbus(cardno, target, sizeof(target)) != 0) {
 		ast_debug(3, "Unable to read usbbus for card %d (may not be a USB device)\n", cardno);
 		return NULL;
 	}
 
-	usb_init();
-	usb_find_busses();
-	usb_find_devices();
+	if (ast_radio_libusb_init() < 0) {
+		return NULL;
+	}
 
-	for (bus = usb_busses; bus; bus = bus->next) {
-		for (dev = bus->devices; dev; dev = dev->next) {
-			char cur[sizeof(bus->dirname) + sizeof(dev->filename) + 1];
+	{
+		struct libusb_device **list = NULL;
+		ssize_t count;
+		size_t dev_index;
+		unsigned int busnum;
+		unsigned int devaddr;
 
+		count = libusb_get_device_list(usb_ctx, &list);
+		if (count < 0) {
+			return NULL;
+		}
+
+		for (dev_index = 0; dev_index < count; dev_index++) {
+			char cur[16];
+
+			dev = list[dev_index];
 			if (!(is_known_device(dev) || is_user_device(dev))) {
 				continue;
 			}
 
-			snprintf(cur, sizeof(cur), "%s/%s", bus->dirname, dev->filename);
+			busnum = libusb_get_bus_number(dev);
+			devaddr = libusb_get_device_address(dev);
+			snprintf(cur, sizeof(cur), "%03u/%03u", busnum, devaddr);
 
 			/* usbbus content is typically case-insensitive */
 			if (strcasecmp(cur, target) == 0) {
+				libusb_ref_device(dev);
+				libusb_free_device_list(list, 1);
 				return dev;
 			}
 		}
+
+		libusb_free_device_list(list, 1);
 	}
+
 	ast_debug(1, "No USB device found matching bus path '%s' for card %d\n", target, cardno);
 	return NULL;
 }
-
 /* Load our configuration */
 static int load_config(int reload)
 {
@@ -1519,6 +1590,14 @@ static int load_config(int reload)
 
 static int reload_module(void)
 {
+	if (ast_radio_libusb_init() < 0) {
+		ast_log(LOG_ERROR, "Unable to initialize libusb\n");
+		return AST_MODULE_LOAD_DECLINE;
+	}
+
+	if (load_config(0)) {
+		return AST_MODULE_LOAD_DECLINE;
+	}
 	return load_config(1);
 }
 
@@ -1534,6 +1613,11 @@ static int load_module(void)
 static int unload_module(void)
 {
 	cleanup_user_devices();
+	if (usb_ctx) {
+		libusb_exit(usb_ctx);
+		usb_ctx = NULL;
+	}
+
 	ast_mutex_lock(&pa_lock);
 	ast_assert(pa_refcount == 0);
 	ast_mutex_unlock(&pa_lock);

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -506,12 +506,16 @@ int ast_radio_hid_device_mklist(void)
 		return -1;
 	}
 
+	if (!usb_ctx) {
+		ast_mutex_unlock(&usb_list_lock);
+		return -1;
+	}
+
 	count = libusb_get_device_list(usb_ctx, &list);
 	if (count < 0) {
 		ast_mutex_unlock(&usb_list_lock);
 		return -1;
 	}
-
 	for (dev_index = 0; dev_index < count; dev_index++) {
 		char *new_list;
 
@@ -690,16 +694,19 @@ int ast_radio_usb_get_serial(const char *devstr, char *buf, size_t buflen)
 	}
 
 	if (libusb_get_device_descriptor(usb_dev, &desc) < 0) {
+		libusb_unref_device(usb_dev);
 		return 0;
 	}
 
 	if (desc.iSerialNumber) {
 		if (libusb_open(usb_dev, &usb_handle) < 0) {
+			libusb_unref_device(usb_dev);
 			return 0;
 		}
 		length = libusb_get_string_descriptor_ascii(usb_handle, desc.iSerialNumber, (unsigned char *) buf, buflen);
 		libusb_close(usb_handle);
 	}
+	libusb_unref_device(usb_dev);
 	if (length < 0) {
 		length = 0;
 	}

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -1597,11 +1597,9 @@ static int load_config(int reload)
 
 static int reload_module(void)
 {
-	if (!usb_ctx) {
-		if (ast_radio_libusb_init() < 0) {
-			ast_log(LOG_ERROR, "Unable to initialize libusb\n");
-			return AST_MODULE_LOAD_DECLINE;
-		}
+	if (ast_radio_libusb_init() < 0) {
+		ast_log(LOG_ERROR, "Unable to initialize libusb\n");
+		return AST_MODULE_LOAD_DECLINE;
 	}
 
 	if (load_config(0)) {

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -84,7 +84,6 @@ AST_MUTEX_DEFINE_STATIC(usb_list_lock);
 static char *usb_device_list = NULL;
 static int usb_device_list_size = 0;
 static struct libusb_context *usb_ctx = NULL;
-struct libusb_device *usb_dev;
 
 /*!
  * \brief Structure for defined usb devices.
@@ -114,7 +113,7 @@ const struct usb_device_entry known_devices[] = {
  */
 static AST_RWLIST_HEAD_STATIC(user_devices, usb_device_entry);
 
-static int ast_radio_libusb_init(void)
+int ast_radio_libusb_init(void)
 {
 	if (usb_ctx) {
 		return 0;
@@ -507,11 +506,6 @@ int ast_radio_hid_device_mklist(void)
 		return -1;
 	}
 
-	if (ast_radio_libusb_init() < 0) {
-		ast_mutex_unlock(&usb_list_lock);
-		return -1;
-	}
-
 	count = libusb_get_device_list(usb_ctx, &list);
 	if (count < 0) {
 		ast_mutex_unlock(&usb_list_lock);
@@ -550,29 +544,29 @@ int ast_radio_hid_device_mklist(void)
 			}
 			cp++;
 			break;
-
-			if (i >= 32) {
-				continue;
-			}
-
-			cplen = strlen(cp);
-			new_list = ast_realloc(usb_device_list, usb_device_list_size + 2 + cplen);
-			if (!new_list) {
-				ast_mutex_unlock(&usb_list_lock);
-				return -1;
-			}
-
-			usb_device_list = new_list;
-			usb_device_list_size += cplen + 2;
-			i = 0;
-
-			while (usb_device_list[i]) {
-				i += strlen(usb_device_list + i) + 1;
-			}
-
-			memcpy(usb_device_list + i, cp, cplen + 1);
-			usb_device_list[i + cplen + 1] = 0;
 		}
+		if (i >= 32) {
+			continue;
+		}
+
+		cplen = strlen(cp);
+		new_list = ast_realloc(usb_device_list, usb_device_list_size + 2 + cplen);
+		if (!new_list) {
+			libusb_free_device_list(list, 1);
+			ast_mutex_unlock(&usb_list_lock);
+			return -1;
+		}
+
+		usb_device_list = new_list;
+		usb_device_list_size += cplen + 2;
+		i = 0;
+
+		while (usb_device_list[i]) {
+			i += strlen(usb_device_list + i) + 1;
+		}
+
+		memcpy(usb_device_list + i, cp, cplen + 1);
+		usb_device_list[i + cplen + 1] = 0;
 	}
 
 	libusb_free_device_list(list, 1);
@@ -592,7 +586,7 @@ struct libusb_device *ast_radio_hid_device_init(const char *desired_device)
 	unsigned int busnum;
 	unsigned int devaddr;
 
-	if (ast_radio_libusb_init() < 0) {
+	if (!usb_ctx) {
 		return NULL;
 	}
 
@@ -636,6 +630,8 @@ struct libusb_device *ast_radio_hid_device_init(const char *desired_device)
 			continue;
 		}
 		if (!strcmp(cp, desired_device)) {
+			libusb_ref_device(dev);
+			libusb_free_device_list(list, 1);
 			return dev;
 		}
 	}
@@ -685,7 +681,7 @@ int ast_radio_usb_get_serial(const char *devstr, char *buf, size_t buflen)
 	struct libusb_device_descriptor desc;
 	int length = 0;
 
-	if (ast_radio_libusb_init() < 0) {
+	if (!usb_ctx) {
 		return 0;
 	}
 	usb_dev = ast_radio_hid_device_init(devstr);
@@ -703,6 +699,9 @@ int ast_radio_usb_get_serial(const char *devstr, char *buf, size_t buflen)
 		}
 		length = libusb_get_string_descriptor_ascii(usb_handle, desc.iSerialNumber, (unsigned char *) buf, buflen);
 		libusb_close(usb_handle);
+	}
+	if (length < 0) {
+		length = 0;
 	}
 
 	return length;
@@ -1473,7 +1472,8 @@ long ast_radio_pa_write_available(struct ast_radio_pa_stream *ps)
  *
  * Notes:
  * - Uses libusb-1.0 enumeration (libusb_init/libusb_get_device_list).
- * - The returned pointer is owned by libusb's internal device list.
+ * - The returned device is reference-counted. The caller must release it with
+ *   libusb_unref_device() when it is no longer needed.
  */
 struct libusb_device *ast_radio_usb_device_from_alsa_card(int cardno)
 {
@@ -1485,7 +1485,7 @@ struct libusb_device *ast_radio_usb_device_from_alsa_card(int cardno)
 		return NULL;
 	}
 
-	if (ast_radio_libusb_init() < 0) {
+	if (!usb_ctx) {
 		return NULL;
 	}
 
@@ -1590,9 +1590,11 @@ static int load_config(int reload)
 
 static int reload_module(void)
 {
-	if (ast_radio_libusb_init() < 0) {
-		ast_log(LOG_ERROR, "Unable to initialize libusb\n");
-		return AST_MODULE_LOAD_DECLINE;
+	if (!usb_ctx) {
+		if (ast_radio_libusb_init() < 0) {
+			ast_log(LOG_ERROR, "Unable to initialize libusb\n");
+			return AST_MODULE_LOAD_DECLINE;
+		}
 	}
 
 	if (load_config(0)) {


### PR DESCRIPTION
Turns out I missed an earlier blocking call in the `attempt_reconnect()`, leaving a few long voice queue warnings 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved call reconnection handling by maintaining channel servicing throughout the reconnect attempt.
  * Improved USB radio device discovery, initialization, and cleanup for greater reliability.
* **Compatibility**
  * Updated USB audio and radio support to use the current libusb interface.
  * Preserved ALSA and PortAudio integration for supported USB radio configurations.
* **Reliability**
  * Added improved error handling when USB devices cannot be initialized or identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->