### PR TITLE
app_rpt.c: autoservice l->pchan before node_lookup blocking call

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2509,6 +2509,10 @@ static void *attempt_reconnect(struct rpt *myrpt, struct rpt_link *l)
 	struct ast_format_cap *cap;
 
 	ast_debug(1, "Attempting Reconnect");
+	/* rpt_make_call is blocking, long dns lookups result in exceptionally long queue warnings
+	 * autoservice handles "eating" the frames and eliminating the warning.
+	 */
+	ast_autoservice_start(l->pchan);
 	if (node_lookup(myrpt, l->name, tmp, sizeof(tmp), 1)) {
 		ast_log(LOG_WARNING, "attempt_reconnect: cannot find node %s\n", l->name);
 		rpt_mutex_lock(&myrpt->lock);
@@ -2556,11 +2560,6 @@ static void *attempt_reconnect(struct rpt *myrpt, struct rpt_link *l)
 	l->rxlingertimer = RX_LINGER_TIME;
 	l->newkeytimer = NEWKEYTIME;
 	l->link_newkey = RADIO_KEY_NOT_ALLOWED;
-
-	/* rpt_make_call is blocking, long dns lookups result in exceptionally long queue warnings
-	 * autoservice handles "eating" the frames and eliminating the warning.
-	 */
-	ast_autoservice_start(l->pchan);
 	l->chan = ast_request(deststr, cap, NULL, NULL, tele, NULL);
 	ao2_ref(cap, -1);
 	while ((f1 = AST_LIST_REMOVE_HEAD(&l->textq, frame_list))) {

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2515,32 +2515,22 @@ static void *attempt_reconnect(struct rpt *myrpt, struct rpt_link *l)
 	ast_autoservice_start(l->pchan);
 	if (node_lookup(myrpt, l->name, tmp, sizeof(tmp), 1)) {
 		ast_log(LOG_WARNING, "attempt_reconnect: cannot find node %s\n", l->name);
-		rpt_mutex_lock(&myrpt->lock);
-		l->retrytimer = RETRY_TIMER_MS;
-		rpt_mutex_unlock(&myrpt->lock);
-		return NULL;
+		goto retry;
 	}
 	/* cannot apply to echolink */
 	if (!strncasecmp(tmp, "echolink", 8)) {
-		rpt_mutex_lock(&myrpt->lock);
-		l->retrytimer = RETRY_TIMER_MS;
-		rpt_mutex_unlock(&myrpt->lock);
+		ast_autoservice_stop(l->pchan);
 		return NULL;
 	}
 	/* cannot apply to tlb */
 	if (!strncasecmp(tmp, "tlb", 3)) {
-		rpt_mutex_lock(&myrpt->lock);
-		l->retrytimer = RETRY_TIMER_MS;
-		rpt_mutex_unlock(&myrpt->lock);
+		ast_autoservice_stop(l->pchan);
 		return NULL;
 	}
 
 	cap = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);
 	if (!cap) {
-		rpt_mutex_lock(&myrpt->lock);
-		l->retrytimer = RETRY_TIMER_MS;
-		rpt_mutex_unlock(&myrpt->lock);
-		return NULL;
+		goto retry;
 	}
 	ast_format_cap_append(cap, ast_format_slin, 0);
 
@@ -2573,15 +2563,23 @@ static void *attempt_reconnect(struct rpt *myrpt, struct rpt_link *l)
 			l->retrytimer = RETRY_TIMER_MS;
 			l->chan = NULL;
 			rpt_mutex_unlock(&myrpt->lock);
+			ast_autoservice_stop(l->pchan);
+			return NULL;
 		}
 	} else {
 		ast_verb(3, "Unable to place call to %s/%s\n", deststr, tele);
-		rpt_mutex_lock(&myrpt->lock);
-		l->retrytimer = RETRY_TIMER_MS;
-		rpt_mutex_unlock(&myrpt->lock);
+		goto retry;
 	}
+
 	ast_autoservice_stop(l->pchan);
 	ast_log(LOG_NOTICE, "Reconnect Attempt to %s in progress\n", l->name);
+	return NULL;
+
+retry:
+	rpt_mutex_lock(&myrpt->lock);
+	l->retrytimer = RETRY_TIMER_MS;
+	rpt_mutex_unlock(&myrpt->lock);
+	ast_autoservice_stop(l->pchan);
 	return NULL;
 }
 

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2519,13 +2519,11 @@ static void *attempt_reconnect(struct rpt *myrpt, struct rpt_link *l)
 	}
 	/* cannot apply to echolink */
 	if (!strncasecmp(tmp, "echolink", 8)) {
-		ast_autoservice_stop(l->pchan);
-		return NULL;
+		goto retry;
 	}
 	/* cannot apply to tlb */
 	if (!strncasecmp(tmp, "tlb", 3)) {
-		ast_autoservice_stop(l->pchan);
-		return NULL;
+		goto retry;
 	}
 
 	cap = ast_format_cap_alloc(AST_FORMAT_CAP_FLAG_DEFAULT);

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2509,7 +2509,7 @@ static void *attempt_reconnect(struct rpt *myrpt, struct rpt_link *l)
 	struct ast_format_cap *cap;
 
 	ast_debug(1, "Attempting Reconnect");
-	/* rpt_make_call is blocking, long dns lookups result in exceptionally long queue warnings
+	/* rpt_make_call and node_lookup are blocking, long dns lookups result in exceptionally long queue warnings
 	 * autoservice handles "eating" the frames and eliminating the warning.
 	 */
 	ast_autoservice_start(l->pchan);


### PR DESCRIPTION
Turns out `node_lookup()` blocks us, leaving a few long voice queue warnings.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconnection handling by keeping the parent channel serviced during connection recovery.
  * Added consistent retry behavior for lookup, unsupported-node, capability, and call-request failures.
  * Reduced the risk of blocked channel activity while reconnect attempts or call setup are in progress.
  * Ensured servicing stops appropriately after successful setup or unrecoverable call-placement failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->