### PR TITLE
chan_voter: Address Issues Identified by CodeRabbit

### DIFF
--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -5529,10 +5529,8 @@ static void *voter_reader(void *data)
 						last_master_count = 0;
 						master_time.vtime_sec = 0;
 						master_time.vtime_nsec = 0;
-						/* Scan through the clients and fill the audio buffer with silence,
-						 * and set RSSI to 0.
-						 */
-						for (client1 = client->next; client1; client1 = client1->next) {
+						/* Fill the audio buffer with silence and set RSSI to 0 for all clients. */
+						for (client1 = clients; client1; client1 = client1->next) {
 							memset(client1->audio, ULAW_SILENCE, client1->buflen);
 							memset(client1->rssi, 0, client1->buflen);
 						}

--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -6169,6 +6169,13 @@ static void *voter_reader(void *data)
 										if (p->voter_test == 1) {
 											p->testindex = ast_random() % i;
 										} else {
+											/* If the test index is out of bounds (number of
+											 * candidates becomes smaller than the previously set
+											 * index), reset it. */
+											if (p->testindex >= i) {
+												p->testindex = 0;
+												p->testcycle = 0;
+											}
 											p->testcycle++;
 											if (p->testcycle >= (p->voter_test - 1)) {
 												p->testcycle = 0;


### PR DESCRIPTION
Clear entire client list on master client loss

Current code leaves stale audio and RSSI samples in buffers for current and previous clients when we lose the master client.

This change clears the entire client list.

Resolves #1132

Ensure `p->testindex` remains valid

If the number of test candidates (`i`) becomes smaller than the previously stored number of candidates in `p->testindex`, reset.

Resolves #1152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup when the master timing source is lost by clearing audio and signal data for all configured clients.
  * Fixed voter test mode handling so invalid test positions reset correctly before advancing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->