### PR TITLE
chan_simpleusb, chan_usbradio, res_usbradio: Add shared USB device management

### DIFF
--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -137,6 +137,7 @@ static FILE *frxcapcooked = NULL;
 static FILE *ftxcapraw = NULL;
 
 AST_MUTEX_DEFINE_STATIC(usb_dev_lock);
+AST_MUTEX_DEFINE_STATIC(device_swap_lock);
 AST_MUTEX_DEFINE_STATIC(pp_lock);
 
 /* variables for communicating with the parallel port */
@@ -168,10 +169,9 @@ static short silence_buf[AST_RADIO_PA_FRAMES_PER_BUFFER * AST_RADIO_PA_OUTPUT_CH
 struct chan_simpleusb_pvt {
 	struct chan_simpleusb_pvt *next;
 
-	char *name;			 /* the internal name of our channel */
-	char hw_device[100]; /* hardware device name */
-	int devtype;		 /* actual type of device */
-	int pttkick[2];		 /* ptt kick pipe */
+	char *name;		/* the internal name of our channel */
+	int devtype;	/* actual type of device */
+	int pttkick[2]; /* ptt kick pipe */
 	enum {
 		M_UNSET,
 		M_FULL,
@@ -180,17 +180,14 @@ struct chan_simpleusb_pvt {
 	} duplex;
 
 	int warned; /* various flags used for warnings */
-	int devicenum;
 	char devstr[128];
 	char serial[128];
-	int spkrmax;
-	int micmax;
-	int micplaymax;
 
 	pthread_t audiothread;
 	pthread_t hidthread;
 
-	struct libusb_device *usb_dev;
+	struct ast_radio_device *radio_device;
+	ast_mutex_t device_lock;
 	struct ast_channel *owner;
 
 	struct ast_radio_pa_stream pa;
@@ -284,10 +281,6 @@ struct chan_simpleusb_pvt {
 	unsigned int rxcapraw:1;			   /* indicator if receive capture is enabled */
 	unsigned int txcapraw:1;			   /* indicator if transmit capture is enabled */
 	unsigned int measure_enabled:1;		   /* indicator if measure mode is enabled */
-	unsigned int device_error:1;		   /* indicator set when we cannot find the USB device */
-	unsigned int newname:1;				   /* indicator that we should use MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW */
-	unsigned int hasusb:1;				   /* indicator for has a USB device */
-	unsigned int usbass:1;				   /* indicator for USB device assigned */
 	unsigned int wanteeprom:1;			   /* indicator if we should use EEPROM */
 	unsigned int usedtmf:1;				   /* indicator is we should decode DTMF */
 	unsigned int invertptt:1;			   /* indicator if we need to invert ptt */
@@ -297,8 +290,20 @@ struct chan_simpleusb_pvt {
 	unsigned int preemphasis:1;			   /* indicator if we need preemphasis filter */
 	unsigned int rx_cos_active:1;		   /* indicator if cos is active - active state after processing */
 	unsigned int rx_ctcss_active:1;		   /* indicator if ctcss is active - active state after processing */
+
+	/* Last shared device result used to rate-limit repeated acquisition errors */
+	enum ast_radio_device_result device_error;
+
 	/* Whole-word latch shared by HID/audio threads (not a bit-field). */
+	volatile sig_atomic_t hasusb;		   /* HID/audio liveness */
 	volatile sig_atomic_t usb_faulted;	   /* set after USB/audio failure; cleared on recovery log */
+	enum {
+		DEVICE_SWAP_IDLE,	   /*!< No device swap requested */
+		DEVICE_SWAP_QUIESCING, /*!< Device handles are stopping */
+		DEVICE_SWAP_READY,	   /*!< Device is ready for lease exchange */
+	} swap_state;
+	unsigned int swap_audio_ready:1;	   /*!< PortAudio stopped for pending swap */
+	ast_mutex_t swap_lock;				   /* protects device swap state */
 	volatile sig_atomic_t stophidthread;   /* indicator to stop hid thread */
 	volatile sig_atomic_t stopaudiothread; /* indicator to stop audio thread */
 
@@ -307,7 +312,6 @@ struct chan_simpleusb_pvt {
 	char eepromctl;
 	ast_mutex_t eepromlock;
 
-	struct libusb_device_handle *usb_handle;
 	struct timeval tonetime;
 	int toneflag;
 	int duplex3;
@@ -396,12 +400,41 @@ static int __attribute__((format(printf, 3, 4))) simpleusb_log_fault(struct chan
 	return 1;
 }
 
+static void simpleusb_device_identity(struct chan_simpleusb_pvt *o, char *devstr, size_t devstr_size, char *serial,
+	size_t serial_size, int *alsa_card)
+{
+	if (devstr && devstr_size) {
+		devstr[0] = '\0';
+	}
+	if (serial && serial_size) {
+		serial[0] = '\0';
+	}
+	if (alsa_card) {
+		*alsa_card = -1;
+	}
+
+	/* Report the acquired identity when the channel currently holds a lease */
+	ast_mutex_lock(&o->device_lock);
+	if (o->radio_device) {
+		if (devstr && devstr_size) {
+			ast_copy_string(devstr, o->radio_device->devstr, devstr_size);
+		}
+		if (serial && serial_size && o->radio_device->serial) {
+			ast_copy_string(serial, o->radio_device->serial, serial_size);
+		}
+		if (alsa_card) {
+			*alsa_card = o->radio_device->alsa_card;
+		}
+	}
+	ast_mutex_unlock(&o->device_lock);
+}
+
 /*!
  * \brief Log once when USB/audio returns after a prior failure.
  */
 static void simpleusb_log_usb_recovered(struct chan_simpleusb_pvt *o)
 {
-	const char *dev;
+	char devstr[sizeof(o->devstr)];
 	sig_atomic_t was_faulted;
 
 	was_faulted = o->usb_faulted;
@@ -409,9 +442,9 @@ static void simpleusb_log_usb_recovered(struct chan_simpleusb_pvt *o)
 	if (!was_faulted) {
 		return;
 	}
-	dev = !ast_strlen_zero(o->devstr) ? o->devstr : o->hw_device;
 	/* Match fault priority so ERROR-level logs pair fault with recovery. */
-	ast_log(LOG_ERROR, "Channel %s: USB radio device recovered (%s)\n", o->name, !ast_strlen_zero(dev) ? dev : "unknown");
+	simpleusb_device_identity(o, devstr, sizeof(devstr), NULL, 0, NULL);
+	ast_log(LOG_ERROR, "Channel %s: USB radio device recovered (%s)\n", o->name, !ast_strlen_zero(devstr) ? devstr : "unknown");
 }
 
 static char *simpleusb_active; /* the active device */
@@ -449,10 +482,14 @@ static int start_stream(struct chan_simpleusb_pvt *pvt)
 		return -1;
 	}
 
-	ast_copy_string(pvt->pa.hw_device, pvt->hw_device, sizeof(pvt->pa.hw_device));
+	ast_mutex_lock(&pvt->device_lock);
+	if (!pvt->radio_device) {
+		ast_mutex_unlock(&pvt->device_lock);
+		return -1;
+	}
 	pvt->pa.input_channels = 1;
-
-	res = ast_radio_pa_open(&pvt->pa);
+	res = ast_radio_pa_open_device(&pvt->pa, pvt->radio_device);
+	ast_mutex_unlock(&pvt->device_lock);
 	if (res != paNoError) {
 		ast_log(LOG_WARNING, "Failed to open stream - (%d) %s\n", res, Pa_GetErrorText(res));
 		return -1;
@@ -737,7 +774,7 @@ static void kickptt(const struct chan_simpleusb_pvt *o)
  * \brief Search our configured channels to find the
  *	one with the matching USB descriptor.
  *	Print a message if the descriptor was not found.
- * \param o		chan_usbradio_pvt.
+ * \param o		chan_simpleusb_pvt
  * \returns		Private structure that matches or NULL if not found.
  */
 static struct chan_simpleusb_pvt *find_desc(const char *dev)
@@ -752,46 +789,6 @@ static struct chan_simpleusb_pvt *find_desc(const char *dev)
 	}
 
 	return o;
-}
-
-/*!
- * \brief Search our configured channels to find the
- *	one with the matching USB descriptor.
- * \param o		chan_usbradio_pvt.
- * \returns		Private structure that matches or NULL if not found.
- */
-static struct chan_simpleusb_pvt *find_desc_usb(const char *devstr)
-{
-	struct chan_simpleusb_pvt *o = NULL;
-
-	if (!devstr) {
-		ast_log(LOG_WARNING, "USB Descriptor is null.\n");
-	}
-
-	for (o = simpleusb_default.next; o && devstr && strcmp(o->devstr, devstr) != 0; o = o->next)
-		;
-
-	return o;
-}
-
-/*!
- * \brief Search installed devices for a match with
- *	one of our configured channels.
- * \returns		Matching device string, or NULL.
- */
-static char *find_installed_usb_match(void)
-{
-	struct chan_simpleusb_pvt *o = NULL;
-	char *match = NULL;
-
-	for (o = simpleusb_default.next; o; o = o->next) {
-		if (ast_radio_usb_list_check(o->devstr)) {
-			match = o->devstr;
-			break;
-		}
-	}
-
-	return match;
 }
 
 /*!
@@ -862,7 +859,6 @@ static int load_tune_config(struct chan_simpleusb_pvt *o, const struct ast_confi
 	int configured = 0;
 	char devstr[sizeof(o->devstr)];
 	char serial[sizeof(o->serial)];
-	char hw_device[sizeof(o->hw_device)];
 
 	o->rxmixerset = 500;
 	o->txmixaset = 500;
@@ -870,7 +866,6 @@ static int load_tune_config(struct chan_simpleusb_pvt *o, const struct ast_confi
 
 	devstr[0] = '\0';
 	serial[0] = '\0';
-	hw_device[0] = '\0';
 
 	if (!cfg) {
 		struct ast_flags zeroflag = { 0 };
@@ -891,18 +886,12 @@ static int load_tune_config(struct chan_simpleusb_pvt *o, const struct ast_confi
 		CV_UINT("txmixbset", o->txmixbset);
 		CV_STR("devstr", devstr);
 		CV_STR("serial", serial);
-		CV_STR("audiodev", hw_device); /* use audiodevice as opposed to the usb device path (devstr) */
 		CV_END;
 	}
 	if (!reload) {
 		/* Using the ternary operator in CV_STR won't work, due to butchering the sizeof, so copy after if needed */
 		ast_copy_string(o->devstr, devstr, sizeof(o->devstr)); /* Safe */
 		ast_copy_string(o->serial, serial, sizeof(o->serial)); /* Safe */
-		if (ast_strlen_zero(devstr)) {
-			ast_copy_string(o->hw_device, hw_device, sizeof(o->hw_device));
-		} else {
-			o->hw_device[0] = '\0';
-		}
 	}
 	if (opened) {
 		ast_config_destroy(cfg2);
@@ -914,220 +903,184 @@ static int load_tune_config(struct chan_simpleusb_pvt *o, const struct ast_confi
 	return 0;
 }
 
-/*! \brief Find and initialize the audio device.
+static void simpleusb_release_device(struct chan_simpleusb_pvt *o)
+{
+	ast_mutex_lock(&o->device_lock);
+	if (!o->radio_device) {
+		ast_mutex_unlock(&o->device_lock);
+		return;
+	}
+
+	ast_radio_device_release(o->radio_device);
+	o->radio_device = NULL;
+	ast_mutex_unlock(&o->device_lock);
+}
+
+static void simpleusb_swap_begin(struct chan_simpleusb_pvt *o)
+{
+	ast_mutex_lock(&o->swap_lock);
+	o->swap_audio_ready = 0;
+	o->swap_state = DEVICE_SWAP_QUIESCING;
+	ast_mutex_unlock(&o->swap_lock);
+}
+
+static void simpleusb_swap_audio_stopped(struct chan_simpleusb_pvt *o)
+{
+	ast_mutex_lock(&o->swap_lock);
+	if (o->swap_state == DEVICE_SWAP_QUIESCING) {
+		o->swap_audio_ready = 1;
+	}
+	ast_mutex_unlock(&o->swap_lock);
+}
+
+static int simpleusb_swap_hid_wait(struct chan_simpleusb_pvt *o)
+{
+	int swapping;
+
+	ast_mutex_lock(&o->swap_lock);
+	swapping = o->swap_state == DEVICE_SWAP_QUIESCING;
+	while (swapping && !o->swap_audio_ready && !o->stophidthread) {
+		ast_mutex_unlock(&o->swap_lock);
+		usleep(10000);
+		ast_mutex_lock(&o->swap_lock);
+		swapping = o->swap_state == DEVICE_SWAP_QUIESCING;
+	}
+	if (swapping && o->swap_audio_ready) {
+		o->swap_state = DEVICE_SWAP_READY;
+	} else {
+		swapping = 0;
+	}
+	while (o->swap_state == DEVICE_SWAP_READY && !o->stophidthread) {
+		ast_mutex_unlock(&o->swap_lock);
+		usleep(10000);
+		ast_mutex_lock(&o->swap_lock);
+	}
+	ast_mutex_unlock(&o->swap_lock);
+	return swapping;
+}
+
+static int simpleusb_swap_ready(struct chan_simpleusb_pvt *o)
+{
+	int ready;
+
+	ast_mutex_lock(&o->swap_lock);
+	ready = o->swap_state == DEVICE_SWAP_READY;
+	ast_mutex_unlock(&o->swap_lock);
+	return ready;
+}
+
+static void simpleusb_swap_finish(struct chan_simpleusb_pvt *o)
+{
+	ast_mutex_lock(&o->swap_lock);
+	o->swap_audio_ready = 0;
+	o->swap_state = DEVICE_SWAP_IDLE;
+	ast_mutex_unlock(&o->swap_lock);
+}
+
+static long simpleusb_rx_mixer_max(struct chan_simpleusb_pvt *o)
+{
+	long maximum = 0;
+
+	ast_mutex_lock(&o->device_lock);
+	if (!o->radio_device) {
+		goto done;
+	}
+	maximum = ast_radio_device_mixer_max(o->radio_device, o->radio_device->mixer_rx_paths, AST_RADIO_MIXER_CAPTURE_VOLUME);
+done:
+	ast_mutex_unlock(&o->device_lock);
+	return maximum;
+}
+
+static long simpleusb_tx_mixer_max(struct chan_simpleusb_pvt *o)
+{
+	long maximum = 0;
+
+	ast_mutex_lock(&o->device_lock);
+	if (!o->radio_device) {
+		goto done;
+	}
+	maximum = ast_radio_device_mixer_max(o->radio_device, o->radio_device->mixer_tx_paths, AST_RADIO_MIXER_PLAYBACK_VOLUME);
+done:
+	ast_mutex_unlock(&o->device_lock);
+	return maximum;
+}
+
+static long simpleusb_sidetone_mixer_max(struct chan_simpleusb_pvt *o)
+{
+	long maximum = 0;
+
+	ast_mutex_lock(&o->device_lock);
+	if (!o->radio_device) {
+		goto done;
+	}
+	maximum = ast_radio_device_mixer_max(o->radio_device, o->radio_device->mixer_sidetone_paths, AST_RADIO_MIXER_PLAYBACK_VOLUME);
+done:
+	ast_mutex_unlock(&o->device_lock);
+	return maximum;
+}
+
+/* Control receive-audio monitoring into playback (Mic Playback Switch on CM108) */
+static void simpleusb_set_sidetone_switch(struct chan_simpleusb_pvt *o, int enabled)
+{
+	ast_mutex_lock(&o->device_lock);
+	if (o->radio_device) {
+		ast_radio_device_set_mixer_paths(o->radio_device, o->radio_device->mixer_sidetone_paths,
+			o->radio_device->mixer_sidetone_path_count, AST_RADIO_MIXER_PLAYBACK_SWITCH, enabled);
+	}
+	ast_mutex_unlock(&o->device_lock);
+}
+
+/*! \brief Find and initialize the audio device
  * \param o pointer to private struct
  */
 static int init_audio_device(struct chan_simpleusb_pvt *o)
 {
-	char serial[sizeof(o->serial)] = { '\0' };
-	char *s;
-	struct chan_simpleusb_pvt *ao;
-	int i;
-	int subdev;
-	int use_newname = 0;
+	struct ast_radio_device *radio_device;
+	struct ast_radio_device_request request = {
+		.devstr = o->devstr,
+		.serial = o->serial,
+		.owner = o->name,
+		.required_caps = AST_RADIO_CAP_CM108_HID,
+		.minimum_input_channels = 1,
+		.minimum_output_channels = 1,
+	};
+	enum ast_radio_device_result result;
+	int automatic;
 
 	ast_radio_time(&o->lasthidtime);
-	ast_mutex_lock(&usb_dev_lock);
 	o->hasusb = 0;
-	o->usbass = 0;
-	o->devicenum = 0;
 
-	if (o->usb_dev) {
-		libusb_unref_device(o->usb_dev);
-		o->usb_dev = NULL;
-	}
+	/* Remember whether acquisition is performing automatic assignment. */
+	automatic = ast_strlen_zero(o->serial) && ast_strlen_zero(o->devstr);
 
-	if (o->hw_device[0]) {
-		/* already configured device, extract the device number and usb_dev */
-		if (!strcasecmp(o->hw_device, "default")) {
-			ast_log(LOG_ERROR, "audiodev=default is not supported for SimpleUSB until HID-less startup is implemented\n");
-			ast_mutex_unlock(&usb_dev_lock);
-			return -1;
-		} else if (ast_radio_parse_alsa_hw_device(o->hw_device, &o->devicenum, &subdev)) {
-			ast_debug(5, "audiodev is defined: %s, Device %d", o->hw_device, o->devicenum);
-			o->usb_dev = ast_radio_usb_device_from_alsa_card(o->devicenum);
-			if (!o->usb_dev) {
-				ast_debug(5, "Unable to find usb device associated with %s\n", o->hw_device);
-				ast_mutex_unlock(&usb_dev_lock);
-				return -1;
-			}
-			for (ao = simpleusb_default.next; ao && ao->name; ao = ao->next) {
-				if (ao != o && ao->usbass && ao->devicenum == o->devicenum) {
-					ast_log(LOG_ERROR, "Channel %s: Audio device %s is already assigned to channel %s\n", o->name, o->hw_device, ao->name);
-					ast_mutex_unlock(&usb_dev_lock);
-					return -1;
-				}
-			}
-
-		} else {
-			ast_log(LOG_ERROR, "Incorrect audio parameter audiodev (should be hw:0 or hw:0,0 format), found %s\n", o->hw_device);
-			ast_mutex_unlock(&usb_dev_lock);
-			return -1;
+	/* Atomically discover and reserve one shared USB radio device. */
+	result = ast_radio_device_acquire(&request, &radio_device);
+	if (result != AST_RADIO_DEVICE_READY) {
+		if (o->device_error != result) {
+			simpleusb_log_fault(o, 0, "Channel %s: %s\n", o->name, ast_radio_device_result_str(result));
 		}
-	} else {
-		/* use the device string */
-		ast_radio_hid_device_mklist();
-
-		/* Check to see if our specified device string
-		 * matches to a device that is attached to this system, or exists
-		 * in our channel configuration.
-		 *
-		 * If no device string is specified, attempt to assign the first
-		 * found device.
-		 */
-		ast_radio_time(&o->lasthidtime);
-
-		/* If configuration has a serial number defined, find the device */
-		if (!ast_strlen_zero(o->serial)) {
-			int index;
-			char *index_devstr = NULL;
-
-			for (index = 0;; index++) {
-				index_devstr = ast_radio_usb_get_devstr(index);
-				if (ast_strlen_zero(index_devstr)) {
-					/* if no more devices */
-					break;
-				}
-
-				/* get the device serial number */
-				if (ast_radio_usb_get_serial(index_devstr, serial, sizeof(serial)) == 0) {
-					/* if no serial number */
-					continue;
-				}
-
-				if (strcmp(o->serial, serial) == 0) {
-					/*
-					 * We found a device with the matching serial number, set
-					 * the devstr to the matching device.
-					 */
-					ast_log(LOG_NOTICE, "Matched device serial %s to %s\n", o->serial, o->name);
-					ast_copy_string(o->devstr, index_devstr, sizeof(o->devstr));
-					break;
-				}
-			}
-		}
-
-		/* Automatically assign a devstr if one was not specified in the configuration. */
-		if (ast_strlen_zero(o->devstr)) {
-			int index = 0;
-			char *index_devstr = NULL;
-
-			for (;;) {
-				index_devstr = ast_radio_usb_get_devstr(index);
-				if (ast_strlen_zero(index_devstr)) {
-					o->device_error =
-						simpleusb_log_fault(o, o->device_error, "Channel %s: No USB devices are available for assignment.\n", o->name);
-					usleep(DEVICE_RETRY);
-					break;
-				}
-				/* We found an available device - see if it already in use */
-				for (ao = simpleusb_default.next; ao && ao->name; ao = ao->next) {
-					if (ao->usbass && (!strcmp(ao->devstr, index_devstr))) {
-						break;
-					}
-				}
-				if (ao) {
-					index++;
-					continue;
-				}
-				/* We found an unused device assign it to our node */
-				ast_copy_string(o->devstr, index_devstr, sizeof(o->devstr));
-				ast_log(LOG_NOTICE, "Channel %s: Automatically assigned USB device %s to SimpleUSB channel\n", o->name, o->devstr);
-				if (ast_radio_usb_get_serial(index_devstr, serial, sizeof(serial)) > 0) {
-					ast_copy_string(o->serial, serial, sizeof(o->serial));
-				}
-				break;
-			}
-			if (ast_strlen_zero(o->devstr)) {
-				ast_mutex_unlock(&usb_dev_lock);
-				return -1;
-			}
-		}
-
-		if ((!ast_radio_usb_list_check(o->devstr)) || (!find_desc_usb(o->devstr))) {
-			/* The device string did not match.
-			 * Now look through the attached devices and see
-			 * one of those is associated with one of our
-			 * configured channels.
-			 */
-			s = find_installed_usb_match();
-
-			if (ast_strlen_zero(s)) {
-				o->device_error =
-					simpleusb_log_fault(o, o->device_error, "Channel %s: Device string %s was not found.\n", o->name, o->devstr);
-				ast_mutex_unlock(&usb_dev_lock);
-				return -1;
-			}
-
-			i = ast_radio_usb_get_usbdev(s);
-			if (i < 0) {
-				ast_mutex_unlock(&usb_dev_lock);
-				return -1;
-			}
-			/* See if this device is already assigned to another usb channel */
-			for (ao = simpleusb_default.next; ao && ao->name; ao = ao->next) {
-				if (ao->usbass && (!strcmp(ao->devstr, s))) {
-					break;
-				}
-			}
-
-			if (ao) {
-				ast_log(LOG_ERROR, "Channel %s: Device string %s is already assigned to channel %s", o->name, s, ao->name);
-				ast_mutex_unlock(&usb_dev_lock);
-				return -1;
-			}
-
-			ast_log(LOG_NOTICE, "Channel %s: Assigned USB device %s to simpleusb channel\n", o->name, s);
-			ast_copy_string(o->devstr, s, sizeof(o->devstr));
-		}
-		/* Double check to see if the device string is assigned to another usb channel */
-		for (ao = simpleusb_default.next; ao && ao->name; ao = ao->next) {
-			if (ao->usbass && (!strcmp(ao->devstr, o->devstr))) {
-				break;
-			}
-		}
-
-		if (ao) {
-			ast_log(LOG_ERROR, "Channel %s: Device string %s is already assigned to channel %s", o->name, o->devstr, ao->name);
-			ast_mutex_unlock(&usb_dev_lock);
-			return -1;
-		}
-
-		/* get the index to the device and assign it to our channel */
-		i = ast_radio_usb_get_usbdev(o->devstr);
-		if (i < 0) {
-			ast_mutex_unlock(&usb_dev_lock);
-			return -1;
-		}
-		snprintf(o->hw_device, sizeof(o->hw_device), "hw:%d", i);
-		o->devicenum = i;
-		o->usb_dev = ast_radio_hid_device_init(o->devstr);
-		if (!o->usb_dev) {
-			ast_log(LOG_ERROR, "Unable to find usb device associated with %s", o->devstr);
-			ast_mutex_unlock(&usb_dev_lock);
-			return -1;
-		}
-	}
-
-	if (ast_radio_init_mixer_limits(o->devicenum, &o->micmax, &o->spkrmax, &o->micplaymax, &use_newname) < 0) {
-		o->device_error = simpleusb_log_fault(o, o->device_error, "Channel %s: Cannot use audio device %s without mixer limits\n",
-			o->name, o->hw_device);
-		ast_mutex_unlock(&usb_dev_lock);
+		o->device_error = result;
 		return -1;
 	}
-	o->newname = use_newname;
-	o->device_error = 0;
+
+	/* Publish the acquired device without changing the configured selectors */
+	ast_mutex_lock(&o->device_lock);
+	o->radio_device = radio_device;
+	ast_mutex_unlock(&o->device_lock);
+
+	if (automatic) {
+		ast_log(LOG_NOTICE, "Channel %s: Automatically assigned USB device %s\n", o->name, radio_device->devstr);
+	}
+
+	o->device_error = AST_RADIO_DEVICE_READY;
 	ast_radio_time(&o->lasthidtime);
-	o->usbass = 1;
-	ast_mutex_unlock(&usb_dev_lock);
 	return 0;
 }
 
 /*!
  * \brief USB sound device GPIO processing thread
- * This thread is responsible for finding and associating the node with the
- * associated usb sound card device.  It performs setup and initialization of
- * the USB device.
+ * This thread uses the USB radio device assigned by res_usbradio and performs
+ * setup and initialization of its HID interface.
  *
  * The CM-XXX USB devices can support up to 8 GPIO pins that can be input or output.
  * It continuously polls the input GPIO pins on the device to see if they have changed.
@@ -1155,6 +1108,7 @@ static int init_audio_device(struct chan_simpleusb_pvt *o)
 static void *hidthread(void *arg)
 {
 	unsigned char buf[4], bufsave[4], keyed, ctcssed, txreq;
+	char assigned_devstr[128];
 	char lasttxtmp;
 	int i, j, k;
 	int res;
@@ -1187,23 +1141,28 @@ static void *hidthread(void *arg)
 	while (!o->stophidthread) {
 		ast_debug(5, "hidthread is entering outer loop");
 
-		/* try to initialize the usb device */
-		res = init_audio_device(o);
-		if (res < 0) {
-			init_audio_failed = simpleusb_log_fault(o, init_audio_failed, "Channel %s: Failed initialize the audio device\n", o->name);
-			usleep(DEVICE_RETRY);
-			continue;
+		/* Acquire a device unless a pending swap retained the existing lease */
+		if (!o->radio_device) {
+			res = init_audio_device(o);
+			if (res < 0) {
+				init_audio_failed = simpleusb_log_fault(o, init_audio_failed, "Channel %s: Failed initialize the audio device\n", o->name);
+				usleep(DEVICE_RETRY);
+				continue;
+			}
 		}
+		simpleusb_device_identity(o, assigned_devstr, sizeof(assigned_devstr), NULL, 0, NULL);
 
-		if (o->usb_dev == NULL) {
-			init_hid_failed = simpleusb_log_fault(o, init_hid_failed, "Channel %s: Cannot initialize device %s\n", o->name, o->devstr);
+		if (!o->radio_device || !o->radio_device->usb_device) {
+			init_hid_failed = simpleusb_log_fault(o, init_hid_failed, "Channel %s: Cannot initialize device %s\n", o->name, assigned_devstr);
+			simpleusb_release_device(o);
 			usleep(DEVICE_RETRY);
 			continue;
 		}
 
 		/* open the usb device device */
-		if (libusb_open(o->usb_dev, &usb_handle) < 0) {
-			open_device_failed = simpleusb_log_fault(o, open_device_failed, "Channel %s: Cannot open device %s\n", o->name, o->devstr);
+		if (libusb_open(o->radio_device->usb_device, &usb_handle) < 0) {
+			open_device_failed = simpleusb_log_fault(o, open_device_failed, "Channel %s: Cannot open device %s\n", o->name, assigned_devstr);
+			simpleusb_release_device(o);
 			usleep(DEVICE_RETRY);
 			continue;
 		}
@@ -1213,6 +1172,7 @@ static void *hidthread(void *arg)
 				detach_failed = simpleusb_log_fault(o, detach_failed, "Channel %s: Is not able to detach the USB device\n", o->name);
 				libusb_close(usb_handle);
 				usb_handle = NULL;
+				simpleusb_release_device(o);
 				usleep(DEVICE_RETRY);
 				continue;
 			}
@@ -1220,6 +1180,7 @@ static void *hidthread(void *arg)
 				claim_failed = simpleusb_log_fault(o, claim_failed, "Channel %s: Is not able to claim the USB device\n", o->name);
 				libusb_close(usb_handle);
 				usb_handle = NULL;
+				simpleusb_release_device(o);
 				usleep(DEVICE_RETRY);
 				continue;
 			}
@@ -1246,36 +1207,23 @@ static void *hidthread(void *arg)
 		}
 		if (pipe2(o->pttkick, O_NONBLOCK) == -1) {
 			pipe_failed = simpleusb_log_fault(o, pipe_failed, "Channel %s: Is not able to create a pipe\n", o->name);
-			ast_mutex_lock(&usb_dev_lock);
-			o->usbass = 0;
 			o->hasusb = 0;
-			if (o->usb_dev) {
-				libusb_unref_device(o->usb_dev);
-				o->usb_dev = NULL;
-			}
-
-			ast_mutex_unlock(&usb_dev_lock);
 			libusb_close(usb_handle);
 			usb_handle = NULL;
+			simpleusb_release_device(o);
 			/* Stay in hidthread and retry; call() only starts the thread once. */
 			usleep(DEVICE_RETRY);
 			continue;
 		}
 
-		{
-			struct libusb_device_descriptor desc;
-
-			if (libusb_get_device_descriptor(o->usb_dev, &desc) < 0) {
-				ast_log(LOG_ERROR, "Channel %s: Unable to read USB device descriptor\n", o->name);
-				o->devtype = 0;
-			} else if ((desc.idProduct & 0xfffc) == C108_PRODUCT_ID) {
-				o->devtype = C108_PRODUCT_ID;
-			} else {
-				o->devtype = desc.idProduct;
-			}
+		/* Classify the device using the descriptor data retained by the lease */
+		if ((o->radio_device->product_id & 0xfffc) == C108_PRODUCT_ID) {
+			o->devtype = C108_PRODUCT_ID;
+		} else {
+			o->devtype = o->radio_device->product_id;
 		}
 		ast_debug(5, "Channel %s: Starting normally.\n", o->name);
-		ast_debug(5, "Channel %s: Attached to usb device %s.\n", o->name, o->devstr);
+		ast_debug(5, "Channel %s: Attached to usb device %s.\n", o->name, assigned_devstr);
 
 		mixer_write(o);
 		load_tune_config(o, NULL, 1);
@@ -1411,7 +1359,7 @@ static void *hidthread(void *arg)
 				buf[o->hid_gpio_ctl_loc] = o->hid_gpio_ctl;
 				ast_mutex_unlock(&o->usblock);
 				gpio_write = 1;
-				ast_debug(2, "Channel %s: update PTT = %d on channel.\n", o->name, txreq);
+				ast_debug(2, "Channel %s: update PTT = %d.\n", o->name, txreq);
 			} else if (!txreq && lasttxtmp) {
 				ast_mutex_lock(&o->usblock);
 				o->hid_gpio_val &= ~o->hid_io_ptt;
@@ -1648,6 +1596,11 @@ static void *hidthread(void *arg)
 			libusb_close(usb_handle);
 			usb_handle = NULL;
 		}
+		/* Park the lease after both HID and audio have stopped for a device swap */
+		if (simpleusb_swap_hid_wait(o)) {
+			continue;
+		}
+		simpleusb_release_device(o);
 	}
 	/* clean up before exiting the thread */
 	o->lasttx = 0;
@@ -1664,6 +1617,7 @@ static void *hidthread(void *arg)
 		libusb_close(usb_handle);
 		usb_handle = NULL;
 	}
+	simpleusb_release_device(o);
 
 	ast_debug(2, "hidthread has exited");
 	return NULL;
@@ -1775,7 +1729,7 @@ static int simpleusb_text(struct ast_channel *c, const char *text)
 	cmd = ast_alloca(strlen(text) + 10);
 
 	/* print received messages */
-	ast_debug(3, "Channel %s: Console Received usbradio text %s >> \n", o->name, text);
+	ast_debug(3, "Channel %s: Console Received simpleusb text %s >> \n", o->name, text);
 
 	/* set receive CTCSS */
 	if (!strncmp(text, "RXCTCSS", 7)) {
@@ -2040,10 +1994,7 @@ static int simpleusb_hangup(struct ast_channel *c)
 		pthread_join(o->hidthread, NULL);
 		o->hidthread = AST_PTHREADT_NULL;
 	}
-	if (o->usb_dev) {
-		libusb_unref_device(o->usb_dev);
-		o->usb_dev = NULL;
-	}
+	simpleusb_release_device(o);
 	o->owner = NULL;
 	ast_channel_tech_pvt_set(c, NULL);
 	ast_module_unref(ast_module_info->self);
@@ -2145,6 +2096,7 @@ static void flush_stream_buffer(struct chan_simpleusb_pvt *o)
 static void stream_cleanup(struct chan_simpleusb_pvt *o)
 {
 	ast_radio_pa_stop(&o->pa);
+	simpleusb_swap_audio_stopped(o);
 	o->audio_thread_ready = 0;
 	flush_stream_buffer(o);
 }
@@ -2176,14 +2128,14 @@ static void *simpleusb_audio_thread(void *arg)
 		ast_radio_time(&o->lastaudiotime);
 
 		if (!o->hasusb) {
+			simpleusb_swap_audio_stopped(o);
 			ast_debug(5, "Audio not ready");
 			usleep(DEVICE_RETRY);
 			continue;
 		}
 
 		if (!o->pa.active && start_stream(o) < 0) {
-			start_stream_failed =
-				simpleusb_log_fault(o, start_stream_failed, "Channel %s: Failed to start audio stream %s\n", o->name, o->hw_device);
+			start_stream_failed = simpleusb_log_fault(o, start_stream_failed, "Channel %s: Failed to start audio stream\n", o->name);
 			o->hasusb = 0;
 			usleep(DEVICE_RETRY);
 			continue;
@@ -2605,7 +2557,8 @@ static void *simpleusb_audio_thread(void *arg)
 				}
 
 				if (o->duplex3) {
-					ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_SW, 0, 0);
+					/* Disable receive sidetone when the receiver unkeys. */
+					simpleusb_set_sidetone_switch(o, 0);
 				}
 			} else if (!o->lastrx && o->rxkeyed) {
 				struct ast_frame wf = {
@@ -2621,7 +2574,8 @@ static void *simpleusb_audio_thread(void *arg)
 				}
 
 				if (o->duplex3) {
-					ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_SW, 1, 0);
+					/* Enable receive sidetone while the receiver is keyed. */
+					simpleusb_set_sidetone_switch(o, 1);
 				}
 			}
 
@@ -2789,6 +2743,7 @@ static void *simpleusb_audio_thread(void *arg)
 				ast_queue_frame(o->owner, f);
 			}
 		}
+		stream_cleanup(o);
 	}
 	stream_cleanup(o);
 	ast_debug(2, "Audio Thread has exited");
@@ -2979,13 +2934,12 @@ static struct ast_channel *simpleusb_request(const char *type, struct ast_format
 
 	if (!(ast_format_cap_iscompatible(cap, simpleusb_tech.capabilities))) {
 		struct ast_str *cap_buf = ast_str_alloca(AST_FORMAT_CAP_NAMES_LEN);
-		ast_log(LOG_NOTICE, "Channel %s: Channel requested with unsupported format(s): '%s'\n", o->name,
-			ast_format_cap_get_names(cap, &cap_buf));
+		ast_log(LOG_NOTICE, "Channel %s: Requested with unsupported format(s): '%s'\n", o->name, ast_format_cap_get_names(cap, &cap_buf));
 		return NULL;
 	}
 
 	if (o->owner) {
-		ast_log(LOG_NOTICE, "Channel %s: Already has a call (chan %p) on the usb channel\n", o->name, o->owner);
+		ast_log(LOG_NOTICE, "Channel %s: Already has a call (chan %p)\n", o->name, o->owner);
 		*cause = AST_CAUSE_BUSY;
 		return NULL;
 	}
@@ -3054,7 +3008,12 @@ static int susb_active(int fd, int argc, const char *const *argv)
 		if (!strcmp(argv[2], "show")) {
 			ast_mutex_lock(&usb_dev_lock);
 			for (o = simpleusb_default.next; o; o = o->next) {
-				ast_cli(fd, "Device [%s] exists as device=%s card=%d\n", o->name, o->devstr, ast_radio_usb_get_usbdev(o->devstr));
+				char devstr[sizeof(o->devstr)];
+				int alsa_card;
+
+				simpleusb_device_identity(o, devstr, sizeof(devstr), NULL, 0, &alsa_card);
+				ast_cli(fd, "Device [%s] is assigned to device=%s card=%d\n", o->name,
+					ast_strlen_zero(devstr) ? "unassigned" : devstr, alsa_card);
 			}
 			ast_mutex_unlock(&usb_dev_lock);
 			return RESULT_SUCCESS;
@@ -3078,14 +3037,15 @@ static int susb_active(int fd, int argc, const char *const *argv)
  */
 static int usb_device_swap(int fd, const char *other)
 {
-	int d;
-	char tmp[128];
-	struct chan_simpleusb_pvt *p = NULL, *o = find_desc(simpleusb_active);
+	struct chan_simpleusb_pvt *p, *o;
+	int attempts;
+	int result;
 
-	if (o == NULL) {
+	if (!other) {
 		return -1;
 	}
-	if (!other) {
+	o = find_desc(simpleusb_active);
+	if (o == NULL) {
 		return -1;
 	}
 	p = find_desc(other);
@@ -3097,19 +3057,64 @@ static int usb_device_swap(int fd, const char *other)
 		ast_cli(fd, "You can't swap active device with itself!!\n");
 		return -1;
 	}
+
+	/* Serialize the complete device swap transaction */
+	ast_mutex_lock(&device_swap_lock);
+	if (!o->hasusb || !p->hasusb) {
+		ast_cli(fd, "Both channels must have assigned USB devices before they can be swapped.\n");
+		ast_mutex_unlock(&device_swap_lock);
+		return -1;
+	}
+
+	/* Stop both device handles while retaining their shared leases */
 	ast_mutex_lock(&usb_dev_lock);
-	ast_copy_string(tmp, p->devstr, sizeof(tmp));
-	d = p->devicenum;
-	ast_copy_string(p->devstr, o->devstr, sizeof(p->devstr));
-	p->devicenum = o->devicenum;
-	ast_copy_string(o->devstr, tmp, sizeof(o->devstr));
-	o->devicenum = d;
+	simpleusb_swap_begin(o);
+	simpleusb_swap_begin(p);
 	o->hasusb = 0;
-	o->usbass = 0;
 	p->hasusb = 0;
-	p->usbass = 0;
-	ast_cli(fd, "USB Devices successfully swapped.\n");
 	ast_mutex_unlock(&usb_dev_lock);
+	kickptt(o);
+	kickptt(p);
+
+	/* Wait for the HID and PortAudio handles to close */
+	for (attempts = 0; attempts < 500; attempts++) {
+		if (simpleusb_swap_ready(o) && simpleusb_swap_ready(p)) {
+			break;
+		}
+		usleep(10000);
+	}
+	if (attempts == 500) {
+		simpleusb_swap_finish(o);
+		simpleusb_swap_finish(p);
+		ast_cli(fd, "Timed out waiting for both USB devices to stop.\n");
+		ast_mutex_unlock(&device_swap_lock);
+		return -1;
+	}
+
+	/* Exchange the parked leases and use their identities for future requests */
+	ast_mutex_lock(&usb_dev_lock);
+	ast_mutex_lock(&o->device_lock);
+	ast_mutex_lock(&p->device_lock);
+	result = ast_radio_device_swap(&o->radio_device, &p->radio_device);
+	if (!result) {
+		ast_copy_string(o->devstr, o->radio_device->devstr, sizeof(o->devstr));
+		ast_copy_string(o->serial, S_OR(o->radio_device->serial, ""), sizeof(o->serial));
+		ast_copy_string(p->devstr, p->radio_device->devstr, sizeof(p->devstr));
+		ast_copy_string(p->serial, S_OR(p->radio_device->serial, ""), sizeof(p->serial));
+	}
+	ast_mutex_unlock(&p->device_lock);
+	ast_mutex_unlock(&o->device_lock);
+	simpleusb_swap_finish(o);
+	simpleusb_swap_finish(p);
+	ast_mutex_unlock(&usb_dev_lock);
+
+	if (result) {
+		ast_cli(fd, "Unable to exchange USB device leases.\n");
+		ast_mutex_unlock(&device_swap_lock);
+		return -1;
+	}
+	ast_cli(fd, "USB Devices successfully swapped.\n");
+	ast_mutex_unlock(&device_swap_lock);
 	return 0;
 }
 
@@ -3404,14 +3409,17 @@ static int _send_tx_test_tone(int fd, struct chan_simpleusb_pvt *o, int ms, int 
  */
 static void _menu_print(int fd, struct chan_simpleusb_pvt *o)
 {
+	char devstr[sizeof(o->devstr)];
+	char serial[sizeof(o->serial)];
+	int alsa_card;
+
+	simpleusb_device_identity(o, devstr, sizeof(devstr), serial, sizeof(serial), &alsa_card);
 	ast_cli(fd, "Active radio interface is [%s]\n", simpleusb_active);
-	ast_mutex_lock(&usb_dev_lock);
-	ast_cli(fd, "Device String is %s\n", o->devstr);
-	if (!ast_strlen_zero(o->serial)) {
-		ast_cli(fd, "Device Serial is %s\n", o->serial);
+	ast_cli(fd, "Device String is %s\n", ast_strlen_zero(devstr) ? "unassigned" : devstr);
+	if (!ast_strlen_zero(serial)) {
+		ast_cli(fd, "Device Serial is %s\n", serial);
 	}
-	ast_mutex_unlock(&usb_dev_lock);
-	ast_cli(fd, "Card is %i\n", ast_radio_usb_get_usbdev(o->devstr));
+	ast_cli(fd, "Card is %i\n", alsa_card);
 	ast_cli(fd, "Rx Level currently set to %d\n", o->rxmixerset);
 	ast_cli(fd, "Tx A Level currently set to %d\n", o->txmixaset);
 	ast_cli(fd, "Tx B Level currently set to %d\n", o->txmixbset);
@@ -3613,34 +3621,38 @@ static void tune_write(struct chan_simpleusb_pvt *o)
 	if (!category) {
 		ast_log(LOG_ERROR, "No category '%s' exists?\n", o->name);
 	} else {
-		/*
-		 * To simplify channel driver setup we allow the "devstr=" value
-		 * to be empty/blank indicating that we should match the first
-		 * available interface.
-		 *
-		 * This works (and will continue to work) well as long as the
-		 * "devstr=" value in the configuration file remains empty/blank.
-		 * But, if the value is ever provided then we only match interfaces
-		 * with the specified string.  Moving the interface (accidentally
-		 * or intentionally) to a different "port" will result in not
-		 * finding/matching the interface.
-		 *
-		 * To minimize conflicts, we want to avoid writing out the specific
-		 * "devstr=" value to the configuration file unless needed.  Here,
-		 * we check if the current "devstr=" value is empty/blank and
-		 * that there is only a single audio interface connected to the
-		 * system.  If so, we leave the value empty/blank.
-		 */
-		const char *val;
-		char *dev;
+		char assigned_devstr[sizeof(o->devstr)];
+		char assigned_serial[sizeof(o->serial)];
+		int automatic;
 
-		val = ast_variable_retrieve(cfg, o->name, "devstr");
-		dev = ast_radio_usb_get_devstr(1);
-		if (!ast_strlen_zero(val) || !ast_strlen_zero(dev)) {
-			/* if the "devstr=" value exists or there is more than 1 sound device */
+		/*
+		 * To simplify channel driver setup, blank "devstr=" and "serial="
+		 * values request automatic assignment of the first compatible USB
+		 * radio device.
+		 *
+		 * We preserve that automatic configuration when only one active lease
+		 * was assigned automatically. When multiple leases were assigned
+		 * automatically, their assignment order is indeterminate, so save this
+		 * channel's acquired identity as an explicit selector.
+		 *
+		 * Explicit selectors are saved unchanged. A topology-based devstr may
+		 * stop matching if the interface is moved to another USB port, while a
+		 * serial selector continues to take precedence over devstr.
+		 */
+		automatic = ast_strlen_zero(o->devstr) && ast_strlen_zero(o->serial);
+		if (!automatic) {
 			CONFIG_UPDATE_STR(devstr);
-			if (!ast_strlen_zero(o->serial)) {
+			if (!ast_strlen_zero(o->serial) || ast_variable_retrieve(cfg, o->name, "serial")) {
 				CONFIG_UPDATE_STR(serial);
+			}
+		} else if (ast_radio_device_automatic_count() > 1) {
+			simpleusb_device_identity(o, assigned_devstr, sizeof(assigned_devstr), assigned_serial, sizeof(assigned_serial), NULL);
+			if (!ast_strlen_zero(assigned_serial)) {
+				if (tune_variable_update(cfg, CONFIG, category, "serial", assigned_serial)) {
+					ast_log(LOG_WARNING, "Failed to update serial\n");
+				}
+			} else if (!ast_strlen_zero(assigned_devstr) && tune_variable_update(cfg, CONFIG, category, "devstr", assigned_devstr)) {
+				ast_log(LOG_WARNING, "Failed to update devstr\n");
 			}
 		}
 		CONFIG_UPDATE_INT(rxmixerset);
@@ -3732,7 +3744,7 @@ static void tune_menusupport(int fd, struct chan_simpleusb_pvt *o, const char *c
 		if (!strcmp(cmd, "0+4")) {
 			ast_cli(fd, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n", o->txmixaset, o->txmixbset, o->echomode, o->rxboost,
 				o->preemphasis, o->deemphasis, o->plfilter, o->invertptt, o->rxcdtype, o->rxsdtype, o->rxondelay, o->txoffdelay,
-				o->rxmixerset, o->micplaymax, o->spkrmax, o->micmax);
+				o->rxmixerset, (int) simpleusb_sidetone_mixer_max(o), (int) simpleusb_tx_mixer_max(o), (int) simpleusb_rx_mixer_max(o));
 		} else {
 			ast_cli(fd, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n", o->txmixaset, o->txmixbset, o->echomode, o->rxboost,
 				o->preemphasis, o->deemphasis, o->plfilter, o->invertptt, o->rxcdtype, o->rxsdtype, o->rxondelay, o->txoffdelay);
@@ -4041,35 +4053,71 @@ static void store_pager(struct chan_simpleusb_pvt *o, char *s)
  */
 static void mixer_write(struct chan_simpleusb_pvt *o)
 {
-	int mic_setting;
+	const struct ast_radio_mixer_element *element;
+	struct ast_radio_device *device;
+	int requested;
+	long rx_max;
+	long sidetone_max;
+	size_t path_index;
 	float f, f1;
 
-	if (o->duplex3) {
-		if (o->duplex3 > o->micplaymax) {
-			o->duplex3 = o->micplaymax;
-		}
-		ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_VOL, o->duplex3, 0);
-	} else {
-		ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_VOL, 0, 0);
+	ast_mutex_lock(&o->device_lock);
+	device = o->radio_device;
+	if (!device) {
+		ast_mutex_unlock(&o->device_lock);
+		return;
 	}
-	ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_SW, 0, 0);
-	ast_radio_setamixer(o->devicenum, (o->newname) ? MIXER_PARAM_SPKR_PLAYBACK_SW_NEW : MIXER_PARAM_SPKR_PLAYBACK_SW, 1, 0);
-	ast_radio_setamixer(o->devicenum, (o->newname) ? MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW : MIXER_PARAM_SPKR_PLAYBACK_VOL,
-		ast_radio_make_spkr_playback_value(o->spkrmax, o->txmixaset, o->devtype),
-		ast_radio_make_spkr_playback_value(o->spkrmax, o->txmixbset, o->devtype));
+
+	/* Configure receive sidetone (Mic Playback controls on CM108) */
+	sidetone_max = ast_radio_device_mixer_max(device, device->mixer_sidetone_paths, AST_RADIO_MIXER_PLAYBACK_VOLUME);
+	if (o->duplex3 > sidetone_max) {
+		o->duplex3 = sidetone_max;
+	}
+	ast_radio_device_set_mixer_paths(device, device->mixer_sidetone_paths, device->mixer_sidetone_path_count,
+		AST_RADIO_MIXER_PLAYBACK_VOLUME, o->duplex3);
+	ast_radio_device_set_mixer_paths(device, device->mixer_sidetone_paths, device->mixer_sidetone_path_count,
+		AST_RADIO_MIXER_PLAYBACK_SWITCH, 0);
+
+	/* Configure transmitter output levels (Speaker/Headphone controls on CM108)
+	 * txmixaset (MIXA) controls mixer_tx_paths[0], and txmixbset (MIXB) controls
+	 * mixer_tx_paths[1] when a second path is present. Additional paths are unchanged.
+	 */
+	for (path_index = 0; path_index < device->mixer_tx_path_count && path_index < 2; path_index++) {
+		element = ast_radio_device_mixer_element(device, &device->mixer_tx_paths[path_index]);
+		if (!element) {
+			continue;
+		}
+		requested = path_index ? o->txmixbset : o->txmixaset;
+		ast_radio_device_set_mixer(device, &device->mixer_tx_paths[path_index], AST_RADIO_MIXER_PLAYBACK_SWITCH, 1);
+		ast_radio_device_set_mixer(device, &device->mixer_tx_paths[path_index], AST_RADIO_MIXER_PLAYBACK_VOLUME,
+			ast_radio_device_mixer_scale(device, &device->mixer_tx_paths[path_index], AST_RADIO_MIXER_PLAYBACK_VOLUME, requested));
+	}
+
 	/* adjust settings based on the device */
 	if (o->devtype == C119B_PRODUCT_ID) {
 		o->rxboost = 1; /*rxboost is always set for this device */
 	}
-	mic_setting = o->rxmixerset * o->micmax / AUDIO_ADJUSTMENT;
-	/* get interval step size */
-	f = AUDIO_ADJUSTMENT / (float) o->micmax;
 
-	ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL, mic_setting, 0);
-	ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_BOOST, o->rxboost, 0);
-	ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_CAPTURE_SW, 1, 0);
+	/* Configure receiver input level and switch (Mic Capture controls on CM108) */
+	for (path_index = 0; path_index < device->mixer_rx_path_count; path_index++) {
+		element = ast_radio_device_mixer_element(device, &device->mixer_rx_paths[path_index]);
+		if (!element) {
+			continue;
+		}
+		ast_radio_device_set_mixer(device, &device->mixer_rx_paths[path_index], AST_RADIO_MIXER_CAPTURE_VOLUME,
+			ast_radio_device_mixer_scale(device, &device->mixer_rx_paths[path_index], AST_RADIO_MIXER_CAPTURE_VOLUME, o->rxmixerset));
+		ast_radio_device_set_mixer(device, &device->mixer_rx_paths[path_index], AST_RADIO_MIXER_CAPTURE_SWITCH, 1);
+	}
+	/* Configure optional receiver input gain/AGC (Auto Gain Control on CM108) */
+	ast_radio_device_set_mixer_paths(device, device->mixer_rx_boost_paths, device->mixer_rx_boost_path_count,
+		AST_RADIO_MIXER_PLAYBACK_SWITCH, o->rxboost);
+
+	/* get interval step size */
+	rx_max = ast_radio_device_mixer_max(device, device->mixer_rx_paths, AST_RADIO_MIXER_CAPTURE_VOLUME);
+	f = rx_max > 0 ? AUDIO_ADJUSTMENT / (float) rx_max : AUDIO_ADJUSTMENT;
 	/* set the received voice adjustment factor */
 	o->rxvoiceadj = 1.0 + (modff(((float) o->rxmixerset) / f, &f1) * .187962);
+	ast_mutex_unlock(&o->device_lock);
 }
 
 /*!
@@ -4103,7 +4151,6 @@ static struct chan_simpleusb_pvt *store_config(struct ast_config *cfg, const cha
 			o->pttkick[1] = -1;
 			o->audiothread = AST_PTHREADT_NULL;
 			o->hidthread = AST_PTHREADT_NULL;
-			o->hw_device[0] = '\0';
 			if (!simpleusb_active) {
 				simpleusb_active = o->name;
 			}
@@ -4114,6 +4161,8 @@ static struct chan_simpleusb_pvt *store_config(struct ast_config *cfg, const cha
 	ast_mutex_init(&o->eepromlock);
 	ast_mutex_init(&o->txqlock);
 	ast_mutex_init(&o->usblock);
+	ast_mutex_init(&o->device_lock);
+	ast_mutex_init(&o->swap_lock);
 	o->echomax = DEFAULT_ECHO_MAX;
 	/* fill other fields from configuration */
 	for (v = ast_variable_browse(cfg, ctg); v; v = v->next) {
@@ -4420,17 +4469,6 @@ static int load_module(void)
 	}
 	ast_format_cap_append(simpleusb_tech.capabilities, ast_format_slin, 0);
 
-	if (ast_radio_libusb_init() < 0) {
-		ast_log(LOG_ERROR, "Unable to initialize libusb\n");
-		ao2_cleanup(simpleusb_tech.capabilities);
-		simpleusb_tech.capabilities = NULL;
-		return AST_MODULE_LOAD_DECLINE;
-	}
-	if (ast_radio_hid_device_mklist()) {
-		ast_log(LOG_ERROR, "Unable to make hid list\n");
-		return AST_MODULE_LOAD_DECLINE;
-	}
-
 	simpleusb_active = NULL;
 
 	/* Copy the default jb config over global_jbconf */
@@ -4508,10 +4546,7 @@ static int unload_module(void)
 			}
 		}
 		ast_free(o->name);
-		if (o->usb_dev) {
-			libusb_unref_device(o->usb_dev);
-			o->usb_dev = NULL;
-		}
+		simpleusb_release_device(o);
 		ast_free(o);
 	}
 

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -140,7 +140,7 @@ static struct ast_jb_conf global_jbconf;
 static FILE *frxcapraw = NULL, *frxcaptrace = NULL, *frxoutraw = NULL;
 static FILE *ftxcapraw = NULL, *ftxcaptrace = NULL, *ftxoutraw = NULL;
 
-AST_MUTEX_DEFINE_STATIC(usb_dev_lock);
+AST_MUTEX_DEFINE_STATIC(device_swap_lock);
 AST_MUTEX_DEFINE_STATIC(pp_lock);
 
 /* variables for communicating with the parallel port */
@@ -180,7 +180,6 @@ struct chan_usbradio_pvt {
 	struct chan_usbradio_pvt *next;
 
 	char *name;				 /* the internal name of our channel */
-	char hw_device[100];	 /* ALSA/PortAudio device (hw:N or hw:N,M) */
 	int devtype;			 /* actual type of device */
 	int pttkick[2];			 /* ptt kick pipe */
 	struct ast_radio_pa_stream pa;
@@ -194,12 +193,8 @@ struct chan_usbradio_pvt {
 	unsigned int queuesize; /* max fragments in queue */
 	unsigned int frags;		/* parameter for SETFRAGMENT */
 
-	char devicenum;
 	char devstr[128];
 	char serial[128];
-	int spkrmax;
-	int micmax;
-	int micplaymax;
 
 	pthread_t hidthread;
 	pthread_t audiothread;
@@ -208,8 +203,20 @@ struct chan_usbradio_pvt {
 	volatile sig_atomic_t hasusb; /* HID/audio liveness; not a bit-field (cross-thread) */
 	char audio_thread_ready;
 	time_t lastaudiotime;
+	enum {
+		DEVICE_SWAP_IDLE,	   /*!< No device swap requested */
+		DEVICE_SWAP_QUIESCING, /*!< Device handles are stopping */
+		DEVICE_SWAP_READY,	   /*!< Device is ready for lease exchange */
+	} swap_state;
+	unsigned int swap_audio_ready:1; /*!< PortAudio stopped for pending swap */
+	ast_mutex_t swap_lock;			 /* protects device swap state */
 
 	struct ast_channel *owner;
+
+	/* Shared USB radio device lease */
+	struct ast_radio_device *radio_device;
+	ast_mutex_t device_lock;
+	enum ast_radio_device_result device_error;
 
 	/* Outbound 8 kHz frames from Asterisk, drained by the audio thread into PmrTx. */
 	AST_LIST_HEAD_NOLOCK(, ast_frame) txq;
@@ -379,9 +386,6 @@ struct chan_usbradio_pvt {
 	unsigned int lsdrxpolarity:1;	/* indicator for lsd receive polarity */
 	unsigned int lsdtxpolarity:1;	/* indicator for lsd transmit polarity */
 	unsigned int radioactive:1;		/* indicator for active radio channel */
-	unsigned int device_error:1;	/* indicator set when we cannot find the USB device */
-	unsigned int newname:1;			/* indicator that we should use MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW */
-	unsigned int usbass:1;			/* indicator for USB device assigned */
 	unsigned int wanteeprom:1;		/* indicator if we should use EEPROM */
 	unsigned int usedtmf:1;			/* indicator is we should decode DTMF */
 	unsigned int invertptt:1;		/* indicator if we need to invert ptt */
@@ -401,7 +405,6 @@ struct chan_usbradio_pvt {
 	char eepromctl;
 	ast_mutex_t eepromlock;
 
-	struct libusb_device_handle *usb_handle;
 	int readerrs;
 	struct timeval tonetime;
 	int toneflag;
@@ -511,12 +514,41 @@ static int __attribute__((format(printf, 3, 4))) usbradio_log_fault(struct chan_
 	return 1;
 }
 
+static void usbradio_device_identity(struct chan_usbradio_pvt *o, char *devstr, size_t devstr_size, char *serial,
+	size_t serial_size, int *alsa_card)
+{
+	if (devstr && devstr_size) {
+		devstr[0] = '\0';
+	}
+	if (serial && serial_size) {
+		serial[0] = '\0';
+	}
+	if (alsa_card) {
+		*alsa_card = -1;
+	}
+
+	/* Acquired device identity */
+	ast_mutex_lock(&o->device_lock);
+	if (o->radio_device) {
+		if (devstr && devstr_size) {
+			ast_copy_string(devstr, o->radio_device->devstr, devstr_size);
+		}
+		if (serial && serial_size && o->radio_device->serial) {
+			ast_copy_string(serial, o->radio_device->serial, serial_size);
+		}
+		if (alsa_card) {
+			*alsa_card = o->radio_device->alsa_card;
+		}
+	}
+	ast_mutex_unlock(&o->device_lock);
+}
+
 /*!
  * \brief Log once when USB/audio returns after a prior failure.
  */
 static void usbradio_log_usb_recovered(struct chan_usbradio_pvt *o)
 {
-	const char *dev;
+	char devstr[sizeof(o->devstr)];
 	sig_atomic_t was_faulted;
 
 	was_faulted = o->usb_faulted;
@@ -524,9 +556,10 @@ static void usbradio_log_usb_recovered(struct chan_usbradio_pvt *o)
 	if (!was_faulted) {
 		return;
 	}
-	dev = !ast_strlen_zero(o->devstr) ? o->devstr : o->hw_device;
+
 	/* Match fault priority so ERROR-level logs pair fault with recovery. */
-	ast_log(LOG_ERROR, "Channel %s: USB radio device recovered (%s)\n", o->name, !ast_strlen_zero(dev) ? dev : "unknown");
+	usbradio_device_identity(o, devstr, sizeof(devstr), NULL, 0, NULL);
+	ast_log(LOG_ERROR, "Channel %s: USB radio device recovered (%s)\n", o->name, S_OR(devstr, "unknown"));
 }
 
 static char *usbradio_active; /* the active device */
@@ -704,46 +737,6 @@ static struct chan_usbradio_pvt *find_desc(const char *dev)
 }
 
 /*!
- * \brief Search our configured channels to find the
- *	one with the matching USB descriptor.
- * \param o		chan_usbradio_pvt.
- * \returns		Private structure that matches or NULL if not found.
- */
-static struct chan_usbradio_pvt *find_desc_usb(const char *devstr)
-{
-	struct chan_usbradio_pvt *o = NULL;
-
-	if (!devstr) {
-		ast_log(LOG_WARNING, "USB Descriptor is null.\n");
-	}
-
-	for (o = usbradio_default.next; o && devstr && strcmp(o->devstr, devstr) != 0; o = o->next)
-		;
-
-	return o;
-}
-
-/*!
- * \brief Search installed devices for a match with
- *	one of our configured channels.
- * \returns		Matching device string, or NULL.
- */
-static char *find_installed_usb_match(void)
-{
-	struct chan_usbradio_pvt *o = NULL;
-	char *match = NULL;
-
-	for (o = usbradio_default.next; o; o = o->next) {
-		if (ast_radio_usb_list_check(o->devstr)) {
-			match = o->devstr;
-			break;
-		}
-	}
-
-	return match;
-}
-
-/*!
  * \brief Parallel port processing thread.
  *	This thread evaluates the timers configured for each
  *  configured parallel port pin.
@@ -811,7 +804,6 @@ static int load_tune_config(struct chan_usbradio_pvt *o, const struct ast_config
 	int configured = 0;
 	char devstr[sizeof(o->devstr)];
 	char serial[sizeof(o->serial)];
-	char hw_device[sizeof(o->hw_device)];
 
 	/* No load defaults */
 	o->rxmixerset = 500;
@@ -825,11 +817,9 @@ static int load_tune_config(struct chan_usbradio_pvt *o, const struct ast_config
 
 	devstr[0] = '\0';
 	serial[0] = '\0';
-	hw_device[0] = '\0';
 	if (!reload) {
 		o->devstr[0] = 0;
 		o->serial[0] = 0;
-		o->hw_device[0] = '\0';
 	}
 
 	if (!cfg) {
@@ -857,18 +847,12 @@ static int load_tune_config(struct chan_usbradio_pvt *o, const struct ast_config
 		CV_UINT("fever", o->fever);
 		CV_STR("devstr", devstr);
 		CV_STR("serial", serial);
-		CV_STR("audiodev", hw_device);
 		CV_END;
 	}
 	if (!reload) {
 		/* Using the ternary operator in CV_STR won't work, due to butchering the sizeof, so copy after if needed */
 		ast_copy_string(o->devstr, devstr, sizeof(o->devstr));
 		ast_copy_string(o->serial, serial, sizeof(o->serial));
-		if (ast_strlen_zero(devstr)) {
-			ast_copy_string(o->hw_device, hw_device, sizeof(o->hw_device));
-		} else {
-			o->hw_device[0] = '\0';
-		}
 	}
 	if (opened) {
 		ast_config_destroy(cfg2);
@@ -958,24 +942,183 @@ static void usbradio_adjust_txmix_for_mono(struct chan_usbradio_pvt *o)
 	}
 }
 
+static void usbradio_release_device(struct chan_usbradio_pvt *o)
+{
+	ast_mutex_lock(&o->device_lock);
+	if (o->radio_device) {
+		ast_radio_device_release(o->radio_device);
+		o->radio_device = NULL;
+	}
+	ast_mutex_unlock(&o->device_lock);
+}
+
+static void usbradio_swap_begin(struct chan_usbradio_pvt *o)
+{
+	ast_mutex_lock(&o->swap_lock);
+	o->swap_audio_ready = 0;
+	o->swap_state = DEVICE_SWAP_QUIESCING;
+	ast_mutex_unlock(&o->swap_lock);
+}
+
+static void usbradio_swap_audio_stopped(struct chan_usbradio_pvt *o)
+{
+	ast_mutex_lock(&o->swap_lock);
+	if (o->swap_state == DEVICE_SWAP_QUIESCING) {
+		o->swap_audio_ready = 1;
+	}
+	ast_mutex_unlock(&o->swap_lock);
+}
+
+static int usbradio_swap_hid_wait(struct chan_usbradio_pvt *o)
+{
+	int swapping;
+
+	ast_mutex_lock(&o->swap_lock);
+	swapping = o->swap_state == DEVICE_SWAP_QUIESCING;
+	while (swapping && !o->swap_audio_ready && !o->stophid) {
+		ast_mutex_unlock(&o->swap_lock);
+		usleep(10000);
+		ast_mutex_lock(&o->swap_lock);
+		swapping = o->swap_state == DEVICE_SWAP_QUIESCING;
+	}
+	if (swapping && o->swap_audio_ready) {
+		o->swap_state = DEVICE_SWAP_READY;
+	} else {
+		swapping = 0;
+	}
+	while (o->swap_state == DEVICE_SWAP_READY && !o->stophid) {
+		ast_mutex_unlock(&o->swap_lock);
+		usleep(10000);
+		ast_mutex_lock(&o->swap_lock);
+	}
+	ast_mutex_unlock(&o->swap_lock);
+	return swapping;
+}
+
+static int usbradio_swap_ready(struct chan_usbradio_pvt *o)
+{
+	int ready;
+
+	ast_mutex_lock(&o->swap_lock);
+	ready = o->swap_state == DEVICE_SWAP_READY;
+	ast_mutex_unlock(&o->swap_lock);
+	return ready;
+}
+
+static void usbradio_swap_finish(struct chan_usbradio_pvt *o)
+{
+	ast_mutex_lock(&o->swap_lock);
+	o->swap_audio_ready = 0;
+	o->swap_state = DEVICE_SWAP_IDLE;
+	ast_mutex_unlock(&o->swap_lock);
+}
+
+static void usbradio_mixer_limits(struct chan_usbradio_pvt *o, int *rx_max, int *tx_max, int *sidetone_max)
+{
+	*rx_max = 0;
+	*tx_max = 0;
+	*sidetone_max = 0;
+
+	ast_mutex_lock(&o->device_lock);
+	if (o->radio_device) {
+		*rx_max = ast_radio_device_mixer_max(o->radio_device, o->radio_device->mixer_rx_paths, AST_RADIO_MIXER_CAPTURE_VOLUME);
+		*tx_max = ast_radio_device_mixer_max(o->radio_device, o->radio_device->mixer_tx_paths, AST_RADIO_MIXER_PLAYBACK_VOLUME);
+		*sidetone_max = ast_radio_device_mixer_max(o->radio_device, o->radio_device->mixer_sidetone_paths, AST_RADIO_MIXER_PLAYBACK_VOLUME);
+	}
+	ast_mutex_unlock(&o->device_lock);
+}
+
+/* Control receive-audio monitoring into playback (Mic Playback Switch on CM108) */
+static void usbradio_set_sidetone_switch(struct chan_usbradio_pvt *o, int enabled)
+{
+	ast_mutex_lock(&o->device_lock);
+	if (o->radio_device) {
+		ast_radio_device_set_mixer_paths(o->radio_device, o->radio_device->mixer_sidetone_paths,
+			o->radio_device->mixer_sidetone_path_count, AST_RADIO_MIXER_PLAYBACK_SWITCH, enabled);
+	}
+	ast_mutex_unlock(&o->device_lock);
+}
+
+/* Control receive input level and optional gain/AGC */
+static void usbradio_set_rx_mixer(struct chan_usbradio_pvt *o, long volume)
+{
+	ast_mutex_lock(&o->device_lock);
+	if (o->radio_device) {
+		ast_radio_device_set_mixer_paths(o->radio_device, o->radio_device->mixer_rx_paths, o->radio_device->mixer_rx_path_count,
+			AST_RADIO_MIXER_CAPTURE_VOLUME, volume);
+		ast_radio_device_set_mixer_paths(o->radio_device, o->radio_device->mixer_rx_boost_paths,
+			o->radio_device->mixer_rx_boost_path_count, AST_RADIO_MIXER_PLAYBACK_SWITCH, o->rxboost);
+	}
+	ast_mutex_unlock(&o->device_lock);
+}
+
+/*! \brief Acquire and initialize the configured USB radio device */
+static int init_audio_device(struct chan_usbradio_pvt *o)
+{
+	struct ast_radio_device *radio_device;
+	struct ast_radio_device_request request = {
+		.devstr = o->devstr,
+		.serial = o->serial,
+		.owner = o->name,
+		.required_caps = AST_RADIO_CAP_CM108_HID,
+		.minimum_input_channels = 1,
+		.minimum_output_channels = 1,
+	};
+	enum ast_radio_device_result result;
+	int automatic;
+
+	automatic = ast_strlen_zero(request.serial) && ast_strlen_zero(request.devstr);
+	result = ast_radio_device_acquire(&request, &radio_device);
+	if (result != AST_RADIO_DEVICE_READY) {
+		if (o->device_error != result) {
+			usbradio_log_fault(o, 0, "Channel %s: %s\n", o->name, ast_radio_device_result_str(result));
+		}
+		o->device_error = result;
+		return -1;
+	}
+
+	/* Required receive and transmit mixer limits */
+	if (ast_radio_device_mixer_max(radio_device, radio_device->mixer_rx_paths, AST_RADIO_MIXER_CAPTURE_VOLUME) <= 0 ||
+		ast_radio_device_mixer_max(radio_device, radio_device->mixer_tx_paths, AST_RADIO_MIXER_PLAYBACK_VOLUME) <= 0) {
+		usbradio_log_fault(o, 0, "Channel %s: Cannot use USB radio device %s without mixer limits\n", o->name, radio_device->devstr);
+		ast_radio_device_release(radio_device);
+		o->device_error = AST_RADIO_DEVICE_ERROR;
+		return -1;
+	}
+
+	/* Acquired device publication without configured selector changes */
+	ast_mutex_lock(&o->device_lock);
+	o->radio_device = radio_device;
+	ast_mutex_unlock(&o->device_lock);
+	o->device_error = AST_RADIO_DEVICE_READY;
+
+	if (automatic) {
+		ast_log(LOG_NOTICE, "Channel %s: Automatically assigned USB device %s\n", o->name, radio_device->devstr);
+	}
+	return 0;
+}
+
 static int usbradio_start_audio(struct chan_usbradio_pvt *o)
 {
+	char devstr[sizeof(o->devstr)];
 	PaError res;
 
 	if (o->pa.active) {
 		return 0;
 	}
 
-	if (!o->hw_device[0]) {
-		snprintf(o->hw_device, sizeof(o->hw_device), "hw:%d", (int) (unsigned char) o->devicenum);
+	/* Exact PortAudio endpoints from the active device lease */
+	ast_mutex_lock(&o->device_lock);
+	if (!o->radio_device) {
+		ast_mutex_unlock(&o->device_lock);
+		return -1;
 	}
-
-	ast_copy_string(o->pa.hw_device, o->hw_device, sizeof(o->pa.hw_device));
-	o->pa.input_channels = 2;
-
-	res = ast_radio_pa_open(&o->pa);
+	ast_copy_string(devstr, o->radio_device->devstr, sizeof(devstr));
+	o->pa.input_channels = o->radio_device->pa_input_channels >= 2 ? 2 : 1;
+	res = ast_radio_pa_open_device(&o->pa, o->radio_device);
+	ast_mutex_unlock(&o->device_lock);
 	if (res != paNoError) {
-		ast_log(LOG_WARNING, "Channel %s: Unable to open PortAudio stream %s (%s)\n", o->name, o->hw_device, Pa_GetErrorText(res));
+		ast_log(LOG_WARNING, "Channel %s: Unable to open PortAudio stream for %s (%s)\n", o->name, devstr, Pa_GetErrorText(res));
 		return -1;
 	}
 
@@ -983,7 +1126,7 @@ static int usbradio_start_audio(struct chan_usbradio_pvt *o)
 
 	res = ast_radio_pa_start(&o->pa);
 	if (res != paNoError) {
-		ast_log(LOG_WARNING, "Channel %s: Unable to start PortAudio stream %s (%s)\n", o->name, o->hw_device, Pa_GetErrorText(res));
+		ast_log(LOG_WARNING, "Channel %s: Unable to start PortAudio stream for %s (%s)\n", o->name, devstr, Pa_GetErrorText(res));
 		ast_radio_pa_stop(&o->pa);
 		return -1;
 	}
@@ -993,9 +1136,8 @@ static int usbradio_start_audio(struct chan_usbradio_pvt *o)
 
 /*!
  * \brief USB sound device GPIO processing thread
- * This thread is responsible for finding and associating the node with the
- * associated usb sound card device.  It performs setup and initialization of
- * the USB device.
+ * This thread uses the USB radio device assigned by res_usbradio and performs
+ * setup and initialization of its HID interface.
  *
  * The CM-XXX USB devices can support up to 8 GPIO pins that can be input or output.
  * It continuously polls the input GPIO pins on the device to see if they have changed.
@@ -1023,23 +1165,19 @@ static int usbradio_start_audio(struct chan_usbradio_pvt *o)
 static void *hidthread(void *arg)
 {
 	unsigned char buf[4], bufsave[4], keyed, ctcssed;
-	char *s, lasttxtmp;
+	char lasttxtmp;
 	int i, j, k;
 	int res;
-	int use_newname = 0;
-	int init_hid_failed = 0;
 	int open_device_failed = 0;
 	int detach_failed = 0;
 	int claim_failed = 0;
 	int pipe_failed = 0;
 	int start_audio_failed = 0;
-	struct libusb_device *usb_dev;
 	struct libusb_device_handle *usb_handle;
-	struct chan_usbradio_pvt *o = arg, *ao;
+	struct chan_usbradio_pvt *o = arg;
 	struct timeval then;
 	struct pollfd rfds[1];
 
-	usb_dev = NULL;
 	usb_handle = NULL;
 	/* enable gpio_set so that we will write GPIO information upon start up */
 	o->gpio_set = 1;
@@ -1056,230 +1194,32 @@ static void *hidthread(void *arg)
 	 * with the usb hid device
 	 */
 	while (!o->stophid) {
-		char serial[sizeof(o->serial)] = { '\0' };
-
 		ast_radio_time(&o->lasthidtime);
-		ast_mutex_lock(&usb_dev_lock);
+
+		/* Prior device teardown */
 		o->hasusb = 0;
-		o->usbass = 0;
-		o->devicenum = 0;
 
 		if (usb_handle) {
 			libusb_close(usb_handle);
 			usb_handle = NULL;
 		}
 
-		if (usb_dev) {
-			libusb_unref_device(usb_dev);
-			usb_dev = NULL;
+		/* Park the lease after both HID and audio have stopped for a device swap */
+		if (usbradio_swap_hid_wait(o)) {
+			continue;
 		}
+		usbradio_release_device(o);
 
-		ast_radio_hid_device_mklist();
-
-		/* audiodev without devstr: bind HID to ALSA card number */
-		if (o->hw_device[0] && ast_strlen_zero(o->devstr)) {
-			int subdev;
-
-			if (ast_radio_parse_alsa_hw_device(o->hw_device, &i, &subdev)) {
-				int card_in_use = 0;
-
-				for (ao = usbradio_default.next; ao && ao->name; ao = ao->next) {
-					if (ao != o && ao->usbass && ao->devicenum == i) {
-						ast_log(LOG_ERROR, "Channel %s: Audio device %s is already assigned to channel %s\n", o->name, o->hw_device, ao->name);
-						card_in_use = 1;
-						break;
-					}
-				}
-				if (card_in_use) {
-					ast_mutex_unlock(&usb_dev_lock);
-					usleep(500000);
-					continue;
-				}
-				usb_dev = ast_radio_usb_device_from_alsa_card(i);
-				if (!usb_dev) {
-					o->device_error =
-						usbradio_log_fault(o, o->device_error, "Channel %s: No USB device for audiodev %s\n", o->name, o->hw_device);
-					ast_mutex_unlock(&usb_dev_lock);
-					usleep(500000);
-					continue;
-				}
-				o->devicenum = i;
-				if (ast_radio_init_mixer_limits(o->devicenum, &o->micmax, &o->spkrmax, &o->micplaymax, &use_newname) < 0) {
-					o->device_error = usbradio_log_fault(o, o->device_error,
-						"Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
-					ast_mutex_unlock(&usb_dev_lock);
-					usleep(500000);
-					continue;
-				}
-				o->newname = use_newname;
-				o->device_error = 0;
-				ast_radio_time(&o->lasthidtime);
-				o->usbass = 1;
-				ast_mutex_unlock(&usb_dev_lock);
-				goto usb_device_ready;
-			}
-			o->device_error =
-				usbradio_log_fault(o, o->device_error, "Channel %s: Invalid audiodev '%s' (use hw:N or hw:N,M)\n", o->name, o->hw_device);
-			ast_mutex_unlock(&usb_dev_lock);
+		/* Shared USB radio device discovery and reservation */
+		if (!o->radio_device && init_audio_device(o)) {
 			usleep(500000);
 			continue;
 		}
 
-		/* Check to see if our specified device string
-		 * matches to a device that is attached to this system, or exists
-		 * in our channel configuration.
-		 *
-		 * If no device string is specified, attempt to assign the first
-		 * found device.
-		 */
-		ast_radio_time(&o->lasthidtime);
-
-		/* If configuration has a serial number defined, find the device */
-		if (!ast_strlen_zero(o->serial)) {
-			int index;
-			char *index_devstr = NULL;
-
-			for (index = 0;; index++) {
-				index_devstr = ast_radio_usb_get_devstr(index);
-				if (ast_strlen_zero(index_devstr)) {
-					/* if no more devices */
-					break;
-				}
-
-				/* get the device serial number */
-				if (ast_radio_usb_get_serial(index_devstr, serial, sizeof(serial)) == 0) {
-					/* if no serial number */
-					continue;
-				}
-
-				if (strcmp(o->serial, serial) == 0) {
-					/*
-					 * We found a device with the matching serial number, set
-					 * the devstr to the matching device.
-					 */
-					ast_log(LOG_NOTICE, "Matched device serial %s to %s\n", o->serial, o->name);
-					ast_copy_string(o->devstr, index_devstr, sizeof(o->devstr));
-					break;
-				}
-			}
-		}
-
-		/* Automatically assign a devstr if one was not specified in the configuration. */
-		if (ast_strlen_zero(o->devstr)) {
-			int index = 0;
-			char *index_devstr = NULL;
-
-			for (;;) {
-				index_devstr = ast_radio_usb_get_devstr(index);
-				if (ast_strlen_zero(index_devstr)) {
-					o->device_error =
-						usbradio_log_fault(o, o->device_error, "Channel %s: No USB devices are available for assignment.\n", o->name);
-					ast_mutex_unlock(&usb_dev_lock);
-					usleep(500000);
-					break;
-				}
-				/* We found an available device - see if it already in use */
-				for (ao = usbradio_default.next; ao && ao->name; ao = ao->next) {
-					if (ao->usbass && (!strcmp(ao->devstr, index_devstr))) {
-						break;
-					}
-				}
-				if (ao) {
-					index++;
-					continue;
-				}
-				/* We found an unused device assign it to our node */
-				ast_copy_string(o->devstr, index_devstr, sizeof(o->devstr));
-				ast_log(LOG_NOTICE, "Channel %s: Automatically assigned USB device %s to USBRadio channel\n", o->name, o->devstr);
-				if (ast_radio_usb_get_serial(index_devstr, serial, sizeof(serial)) > 0) {
-					ast_copy_string(o->serial, serial, sizeof(o->serial));
-				}
-				break;
-			}
-			if (ast_strlen_zero(o->devstr)) {
-				continue;
-			}
-		}
-
-		if ((!ast_radio_usb_list_check(o->devstr)) || (!find_desc_usb(o->devstr))) {
-			/* The device string did not match.
-			 * Now look through the attached devices and see
-			 * one of those is associated with one of our
-			 * configured channels.
-			 */
-			s = find_installed_usb_match();
-			if (ast_strlen_zero(s)) {
-				o->device_error =
-					usbradio_log_fault(o, o->device_error, "Channel %s: Device string %s was not found.\n", o->name, o->devstr);
-				ast_mutex_unlock(&usb_dev_lock);
-				usleep(500000);
-				continue;
-			}
-			i = ast_radio_usb_get_usbdev(s);
-			if (i < 0) {
-				ast_mutex_unlock(&usb_dev_lock);
-				usleep(500000);
-				continue;
-			}
-			/* See if this device is already assigned to another usb channel */
-			for (ao = usbradio_default.next; ao && ao->name; ao = ao->next) {
-				if (ao->usbass && (!strcmp(ao->devstr, s))) {
-					break;
-				}
-			}
-			if (ao) {
-				ast_log(LOG_ERROR, "Channel %s: Device string %s is already assigned to channel %s", o->name, s, ao->name);
-				ast_mutex_unlock(&usb_dev_lock);
-				usleep(500000);
-				continue;
-			}
-			ast_log(LOG_NOTICE, "Channel %s: Assigned USB device %s to usbradio channel\n", o->name, s);
-			ast_copy_string(o->devstr, s, sizeof(o->devstr));
-		}
-		/* Double check to see if the device string is assigned to another usb channel */
-		for (ao = usbradio_default.next; ao && ao->name; ao = ao->next) {
-			if (ao->usbass && (!strcmp(ao->devstr, o->devstr))) {
-				break;
-			}
-		}
-		if (ao) {
-			ast_log(LOG_ERROR, "Channel %s: Device string %s is already assigned to channel %s", o->name, o->devstr, ao->name);
-			ast_mutex_unlock(&usb_dev_lock);
-			usleep(500000);
-			continue;
-		}
-		/* get the index to the device and assign it to our channel */
-		i = ast_radio_usb_get_usbdev(o->devstr);
-		if (i < 0) {
-			ast_mutex_unlock(&usb_dev_lock);
-			usleep(500000);
-			continue;
-		}
-		o->devicenum = i;
-		snprintf(o->hw_device, sizeof(o->hw_device), "hw:%d", i);
-		if (ast_radio_init_mixer_limits(o->devicenum, &o->micmax, &o->spkrmax, &o->micplaymax, &use_newname) < 0) {
-			o->device_error = usbradio_log_fault(o, o->device_error,
-				"Channel %s: Cannot use audio device %s without mixer limits\n", o->name, o->hw_device);
-			ast_mutex_unlock(&usb_dev_lock);
-			usleep(500000);
-			continue;
-		}
-		o->newname = use_newname;
-		o->device_error = 0;
-		ast_radio_time(&o->lasthidtime);
-		o->usbass = 1;
-		ast_mutex_unlock(&usb_dev_lock);
-		/* initialize the usb device */
-		usb_dev = ast_radio_hid_device_init(o->devstr);
-		if (usb_dev == NULL) {
-			init_hid_failed = usbradio_log_fault(o, init_hid_failed, "Channel %s: Cannot initialize device %s\n", o->name, o->devstr);
-			usleep(500000);
-			continue;
-		}
-usb_device_ready:
-		/* open the usb device device */
-		if (libusb_open(usb_dev, &usb_handle) < 0) {
-			open_device_failed = usbradio_log_fault(o, open_device_failed, "Channel %s: Cannot open device %s\n", o->name, o->devstr);
+		/* Open the USB device */
+		if (libusb_open(o->radio_device->usb_device, &usb_handle) < 0) {
+			open_device_failed =
+				usbradio_log_fault(o, open_device_failed, "Channel %s: Cannot open device %s\n", o->name, o->radio_device->devstr);
 			usleep(500000);
 			continue;
 		}
@@ -1318,30 +1258,21 @@ usb_device_ready:
 			pipe_failed = usbradio_log_fault(o, pipe_failed, "Channel %s: Is not able to create a pipe\n", o->name);
 			libusb_close(usb_handle);
 			usb_handle = NULL;
-			ast_mutex_lock(&usb_dev_lock);
-			o->usbass = 0;
 			o->hasusb = 0;
-			ast_mutex_unlock(&usb_dev_lock);
 			/* Stay in hidthread and retry; call() only starts the thread once. */
 			usleep(500000);
 			continue;
 		}
 
-		{
-			struct libusb_device_descriptor desc;
-
-			if (libusb_get_device_descriptor(usb_dev, &desc) < 0) {
-				ast_log(LOG_ERROR, "Channel %s: Unable to read USB device descriptor\n", o->name);
-				o->devtype = 0;
-			} else if ((desc.idProduct & 0xfffc) == C108_PRODUCT_ID) {
-				o->devtype = C108_PRODUCT_ID;
-			} else {
-				o->devtype = desc.idProduct;
-			}
+		/* Existing HID product-family mapping */
+		if ((o->radio_device->product_id & 0xfffc) == C108_PRODUCT_ID) {
+			o->devtype = C108_PRODUCT_ID;
+		} else {
+			o->devtype = o->radio_device->product_id;
 		}
 		ast_debug(5, "Channel %s: Starting normally.\n", o->name);
 
-		ast_debug(5, "Channel %s: Attached to usb device %s.\n", o->name, o->devstr);
+		ast_debug(5, "Channel %s: Attached to USB device %s.\n", o->name, o->radio_device->devstr);
 		/* setup the xmpr subsystem */
 		if (o->pmrChan == NULL) {
 			t_pmr_chan tChan;
@@ -1454,16 +1385,11 @@ usb_device_ready:
 		ast_mutex_unlock(&o->eepromlock);
 
 		if (usbradio_start_audio(o) < 0) {
-			start_audio_failed =
-				usbradio_log_fault(o, start_audio_failed, "Channel %s: Unable to start audio for %s\n", o->name, o->hw_device);
-			ast_mutex_lock(&usb_dev_lock);
-			o->usbass = 0;
-			ast_mutex_unlock(&usb_dev_lock);
+			start_audio_failed = usbradio_log_fault(o, start_audio_failed, "Channel %s: Unable to start audio stream\n", o->name);
 			usleep(500000);
 			continue;
 		}
 		/* Reset the failure flags, we succeeded */
-		init_hid_failed = 0;
 		open_device_failed = 0;
 		detach_failed = 0;
 		claim_failed = 0;
@@ -1779,9 +1705,7 @@ usb_device_ready:
 		usb_handle = NULL;
 	}
 
-	if (usb_dev) {
-		libusb_unref_device(usb_dev);
-	}
+	usbradio_release_device(o);
 
 	return NULL;
 }
@@ -2192,6 +2116,7 @@ static void flush_tx_queue(struct chan_usbradio_pvt *o)
 static void stream_cleanup(struct chan_usbradio_pvt *o)
 {
 	ast_radio_pa_stop(&o->pa);
+	usbradio_swap_audio_stopped(o);
 	o->audio_thread_ready = 0;
 	flush_tx_queue(o);
 	if (o->pmrChan) {
@@ -2202,8 +2127,7 @@ static void stream_cleanup(struct chan_usbradio_pvt *o)
 /*!
  * \brief Feed queued Asterisk TX frames into XPMR (PmrTx / dedrift buffer).
  *
- * Feeds at most \a max_frames frames so a stuck PortAudio TX path can leave
- * backlog in txq for the MAX_FRAME_DELAY watchdog. Returns frames fed.
+ * Feeds at most \a max_frames frames. Returns frames fed.
  */
 static int usbradio_feed_tx_queue(struct chan_usbradio_pvt *o, int max_frames)
 {
@@ -2237,6 +2161,7 @@ static void *usbradio_audio_thread(void *arg)
 	int lastpttout;
 	int cd, sd;
 	int num_frames;
+	int tx_write_ready;
 	long frames_available;
 	struct chan_usbradio_pvt *o = arg;
 	struct ast_frame *f = &o->read_f, *f1;
@@ -2250,12 +2175,13 @@ static void *usbradio_audio_thread(void *arg)
 		ast_radio_time(&o->lastaudiotime);
 
 		if (!o->hasusb) {
+			usbradio_swap_audio_stopped(o);
 			usleep(DEVICE_RETRY);
 			continue;
 		}
 
 		if (!o->pa.active && usbradio_start_audio(o) < 0) {
-			usbradio_log_fault(o, 0, "Channel %s: Failed to start audio stream %s\n", o->name, o->hw_device);
+			usbradio_log_fault(o, 0, "Channel %s: Failed to start audio stream\n", o->name);
 			o->hasusb = 0;
 			usleep(DEVICE_RETRY);
 			continue;
@@ -2300,11 +2226,26 @@ static void *usbradio_audio_thread(void *arg)
 						ast_queue_frame(o->owner, &wf);
 					}
 					if (o->duplex3) {
-						ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_SW, 0, 0);
+						usbradio_set_sidetone_switch(o, 0);
 					}
 				}
 				stream_cleanup(o);
 				break;
+			}
+
+			/* One PortAudio input block for loop pacing */
+			pa_res = usbradio_read_pa_stereo(o);
+			if (pa_res != paNoError) {
+				if (pa_res == paTimedOut || pa_res == paInputOverflowed) {
+					/* RX silence when no input block is available */
+					memset(o->usbradio_read_buf + AST_FRIENDLY_OFFSET, 0, sizeof(o->usbradio_read_buf) - AST_FRIENDLY_OFFSET);
+				} else {
+					usbradio_log_fault(o, 0, "Channel %s: PortAudio read failed (%s); restarting audio stream\n", o->name,
+						Pa_GetErrorText(pa_res));
+					o->hasusb = 0;
+					stream_cleanup(o);
+					break;
+				}
 			}
 
 			/* If we have stopped echoing, clear the echo queue */
@@ -2321,8 +2262,19 @@ static void *usbradio_audio_thread(void *arg)
 				ast_mutex_unlock(&o->echolock);
 			}
 
+			/* PortAudio output capacity check */
+			frames_available = ast_radio_pa_write_available(&o->pa);
+			if (frames_available < 0) {
+				ast_debug(2, "Channel %s: Pa_GetStreamWriteAvailable error %s\n", o->name, Pa_GetErrorText(frames_available));
+				o->usb_faulted = 1;
+				o->hasusb = 0;
+				stream_cleanup(o);
+				break;
+			}
+			tx_write_ready = frames_available >= AST_RADIO_PA_FRAMES_PER_BUFFER;
+
 			/* Echo playback feeds PmrTx directly (same as pre-thread path). */
-			if (o->echomode && (!o->rxkeyed)) {
+			if (tx_write_ready && o->echomode && (!o->rxkeyed)) {
 				struct usbecho *u;
 
 				ast_mutex_lock(&o->echolock);
@@ -2351,47 +2303,26 @@ static void *usbradio_audio_thread(void *arg)
 			}
 			ast_mutex_unlock(&o->txqlock);
 
-			frames_available = ast_radio_pa_write_available(&o->pa);
-			if (frames_available < 0) {
-				ast_debug(2, "Channel %s: Pa_GetStreamWriteAvailable error %s\n", o->name, Pa_GetErrorText(frames_available));
-				o->usb_faulted = 1;
-				o->hasusb = 0;
-				stream_cleanup(o);
-				break;
-			}
-
-			if ((num_frames <= 3) && (o->txkeyed || o->txtestkey)) {
-				/* Waiting for a few frames in the buffer is normal while keyed. */
+			/* Intentional keyed TX queue cushion */
+			if (num_frames <= 3 && (o->txkeyed || o->txtestkey)) {
 				last_frame_time = ast_radio_tvnow();
 			}
 
-			if (num_frames && frames_available >= AST_RADIO_PA_FRAMES_PER_BUFFER) {
+			/* One queued frame per available output block */
+			if (tx_write_ready && num_frames && (num_frames > 3 || (!o->txkeyed && !o->txtestkey))) {
 				if (usbradio_feed_tx_queue(o, 1)) {
 					o->didpmrtx = 1;
+					last_frame_time = ast_radio_tvnow();
 				}
-				last_frame_time = ast_radio_tvnow();
 			}
 
-			if (num_frames && (ast_tvdiff_ms(ast_radio_tvnow(), last_frame_time) > MAX_FRAME_DELAY)) {
+			/* Stream restart after 200 ms without TX queue progress */
+			if (num_frames && ast_tvdiff_ms(ast_radio_tvnow(), last_frame_time) > MAX_FRAME_DELAY) {
 				usbradio_log_fault(o, 0, "Channel %s: Audio thread has not drained TX for over %d ms, restarting stream.\n",
 					o->name, MAX_FRAME_DELAY);
 				o->hasusb = 0;
 				stream_cleanup(o);
 				break;
-			}
-
-			pa_res = usbradio_read_pa_stereo(o);
-			if (pa_res != paNoError) {
-				if (pa_res == paTimedOut || pa_res == paInputOverflowed) {
-					/* No RX audio available; still run PTT/TX processing with silence. */
-					memset(o->usbradio_read_buf + AST_FRIENDLY_OFFSET, 0, sizeof(o->usbradio_read_buf) - AST_FRIENDLY_OFFSET);
-				} else {
-					usbradio_log_fault(o, 0, "Channel %s: PortAudio read failed (%s); restarting audio stream\n", o->name,
-						Pa_GetErrorText(pa_res));
-					o->hasusb = 0;
-					stream_cleanup(o);
-					break;
-				}
 			}
 
 #if DEBUG_CAPTURES == 1
@@ -2497,15 +2428,17 @@ static void *usbradio_audio_thread(void *arg)
 			}
 
 			/*
-			 * One frame per 20 ms tick. When unkeyed, soundcard_writeframe()
-			 * substitutes silence; ast_radio_pa_write() primes one more on
-			 * underrun. Do not fill remaining PA room; that adds TX delay.
+			 * Write one frame when PortAudio has room. When unkeyed,
+			 * soundcard_writeframe() substitutes silence. Do not fill remaining
+			 * PortAudio room; that adds TX delay.
 			 */
-			if (!soundcard_writeframe(o, o->usbradio_write_buf)) {
-				stream_cleanup(o);
-				break;
+			if (tx_write_ready) {
+				if (!soundcard_writeframe(o, o->usbradio_write_buf)) {
+					stream_cleanup(o);
+					break;
+				}
+				ast_radio_check_audio(o->usbradio_write_buf, &o->txaudiostats, AST_RADIO_PA_48K_STEREO_SAMPLES, 0);
 			}
-			ast_radio_check_audio(o->usbradio_write_buf, &o->txaudiostats, AST_RADIO_PA_48K_STEREO_SAMPLES, 0);
 
 #if DEBUG_CAPTURES == 1 && XPMR_DEBUG0 == 1
 			if (frxcaptrace && o->rxcap2 && o->pmrChan->b.radioactive) {
@@ -2655,7 +2588,7 @@ static void *usbradio_audio_thread(void *arg)
 					ast_queue_frame(o->owner, &wf);
 				}
 				if (o->duplex3) {
-					ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_SW, 0, 0);
+					usbradio_set_sidetone_switch(o, 0);
 				}
 			} else if ((!o->lastrx) && (o->rxkeyed)) {
 				struct ast_frame wf = {
@@ -2675,7 +2608,7 @@ static void *usbradio_audio_thread(void *arg)
 				}
 				o->count_rssi_update = 1;
 				if (o->duplex3) {
-					ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_SW, 1, 0);
+					usbradio_set_sidetone_switch(o, 1);
 				}
 			}
 
@@ -2762,6 +2695,7 @@ static void *usbradio_audio_thread(void *arg)
 
 			ast_queue_frame(o->owner, f);
 		}
+		stream_cleanup(o);
 	}
 
 	stream_cleanup(o);
@@ -3040,11 +2974,14 @@ static int radio_active(int fd, int argc, const char *const *argv)
 	} else {
 		struct chan_usbradio_pvt *o;
 		if (!strcmp(argv[2], "show")) {
-			ast_mutex_lock(&usb_dev_lock);
 			for (o = usbradio_default.next; o; o = o->next) {
-				ast_cli(fd, "Device [%s] exists as device=%s card=%d\n", o->name, o->devstr, ast_radio_usb_get_usbdev(o->devstr));
+				char devstr[sizeof(o->devstr)];
+				int alsa_card;
+
+				usbradio_device_identity(o, devstr, sizeof(devstr), NULL, 0, &alsa_card);
+				ast_cli(fd, "Device [%s] is assigned to device=%s card=%d\n", o->name,
+					ast_strlen_zero(devstr) ? "unassigned" : devstr, alsa_card);
 			}
-			ast_mutex_unlock(&usb_dev_lock);
 			return RESULT_SUCCESS;
 		}
 		o = find_desc(argv[2]);
@@ -3071,14 +3008,15 @@ static int radio_active(int fd, int argc, const char *const *argv)
  */
 static int usb_device_swap(int fd, const char *other)
 {
-	int d;
-	char tmp[128];
-	struct chan_usbradio_pvt *p = NULL, *o = find_desc(usbradio_active);
+	struct chan_usbradio_pvt *p, *o;
+	int attempts;
+	int result;
 
-	if (o == NULL) {
+	if (!other) {
 		return -1;
 	}
-	if (!other) {
+	o = find_desc(usbradio_active);
+	if (o == NULL) {
 		return -1;
 	}
 	p = find_desc(other);
@@ -3090,19 +3028,60 @@ static int usb_device_swap(int fd, const char *other)
 		ast_cli(fd, "You can't swap active device with itself!!\n");
 		return -1;
 	}
-	ast_mutex_lock(&usb_dev_lock);
-	ast_copy_string(tmp, p->devstr, sizeof(tmp));
-	d = p->devicenum;
-	ast_copy_string(p->devstr, o->devstr, sizeof(p->devstr));
-	p->devicenum = o->devicenum;
-	ast_copy_string(o->devstr, tmp, sizeof(o->devstr));
-	o->devicenum = d;
+
+	/* Serialize the complete device swap transaction */
+	ast_mutex_lock(&device_swap_lock);
+	if (!o->hasusb || !p->hasusb) {
+		ast_cli(fd, "Both channels must have assigned USB devices before they can be swapped.\n");
+		ast_mutex_unlock(&device_swap_lock);
+		return -1;
+	}
+
+	/* Stop both device handles while retaining their shared leases */
+	usbradio_swap_begin(o);
+	usbradio_swap_begin(p);
 	o->hasusb = 0;
-	o->usbass = 0;
 	p->hasusb = 0;
-	p->usbass = 0;
+	kickptt(o);
+	kickptt(p);
+
+	/* Wait for the HID and PortAudio handles to close */
+	for (attempts = 0; attempts < 500; attempts++) {
+		if (usbradio_swap_ready(o) && usbradio_swap_ready(p)) {
+			break;
+		}
+		usleep(10000);
+	}
+	if (attempts == 500) {
+		usbradio_swap_finish(o);
+		usbradio_swap_finish(p);
+		ast_cli(fd, "Timed out waiting for both USB devices to stop.\n");
+		ast_mutex_unlock(&device_swap_lock);
+		return -1;
+	}
+
+	/* Exchange the parked leases and use their identities for future requests */
+	ast_mutex_lock(&o->device_lock);
+	ast_mutex_lock(&p->device_lock);
+	result = ast_radio_device_swap(&o->radio_device, &p->radio_device);
+	if (!result) {
+		ast_copy_string(o->devstr, o->radio_device->devstr, sizeof(o->devstr));
+		ast_copy_string(o->serial, S_OR(o->radio_device->serial, ""), sizeof(o->serial));
+		ast_copy_string(p->devstr, p->radio_device->devstr, sizeof(p->devstr));
+		ast_copy_string(p->serial, S_OR(p->radio_device->serial, ""), sizeof(p->serial));
+	}
+	ast_mutex_unlock(&p->device_lock);
+	ast_mutex_unlock(&o->device_lock);
+	usbradio_swap_finish(o);
+	usbradio_swap_finish(p);
+
+	if (result) {
+		ast_cli(fd, "Unable to exchange USB device leases.\n");
+		ast_mutex_unlock(&device_swap_lock);
+		return -1;
+	}
 	ast_cli(fd, "USB Devices successfully swapped.\n");
-	ast_mutex_unlock(&usb_dev_lock);
+	ast_mutex_unlock(&device_swap_lock);
 	return 0;
 }
 
@@ -3683,6 +3662,7 @@ static void tune_rxinput(int fd, struct chan_usbradio_pvt *o, int setsql, int in
 	int target;
 	int tolerance = 2750;
 	int setting = 0, tries = 0, tmpdiscfactor, meas, measnoise;
+	int micmax, spkrmax, micplaymax;
 	float settingmax, f;
 
 	if (o->rxdemod == RX_AUDIO_SPEAKER && o->rxcdtype == CD_XPMR_NOISE) {
@@ -3695,7 +3675,12 @@ static void tune_rxinput(int fd, struct chan_usbradio_pvt *o, int setsql, int in
 		target = 23000;
 	}
 
-	settingmax = o->micmax;
+	usbradio_mixer_limits(o, &micmax, &spkrmax, &micplaymax);
+	if (micmax <= 0) {
+		ast_cli(fd, "ERROR: RX mixer is unavailable.\n");
+		return;
+	}
+	settingmax = micmax;
 
 	o->fever = 1;
 	o->pmrChan->fever = 1;
@@ -3707,8 +3692,7 @@ static void tune_rxinput(int fd, struct chan_usbradio_pvt *o, int setsql, int in
 	ast_cli(fd, "tune rxnoise maxtries=%i, target=%i, tolerance=%i\n", maxtries, target, tolerance);
 
 	while (tries < maxtries) {
-		ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL, setting, 0);
-		ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_BOOST, o->rxboost, 0);
+		usbradio_set_rx_mixer(o, setting);
 
 		if (ast_radio_wait_or_poll(fd, 100, intflag)) {
 			o->pmrChan->b.tuning = 0;
@@ -3770,13 +3754,13 @@ static void tune_rxinput(int fd, struct chan_usbradio_pvt *o, int setsql, int in
 		return;
 	}
 
-	ast_cli(fd, "DONE tries=%i, setting=%i, meas=%i, sqnoise=%i\n", tries, ((setting * 1000) + (o->micmax / 2)) / o->micmax, meas, measnoise);
+	ast_cli(fd, "DONE tries=%i, setting=%i, meas=%i, sqnoise=%i\n", tries, ((setting * 1000) + (micmax / 2)) / micmax, meas, measnoise);
 
 	if (meas < (target - tolerance) || meas > (target + tolerance)) {
 		ast_cli(fd, "ERROR: RX INPUT ADJUST FAILED.\n");
 	} else {
 		ast_cli(fd, "INFO: RX INPUT ADJUST SUCCESS.\n");
-		o->rxmixerset = ((setting * 1000) + (o->micmax / 2)) / o->micmax;
+		o->rxmixerset = ((setting * 1000) + (micmax / 2)) / micmax;
 
 		if (o->rxcdtype == CD_XPMR_NOISE) {
 			int normRssi = ((32767 - o->pmrChan->rxRssi) * AUDIO_ADJUSTMENT / 32767);
@@ -3909,6 +3893,7 @@ static void tune_rxtx_status(int fd, struct chan_usbradio_pvt *o)
 static void _menu_rxvoice(int fd, struct chan_usbradio_pvt *o, const char *str)
 {
 	int i, x;
+	int micmax, spkrmax, micplaymax;
 	float f, f1;
 	int adjustment;
 
@@ -3932,17 +3917,21 @@ static void _menu_rxvoice(int fd, struct chan_usbradio_pvt *o, const char *str)
 	if (o->rxdemod == RX_AUDIO_FLAT) {
 		o->rxvoiceadj = (float) i / 200.0;
 	} else {
+		usbradio_mixer_limits(o, &micmax, &spkrmax, &micplaymax);
+		if (micmax <= 0) {
+			ast_cli(fd, "RX mixer is unavailable.\n");
+			return;
+		}
 		o->rxmixerset = i;
 		/* adjust settings based on the device */
 		if (o->devtype == C119B_PRODUCT_ID) {
 			o->rxboost = 1; /*rxboost is always set for this device */
 		}
-		adjustment = o->rxmixerset * o->micmax / AUDIO_ADJUSTMENT;
+		adjustment = o->rxmixerset * micmax / AUDIO_ADJUSTMENT;
 		/* get interval step size */
-		f = AUDIO_ADJUSTMENT / (float) o->micmax;
+		f = AUDIO_ADJUSTMENT / (float) micmax;
 
-		ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL, adjustment, 0);
-		ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_BOOST, o->rxboost, 0);
+		usbradio_set_rx_mixer(o, adjustment);
 		o->rxvoiceadj = 0.5 + (modff(((float) i) / f, &f1) * .093981);
 	}
 	*(o->pmrChan->prxVoiceAdjust) = o->rxvoiceadj * M_Q8; /* updates xpmr outputGain */
@@ -3956,14 +3945,17 @@ static void _menu_rxvoice(int fd, struct chan_usbradio_pvt *o, const char *str)
  */
 static void _menu_print(int fd, struct chan_usbradio_pvt *o)
 {
+	char devstr[sizeof(o->devstr)];
+	char serial[sizeof(o->serial)];
+	int alsa_card;
+
+	usbradio_device_identity(o, devstr, sizeof(devstr), serial, sizeof(serial), &alsa_card);
 	ast_cli(fd, "Active radio interface is [%s]\n", usbradio_active);
-	ast_mutex_lock(&usb_dev_lock);
-	ast_cli(fd, "Device String is %s\n", o->devstr);
-	if (!ast_strlen_zero(o->serial)) {
-		ast_cli(fd, "Device Serial is %s\n", o->serial);
+	ast_cli(fd, "Device String is %s\n", ast_strlen_zero(devstr) ? "unassigned" : devstr);
+	if (!ast_strlen_zero(serial)) {
+		ast_cli(fd, "Device Serial is %s\n", serial);
 	}
-	ast_mutex_unlock(&usb_dev_lock);
-	ast_cli(fd, "Card is %i\n", ast_radio_usb_get_usbdev(o->devstr));
+	ast_cli(fd, "Card is %i\n", alsa_card);
 	ast_cli(fd, "Output A is currently set to ");
 	if (o->txmixa == TX_OUT_COMPOSITE) {
 		ast_cli(fd, "composite.\n");
@@ -4237,6 +4229,7 @@ static void _menu_txtone(int fd, struct chan_usbradio_pvt *o, const char *cstr)
 static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cmd)
 {
 	int x, oldverbose, flatrx, txhasctcss;
+	int micmax, spkrmax, micplaymax;
 	struct chan_usbradio_pvt *oy = NULL;
 
 	oldverbose = option_verbose;
@@ -4251,6 +4244,7 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 	}
 	switch (cmd[0]) {
 	case '0': /* return audio processing configuration */
+		usbradio_mixer_limits(o, &micmax, &spkrmax, &micplaymax);
 		/* note: to maintain backward compatibility for those expecting a specific # of
 		   values to be returned (and in a specific order).  So, we only add to the end
 		   of the returned list.  Also, once an update has been released we can't change
@@ -4259,12 +4253,12 @@ static void tune_menusupport(int fd, struct chan_usbradio_pvt *o, const char *cm
 			ast_cli(fd, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%f,%d,%d,%d,%d,%d,%d,%d,%d\n", flatrx, txhasctcss,
 				o->echomode, o->rxboost, o->txboost, o->rxcdtype, o->rxsdtype, o->rxondelay, o->txoffdelay, o->txprelim,
 				o->txlimonly, o->rxdemod, o->txmixa, o->txmixb, o->rxmixerset, o->rxvoiceadj, o->rxsquelchadj, o->txmixaset,
-				o->txmixbset, o->txctcssadj, o->micplaymax, o->spkrmax, o->micmax, o->txslimsp);
+				o->txmixbset, o->txctcssadj, micplaymax, spkrmax, micmax, o->txslimsp);
 		} else if (!strcmp(cmd, "0+9")) {
 			ast_cli(fd, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%f,%d,%d,%d,%d,%d,%d,%d\n", flatrx, txhasctcss, o->echomode,
 				o->rxboost, o->txboost, o->rxcdtype, o->rxsdtype, o->rxondelay, o->txoffdelay, o->txprelim, o->txlimonly,
 				o->rxdemod, o->txmixa, o->txmixb, o->rxmixerset, o->rxvoiceadj, o->rxsquelchadj, o->txmixaset, o->txmixbset,
-				o->txctcssadj, o->micplaymax, o->spkrmax, o->micmax);
+				o->txctcssadj, micplaymax, spkrmax, micmax);
 		} else {
 			ast_cli(fd, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n", flatrx, txhasctcss, o->echomode, o->rxboost, o->txboost,
 				o->rxcdtype, o->rxsdtype, o->rxondelay, o->txoffdelay, o->txprelim, o->txlimonly, o->rxdemod, o->txmixa, o->txmixb);
@@ -4824,34 +4818,38 @@ static void tune_write(struct chan_usbradio_pvt *o)
 	if (!category) {
 		ast_log(LOG_ERROR, "No category '%s' exists?\n", o->name);
 	} else {
-		/*
-		 * To simplify channel driver setup we allow the "devstr=" value
-		 * to be empty/blank indicating that we should match the first
-		 * available interface.
-		 *
-		 * This works (and will continue to work) well as long as the
-		 * "devstr=" value in the configuration file remains empty/blank.
-		 * But, if the value is ever provided then we only match interfaces
-		 * with the specified string.  Moving the interface (accidentally
-		 * or intentionally) to a different "port" will result in not
-		 * finding/matching the interface.
-		 *
-		 * To minimize conflicts, we want to avoid writing out the specific
-		 * "devstr=" value to the configuration file unless needed.  Here,
-		 * we check if the current "devstr=" value is empty/blank and
-		 * that there is only a single audio interface connected to the
-		 * system.  If so, we leave the value empty/blank.
-		 */
-		const char *val;
-		char *dev;
+		char assigned_devstr[sizeof(o->devstr)];
+		char assigned_serial[sizeof(o->serial)];
+		int automatic;
 
-		val = ast_variable_retrieve(cfg, o->name, "devstr");
-		dev = ast_radio_usb_get_devstr(1);
-		if (!ast_strlen_zero(val) || !ast_strlen_zero(dev)) {
-			/* if the "devstr=" value exists or there is more than 1 sound device */
+		/*
+		 * To simplify channel driver setup, blank "devstr=" and "serial="
+		 * values request automatic assignment of the first compatible USB
+		 * radio device.
+		 *
+		 * We preserve that automatic configuration when only one active lease
+		 * was assigned automatically. When multiple leases were assigned
+		 * automatically, their assignment order is indeterminate, so save this
+		 * channel's acquired identity as an explicit selector.
+		 *
+		 * Explicit selectors are saved unchanged. A topology-based devstr may
+		 * stop matching if the interface is moved to another USB port, while a
+		 * serial selector continues to take precedence over devstr.
+		 */
+		automatic = ast_strlen_zero(o->devstr) && ast_strlen_zero(o->serial);
+		if (!automatic) {
 			CONFIG_UPDATE_STR(devstr);
-			if (!ast_strlen_zero(o->serial)) {
+			if (!ast_strlen_zero(o->serial) || ast_variable_retrieve(cfg, o->name, "serial")) {
 				CONFIG_UPDATE_STR(serial);
+			}
+		} else if (ast_radio_device_automatic_count() > 1) {
+			usbradio_device_identity(o, assigned_devstr, sizeof(assigned_devstr), assigned_serial, sizeof(assigned_serial), NULL);
+			if (!ast_strlen_zero(assigned_serial)) {
+				if (tune_variable_update(cfg, CONFIG, category, "serial", assigned_serial)) {
+					ast_log(LOG_WARNING, "Failed to update serial\n");
+				}
+			} else if (!ast_strlen_zero(assigned_devstr) && tune_variable_update(cfg, CONFIG, category, "devstr", assigned_devstr)) {
+				ast_log(LOG_WARNING, "Failed to update devstr\n");
 			}
 		}
 		CONFIG_UPDATE_INT(rxmixerset);
@@ -4914,29 +4912,64 @@ static void tune_write(struct chan_usbradio_pvt *o)
  */
 static void mixer_write(struct chan_usbradio_pvt *o)
 {
-	int mic_setting;
+	const struct ast_radio_mixer_element *element;
+	struct ast_radio_device *device;
+	int requested;
+	long sidetone_max;
+	size_t path_index;
 
-	if (o->duplex3) {
-		if (o->duplex3 > o->micplaymax) {
-			o->duplex3 = o->micplaymax;
-		}
-		ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_VOL, o->duplex3, 0);
-	} else {
-		ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_VOL, 0, 0);
+	ast_mutex_lock(&o->device_lock);
+	device = o->radio_device;
+	if (!device) {
+		ast_mutex_unlock(&o->device_lock);
+		return;
 	}
-	ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_PLAYBACK_SW, 0, 0);
-	ast_radio_setamixer(o->devicenum, (o->newname) ? MIXER_PARAM_SPKR_PLAYBACK_SW_NEW : MIXER_PARAM_SPKR_PLAYBACK_SW, 1, 0);
-	ast_radio_setamixer(o->devicenum, (o->newname) ? MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW : MIXER_PARAM_SPKR_PLAYBACK_VOL,
-		ast_radio_make_spkr_playback_value(o->spkrmax, o->txmixaset, o->devtype),
-		ast_radio_make_spkr_playback_value(o->spkrmax, o->txmixbset, o->devtype));
+
+	/* Receive sidetone paths (Mic Playback controls on CM108) */
+	sidetone_max = ast_radio_device_mixer_max(device, device->mixer_sidetone_paths, AST_RADIO_MIXER_PLAYBACK_VOLUME);
+	if (o->duplex3 > sidetone_max) {
+		o->duplex3 = sidetone_max;
+	}
+	ast_radio_device_set_mixer_paths(device, device->mixer_sidetone_paths, device->mixer_sidetone_path_count,
+		AST_RADIO_MIXER_PLAYBACK_VOLUME, o->duplex3);
+	ast_radio_device_set_mixer_paths(device, device->mixer_sidetone_paths, device->mixer_sidetone_path_count,
+		AST_RADIO_MIXER_PLAYBACK_SWITCH, 0);
+
+	/* Transmitter output paths (Speaker/Headphone controls on CM108)
+	 * txmixaset (MIXA) controls mixer_tx_paths[0], and txmixbset (MIXB) controls
+	 * mixer_tx_paths[1] when a second path is present. Additional paths are unchanged.
+	 */
+	for (path_index = 0; path_index < device->mixer_tx_path_count && path_index < 2; path_index++) {
+		element = ast_radio_device_mixer_element(device, &device->mixer_tx_paths[path_index]);
+		if (!element) {
+			continue;
+		}
+		requested = path_index ? o->txmixbset : o->txmixaset;
+		ast_radio_device_set_mixer(device, &device->mixer_tx_paths[path_index], AST_RADIO_MIXER_PLAYBACK_SWITCH, 1);
+		ast_radio_device_set_mixer(device, &device->mixer_tx_paths[path_index], AST_RADIO_MIXER_PLAYBACK_VOLUME,
+			ast_radio_device_mixer_scale(device, &device->mixer_tx_paths[path_index], AST_RADIO_MIXER_PLAYBACK_VOLUME, requested));
+	}
+
 	/* adjust settings based on the device */
 	if (o->devtype == C119B_PRODUCT_ID) {
 		o->rxboost = 1; /*rxboost is always set for this device */
 	}
-	mic_setting = o->rxmixerset * o->micmax / AUDIO_ADJUSTMENT;
-	ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_CAPTURE_VOL, mic_setting, 0);
-	ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_BOOST, o->rxboost, 0);
-	ast_radio_setamixer(o->devicenum, MIXER_PARAM_MIC_CAPTURE_SW, 1, 0);
+
+	/* Receiver input paths (Mic Capture controls on CM108) */
+	for (path_index = 0; path_index < device->mixer_rx_path_count; path_index++) {
+		element = ast_radio_device_mixer_element(device, &device->mixer_rx_paths[path_index]);
+		if (!element) {
+			continue;
+		}
+		ast_radio_device_set_mixer(device, &device->mixer_rx_paths[path_index], AST_RADIO_MIXER_CAPTURE_VOLUME,
+			ast_radio_device_mixer_scale(device, &device->mixer_rx_paths[path_index], AST_RADIO_MIXER_CAPTURE_VOLUME, o->rxmixerset));
+		ast_radio_device_set_mixer(device, &device->mixer_rx_paths[path_index], AST_RADIO_MIXER_CAPTURE_SWITCH, 1);
+	}
+
+	/* Optional receiver input gain/AGC paths */
+	ast_radio_device_set_mixer_paths(device, device->mixer_rx_boost_paths, device->mixer_rx_boost_path_count,
+		AST_RADIO_MIXER_PLAYBACK_SWITCH, o->rxboost);
+	ast_mutex_unlock(&o->device_lock);
 }
 
 /*!
@@ -4995,18 +5028,23 @@ static void pmrdump(struct chan_usbradio_pvt *o, int fd)
 {
 	t_pmr_chan *p;
 	int i;
+	int micmax, spkrmax, micplaymax;
 
 	p = o->pmrChan;
 
 	ast_cli(fd, "\nodump()\n");
 
-	pd(o->devicenum);
-	ast_mutex_lock(&usb_dev_lock);
-	ps(o->devstr);
-	ast_mutex_unlock(&usb_dev_lock);
+	/* Acquired device identity */
+	ast_mutex_lock(&o->device_lock);
+	if (o->radio_device) {
+		ast_cli(fd, "radio_device->devstr = %s\n", o->radio_device->devstr);
+		ast_cli(fd, "radio_device->alsa_card = %d\n", o->radio_device->alsa_card);
+	}
+	ast_mutex_unlock(&o->device_lock);
 
-	pd(o->micmax);
-	pd(o->spkrmax);
+	usbradio_mixer_limits(o, &micmax, &spkrmax, &micplaymax);
+	pd(micmax);
+	pd(spkrmax);
 
 	pd(o->rxdemod);
 	pd(o->rxcdtype);
@@ -5201,7 +5239,6 @@ static struct chan_usbradio_pvt *store_config(struct ast_config *cfg, const char
 			o->pttkick[1] = -1;
 			o->hidthread = AST_PTHREADT_NULL;
 			o->audiothread = AST_PTHREADT_NULL;
-			o->hw_device[0] = '\0';
 			if (!usbradio_active) {
 				usbradio_active = o->name;
 			}
@@ -5211,7 +5248,9 @@ static struct chan_usbradio_pvt *store_config(struct ast_config *cfg, const char
 	ast_mutex_init(&o->echolock);
 	ast_mutex_init(&o->eepromlock);
 	ast_mutex_init(&o->usblock);
+	ast_mutex_init(&o->device_lock);
 	ast_mutex_init(&o->txqlock);
+	ast_mutex_init(&o->swap_lock);
 	o->echomax = DEFAULT_ECHO_MAX;
 	/* fill other fields from configuration */
 	for (v = ast_variable_browse(cfg, ctg); v; v = v->next) {
@@ -5780,16 +5819,6 @@ static int load_module(void)
 	}
 	ast_format_cap_append(usbradio_tech.capabilities, ast_format_slin, 0);
 
-	if (ast_radio_libusb_init() < 0) {
-		ast_log(LOG_ERROR, "Unable to initialize libusb\n");
-		return AST_MODULE_LOAD_DECLINE;
-	}
-
-	if (ast_radio_hid_device_mklist()) {
-		ast_log(LOG_ERROR, "Unable to make hid list\n");
-		return AST_MODULE_LOAD_DECLINE;
-	}
-
 	usbradio_active = NULL;
 
 	/* Copy the default jb config over global_jbconf */
@@ -5877,6 +5906,7 @@ static int unload_module(void)
 			o->hidthread = AST_PTHREADT_NULL;
 		}
 		ast_radio_pa_stop(&o->pa);
+		usbradio_release_device(o);
 		if (o->pmrChan) {
 			destroyPmrChannel(o->pmrChan);
 			o->pmrChan = NULL;

--- a/configs/samples/simpleusb.conf.sample
+++ b/configs/samples/simpleusb.conf.sample
@@ -118,8 +118,6 @@ legacyaudioscaling = no     ; If yes, continue to do raw audio sample scaling an
 ;;;;; Tune settings ;;;;;
 ;devstr=
 ;serial=
-;audiodev=hw:0              ; Optional ALSA device for PortAudio audio (hw:N or hw:N,M).
-                            ; Use instead of devstr when binding audio by card number.
 ;rxmixerset=500
 ;txmixaset=500
 ;txmixbset=500

--- a/configs/samples/usbradio.conf.sample
+++ b/configs/samples/usbradio.conf.sample
@@ -193,8 +193,6 @@ legacyaudioscaling = no     ; If yes, continue to do raw audio sample scaling an
 ;;;;; Tune settings ;;;;;
 ;devstr=
 ;serial=
-;audiodev=hw:0              ; Optional ALSA device for PortAudio audio (hw:N or hw:N,M).
-                            ; Use instead of devstr when binding audio by card number.
 ;rxmixerset=500
 ;txmixaset=500
 ;txmixbset=500

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -33,19 +33,6 @@
 #include <signal.h>
 
 /*!
- * \brief Defines for interacting with ALSA controls.
- */
-#define MIXER_PARAM_MIC_PLAYBACK_SW "Mic Playback Switch"
-#define MIXER_PARAM_MIC_PLAYBACK_VOL "Mic Playback Volume"
-#define MIXER_PARAM_MIC_CAPTURE_SW "Mic Capture Switch"
-#define MIXER_PARAM_MIC_CAPTURE_VOL "Mic Capture Volume"
-#define MIXER_PARAM_MIC_BOOST "Auto Gain Control"
-#define MIXER_PARAM_SPKR_PLAYBACK_SW "Speaker Playback Switch"
-#define MIXER_PARAM_SPKR_PLAYBACK_VOL "Speaker Playback Volume"
-#define MIXER_PARAM_SPKR_PLAYBACK_SW_NEW "Headphone Playback Switch"
-#define MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW "Headphone Playback Volume"
-
-/*!
  * \brief CMxxx USB device identifiers.
  */
 #define C108_VENDOR_ID 0x0d8c
@@ -179,6 +166,208 @@
 #define DEV_DSP "/dev/dsp"
 #endif
 
+/*!
+ * \brief Optional hardware capabilities required by a channel driver
+ *
+ * USB capture and playback are always required and are therefore implicit.
+ * Multiple flags use AND semantics: every requested capability must be
+ * available for a device to match.
+ */
+enum ast_radio_device_capability {
+	AST_RADIO_CAP_NONE = 0,
+	AST_RADIO_CAP_CM108_HID = (1U << 0),
+	AST_RADIO_CAP_PARALLEL = (1U << 1),
+};
+
+/*!
+ * \brief Criteria supplied when requesting a USB radio device
+ *
+ * Selection precedence is serial, then devstr, then automatic assignment.
+ * A configured selector that has no current match does not fall back to a
+ * lower-priority selector.
+ */
+struct ast_radio_device_request {
+	const char *devstr;					  /*!< Optional sysfs topology or ALSA device selector */
+	const char *serial;					  /*!< Optional USB serial number; takes precedence over devstr */
+	const char *owner;					  /*!< Required channel instance name used for diagnostics */
+	unsigned int required_caps;			  /*!< ORed ast_radio_device_capability values; all are required */
+	unsigned int minimum_input_channels;  /*!< Minimum PortAudio input channels required */
+	unsigned int minimum_output_channels; /*!< Minimum PortAudio output channels required */
+};
+
+/*!
+ * \brief Result of a USB radio device acquisition attempt
+ */
+enum ast_radio_device_result {
+	AST_RADIO_DEVICE_READY,			 /*!< A viable device was exclusively leased and returned */
+	AST_RADIO_DEVICE_WAIT,			 /*!< No viable, available device currently satisfies the request */
+	AST_RADIO_DEVICE_CONFLICT,		 /*!< The explicitly selected device is leased to another owner */
+	AST_RADIO_DEVICE_INVALID_CONFIG, /*!< The request contains malformed or unsupported selector syntax */
+	AST_RADIO_DEVICE_ERROR,			 /*!< Discovery failed because of an internal or system error */
+};
+
+/*! \brief Return a printable description of a device acquisition result */
+const char *ast_radio_device_result_str(enum ast_radio_device_result result);
+
+enum ast_radio_mixer_capability {
+	AST_RADIO_MIXER_CAPTURE_VOLUME = (1U << 0),
+	AST_RADIO_MIXER_CAPTURE_SWITCH = (1U << 1),
+	AST_RADIO_MIXER_PLAYBACK_VOLUME = (1U << 2),
+	AST_RADIO_MIXER_PLAYBACK_SWITCH = (1U << 3),
+};
+
+struct ast_radio_mixer_element {
+	const char *name;		   /*!< ALSA simple mixer element name */
+	unsigned int index;		   /*!< ALSA simple mixer element index */
+	unsigned int capabilities; /*!< ORed ast_radio_mixer_capability values */
+	long capture_min;		   /*!< Minimum capture-volume value */
+	long capture_max;		   /*!< Maximum capture-volume value */
+	long playback_min;		   /*!< Minimum playback-volume value */
+	long playback_max;		   /*!< Maximum playback-volume value */
+};
+
+struct ast_radio_mixer_path {
+	unsigned int element; /*!< Index into ast_radio_device.mixer_elements */
+	int channel;		  /*!< ALSA simple mixer channel identifier */
+};
+
+/*!
+ * \brief Resolved USB radio device information and exclusive lease
+ *
+ * The identity and endpoint fields are populated by
+ * ast_radio_device_acquire(). The caller may use them to open the HID and
+ * audio subsystems. The caller must stop using any derived subsystem handles
+ * before passing this object to ast_radio_device_release().
+ *
+ * String fields are owned by res_usbradio, remain valid for the lifetime of
+ * the lease, and must not be modified or freed by callers.
+ *
+ * Fields documented as internal are owned by res_usbradio and must not be
+ * inspected or modified by callers.
+ */
+struct ast_radio_device {
+	/* Device identity and capabilities */
+	const char *devstr;		   /*!< Canonical sysfs topology identity */
+	const char *serial;		   /*!< USB serial number, or NULL when unavailable */
+	unsigned short vendor_id;  /*!< USB vendor identifier */
+	unsigned short product_id; /*!< USB product identifier */
+	unsigned int capabilities; /*!< Available ast_radio_device_capability values */
+
+	/* ALSA PCM endpoints */
+	int alsa_card;					/*!< Resolved ALSA card number */
+	int alsa_capture_device;		/*!< Resolved ALSA capture PCM device number */
+	int alsa_playback_device;		/*!< Resolved ALSA playback PCM device number */
+	const char *alsa_capture_name;	/*!< ALSA capture endpoint name */
+	const char *alsa_playback_name; /*!< ALSA playback endpoint name */
+
+	/* ALSA mixer elements and logical paths */
+	struct ast_radio_mixer_element *mixer_elements;	   /*!< Unique ALSA mixer elements */
+	size_t mixer_element_count;						   /*!< Number of mixer elements */
+	struct ast_radio_mixer_path *mixer_rx_paths;	   /*!< Capture input paths (Mic Capture on CM108) */
+	size_t mixer_rx_path_count;						   /*!< Number of RX paths */
+	struct ast_radio_mixer_path *mixer_tx_paths;	   /*!< Playback output paths (Speaker/Headphone on CM108) */
+	size_t mixer_tx_path_count;						   /*!< Number of TX paths */
+	struct ast_radio_mixer_path *mixer_sidetone_paths; /*!< Optional capture-to-playback paths (Mic Playback on CM108) */
+	size_t mixer_sidetone_path_count;				   /*!< Number of sidetone paths */
+	struct ast_radio_mixer_path *mixer_rx_boost_paths; /*!< Optional input gain/AGC switch paths */
+	size_t mixer_rx_boost_path_count;				   /*!< Number of receive-boost paths */
+
+	/* libusb device reference and current transport address */
+	struct libusb_device *usb_device; /*!< Referenced libusb device for the lease lifetime */
+	unsigned int usb_bus;			  /*!< Current libusb bus number */
+	unsigned int usb_address;		  /*!< Current, potentially ephemeral USB address */
+
+	/* PortAudio endpoints; two valid indices imply one library reference held by the lease */
+	PaDeviceIndex pa_input_device;	 /*!< PortAudio input index, or paNoDevice */
+	PaDeviceIndex pa_output_device;	 /*!< PortAudio output index, or paNoDevice */
+	unsigned int pa_input_channels;	 /*!< Maximum PortAudio input channels */
+	unsigned int pa_output_channels; /*!< Maximum PortAudio output channels */
+
+	/* Internal lease bookkeeping */
+	void *private_data; /*!< Internal res_usbradio lease bookkeeping */
+};
+
+/*!
+ * \brief Determine whether an acquired device is usable through PortAudio
+ */
+static inline int ast_radio_device_pa_ready(const struct ast_radio_device *device)
+{
+	return device && device->pa_input_device != paNoDevice && device->pa_output_device != paNoDevice;
+}
+
+/*!
+ * \brief Acquire an exclusive lease on a USB radio device
+ *
+ * \param request Device selection criteria and required capabilities
+ * \param[out] device Acquired device on AST_RADIO_DEVICE_READY; NULL for every other result
+ *
+ * \note The caller must release a returned device with ast_radio_device_release()
+ *
+ * \return An ast_radio_device_result describing the acquisition attempt
+ */
+enum ast_radio_device_result ast_radio_device_acquire(const struct ast_radio_device_request *request, struct ast_radio_device **device);
+
+/*! \brief Return the number of active leases created by automatic assignment */
+unsigned int ast_radio_device_automatic_count(void);
+
+/*!
+ * \brief Atomically exchange two active USB radio device leases
+ *
+ * Callers must stop using all subsystem handles derived from both devices
+ * before exchanging the leases.
+ *
+ * \param first First device lease pointer to exchange
+ * \param second Second device lease pointer to exchange
+ *
+ * \retval 0 on success
+ * \retval -1 when either pointer does not identify an active lease
+ */
+int ast_radio_device_swap(struct ast_radio_device **first, struct ast_radio_device **second);
+
+/*!
+ * \brief Release a USB radio device lease
+ *
+ * The caller must first stop using all subsystem handles derived from the
+ * device. Passing NULL is permitted and has no effect.
+ *
+ * \param device Device lease returned by ast_radio_device_acquire()
+ */
+void ast_radio_device_release(struct ast_radio_device *device);
+
+/*! \brief Return the mixer element referenced by a device path */
+const struct ast_radio_mixer_element *ast_radio_device_mixer_element(const struct ast_radio_device *device,
+	const struct ast_radio_mixer_path *path);
+
+/*! \brief Return the maximum value for one mixer path capability */
+long ast_radio_device_mixer_max(const struct ast_radio_device *device, const struct ast_radio_mixer_path *path, unsigned int capability);
+
+/*! \brief Scale an AUDIO_ADJUSTMENT setting into one mixer path range */
+long ast_radio_device_mixer_scale(const struct ast_radio_device *device, const struct ast_radio_mixer_path *path,
+	unsigned int capability, int setting);
+
+/*!
+ * \brief Set one control on a discovered mixer path
+ *
+ * \param device Device lease returned by ast_radio_device_acquire()
+ * \param path Mixer path belonging to the acquired device
+ * \param capability One ast_radio_mixer_capability value selecting the control
+ * \param value ALSA volume value or zero/nonzero switch state
+ *
+ * \retval 0 on success
+ * \retval -1 for an invalid path or when the mixer control cannot be updated
+ */
+int ast_radio_device_set_mixer(const struct ast_radio_device *device, const struct ast_radio_mixer_path *path,
+	unsigned int capability, long value);
+
+/*!
+ * \brief Set one control across a collection of discovered mixer paths
+ *
+ * \retval 0 when every path was updated
+ * \retval -1 when any path could not be updated
+ */
+int ast_radio_device_set_mixer_paths(const struct ast_radio_device *device, const struct ast_radio_mixer_path *paths,
+	size_t path_count, unsigned int capability, long value);
+
 struct usbecho {
 	struct qelem *q_forw;
 	struct qelem *q_prev;
@@ -211,72 +400,6 @@ struct audiostatistics {
  * \retval 			Rounded number as a long.
  */
 long ast_radio_lround(double x);
-
-/*!
- * \brief Calculate the speaker playback volume value.
- * 	Calculates the speaker playback volume.
- *
- *	The calling routine passes the maximum setting for
- *	for the speaker output.  This routine scales the
- *	requested value against the maximum.
- *
- *	Some devices may require a different scaling divisor.
- *	This routine can be customized for the requirements
- *	for new devices.
- *
- *	In some implementations, the scaling factor has been
- *	determined by spkrmax - 20 * log(ratio) or spkrmax - 10 * log(ratio).
- *	Discussions with radio engineers indicate that we should
- *	be using a linear scale.  FM deviation is linear.
- *
- * \param spkrmax		Speaker maximum value.
- * \param request_value	Requested volume value.
- * \param devtype		USB device type.
- *
- * \retval 				The calculated volume value.
- */
-int ast_radio_make_spkr_playback_value(int spkrmax, int request_value, int devtype);
-
-/* Note: must add -lasound to end of linkage */
-
-/*!
- * \brief Get mixer max value
- * 	Gets the mixer max value from ALSA for the specified device and control.
- *
- * \param devnum		The ALSA major device number to update.
- * \param param			Pointer to the string mixer device name (control) to retrieve.
- *
- * \retval 				The maximum value.
- */
-int ast_radio_amixer_max(int devnum, char *param);
-
-/*!
- * \brief Query required ALSA mixer maximums for a USB radio device.
- *
- * Reads mic capture, speaker playback (with alternate control name), and
- * mic playback limits. Fails when any required limit is unavailable.
- *
- * \param devnum ALSA card number.
- * \param micmax Returned Mic Capture Volume maximum.
- * \param spkrmax Returned Speaker Playback Volume maximum.
- * \param micplaymax Returned Mic Playback Volume maximum.
- * \param newname Set to 1 when the alternate speaker control name is used.
- *
- * \retval 0 on success.
- * \retval -1 if any required mixer limit is unavailable.
- */
-int ast_radio_init_mixer_limits(int devnum, int *micmax, int *spkrmax, int *micplaymax, int *newname);
-
-/*!
- * \brief Set mixer
- * 	Sets the mixer values for the specified device and control.
- *
- * \param devnum		The ALSA major device number to update.
- * \param param			Pointer to the string mixer device name (control) to update.
- * \param v1			Value 1 to set.  Values: 0-99 (percent) or 0-1 for baboon.
- * \param v2			Value 2 to set or zero if only one value.
- */
-int ast_radio_setamixer(int devnum, char *param, int v1, int v2);
 
 /*!
  * \brief Set USB HID outputs
@@ -334,69 +457,6 @@ unsigned short ast_radio_get_eeprom(struct libusb_device_handle *handle, unsigne
  *						The buffer must be an array of 13 unsigned shorts.
  */
 void ast_radio_put_eeprom(struct libusb_device_handle *handle, unsigned short *buf);
-
-/*!
- * \brief Make a list of HID devices.
- * Populates usb_device_list with a list of devices that we
- * know that are compatible.
- *
- * Each device string in usb_device_list is delimited with zero.  The
- * final element is zero.
- *
- * \retval 0	List was created.
- * \retval -1	List was not created.
- */
-int ast_radio_hid_device_mklist(void);
-
-/*!
- * \brief Initialize a USB device.
- * 	Searches for a USB device that matches the passed device string.
- *
- * \note It will only evaluate USB devices known to work with this application.
- *
- * \param desired_device	Pointer to a string that contains the device string to find.
- * \retval 					Returns a libusb_device structure with the found device.
- * 							This device has a libusb_ref_device and must be freed with libusb_unref_device by the caller.
- *							If the device was not found, it returns null.
- */
-struct libusb_device *ast_radio_hid_device_init(const char *desired_device);
-
-/*!
- * \brief Get USB device number from device string
- * 	Checks the symbolic links to see if the device string exists.
- *
- * \param devstr		Pointer to a string that contains the device string to find.
- * \retval 				Returns an index for the found device number.
- * \retval -1			If the device was not found.
- */
-int ast_radio_usb_get_usbdev(const char *devstr);
-
-/*!
- * \brief Get serial number from device if available
- *	This function will attempt to get the serial number from a media device
- *
- * \param devstr		The USB device string
- * \param buf			Pointer to buffer for serial number
- * \param buflen		Length of the serial number buffer
- * \retval				Length of returned serial number; 0 if no serial
- */
-int ast_radio_usb_get_serial(const char *devstr, char *buf, size_t buflen);
-
-/*!
- * \brief See if the internal usb_device_list contains the
- * specified device string.
- * \param devstr	Device string to check.
- * \retval 0		Device string was not found.
- * \retval 1		Device string was found.
- */
-int ast_radio_usb_list_check(char *devstr);
-
-/*!
- * \brief Get a device string at the specified index
- * from usb_device_list.
- * \returns			Device string or null if not found.
- */
-char *ast_radio_usb_get_devstr(int index);
 
 /*!
  * \brief Open the specified parallel port
@@ -542,18 +602,6 @@ int ast_radio_check_audio(short *sbuf, struct audiostatistics *o, short len, sho
  */
 void ast_radio_print_audio_stats(int fd, struct audiostatistics *o, const char *prefix_text);
 
-/*!
- * \brief Returns the libusb device that backs ALSA /proc/asound/card<cardno>/usbbus.
- * \retval usb_device *  Pointer to the libusb device on success.
- * \retval NULL          If device could not be found.
- *
- * \note
- * - Uses libusb-0.1 enumeration (usb_init/usb_find_busses/usb_find_devices).
- * - The returned pointer is owned by libusb's internal device list.
- * \param cardno The ALSA card number as found in HW:<cardno>
- */
-struct libusb_device *ast_radio_usb_device_from_alsa_card(int cardno);
-
 #define AST_RADIO_PA_SAMPLE_RATE 48000
 #define AST_RADIO_PA_FRAMES_PER_BUFFER (FRAME_SIZE * 6)
 #define AST_RADIO_PA_OUTPUT_CHANNELS 2
@@ -563,36 +611,25 @@ struct libusb_device *ast_radio_usb_device_from_alsa_card(int cardno);
 /*!
  * \brief PortAudio stream state shared by chan_simpleusb and chan_usbradio.
  *
- * After ast_radio_pa_open(), use ps->input_channels for RX buffer layout and
- * ps->output_channels for TX. Callers still pass stereo interleaved TX to
- * ast_radio_pa_write(); mono hardware is downmixed there (AIOC and similar).
+ * Set ps->input_channels to the required RX channel count before calling
+ * ast_radio_pa_open_device(). After opening, use ps->input_channels for RX
+ * buffer layout and ps->output_channels for TX. Callers still pass stereo
+ * interleaved TX to ast_radio_pa_write(); mono hardware is downmixed there.
  * ast_radio_pa_read() and ast_radio_pa_write() take frames per channel
  * (typically AST_RADIO_PA_FRAMES_PER_BUFFER).
  */
 struct ast_radio_pa_stream {
 	PaStream *stream;
 	int active;
-	unsigned int input_channels;  /*!< Actual RX channel count after ast_radio_pa_open() */
-	unsigned int output_channels; /*!< Actual TX channel count after ast_radio_pa_open() */
-	char hw_device[100];
+	unsigned int input_channels;  /*!< Required and actual RX channel count for ast_radio_pa_open_device() */
+	unsigned int output_channels; /*!< Actual TX channel count after ast_radio_pa_open_device() */
 };
 
-/*!
- * \brief Parse "hw:<card>" or "hw:<card>,<dev>" from anywhere in s.
- * \retval 1 if found; sets *card; sets *dev to parsed value or -1 if absent.
- */
-int ast_radio_parse_alsa_hw_device(const char *s, int *card, int *dev);
-
-PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps);
+/* Open a stream using the exact PortAudio endpoints held by a device lease */
+PaError ast_radio_pa_open_device(struct ast_radio_pa_stream *ps, const struct ast_radio_device *device);
 PaError ast_radio_pa_start(struct ast_radio_pa_stream *ps);
 void ast_radio_pa_stop(struct ast_radio_pa_stream *ps);
 
 PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned long frames, int timeout_ms, volatile sig_atomic_t *stop);
 PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, unsigned long frames);
 long ast_radio_pa_write_available(struct ast_radio_pa_stream *ps);
-
-/*!
- * \brief initialize the usb_ctx register for access to usb devices.
- * \retval libusb_init status 0 on success, negative on failure.
- */
-int ast_radio_libusb_init(void);

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -36,6 +36,7 @@
 
 #include <stdio.h>
 #include <ctype.h>
+#include <limits.h>
 #include <math.h>
 #include <string.h>
 #include <unistd.h>
@@ -52,6 +53,8 @@
 #include <portaudio.h>
 
 #include "asterisk/res_usbradio.h"
+
+#define MIXER_RX_BOOST_ELEMENT "Auto Gain Control"
 
 #ifdef HAVE_SYS_IO
 #include <sys/io.h>
@@ -74,16 +77,158 @@
 
 #define CONFIG_FILE "res_usbradio.conf"
 
-AST_MUTEX_DEFINE_STATIC(usb_list_lock);
+/* Share a recently completed inventory between asynchronous channel threads */
+#define DEVICE_INVENTORY_CACHE_MS 1000
+#define DEVICE_REJECTION_LOG_SLOTS 16
+#define FNV1A_64_OFFSET_BASIS 14695981039346656037ULL
+#define FNV1A_64_PRIME 1099511628211ULL
+
+/*
+ * Add one value to an internal FNV-1a-style change signature.  The multiply
+ * mixes each XORed value into the hash; see
+ * https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+ */
+static inline void signature_init(uint64_t *signature)
+{
+	*signature = FNV1A_64_OFFSET_BASIS;
+}
+
+static inline void signature_add(uint64_t *signature, uint64_t value)
+{
+	*signature = (*signature ^ value) * FNV1A_64_PRIME;
+}
+
+AST_MUTEX_DEFINE_STATIC(radio_device_inventory_lock);
+AST_MUTEX_DEFINE_STATIC(radio_device_inventory_refresh_lock);
+
+static struct libusb_context *usb_ctx = NULL;
+
+static int pa_lib_acquire(void);
+static void pa_lib_release(void);
+static PaDeviceIndex pa_find_device(const char *hw_device, int want_input, int want_output);
+static int radio_parse_alsa_hw_device(const char *s, int *card, int *dev);
 
 /*!
- * \var usb_device_list
- * \brief Each device string in usb_device_list is delimited with zero.  The
- * final element is zero.
+ * \brief Correlated information about one discovered USB radio device
+ *
+ * Inventory entries own all string fields and one libusb device reference.
+ * Entries do not represent an exclusive channel-driver lease.
  */
-static char *usb_device_list = NULL;
-static int usb_device_list_size = 0;
-static struct libusb_context *usb_ctx = NULL;
+struct radio_device_inventory_entry {
+	struct ast_radio_device device;
+	char *owner;
+
+	/* Mixer handle retained while the device is leased */
+	snd_mixer_t *mixer;
+	ast_mutex_t mixer_lock;
+
+	unsigned int automatic:1;
+	unsigned int pa_reference:1;
+	AST_LIST_ENTRY(radio_device_inventory_entry) entry;
+};
+
+AST_LIST_HEAD_NOLOCK(radio_device_inventory_entries, radio_device_inventory_entry);
+
+static void radio_device_pa_release(struct radio_device_inventory_entry *inventory_entry)
+{
+	if (!inventory_entry->pa_reference) {
+		return;
+	}
+	inventory_entry->pa_reference = 0;
+	pa_lib_release();
+}
+
+static void radio_device_mixer_release(struct radio_device_inventory_entry *inventory_entry)
+{
+	if (!inventory_entry->mixer) {
+		return;
+	}
+	snd_mixer_close(inventory_entry->mixer);
+	inventory_entry->mixer = NULL;
+}
+
+static int radio_device_mixer_acquire(struct radio_device_inventory_entry *inventory_entry)
+{
+	char mixer_name[32];
+	snd_mixer_t *mixer;
+	int result;
+
+	snprintf(mixer_name, sizeof(mixer_name), "hw:%d", inventory_entry->device.alsa_card);
+	result = snd_mixer_open(&mixer, 0);
+	if (result < 0) {
+		return -1;
+	}
+	result = snd_mixer_attach(mixer, mixer_name);
+	if (result >= 0) {
+		result = snd_mixer_selem_register(mixer, NULL, NULL);
+	}
+	if (result >= 0) {
+		result = snd_mixer_load(mixer);
+	}
+	if (result < 0) {
+		snd_mixer_close(mixer);
+		return -1;
+	}
+
+	inventory_entry->mixer = mixer;
+	return 0;
+}
+
+/*!
+ * \brief Most recently completed device inventory snapshot
+ *
+ * A refresh is built separately and published under radio_device_inventory_lock so
+ * callers never observe a partially populated inventory.
+ */
+static struct {
+	struct radio_device_inventory_entries available;
+	struct radio_device_inventory_entries leased;
+	struct timeval refreshed_at;
+	unsigned int generation;
+	unsigned int logged_candidate_count;
+	unsigned int logged_inventory_ready_count;
+	unsigned int logged_pa_ready_count;
+	uint64_t logged_signature;
+	uint64_t logged_rejections[DEVICE_REJECTION_LOG_SLOTS];
+	size_t logged_rejection_count;
+	unsigned int log_initialized:1;
+	unsigned int valid:1;
+} radio_device_inventory;
+
+/* radio_device_inventory_lock must be held by the caller. */
+static int radio_device_rejection_should_log(const struct ast_radio_device *device,
+	const struct ast_radio_device_request *request, unsigned int reason)
+{
+	const unsigned char *text;
+	uint64_t signature;
+	size_t index;
+
+	signature_init(&signature);
+	for (text = (const unsigned char *) device->devstr; *text; text++) {
+		signature_add(&signature, *text);
+	}
+	for (text = (const unsigned char *) request->owner; *text; text++) {
+		signature_add(&signature, *text);
+	}
+	signature_add(&signature, reason);
+	signature_add(&signature, device->capabilities);
+	signature_add(&signature, device->pa_input_channels);
+	signature_add(&signature, device->pa_output_channels);
+	signature_add(&signature, request->required_caps);
+	signature_add(&signature, request->minimum_input_channels);
+	signature_add(&signature, request->minimum_output_channels);
+
+	for (index = 0; index < radio_device_inventory.logged_rejection_count; index++) {
+		if (radio_device_inventory.logged_rejections[index] == signature) {
+			return 0;
+		}
+	}
+	if (radio_device_inventory.logged_rejection_count >= DEVICE_REJECTION_LOG_SLOTS) {
+		return 0;
+	}
+	radio_device_inventory.logged_rejections[radio_device_inventory.logged_rejection_count++] = signature;
+	return 1;
+}
 
 /*!
  * \brief Structure for defined usb devices.
@@ -113,165 +258,64 @@ const struct usb_device_entry known_devices[] = {
  */
 static AST_RWLIST_HEAD_STATIC(user_devices, usb_device_entry);
 
-int ast_radio_libusb_init(void)
+/*! \brief Release the resources owned by an inventory or leased device */
+static void radio_device_contents_cleanup(struct ast_radio_device *device)
 {
-	if (usb_ctx) {
-		return 0;
+	size_t mixer_index;
+
+	if (device->usb_device) {
+		libusb_unref_device(device->usb_device);
 	}
 
-	return libusb_init(&usb_ctx);
+	ast_free((char *) device->devstr);
+	ast_free((char *) device->serial);
+	ast_free((char *) device->alsa_capture_name);
+	ast_free((char *) device->alsa_playback_name);
+	for (mixer_index = 0; mixer_index < device->mixer_element_count; mixer_index++) {
+		ast_free((char *) device->mixer_elements[mixer_index].name);
+	}
+	ast_free(device->mixer_elements);
+	ast_free(device->mixer_rx_paths);
+	ast_free(device->mixer_tx_paths);
+	ast_free(device->mixer_sidetone_paths);
+	ast_free(device->mixer_rx_boost_paths);
+}
+
+/*! \brief Free one device inventory entry and its owned resources */
+static void device_inventory_entry_free(struct radio_device_inventory_entry *inventory_entry)
+{
+	if (!inventory_entry) {
+		return;
+	}
+
+	radio_device_pa_release(inventory_entry);
+	radio_device_mixer_release(inventory_entry);
+	radio_device_contents_cleanup(&inventory_entry->device);
+	ast_free(inventory_entry->owner);
+	ast_mutex_destroy(&inventory_entry->mixer_lock);
+	ast_free(inventory_entry);
+}
+
+/*!
+ * \brief Remove and free every entry in the published device inventory
+ */
+static void device_inventory_cleanup(void)
+{
+	struct radio_device_inventory_entry *device;
+
+	ast_mutex_lock(&radio_device_inventory_lock);
+	while ((device = AST_LIST_REMOVE_HEAD(&radio_device_inventory.available, entry))) {
+		device_inventory_entry_free(device);
+	}
+	memset(&radio_device_inventory.refreshed_at, 0, sizeof(radio_device_inventory.refreshed_at));
+	radio_device_inventory.log_initialized = 0;
+	radio_device_inventory.valid = 0;
+	ast_mutex_unlock(&radio_device_inventory_lock);
 }
 
 long ast_radio_lround(double x)
 {
 	return (long) ((x - ((long) x) >= 0.5f) ? (((long) x) + 1) : ((long) x));
-}
-
-int ast_radio_make_spkr_playback_value(int spkrmax, int request_value, int devtype)
-{
-	/* spkrmax is validated by ast_radio_init_mixer_limits() before use. */
-	return (request_value * spkrmax) / AUDIO_ADJUSTMENT;
-}
-
-int ast_radio_init_mixer_limits(int devnum, int *micmax, int *spkrmax, int *micplaymax, int *newname)
-{
-	int rv;
-
-	rv = ast_radio_amixer_max(devnum, MIXER_PARAM_MIC_CAPTURE_VOL);
-	if (rv <= 0) {
-		return -1;
-	}
-	*micmax = rv;
-
-	*newname = 0;
-	rv = ast_radio_amixer_max(devnum, MIXER_PARAM_SPKR_PLAYBACK_VOL);
-	if (rv <= 0) {
-		rv = ast_radio_amixer_max(devnum, MIXER_PARAM_SPKR_PLAYBACK_VOL_NEW);
-		if (rv <= 0) {
-			return -1;
-		}
-		*newname = 1;
-	}
-	*spkrmax = rv;
-
-	rv = ast_radio_amixer_max(devnum, MIXER_PARAM_MIC_PLAYBACK_VOL);
-	if (rv <= 0) {
-		return -1;
-	}
-	*micplaymax = rv;
-
-	return 0;
-}
-
-int ast_radio_amixer_max(int devnum, char *param)
-{
-	int rv, type;
-	char str[100];
-	snd_hctl_t *hctl;
-	snd_ctl_elem_id_t *id;
-	snd_hctl_elem_t *elem;
-	snd_ctl_elem_info_t *info;
-
-	snprintf(str, sizeof(str), "hw:%d", devnum);
-
-	if (snd_hctl_open(&hctl, str, 0) < 0) {
-		return -1;
-	}
-
-	if (snd_hctl_load(hctl) < 0) {
-		snd_hctl_close(hctl);
-		return -1;
-	}
-
-	snd_ctl_elem_id_alloca(&id);
-	snd_ctl_elem_id_set_interface(id, SND_CTL_ELEM_IFACE_MIXER);
-	snd_ctl_elem_id_set_name(id, param);
-
-	elem = snd_hctl_find_elem(hctl, id);
-	if (!elem) {
-		snd_hctl_close(hctl);
-		return -1;
-	}
-
-	snd_ctl_elem_info_alloca(&info);
-	if (snd_hctl_elem_info(elem, info) < 0) {
-		snd_hctl_close(hctl);
-		return -1;
-	}
-	type = snd_ctl_elem_info_get_type(info);
-	rv = 0;
-
-	switch (type) {
-	case SND_CTL_ELEM_TYPE_INTEGER:
-		rv = snd_ctl_elem_info_get_max(info);
-		break;
-	case SND_CTL_ELEM_TYPE_BOOLEAN:
-		rv = 1;
-		break;
-	}
-
-	snd_hctl_close(hctl);
-	return rv;
-}
-
-int ast_radio_setamixer(int devnum, char *param, int v1, int v2)
-{
-	int type;
-	char str[100];
-	snd_hctl_t *hctl;
-	snd_ctl_elem_id_t *id;
-	snd_ctl_elem_value_t *control;
-	snd_hctl_elem_t *elem;
-	snd_ctl_elem_info_t *info;
-
-	snprintf(str, sizeof(str), "hw:%d", devnum);
-
-	if (snd_hctl_open(&hctl, str, 0) < 0) {
-		return -1;
-	}
-
-	if (snd_hctl_load(hctl) < 0) {
-		snd_hctl_close(hctl);
-		return -1;
-	}
-	snd_ctl_elem_id_alloca(&id);
-	snd_ctl_elem_id_set_interface(id, SND_CTL_ELEM_IFACE_MIXER);
-	snd_ctl_elem_id_set_name(id, param);
-
-	elem = snd_hctl_find_elem(hctl, id);
-	if (!elem) {
-		snd_hctl_close(hctl);
-		return -1;
-	}
-
-	snd_ctl_elem_info_alloca(&info);
-	if (snd_hctl_elem_info(elem, info) < 0) {
-		snd_hctl_close(hctl);
-		return -1;
-	}
-	type = snd_ctl_elem_info_get_type(info);
-	snd_ctl_elem_value_alloca(&control);
-	snd_ctl_elem_value_set_id(control, id);
-
-	switch (type) {
-	case SND_CTL_ELEM_TYPE_INTEGER:
-		snd_ctl_elem_value_set_integer(control, 0, v1);
-		if (v2 > 0) {
-			snd_ctl_elem_value_set_integer(control, 1, v2);
-		}
-		break;
-	case SND_CTL_ELEM_TYPE_BOOLEAN:
-		snd_ctl_elem_value_set_integer(control, 0, (v1 != 0));
-		break;
-	}
-
-	if (snd_hctl_elem_write(elem, control)) {
-		snd_hctl_close(hctl);
-		return -1;
-	}
-
-	snd_hctl_close(hctl);
-	return 0;
 }
 
 int ast_radio_hid_set_outputs(struct libusb_device_handle *handle, unsigned char *outputs)
@@ -479,285 +523,1039 @@ static int read_card_usbbus(int cardno, char *out, int outsz)
 	return (n > 0) ? 0 : -1;
 }
 
-int ast_radio_hid_device_mklist(void)
+/*
+ * Correlate a libusb device with the ALSA card and sysfs topology already
+ * used by the channel drivers.  A device is not viable until all three views
+ * agree that it is present.
+ */
+static int radio_device_find_alsa_card(struct libusb_device *usb_device, int *card, char **sysfs_device)
 {
-	struct libusb_device *dev;
-	char devstr[10000], str[200], desdev[200], *cp;
-	ssize_t linklen;
-	size_t cplen;
-	int i;
-	struct libusb_device **list = NULL;
-	ssize_t count;
-	size_t dev_index;
-	unsigned int busnum;
-	unsigned int devaddr;
+	char usb_bus[16];
+	char alsa_bus[64];
+	char sysfs_path[128];
+	char link_target[PATH_MAX];
+	char *topology;
+	ssize_t link_length;
+	int card_number;
 
-	ast_mutex_lock(&usb_list_lock);
+	snprintf(usb_bus, sizeof(usb_bus), "%03u/%03u", libusb_get_bus_number(usb_device), libusb_get_device_address(usb_device));
 
-	/* See usb_device_list definition for the format */
-	if (usb_device_list) {
-		ast_free(usb_device_list);
-	}
-	usb_device_list_size = 0;
-	usb_device_list = ast_calloc(1, 2);
-
-	if (!usb_device_list) {
-		ast_mutex_unlock(&usb_list_lock);
-		return -1;
-	}
-
-	if (!usb_ctx) {
-		ast_mutex_unlock(&usb_list_lock);
-		return -1;
-	}
-
-	count = libusb_get_device_list(usb_ctx, &list);
-	if (count < 0) {
-		ast_mutex_unlock(&usb_list_lock);
-		return -1;
-	}
-	for (dev_index = 0; dev_index < count; dev_index++) {
-		char *new_list;
-
-		dev = list[dev_index];
-		if (!(is_known_device(dev) || is_user_device(dev))) {
+	for (card_number = 0; card_number < 32; card_number++) {
+		if (read_card_usbbus(card_number, alsa_bus, sizeof(alsa_bus)) || strcasecmp(alsa_bus, usb_bus)) {
 			continue;
 		}
 
-		busnum = libusb_get_bus_number(dev);
-		devaddr = libusb_get_device_address(dev);
-		snprintf(devstr, sizeof(devstr), "%03u/%03u", busnum, devaddr);
-		for (i = 0; i < 32; i++) {
-			if (read_card_usbbus(i, desdev, sizeof(desdev))) {
-				continue;
-			}
-
-			if (strcasecmp(desdev, devstr)) {
-				continue;
-			}
-
-			snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
-			linklen = readlink(str, desdev, sizeof(desdev) - 1);
-			if (linklen == -1) {
-				continue;
-			}
-			desdev[linklen] = '\0';
-			cp = strrchr(desdev, '/');
-			if (!cp) {
-				continue;
-			}
-			cp++;
-			break;
+		snprintf(sysfs_path, sizeof(sysfs_path), "/sys/class/sound/card%d/device", card_number);
+		link_length = readlink(sysfs_path, link_target, sizeof(link_target) - 1);
+		if (link_length < 0) {
+			continue;
 		}
-		if (i >= 32) {
+		link_target[link_length] = '\0';
+		topology = strrchr(link_target, '/');
+		if (!topology || ast_strlen_zero(++topology)) {
 			continue;
 		}
 
-		cplen = strlen(cp);
-		new_list = ast_realloc(usb_device_list, usb_device_list_size + 2 + cplen);
-		if (!new_list) {
-			libusb_free_device_list(list, 1);
-			ast_mutex_unlock(&usb_list_lock);
+		*sysfs_device = ast_strdup(topology);
+		if (!*sysfs_device) {
 			return -1;
 		}
-
-		usb_device_list = new_list;
-		usb_device_list_size += cplen + 2;
-		i = 0;
-
-		while (usb_device_list[i]) {
-			i += strlen(usb_device_list + i) + 1;
-		}
-
-		memcpy(usb_device_list + i, cp, cplen + 1);
-		usb_device_list[i + cplen + 1] = 0;
+		*card = card_number;
+		return 0;
 	}
 
-	libusb_free_device_list(list, 1);
-	ast_mutex_unlock(&usb_list_lock);
+	return -1;
+}
+
+/* Check whether an ALSA PCM device supports the requested stream direction */
+static int radio_device_alsa_pcm_available(snd_ctl_t *control, snd_pcm_info_t *pcm_info, int pcm_device, snd_pcm_stream_t stream)
+{
+	snd_pcm_info_set_device(pcm_info, pcm_device);
+	snd_pcm_info_set_subdevice(pcm_info, 0);
+	snd_pcm_info_set_stream(pcm_info, stream);
+	if (snd_ctl_pcm_info(control, pcm_info) < 0) {
+		return 0;
+	}
+	return 1;
+}
+
+/* Find capture and playback PCM devices through ALSA without opening either stream */
+static int radio_device_find_alsa_endpoints(int card, int *capture_device, int *playback_device)
+{
+	char control_name[32];
+	snd_ctl_t *control;
+	snd_pcm_info_t *pcm_info;
+	int pcm_device = -1;
+	int result;
+
+	*capture_device = -1;
+	*playback_device = -1;
+	snprintf(control_name, sizeof(control_name), "hw:%d", card);
+	result = snd_ctl_open(&control, control_name, 0);
+	if (result < 0) {
+		ast_debug(5, "ALSA control interface for card %d is not yet available: %s\n", card, snd_strerror(result));
+		return -1;
+	}
+
+	snd_pcm_info_alloca(&pcm_info);
+	for (;;) {
+		result = snd_ctl_pcm_next_device(control, &pcm_device);
+		if (result < 0) {
+			ast_debug(5, "Unable to enumerate PCM devices for ALSA card %d: %s\n", card, snd_strerror(result));
+			break;
+		}
+		if (pcm_device < 0) {
+			break;
+		}
+		if (*capture_device < 0) {
+			if (radio_device_alsa_pcm_available(control, pcm_info, pcm_device, SND_PCM_STREAM_CAPTURE)) {
+				*capture_device = pcm_device;
+			}
+		}
+		if (*playback_device < 0) {
+			if (radio_device_alsa_pcm_available(control, pcm_info, pcm_device, SND_PCM_STREAM_PLAYBACK)) {
+				*playback_device = pcm_device;
+			}
+		}
+		if (*capture_device >= 0) {
+			if (*playback_device >= 0) {
+				break;
+			}
+		}
+	}
+	snd_ctl_close(control);
+
+	result = 0;
+	if (*capture_device < 0) {
+		ast_debug(5, "ALSA card %d does not have an available capture PCM device\n", card);
+		result = -1;
+	}
+	if (*playback_device < 0) {
+		ast_debug(5, "ALSA card %d does not have an available playback PCM device\n", card);
+		result = -1;
+	}
+	return result;
+}
+
+static int radio_device_mixer_path_append(struct ast_radio_mixer_path **paths, size_t *path_count, unsigned int element, int channel)
+{
+	struct ast_radio_mixer_path *new_paths;
+
+	/* Grow the path array and append the discovered element channel. */
+	new_paths = ast_realloc(*paths, (*path_count + 1) * sizeof(*new_paths));
+	if (!new_paths) {
+		return -1;
+	}
+
+	*paths = new_paths;
+	new_paths[*path_count].element = element;
+	new_paths[*path_count].channel = channel;
+	(*path_count)++;
 	return 0;
 }
 
-struct libusb_device *ast_radio_hid_device_init(const char *desired_device)
+static int radio_device_mixer_element_append(struct ast_radio_device *device, snd_mixer_elem_t *mixer_element, unsigned int *element_index)
 {
-	struct libusb_device *dev;
-	char devstr[10000], str[200], desdev[200], *cp;
-	ssize_t linklen;
-	int i;
-	struct libusb_device **list = NULL;
-	ssize_t count;
-	size_t dev_index;
-	unsigned int busnum;
-	unsigned int devaddr;
+	struct ast_radio_mixer_element *element;
+	struct ast_radio_mixer_element *new_elements;
 
-	if (!usb_ctx) {
-		return NULL;
+	/* Add storage for the discovered simple mixer element. */
+	new_elements = ast_realloc(device->mixer_elements, (device->mixer_element_count + 1) * sizeof(*new_elements));
+	if (!new_elements) {
+		return -1;
 	}
 
-	count = libusb_get_device_list(usb_ctx, &list);
-	if (count < 0) {
-		return NULL;
+	/* Retain the element identity needed for later mixer operations. */
+	device->mixer_elements = new_elements;
+	element = &new_elements[device->mixer_element_count];
+	memset(element, 0, sizeof(*element));
+	element->name = ast_strdup(snd_mixer_selem_get_name(mixer_element));
+	if (!element->name) {
+		return -1;
+	}
+	element->index = snd_mixer_selem_get_index(mixer_element);
+
+	/* Record capture capabilities and volume range. */
+	if (snd_mixer_selem_has_capture_volume(mixer_element)) {
+		element->capabilities |= AST_RADIO_MIXER_CAPTURE_VOLUME;
+		snd_mixer_selem_get_capture_volume_range(mixer_element, &element->capture_min, &element->capture_max);
+	}
+	if (snd_mixer_selem_has_capture_switch(mixer_element)) {
+		element->capabilities |= AST_RADIO_MIXER_CAPTURE_SWITCH;
 	}
 
-	for (dev_index = 0; dev_index < count; dev_index++) {
-		dev = list[dev_index];
-		if (!(is_known_device(dev) || is_user_device(dev))) {
+	/* Record playback capabilities and volume range. */
+	if (snd_mixer_selem_has_playback_volume(mixer_element)) {
+		element->capabilities |= AST_RADIO_MIXER_PLAYBACK_VOLUME;
+		snd_mixer_selem_get_playback_volume_range(mixer_element, &element->playback_min, &element->playback_max);
+	}
+	if (snd_mixer_selem_has_playback_switch(mixer_element)) {
+		element->capabilities |= AST_RADIO_MIXER_PLAYBACK_SWITCH;
+	}
+
+	*element_index = device->mixer_element_count;
+	device->mixer_element_count++;
+	return 0;
+}
+
+static int radio_device_mixer_paths_add(struct ast_radio_device *device, snd_mixer_elem_t *mixer_element, unsigned int element_index)
+{
+	int channel;
+	int has_capture;
+	int has_playback;
+
+	/* The receive boost is a named semantic control with no volume capability. */
+	if (!strcasecmp(snd_mixer_selem_get_name(mixer_element), MIXER_RX_BOOST_ELEMENT) && snd_mixer_selem_has_playback_switch(mixer_element)) {
+		for (channel = 0; channel <= SND_MIXER_SCHN_LAST; channel++) {
+			if (!snd_mixer_selem_has_playback_channel(mixer_element, channel)) {
+				continue;
+			}
+			if (radio_device_mixer_path_append(&device->mixer_rx_boost_paths, &device->mixer_rx_boost_path_count, element_index, channel)) {
+				return -1;
+			}
+		}
+		return 0;
+	}
+
+	/* Classify capture-volume channels as receive paths */
+	has_capture = snd_mixer_selem_has_capture_volume(mixer_element);
+	if (has_capture) {
+		for (channel = 0; channel <= SND_MIXER_SCHN_LAST; channel++) {
+			if (!snd_mixer_selem_has_capture_channel(mixer_element, channel)) {
+				continue;
+			}
+			if (radio_device_mixer_path_append(&device->mixer_rx_paths, &device->mixer_rx_path_count, element_index, channel)) {
+				return -1;
+			}
+		}
+	}
+
+	/* Classify playback channels as sidetone or transmit paths */
+	has_playback = snd_mixer_selem_has_playback_volume(mixer_element);
+	if (!has_playback) {
+		return 0;
+	}
+
+	for (channel = 0; channel <= SND_MIXER_SCHN_LAST; channel++) {
+		if (!snd_mixer_selem_has_playback_channel(mixer_element, channel)) {
 			continue;
 		}
+		if (has_capture) {
+			if (radio_device_mixer_path_append(&device->mixer_sidetone_paths, &device->mixer_sidetone_path_count, element_index, channel)) {
+				return -1;
+			}
+			continue;
+		}
+		if (radio_device_mixer_path_append(&device->mixer_tx_paths, &device->mixer_tx_path_count, element_index, channel)) {
+			return -1;
+		}
+	}
+	return 0;
+}
 
-		busnum = libusb_get_bus_number(dev);
-		devaddr = libusb_get_device_address(dev);
-		snprintf(devstr, sizeof(devstr), "%03u/%03u", busnum, devaddr);
+/* Discover mixer elements by capability rather than device-specific names */
+static int radio_device_find_mixer_paths(struct ast_radio_device *device)
+{
+	char mixer_name[32];
+	snd_mixer_t *mixer;
+	snd_mixer_elem_t *mixer_element;
+	unsigned int element_index;
+	int result;
 
-		for (i = 0; i < 32; i++) {
-			if (read_card_usbbus(i, desdev, sizeof(desdev))) {
-				continue;
-			}
+	/* Open and load the card's ALSA simple mixer elements. */
+	snprintf(mixer_name, sizeof(mixer_name), "hw:%d", device->alsa_card);
+	result = snd_mixer_open(&mixer, 0);
+	if (result < 0) {
+		return -1;
+	}
+	result = snd_mixer_attach(mixer, mixer_name);
+	if (result < 0) {
+		snd_mixer_close(mixer);
+		return -1;
+	}
+	result = snd_mixer_selem_register(mixer, NULL, NULL);
+	if (result < 0) {
+		snd_mixer_close(mixer);
+		return -1;
+	}
+	result = snd_mixer_load(mixer);
+	if (result < 0) {
+		snd_mixer_close(mixer);
+		return -1;
+	}
 
-			if (strcasecmp(desdev, devstr)) {
-				continue;
-			}
-			snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
-			linklen = readlink(str, desdev, sizeof(desdev) - 1);
-			if (linklen == -1) {
-				continue;
-			}
-			desdev[linklen] = '\0';
-			cp = strrchr(desdev, '/');
-			if (!cp) {
-				continue;
-			}
-			cp++;
+	/* Retain active volume elements and the optional named receive-boost control. */
+	for (mixer_element = snd_mixer_first_elem(mixer); mixer_element; mixer_element = snd_mixer_elem_next(mixer_element)) {
+		if (!snd_mixer_selem_is_active(mixer_element)) {
+			continue;
+		}
+		if (!snd_mixer_selem_has_capture_volume(mixer_element) && !snd_mixer_selem_has_playback_volume(mixer_element) &&
+			(strcasecmp(snd_mixer_selem_get_name(mixer_element), MIXER_RX_BOOST_ELEMENT) || !snd_mixer_selem_has_playback_switch(mixer_element))) {
+			continue;
+		}
+		if (radio_device_mixer_element_append(device, mixer_element, &element_index)) {
+			result = -1;
 			break;
 		}
-		if (i >= 32) {
-			continue;
-		}
-		if (!strcmp(cp, desired_device)) {
-			libusb_ref_device(dev);
-			libusb_free_device_list(list, 1);
-			return dev;
+		if (radio_device_mixer_paths_add(device, mixer_element, element_index)) {
+			result = -1;
+			break;
 		}
 	}
-	libusb_free_device_list(list, 1);
+	snd_mixer_close(mixer);
+
+	if (result < 0) {
+		return -1;
+	}
+
+	/* Receive and transmit paths are required; sidetone is optional. */
+	if (!device->mixer_rx_path_count) {
+		ast_debug(5, "USB radio device %s (ALSA card %d) has no capture-volume mixer path\n", device->devstr, device->alsa_card);
+		return -1;
+	}
+	if (!device->mixer_tx_path_count) {
+		ast_debug(5, "USB radio device %s (ALSA card %d) has no playback-volume mixer path\n", device->devstr, device->alsa_card);
+		return -1;
+	}
+	ast_debug(7, "USB radio device %s mixers: RX:%zu TX:%zu sidetone:%zu boost:%zu (%zu elements)\n", device->devstr,
+		device->mixer_rx_path_count, device->mixer_tx_path_count, device->mixer_sidetone_path_count,
+		device->mixer_rx_boost_path_count, device->mixer_element_count);
+	return 0;
+}
+
+/* Read the serial from the parent USB device without opening the hardware */
+static char *radio_device_read_serial(const char *sysfs_device)
+{
+	char *usb_device;
+	char *interface_separator;
+	char path[PATH_MAX];
+	char *serial = NULL;
+	char *owned_serial;
+	size_t serial_size = 0;
+	ssize_t serial_length;
+	FILE *serial_file;
+
+	usb_device = ast_strdup(sysfs_device);
+	if (!usb_device) {
+		return NULL;
+	}
+	interface_separator = strchr(usb_device, ':');
+	if (interface_separator) {
+		*interface_separator = '\0';
+	}
+
+	snprintf(path, sizeof(path), "/sys/bus/usb/devices/%s/serial", usb_device);
+	ast_free(usb_device);
+
+	serial_file = fopen(path, "r");
+	if (!serial_file) {
+		return NULL;
+	}
+
+	serial_length = getline(&serial, &serial_size, serial_file);
+	fclose(serial_file);
+	if (serial_length < 0) {
+		ast_std_free(serial);
+		return NULL;
+	}
+
+	while (serial_length > 0 && isspace((unsigned char) serial[serial_length - 1])) {
+		serial[--serial_length] = '\0';
+	}
+	if (!serial_length) {
+		ast_std_free(serial);
+		return NULL;
+	}
+
+	/* getline() uses libc allocation; copy into Asterisk-owned inventory storage. */
+	owned_serial = ast_strdup(serial);
+	ast_std_free(serial);
+	return owned_serial;
+}
+
+static struct radio_device_inventory_entry *radio_device_inventory_entry_create(struct libusb_device *usb_device)
+{
+	struct radio_device_inventory_entry *inventory_entry;
+	struct libusb_device_descriptor descriptor;
+	char capture_name[32];
+	char playback_name[32];
+	int alsa_card;
+	int capture_device;
+	int playback_device;
+	char *sysfs_device;
+
+	if (libusb_get_device_descriptor(usb_device, &descriptor) < 0) {
+		ast_debug(5, "Unable to read the descriptor for libusb device at bus %u address %u\n", libusb_get_bus_number(usb_device),
+			libusb_get_device_address(usb_device));
+		return NULL;
+	}
+	if (radio_device_find_alsa_card(usb_device, &alsa_card, &sysfs_device)) {
+		ast_debug(7, "USB bus %u address %u: ALSA/sysfs match pending\n", libusb_get_bus_number(usb_device),
+			libusb_get_device_address(usb_device));
+		return NULL;
+	}
+	if (radio_device_find_alsa_endpoints(alsa_card, &capture_device, &playback_device)) {
+		ast_debug(5, "USB radio device %s (ALSA card %d) does not have usable capture and playback endpoints\n", sysfs_device, alsa_card);
+		ast_free(sysfs_device);
+		return NULL;
+	}
+
+	inventory_entry = ast_calloc(1, sizeof(*inventory_entry));
+	if (!inventory_entry) {
+		ast_free(sysfs_device);
+		return NULL;
+	}
+	ast_mutex_init(&inventory_entry->mixer_lock);
+	inventory_entry->device.devstr = sysfs_device;
+	inventory_entry->device.alsa_card = alsa_card;
+	if (radio_device_find_mixer_paths(&inventory_entry->device)) {
+		goto allocation_failed;
+	}
+
+	snprintf(capture_name, sizeof(capture_name), "hw:%d,%d", alsa_card, capture_device);
+	snprintf(playback_name, sizeof(playback_name), "hw:%d,%d", alsa_card, playback_device);
+	inventory_entry->device.serial = radio_device_read_serial(sysfs_device);
+	inventory_entry->device.alsa_capture_name = ast_strdup(capture_name);
+	if (!inventory_entry->device.alsa_capture_name) {
+		goto allocation_failed;
+	}
+	inventory_entry->device.alsa_playback_name = ast_strdup(playback_name);
+	if (!inventory_entry->device.alsa_playback_name) {
+		goto allocation_failed;
+	}
+
+	inventory_entry->device.vendor_id = descriptor.idVendor;
+	inventory_entry->device.product_id = descriptor.idProduct;
+	inventory_entry->device.capabilities = AST_RADIO_CAP_CM108_HID;
+	inventory_entry->device.alsa_capture_device = capture_device;
+	inventory_entry->device.alsa_playback_device = playback_device;
+	inventory_entry->device.usb_device = libusb_ref_device(usb_device);
+	inventory_entry->device.usb_bus = libusb_get_bus_number(usb_device);
+	inventory_entry->device.usb_address = libusb_get_device_address(usb_device);
+	inventory_entry->device.pa_input_device = paNoDevice;
+	inventory_entry->device.pa_output_device = paNoDevice;
+
+	return inventory_entry;
+
+allocation_failed:
+	device_inventory_entry_free(inventory_entry);
 	return NULL;
 }
 
-int ast_radio_usb_get_usbdev(const char *devstr)
+static int radio_device_inventory_needs_update(void)
 {
-	int i;
-	char str[200], desdev[200], *cp;
+	long inventory_age;
+	int needs_update;
 
-	for (i = 0; i < 32; i++) {
-		snprintf(str, sizeof(str), "/sys/class/sound/card%d/device", i);
-		memset(desdev, 0, sizeof(desdev));
-		if (readlink(str, desdev, sizeof(desdev) - 1) == -1) {
-			continue;
-		}
-		cp = strrchr(desdev, '/');
-		if (!cp) {
-			continue;
-		}
-		cp++;
-		if (!strcasecmp(cp, devstr)) {
-			break;
-		}
+	ast_mutex_lock(&radio_device_inventory_lock);
+	inventory_age = ast_tvdiff_ms(ast_tvnow(), radio_device_inventory.refreshed_at);
+	needs_update = 0;
+	if (!radio_device_inventory.valid) {
+		needs_update = 1;
+	} else if (inventory_age >= DEVICE_INVENTORY_CACHE_MS) {
+		needs_update = 1;
 	}
-	if (i >= 32) {
-		return -1;
-	}
-	return i;
+	ast_mutex_unlock(&radio_device_inventory_lock);
+	return needs_update;
 }
 
-/*!
- * \brief Get serial number from device if available
- *	This function will attempt to get the serial number from a media device
- *
- * \param devstr		The USB device string
- * \param buf			Pointer to buffer for serial number
- * \param buflen		Length of the serial number buffer
- * \retval				Length of returned serial number; 0 if no serial
- */
-int ast_radio_usb_get_serial(const char *devstr, char *buf, size_t buflen)
+static struct radio_device_inventory_entry *radio_device_find_lease(const struct ast_radio_device *device);
+
+static void radio_device_pa_update_indices(struct ast_radio_device *device)
 {
-	struct libusb_device *usb_dev;
-	struct libusb_device_handle *usb_handle;
-	struct libusb_device_descriptor desc;
-	int length = 0;
+	const PaDeviceInfo *input_info;
+	const PaDeviceInfo *output_info;
 
-	if (!usb_ctx) {
-		return 0;
-	}
-	usb_dev = ast_radio_hid_device_init(devstr);
-	if (!usb_dev) {
-		return 0;
-	}
+	device->pa_input_device = pa_find_device(device->alsa_capture_name, 1, 0);
+	device->pa_output_device = pa_find_device(device->alsa_playback_name, 0, 1);
+	device->pa_input_channels = 0;
+	device->pa_output_channels = 0;
 
-	if (libusb_get_device_descriptor(usb_dev, &desc) < 0) {
-		libusb_unref_device(usb_dev);
-		return 0;
+	/* Record the channel capacity of each resolved PortAudio endpoint */
+	input_info = device->pa_input_device == paNoDevice ? NULL : Pa_GetDeviceInfo(device->pa_input_device);
+	if (input_info && input_info->maxInputChannels > 0) {
+		device->pa_input_channels = (unsigned int) input_info->maxInputChannels;
 	}
 
-	if (desc.iSerialNumber) {
-		if (libusb_open(usb_dev, &usb_handle) < 0) {
-			libusb_unref_device(usb_dev);
+	output_info = device->pa_output_device == paNoDevice ? NULL : Pa_GetDeviceInfo(device->pa_output_device);
+	if (output_info && output_info->maxOutputChannels > 0) {
+		device->pa_output_channels = (unsigned int) output_info->maxOutputChannels;
+	}
+}
+
+static void radio_device_inventory_pa_update(struct radio_device_inventory_entries *entries)
+{
+	struct radio_device_inventory_entry *inventory_entry;
+
+	if (pa_lib_acquire() < 0) {
+		ast_debug(3, "PortAudio is unavailable while refreshing the USB radio device inventory\n");
+		return;
+	}
+
+	AST_LIST_TRAVERSE(entries, inventory_entry, entry) {
+		radio_device_pa_update_indices(&inventory_entry->device);
+		if (!ast_radio_device_pa_ready(&inventory_entry->device)) {
+			ast_debug(7, "USB radio device %s: PortAudio not ready\n", inventory_entry->device.devstr);
+		} else {
+			ast_debug(7, "USB radio device %s PortAudio: in %d/%u ch, out %d/%u ch\n", inventory_entry->device.devstr,
+				inventory_entry->device.pa_input_device, inventory_entry->device.pa_input_channels,
+				inventory_entry->device.pa_output_device, inventory_entry->device.pa_output_channels);
+		}
+	}
+
+	pa_lib_release();
+}
+
+/* Build a complete snapshot before replacing the inventory visible to callers */
+static int radio_device_inventory_refresh(int force)
+{
+	struct radio_device_inventory_entries refreshed_entries;
+	struct radio_device_inventory_entry *inventory_entry;
+	struct radio_device_inventory_entry *old_entry;
+	struct libusb_device **usb_devices = NULL;
+	ssize_t device_count;
+	ssize_t device_index;
+	unsigned int candidate_count = 0;
+	unsigned int inventory_ready_count = 0;
+	unsigned int pa_ready_count = 0;
+	unsigned int generation;
+	uint64_t signature;
+	int log_inventory;
+
+	signature_init(&signature);
+	AST_LIST_HEAD_INIT_NOLOCK(&refreshed_entries);
+	ast_mutex_lock(&radio_device_inventory_refresh_lock);
+	if (!force) {
+		if (!radio_device_inventory_needs_update()) {
+			ast_mutex_unlock(&radio_device_inventory_refresh_lock);
 			return 0;
 		}
-		length = libusb_get_string_descriptor_ascii(usb_handle, desc.iSerialNumber, (unsigned char *) buf, buflen);
-		libusb_close(usb_handle);
 	}
-	libusb_unref_device(usb_dev);
-	if (length < 0) {
-		length = 0;
+	if (!usb_ctx) {
+		ast_mutex_unlock(&radio_device_inventory_refresh_lock);
+		return -1;
 	}
 
-	return length;
+	device_count = libusb_get_device_list(usb_ctx, &usb_devices);
+	if (device_count < 0) {
+		ast_mutex_unlock(&radio_device_inventory_refresh_lock);
+		return -1;
+	}
+
+	for (device_index = 0; device_index < device_count; device_index++) {
+		if (!is_known_device(usb_devices[device_index])) {
+			if (!is_user_device(usb_devices[device_index])) {
+				continue;
+			}
+		}
+		candidate_count++;
+		signature_add(&signature, libusb_get_bus_number(usb_devices[device_index]));
+		signature_add(&signature, libusb_get_device_address(usb_devices[device_index]));
+
+		inventory_entry = radio_device_inventory_entry_create(usb_devices[device_index]);
+		if (!inventory_entry) {
+			continue;
+		}
+
+		AST_LIST_INSERT_TAIL(&refreshed_entries, inventory_entry, entry);
+		inventory_ready_count++;
+		ast_debug(7, "USB radio device %s%s%s discovered: ALSA in %s, out %s (%04x:%04x)\n", inventory_entry->device.devstr,
+			inventory_entry->device.serial ? " serial " : "", S_OR(inventory_entry->device.serial, ""), inventory_entry->device.alsa_capture_name,
+			inventory_entry->device.alsa_playback_name, inventory_entry->device.vendor_id, inventory_entry->device.product_id);
+	}
+	libusb_free_device_list(usb_devices, 1);
+	radio_device_inventory_pa_update(&refreshed_entries);
+	AST_LIST_TRAVERSE(&refreshed_entries, inventory_entry, entry) {
+		const unsigned char *identity;
+
+		for (identity = (const unsigned char *) inventory_entry->device.devstr; *identity; identity++) {
+			signature_add(&signature, *identity);
+		}
+		signature_add(&signature, inventory_entry->device.pa_input_channels);
+		signature_add(&signature, inventory_entry->device.pa_output_channels);
+		if (ast_radio_device_pa_ready(&inventory_entry->device)) {
+			pa_ready_count++;
+		}
+	}
+
+	ast_mutex_lock(&radio_device_inventory_lock);
+	while ((old_entry = AST_LIST_REMOVE_HEAD(&radio_device_inventory.available, entry))) {
+		device_inventory_entry_free(old_entry);
+	}
+	while ((inventory_entry = AST_LIST_REMOVE_HEAD(&refreshed_entries, entry))) {
+		if (radio_device_find_lease(&inventory_entry->device)) {
+			device_inventory_entry_free(inventory_entry);
+		} else {
+			AST_LIST_INSERT_TAIL(&radio_device_inventory.available, inventory_entry, entry);
+		}
+	}
+	radio_device_inventory.refreshed_at = ast_tvnow();
+	log_inventory = !radio_device_inventory.log_initialized || candidate_count != radio_device_inventory.logged_candidate_count ||
+					inventory_ready_count != radio_device_inventory.logged_inventory_ready_count ||
+					pa_ready_count != radio_device_inventory.logged_pa_ready_count || signature != radio_device_inventory.logged_signature;
+	generation = radio_device_inventory.generation;
+	if (log_inventory) {
+		generation = ++radio_device_inventory.generation;
+	}
+	radio_device_inventory.logged_candidate_count = candidate_count;
+	radio_device_inventory.logged_inventory_ready_count = inventory_ready_count;
+	radio_device_inventory.logged_pa_ready_count = pa_ready_count;
+	radio_device_inventory.logged_signature = signature;
+	if (log_inventory) {
+		radio_device_inventory.logged_rejection_count = 0;
+	}
+	radio_device_inventory.log_initialized = 1;
+	radio_device_inventory.valid = 1;
+	ast_mutex_unlock(&radio_device_inventory_lock);
+	ast_mutex_unlock(&radio_device_inventory_refresh_lock);
+
+	if (log_inventory) {
+		ast_debug(3, "USB radio inventory generation %u: %u recognized, %u ALSA/mixer-ready, %u PortAudio-ready\n", generation,
+			candidate_count, inventory_ready_count, pa_ready_count);
+	}
+	return 0;
 }
 
-int ast_radio_usb_list_check(char *devstr)
+/* radio_device_inventory_lock must be held by the caller. */
+static struct radio_device_inventory_entry *radio_device_find_lease(const struct ast_radio_device *device)
 {
-	/* See usb_device_list definition for the format */
-	char *s = usb_device_list;
-	int res = 0;
+	struct radio_device_inventory_entry *leased_entry;
 
-	if (!s) {
+	AST_LIST_TRAVERSE(&radio_device_inventory.leased, leased_entry, entry) {
+		if (!strcmp(leased_entry->device.devstr, device->devstr)) {
+			return leased_entry;
+		}
+	}
+	return NULL;
+}
+
+static int radio_device_matches_devstr(const struct ast_radio_device *device, const char *devstr)
+{
+	int card;
+	int pcm_device;
+
+	if (!strcasecmp(device->devstr, devstr)) {
+		return 1;
+	}
+	if (!strcasecmp(device->alsa_capture_name, devstr)) {
+		return 1;
+	}
+	if (!strcasecmp(device->alsa_playback_name, devstr)) {
+		return 1;
+	}
+
+	if (!radio_parse_alsa_hw_device(devstr, &card, &pcm_device)) {
 		return 0;
 	}
-
-	ast_mutex_lock(&usb_list_lock);
-
-	while (*s) {
-		if (!strcasecmp(s, devstr)) {
-			res = 1;
-			break;
-		}
-		s += strlen(s) + 1;
+	if (card != device->alsa_card) {
+		return 0;
 	}
-
-	ast_mutex_unlock(&usb_list_lock);
-
-	return res;
+	if (pcm_device < 0) {
+		return 1;
+	}
+	if (pcm_device == device->alsa_capture_device) {
+		return 1;
+	}
+	if (pcm_device == device->alsa_playback_device) {
+		return 1;
+	}
+	return 0;
 }
 
-char *ast_radio_usb_get_devstr(int index)
+static int radio_device_matches_request(const struct ast_radio_device *device, const struct ast_radio_device_request *request)
 {
-	/* See usb_device_list definition for the format */
-	char *s = usb_device_list;
-	int devstr_index = 0;
-
-	ast_mutex_lock(&usb_list_lock);
-
-	while (*s) {
-		if (index == devstr_index) {
-			break;
+	if (!ast_strlen_zero(request->serial)) {
+		if (!device->serial) {
+			return 0;
 		}
-		devstr_index++;
-		s += strlen(s) + 1;
+		if (strcmp(device->serial, request->serial)) {
+			return 0;
+		}
+		return 1;
+	}
+	if (!ast_strlen_zero(request->devstr)) {
+		return radio_device_matches_devstr(device, request->devstr);
+	}
+	return 1;
+}
+
+static int radio_device_supports_request(const struct ast_radio_device *device, const struct ast_radio_device_request *request)
+{
+	if ((device->capabilities & request->required_caps) != request->required_caps) {
+		return 0;
+	}
+	if (device->pa_input_channels < request->minimum_input_channels) {
+		return 0;
+	}
+	if (device->pa_output_channels < request->minimum_output_channels) {
+		return 0;
+	}
+	return 1;
+}
+
+static void radio_device_pa_acquire(struct radio_device_inventory_entry *leased_entry)
+{
+	struct ast_radio_device *device = &leased_entry->device;
+
+	device->pa_input_device = paNoDevice;
+	device->pa_output_device = paNoDevice;
+	if (pa_lib_acquire() < 0) {
+		return;
 	}
 
-	ast_mutex_unlock(&usb_list_lock);
+	radio_device_pa_update_indices(device);
+	if (!ast_radio_device_pa_ready(device)) {
+		pa_lib_release();
+		return;
+	}
+	leased_entry->pa_reference = 1;
+}
 
-	return s;
+const char *ast_radio_device_result_str(enum ast_radio_device_result result)
+{
+	switch (result) {
+	case AST_RADIO_DEVICE_READY:
+		return "USB radio device is ready";
+	case AST_RADIO_DEVICE_WAIT:
+		return "No matching USB radio device is currently available";
+	case AST_RADIO_DEVICE_CONFLICT:
+		return "The selected USB radio device is already in use";
+	case AST_RADIO_DEVICE_INVALID_CONFIG:
+		return "The configured USB radio device selector is invalid";
+	case AST_RADIO_DEVICE_ERROR:
+		return "USB radio device discovery failed";
+	default:
+		return "Unknown USB radio device result";
+	}
+}
+
+enum ast_radio_device_result ast_radio_device_acquire(const struct ast_radio_device_request *request, struct ast_radio_device **device)
+{
+	struct radio_device_inventory_entry *inventory_entry;
+	struct radio_device_inventory_entry *candidate = NULL;
+	struct radio_device_inventory_entry *active_lease;
+	int automatic;
+	int ignored_devstr = 0;
+	int result;
+
+	if (device) {
+		*device = NULL;
+	}
+	if (!request) {
+		return AST_RADIO_DEVICE_INVALID_CONFIG;
+	}
+	if (!device) {
+		return AST_RADIO_DEVICE_INVALID_CONFIG;
+	}
+	if (ast_strlen_zero(request->owner)) {
+		return AST_RADIO_DEVICE_INVALID_CONFIG;
+	}
+	if (request->required_caps & ~(AST_RADIO_CAP_CM108_HID | AST_RADIO_CAP_PARALLEL)) {
+		return AST_RADIO_DEVICE_INVALID_CONFIG;
+	}
+
+	automatic = ast_strlen_zero(request->serial) && ast_strlen_zero(request->devstr);
+	if (!automatic) {
+		ast_mutex_lock(&radio_device_inventory_lock);
+		AST_LIST_TRAVERSE(&radio_device_inventory.leased, active_lease, entry) {
+			if (!radio_device_matches_request(&active_lease->device, request)) {
+				continue;
+			}
+			if (!radio_device_supports_request(&active_lease->device, request)) {
+				continue;
+			}
+			ast_mutex_unlock(&radio_device_inventory_lock);
+			return AST_RADIO_DEVICE_CONFLICT;
+		}
+		ast_mutex_unlock(&radio_device_inventory_lock);
+	}
+
+	if (radio_device_inventory_refresh(0)) {
+		return AST_RADIO_DEVICE_ERROR;
+	}
+
+	ast_mutex_lock(&radio_device_inventory_lock);
+	AST_LIST_TRAVERSE(&radio_device_inventory.available, inventory_entry, entry) {
+		if (!radio_device_matches_request(&inventory_entry->device, request)) {
+			continue;
+		}
+		if (!ast_radio_device_pa_ready(&inventory_entry->device)) {
+			if (!radio_device_rejection_should_log(&inventory_entry->device, request, 1)) {
+				continue;
+			}
+			ast_debug(3, "USB radio device %s rejected for %s: PortAudio not ready\n", inventory_entry->device.devstr, request->owner);
+			continue;
+		}
+		if ((inventory_entry->device.capabilities & request->required_caps) != request->required_caps) {
+			if (!radio_device_rejection_should_log(&inventory_entry->device, request, 2)) {
+				continue;
+			}
+			ast_debug(3, "USB radio device %s rejected for %s: Need capabilities 0x%x, have 0x%x\n",
+				inventory_entry->device.devstr, request->owner, request->required_caps, inventory_entry->device.capabilities);
+			continue;
+		}
+		if (inventory_entry->device.pa_input_channels < request->minimum_input_channels ||
+			inventory_entry->device.pa_output_channels < request->minimum_output_channels) {
+			if (!radio_device_rejection_should_log(&inventory_entry->device, request, 3)) {
+				continue;
+			}
+			ast_debug(3, "USB radio device %s rejected for %s: Need in:%u/out:%u, have %u/%u\n", inventory_entry->device.devstr,
+				request->owner, request->minimum_input_channels, request->minimum_output_channels,
+				inventory_entry->device.pa_input_channels, inventory_entry->device.pa_output_channels);
+			continue;
+		}
+
+		if (!automatic) {
+			candidate = inventory_entry;
+			break;
+		}
+		if (!candidate) {
+			candidate = inventory_entry;
+			continue;
+		}
+		if (inventory_entry->device.alsa_card < candidate->device.alsa_card) {
+			candidate = inventory_entry;
+		}
+	}
+
+	if (!candidate) {
+		ast_mutex_unlock(&radio_device_inventory_lock);
+		return AST_RADIO_DEVICE_WAIT;
+	}
+	if (!ast_strlen_zero(request->serial)) {
+		if (!ast_strlen_zero(request->devstr)) {
+			if (!radio_device_matches_devstr(&candidate->device, request->devstr)) {
+				ignored_devstr = 1;
+			}
+		}
+	}
+
+	candidate->owner = ast_strdup(request->owner);
+	if (!candidate->owner) {
+		ast_mutex_unlock(&radio_device_inventory_lock);
+		return AST_RADIO_DEVICE_ERROR;
+	}
+	AST_LIST_REMOVE(&radio_device_inventory.available, candidate, entry);
+	candidate->automatic = automatic;
+	candidate->device.private_data = candidate;
+	AST_LIST_INSERT_TAIL(&radio_device_inventory.leased, candidate, entry);
+	result = radio_device_mixer_acquire(candidate);
+	if (!result) {
+		radio_device_pa_acquire(candidate);
+	}
+	if (result || !ast_radio_device_pa_ready(&candidate->device) || !radio_device_supports_request(&candidate->device, request)) {
+		radio_device_pa_release(candidate);
+		radio_device_mixer_release(candidate);
+		AST_LIST_REMOVE(&radio_device_inventory.leased, candidate, entry);
+		candidate->device.private_data = NULL;
+		candidate->automatic = 0;
+		ast_free(candidate->owner);
+		candidate->owner = NULL;
+		AST_LIST_INSERT_TAIL(&radio_device_inventory.available, candidate, entry);
+		ast_mutex_unlock(&radio_device_inventory_lock);
+		return AST_RADIO_DEVICE_WAIT;
+	}
+	ast_mutex_unlock(&radio_device_inventory_lock);
+
+	if (ignored_devstr) {
+		ast_log(LOG_WARNING, "USB radio request from %s selected serial %s; ignoring conflicting devstr %s\n", request->owner,
+			request->serial, request->devstr);
+	}
+	*device = &candidate->device;
+	ast_debug(3, "USB radio device %s acquired by %s\n", candidate->device.devstr, candidate->owner);
+	return AST_RADIO_DEVICE_READY;
+}
+
+unsigned int ast_radio_device_automatic_count(void)
+{
+	struct radio_device_inventory_entry *leased_entry;
+	unsigned int count = 0;
+
+	ast_mutex_lock(&radio_device_inventory_lock);
+	AST_LIST_TRAVERSE(&radio_device_inventory.leased, leased_entry, entry) {
+		if (leased_entry->automatic) {
+			count++;
+		}
+	}
+	ast_mutex_unlock(&radio_device_inventory_lock);
+	return count;
+}
+
+int ast_radio_device_swap(struct ast_radio_device **first, struct ast_radio_device **second)
+{
+	struct radio_device_inventory_entry *first_entry;
+	struct radio_device_inventory_entry *second_entry;
+	struct ast_radio_device *device;
+	char *owner;
+	unsigned int automatic;
+
+	if (!first || !*first || !second || !*second || *first == *second) {
+		return -1;
+	}
+
+	/* Exchange lease ownership and caller pointers as one inventory operation */
+	ast_mutex_lock(&radio_device_inventory_lock);
+	first_entry = (*first)->private_data;
+	second_entry = (*second)->private_data;
+	if (!first_entry || !second_entry || &first_entry->device != *first || &second_entry->device != *second) {
+		ast_mutex_unlock(&radio_device_inventory_lock);
+		return -1;
+	}
+	owner = first_entry->owner;
+	first_entry->owner = second_entry->owner;
+	second_entry->owner = owner;
+	automatic = first_entry->automatic;
+	first_entry->automatic = second_entry->automatic;
+	second_entry->automatic = automatic;
+	device = *first;
+	*first = *second;
+	*second = device;
+	ast_debug(3, "USB radio device leases for %s and %s were exchanged\n", first_entry->owner, second_entry->owner);
+	ast_mutex_unlock(&radio_device_inventory_lock);
+	return 0;
+}
+
+void ast_radio_device_release(struct ast_radio_device *device)
+{
+	struct radio_device_inventory_entry *leased_entry;
+
+	if (!device) {
+		return;
+	}
+
+	leased_entry = device->private_data;
+	if (!leased_entry) {
+		return;
+	}
+
+	ast_mutex_lock(&radio_device_inventory_lock);
+	AST_LIST_REMOVE(&radio_device_inventory.leased, leased_entry, entry);
+	/* Force the next acquisition to confirm that released hardware is present. */
+	radio_device_inventory.valid = 0;
+	ast_mutex_unlock(&radio_device_inventory_lock);
+
+	ast_debug(3, "USB radio device %s released by %s\n", leased_entry->device.devstr, leased_entry->owner);
+	device_inventory_entry_free(leased_entry);
+}
+
+const struct ast_radio_mixer_element *ast_radio_device_mixer_element(const struct ast_radio_device *device,
+	const struct ast_radio_mixer_path *path)
+{
+	if (!device || !path || path->element >= device->mixer_element_count) {
+		return NULL;
+	}
+	return &device->mixer_elements[path->element];
+}
+
+long ast_radio_device_mixer_max(const struct ast_radio_device *device, const struct ast_radio_mixer_path *path, unsigned int capability)
+{
+	const struct ast_radio_mixer_element *element;
+
+	element = ast_radio_device_mixer_element(device, path);
+	if (!element || (capability != AST_RADIO_MIXER_CAPTURE_VOLUME && capability != AST_RADIO_MIXER_PLAYBACK_VOLUME) ||
+		!(element->capabilities & capability)) {
+		return 0;
+	}
+	return capability == AST_RADIO_MIXER_CAPTURE_VOLUME ? element->capture_max : element->playback_max;
+}
+
+long ast_radio_device_mixer_scale(const struct ast_radio_device *device, const struct ast_radio_mixer_path *path,
+	unsigned int capability, int setting)
+{
+	const struct ast_radio_mixer_element *element;
+	long minimum;
+	long maximum;
+
+	element = ast_radio_device_mixer_element(device, path);
+	if (!element || (capability != AST_RADIO_MIXER_CAPTURE_VOLUME && capability != AST_RADIO_MIXER_PLAYBACK_VOLUME) ||
+		!(element->capabilities & capability)) {
+		return 0;
+	}
+	minimum = capability == AST_RADIO_MIXER_CAPTURE_VOLUME ? element->capture_min : element->playback_min;
+	maximum = capability == AST_RADIO_MIXER_CAPTURE_VOLUME ? element->capture_max : element->playback_max;
+	return minimum + ((long) setting * (maximum - minimum)) / AUDIO_ADJUSTMENT;
+}
+
+static int radio_device_set_mixer_batch(const struct ast_radio_device *device, const struct ast_radio_mixer_path *paths,
+	size_t path_count, unsigned int capability, long value)
+{
+	struct radio_device_inventory_entry *inventory_entry;
+	const struct ast_radio_mixer_element *element;
+	snd_mixer_elem_t *mixer_element;
+	snd_mixer_selem_id_t *element_id;
+	int result = 0;
+	size_t path_index;
+
+	if (!device || !device->private_data || (path_count && !paths)) {
+		return -1;
+	}
+	if (capability != AST_RADIO_MIXER_CAPTURE_VOLUME && capability != AST_RADIO_MIXER_CAPTURE_SWITCH &&
+		capability != AST_RADIO_MIXER_PLAYBACK_VOLUME && capability != AST_RADIO_MIXER_PLAYBACK_SWITCH) {
+		return -1;
+	}
+	for (path_index = 0; path_index < path_count; path_index++) {
+		if (paths[path_index].element >= device->mixer_element_count || paths[path_index].channel < 0 ||
+			paths[path_index].channel > SND_MIXER_SCHN_LAST ||
+			!(device->mixer_elements[paths[path_index].element].capabilities & capability)) {
+			return -1;
+		}
+	}
+
+	inventory_entry = device->private_data;
+	ast_mutex_lock(&inventory_entry->mixer_lock);
+	if (!inventory_entry->mixer) {
+		ast_mutex_unlock(&inventory_entry->mixer_lock);
+		return -1;
+	}
+
+	/* Apply every path through the mixer retained by the active lease */
+	snd_mixer_selem_id_alloca(&element_id);
+	for (path_index = 0; path_index < path_count; path_index++) {
+		element = &device->mixer_elements[paths[path_index].element];
+		snd_mixer_selem_id_set_name(element_id, element->name);
+		snd_mixer_selem_id_set_index(element_id, element->index);
+		mixer_element = snd_mixer_find_selem(inventory_entry->mixer, element_id);
+		if (!mixer_element) {
+			result = -1;
+			continue;
+		}
+
+		switch (capability) {
+		case AST_RADIO_MIXER_CAPTURE_VOLUME:
+			if (snd_mixer_selem_set_capture_volume(mixer_element, paths[path_index].channel, value) < 0) {
+				result = -1;
+			}
+			break;
+		case AST_RADIO_MIXER_CAPTURE_SWITCH:
+			if (snd_mixer_selem_set_capture_switch(mixer_element, paths[path_index].channel, value != 0) < 0) {
+				result = -1;
+			}
+			break;
+		case AST_RADIO_MIXER_PLAYBACK_VOLUME:
+			if (snd_mixer_selem_set_playback_volume(mixer_element, paths[path_index].channel, value) < 0) {
+				result = -1;
+			}
+			break;
+		case AST_RADIO_MIXER_PLAYBACK_SWITCH:
+			if (snd_mixer_selem_set_playback_switch(mixer_element, paths[path_index].channel, value != 0) < 0) {
+				result = -1;
+			}
+			break;
+		}
+	}
+	ast_mutex_unlock(&inventory_entry->mixer_lock);
+	return result;
+}
+
+int ast_radio_device_set_mixer(const struct ast_radio_device *device, const struct ast_radio_mixer_path *path, unsigned int capability, long value)
+{
+	return radio_device_set_mixer_batch(device, path, 1, capability, value);
+}
+
+int ast_radio_device_set_mixer_paths(const struct ast_radio_device *device, const struct ast_radio_mixer_path *paths,
+	size_t path_count, unsigned int capability, long value)
+{
+	return radio_device_set_mixer_batch(device, paths, path_count, capability, value);
 }
 
 int ast_radio_load_parallel_port(int *haspp, int *ppfd, int *pbase, const char *pport, int reload)
@@ -1112,7 +1910,7 @@ static int hw_token_boundary_ok(char c)
  * \brief Parse "hw:<card>" or "hw:<card>,<dev>" from anywhere in s.
  * \retval 1 if found; sets *card; sets *dev to parsed value or -1 if absent.
  */
-int ast_radio_parse_alsa_hw_device(const char *s, int *card, int *dev)
+static int radio_parse_alsa_hw_device(const char *s, int *card, int *dev)
 {
 	const char *p = s;
 
@@ -1156,12 +1954,12 @@ static int pa_hw_match(const char *haystack, const char *needle)
 	int haystack_c, haystack_d, needle_c, needle_d;
 	const char *p = haystack ? haystack : "";
 
-	if (!ast_radio_parse_alsa_hw_device(needle, &needle_c, &needle_d)) {
+	if (!radio_parse_alsa_hw_device(needle, &needle_c, &needle_d)) {
 		return 0;
 	}
 
 	while ((p = strstr(p, "hw:")) != NULL) {
-		if (ast_radio_parse_alsa_hw_device(p, &haystack_c, &haystack_d)) {
+		if (radio_parse_alsa_hw_device(p, &haystack_c, &haystack_d)) {
 			if (haystack_c == needle_c) {
 				if (needle_d < 0 || haystack_d == needle_d) {
 					return 1;
@@ -1221,7 +2019,7 @@ static int pa_device_matches(const PaDeviceInfo *dev, const char *hw_device, int
 		return 1;
 	}
 
-	if (!ast_radio_parse_alsa_hw_device(hw_device, &card, &devnum) || !match_card_id(dev->name, card)) {
+	if (!radio_parse_alsa_hw_device(hw_device, &card, &devnum) || !match_card_id(dev->name, card)) {
 		return 0;
 	}
 
@@ -1230,7 +2028,7 @@ static int pa_device_matches(const PaDeviceInfo *dev, const char *hw_device, int
 		return 1;
 	}
 
-	if (!ast_radio_parse_alsa_hw_device(dev->name, &hay_card, &hay_dev)) {
+	if (!radio_parse_alsa_hw_device(dev->name, &hay_card, &hay_dev)) {
 		return 0;
 	}
 
@@ -1257,98 +2055,44 @@ static PaDeviceIndex pa_find_device(const char *hw_device, int want_input, int w
 	return paNoDevice;
 }
 
-static void pa_clamp_input_channels(PaDeviceIndex device, unsigned int *input_channels)
+PaError ast_radio_pa_open_device(struct ast_radio_pa_stream *ps, const struct ast_radio_device *device)
 {
-	const PaDeviceInfo *in_dev;
-
-	if (!input_channels || device == paNoDevice) {
-		return;
-	}
-
-	in_dev = Pa_GetDeviceInfo(device);
-	if (in_dev && *input_channels > (unsigned int) in_dev->maxInputChannels) {
-		*input_channels = in_dev->maxInputChannels ? (unsigned int) in_dev->maxInputChannels : 1;
-	}
-}
-
-/*!
- * \brief Cap requested TX channels to what PortAudio reports for the device.
- * Mono URIs (AIOC) advertise maxOutputChannels=1; CM108-class devices report 2.
- */
-static void pa_clamp_output_channels(PaDeviceIndex device, unsigned int *output_channels)
-{
-	const PaDeviceInfo *out_dev;
-
-	if (!output_channels || device == paNoDevice) {
-		return;
-	}
-
-	out_dev = Pa_GetDeviceInfo(device);
-	if (out_dev && *output_channels > (unsigned int) out_dev->maxOutputChannels) {
-		*output_channels = out_dev->maxOutputChannels ? (unsigned int) out_dev->maxOutputChannels : 1;
-	}
-}
-
-PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
-{
-	PaError res = paInternalError;
+	PaStreamParameters input_params;
+	PaStreamParameters output_params;
+	PaError res;
 	const PaStreamInfo *si;
 
 	if (!ps) {
 		return paBadStreamPtr;
 	}
+	if (!ast_radio_device_pa_ready(device)) {
+		return paDeviceUnavailable;
+	}
+	ps->output_channels = MIN(AST_RADIO_PA_OUTPUT_CHANNELS, device->pa_output_channels);
+	if (!ps->input_channels || ps->input_channels > device->pa_input_channels || !ps->output_channels) {
+		return paInvalidChannelCount;
+	}
 
 	ps->stream = NULL;
 	ps->active = 0;
-	ps->output_channels = AST_RADIO_PA_OUTPUT_CHANNELS;
-
 	if (pa_lib_acquire() < 0) {
 		return paInternalError;
 	}
 
-	if (!strcasecmp(ps->hw_device, "default")) {
-		pa_clamp_input_channels(Pa_GetDefaultInputDevice(), &ps->input_channels);
-		pa_clamp_output_channels(Pa_GetDefaultOutputDevice(), &ps->output_channels);
-		res = Pa_OpenDefaultStream(&ps->stream, ps->input_channels, ps->output_channels, paInt16, AST_RADIO_PA_SAMPLE_RATE,
-			AST_RADIO_PA_FRAMES_PER_BUFFER, NULL, NULL);
-	} else {
-		PaStreamParameters input_params = {
-			.channelCount = ps->input_channels,
-			.sampleFormat = paInt16,
-			.suggestedLatency = (1.0 / 50.0),
-			.device = paNoDevice,
-		};
-		PaStreamParameters output_params = {
-			.channelCount = ps->output_channels,
-			.sampleFormat = paInt16,
-			.suggestedLatency = (1.0 / 50.0),
-			.device = paNoDevice,
-		};
+	/* Open the exact PortAudio endpoints retained by the device lease */
+	input_params.device = device->pa_input_device;
+	input_params.channelCount = ps->input_channels;
+	input_params.sampleFormat = paInt16;
+	input_params.suggestedLatency = (1.0 / 50.0);
+	input_params.hostApiSpecificStreamInfo = NULL;
+	output_params.device = device->pa_output_device;
+	output_params.channelCount = ps->output_channels;
+	output_params.sampleFormat = paInt16;
+	output_params.suggestedLatency = (1.0 / 50.0);
+	output_params.hostApiSpecificStreamInfo = NULL;
 
-		input_params.device = pa_find_device(ps->hw_device, 1, 0);
-		output_params.device = pa_find_device(ps->hw_device, 0, 1);
-
-		if (input_params.device == paNoDevice) {
-			ast_log(LOG_ERROR, "No PortAudio input device found for '%s'\n", ps->hw_device);
-			pa_lib_release();
-			return paDeviceUnavailable;
-		}
-
-		if (output_params.device == paNoDevice) {
-			ast_log(LOG_ERROR, "No PortAudio output device found for '%s'\n", ps->hw_device);
-			pa_lib_release();
-			return paDeviceUnavailable;
-		}
-
-		pa_clamp_input_channels(input_params.device, &ps->input_channels);
-		input_params.channelCount = ps->input_channels;
-		pa_clamp_output_channels(output_params.device, &ps->output_channels);
-		output_params.channelCount = ps->output_channels;
-
-		res = Pa_OpenStream(&ps->stream, &input_params, &output_params, AST_RADIO_PA_SAMPLE_RATE, AST_RADIO_PA_FRAMES_PER_BUFFER,
-			paNoFlag, NULL, NULL);
-	}
-
+	res = Pa_OpenStream(&ps->stream, &input_params, &output_params, AST_RADIO_PA_SAMPLE_RATE, AST_RADIO_PA_FRAMES_PER_BUFFER,
+		paNoFlag, NULL, NULL);
 	if (res != paNoError) {
 		if (ps->stream) {
 			Pa_CloseStream(ps->stream);
@@ -1362,9 +2106,7 @@ PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
 	if (si) {
 		ast_debug(5, "PortAudio stream latency in %.3f ms out %.3f ms\n", si->inputLatency * 1000.0, si->outputLatency * 1000.0);
 	}
-
-	ast_debug(3, "PortAudio opened '%s' with %u input and %u output channel(s)\n", ps->hw_device, ps->input_channels, ps->output_channels);
-
+	ast_debug(3, "USB radio device %s PortAudio opened: %u in/%u out\n", device->devstr, ps->input_channels, ps->output_channels);
 	return res;
 }
 
@@ -1508,68 +2250,6 @@ long ast_radio_pa_write_available(struct ast_radio_pa_stream *ps)
 	return Pa_GetStreamWriteAvailable(ps->stream);
 }
 
-/*
- * Returns the libusb device that backs ALSA /proc/asound/card<cardno>/usbbus.
- * On success: returns a pointer to a libusb struct usb_device.
- * On failure: returns NULL.
- *
- * Notes:
- * - Uses libusb-1.0 enumeration (libusb_init/libusb_get_device_list).
- * - The returned device is reference-counted. The caller must release it with
- *   libusb_unref_device() when it is no longer needed.
- */
-struct libusb_device *ast_radio_usb_device_from_alsa_card(int cardno)
-{
-	char target[64]; /* usually "001/005" fits easily */
-	struct libusb_device *dev;
-
-	if (read_card_usbbus(cardno, target, sizeof(target)) != 0) {
-		ast_debug(3, "Unable to read usbbus for card %d (may not be a USB device)\n", cardno);
-		return NULL;
-	}
-
-	if (!usb_ctx) {
-		return NULL;
-	}
-
-	{
-		struct libusb_device **list = NULL;
-		ssize_t count;
-		size_t dev_index;
-		unsigned int busnum;
-		unsigned int devaddr;
-
-		count = libusb_get_device_list(usb_ctx, &list);
-		if (count < 0) {
-			return NULL;
-		}
-
-		for (dev_index = 0; dev_index < count; dev_index++) {
-			char cur[16];
-
-			dev = list[dev_index];
-			if (!(is_known_device(dev) || is_user_device(dev))) {
-				continue;
-			}
-
-			busnum = libusb_get_bus_number(dev);
-			devaddr = libusb_get_device_address(dev);
-			snprintf(cur, sizeof(cur), "%03u/%03u", busnum, devaddr);
-
-			/* usbbus content is typically case-insensitive */
-			if (strcasecmp(cur, target) == 0) {
-				libusb_ref_device(dev);
-				libusb_free_device_list(list, 1);
-				return dev;
-			}
-		}
-
-		libusb_free_device_list(list, 1);
-	}
-
-	ast_debug(1, "No USB device found matching bus path '%s' for card %d\n", target, cardno);
-	return NULL;
-}
 /* Load our configuration */
 static int load_config(int reload)
 {
@@ -1633,29 +2313,49 @@ static int load_config(int reload)
 
 static int reload_module(void)
 {
-	if (ast_radio_libusb_init() < 0) {
+	if (load_config(1)) {
+		return AST_MODULE_RELOAD_ERROR;
+	}
+
+	/* Apply updated device definitions during the next acquisition */
+	ast_mutex_lock(&radio_device_inventory_lock);
+	radio_device_inventory.valid = 0;
+	ast_mutex_unlock(&radio_device_inventory_lock);
+
+	return AST_MODULE_RELOAD_SUCCESS;
+}
+
+static int load_module(void)
+{
+	AST_LIST_HEAD_INIT_NOLOCK(&radio_device_inventory.available);
+	AST_LIST_HEAD_INIT_NOLOCK(&radio_device_inventory.leased);
+
+	if (libusb_init(&usb_ctx) < 0) {
 		ast_log(LOG_ERROR, "Unable to initialize libusb\n");
 		return AST_MODULE_LOAD_DECLINE;
 	}
 
 	if (load_config(0)) {
-		return AST_MODULE_LOAD_DECLINE;
-	}
-	return load_config(1);
-}
-
-static int load_module(void)
-{
-	if (load_config(0)) {
+		libusb_exit(usb_ctx);
+		usb_ctx = NULL;
 		return AST_MODULE_LOAD_DECLINE;
 	}
 
-	return 0;
+	return AST_MODULE_LOAD_SUCCESS;
 }
 
 static int unload_module(void)
 {
+	ast_mutex_lock(&radio_device_inventory_lock);
+	if (!AST_LIST_EMPTY(&radio_device_inventory.leased)) {
+		ast_mutex_unlock(&radio_device_inventory_lock);
+		ast_log(LOG_ERROR, "Unable to unload res_usbradio while USB radio device leases are active\n");
+		return -1;
+	}
+	ast_mutex_unlock(&radio_device_inventory_lock);
+
 	cleanup_user_devices();
+	device_inventory_cleanup();
 	if (usb_ctx) {
 		libusb_exit(usb_ctx);
 		usb_ctx = NULL;


### PR DESCRIPTION
res_usbradio:
- discover and correlate USB, ALSA, PortAudio, and mixer resources
- provide shared device acquisition, release, swap, and automatic-assignment APIs
- centralize mixer and PortAudio endpoint handling
- remove obsolete discovery, mixer, and device lookup APIs

chan_simpleusb, chan_usbradio:
- use shared device leases, PortAudio endpoints, and mixer paths
- preserve automatic assignment while reporting and saving acquired identities
- exchange shared leases when swapping devices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic USB radio discovery, assignment, and persistence using device identity or serial selection.
  * Improved shared access to radio devices, mixer controls, sidetone, transmit, receive, and boost settings.
  * Enhanced status, tuning, and sidetone reporting with current device information.

* **Bug Fixes**
  * Improved USB and audio recovery, including stream restart and device swapping.
  * Added clearer diagnostics and rate-limited acquisition errors.
  * Improved handling of mono input, unavailable output, unkeyed transmission, and stalled queues.

* **Configuration**
  * Replaced legacy audio-device selection with device and serial selectors in sample configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->