### PR TITLE
chan_usbradio: reset XPMR dedrift and keep PA TX full when idle

### DIFF
--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -2416,43 +2416,16 @@ static void *usbradio_audio_thread(void *arg)
 				}
 			}
 
+			/*
+			 * One frame per 20 ms tick. When unkeyed, soundcard_writeframe()
+			 * substitutes silence; ast_radio_pa_write() primes one more on
+			 * underrun. Do not fill remaining PA room; that adds TX delay.
+			 */
 			if (!soundcard_writeframe(o, o->usbradio_write_buf)) {
 				stream_cleanup(o);
 				break;
 			}
 			ast_radio_check_audio(o->usbradio_write_buf, &o->txaudiostats, AST_RADIO_PA_48K_STEREO_SAMPLES, 0);
-
-			/*
-			 * Unkeyed: fill remaining PortAudio room with silence so a late USB
-			 * read does not underrun (simpleusb #1161). Do not call PmrRx again;
-			 * that would advance RX timers. Keyed TX stays one XPMR frame per tick
-			 * until PmrGetTx exists.
-			 */
-			if (!o->pmrChan->txPttIn && !o->pmrChan->txPttOut) {
-				int fill_failed = 0;
-
-				while (!fill_failed) {
-					frames_available = ast_radio_pa_write_available(&o->pa);
-					if (frames_available < 0) {
-						ast_debug(2, "Channel %s: Pa_GetStreamWriteAvailable error %s\n", o->name, Pa_GetErrorText(frames_available));
-						o->usb_faulted = 1;
-						o->hasusb = 0;
-						fill_failed = 1;
-						break;
-					}
-					if (frames_available < AST_RADIO_PA_FRAMES_PER_BUFFER) {
-						break;
-					}
-					if (!soundcard_writeframe(o, silence_buf)) {
-						fill_failed = 1;
-						break;
-					}
-				}
-				if (fill_failed) {
-					stream_cleanup(o);
-					break;
-				}
-			}
 
 #if DEBUG_CAPTURES == 1 && XPMR_DEBUG0 == 1
 			if (frxcaptrace && o->rxcap2 && o->pmrChan->b.radioactive) {

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -2114,6 +2114,9 @@ static void stream_cleanup(struct chan_usbradio_pvt *o)
 	ast_radio_pa_stop(&o->pa);
 	o->audio_thread_ready = 0;
 	flush_tx_queue(o);
+	if (o->pmrChan) {
+		dedrift_reset(o->pmrChan);
+	}
 }
 
 /*!
@@ -2179,6 +2182,9 @@ static void *usbradio_audio_thread(void *arg)
 		}
 
 		flush_tx_queue(o);
+		if (o->pmrChan) {
+			dedrift_reset(o->pmrChan);
+		}
 		/* Prime one silence frame so a late first wake-up does not underrun. */
 		ast_radio_pa_write(&o->pa, silence_buf, AST_RADIO_PA_FRAMES_PER_BUFFER);
 		o->audio_thread_ready = 1;
@@ -2410,8 +2416,43 @@ static void *usbradio_audio_thread(void *arg)
 				}
 			}
 
-			soundcard_writeframe(o, o->usbradio_write_buf);
+			if (!soundcard_writeframe(o, o->usbradio_write_buf)) {
+				stream_cleanup(o);
+				break;
+			}
 			ast_radio_check_audio(o->usbradio_write_buf, &o->txaudiostats, AST_RADIO_PA_48K_STEREO_SAMPLES, 0);
+
+			/*
+			 * Unkeyed: fill remaining PortAudio room with silence so a late USB
+			 * read does not underrun (simpleusb #1161). Do not call PmrRx again;
+			 * that would advance RX timers. Keyed TX stays one XPMR frame per tick
+			 * until PmrGetTx exists.
+			 */
+			if (!o->pmrChan->txPttIn && !o->pmrChan->txPttOut) {
+				int fill_failed = 0;
+
+				while (!fill_failed) {
+					frames_available = ast_radio_pa_write_available(&o->pa);
+					if (frames_available < 0) {
+						ast_debug(2, "Channel %s: Pa_GetStreamWriteAvailable error %s\n", o->name, Pa_GetErrorText(frames_available));
+						o->usb_faulted = 1;
+						o->hasusb = 0;
+						fill_failed = 1;
+						break;
+					}
+					if (frames_available < AST_RADIO_PA_FRAMES_PER_BUFFER) {
+						break;
+					}
+					if (!soundcard_writeframe(o, silence_buf)) {
+						fill_failed = 1;
+						break;
+					}
+				}
+				if (fill_failed) {
+					stream_cleanup(o);
+					break;
+				}
+			}
 
 #if DEBUG_CAPTURES == 1 && XPMR_DEBUG0 == 1
 			if (frxcaptrace && o->rxcap2 && o->pmrChan->b.radioactive) {

--- a/channels/xpmr/xpmr.c
+++ b/channels/xpmr/xpmr.c
@@ -3491,6 +3491,32 @@ void dedrift(t_pmr_chan *pChan)
 
 /*
  */
+void dedrift_reset(t_pmr_chan *pChan)
+{
+	size_t bytes;
+
+	if (!pChan || !pChan->dd.buff) {
+		return;
+	}
+
+	bytes = pChan->dd.buffersize > 0 ? (size_t) pChan->dd.buffersize * sizeof(i16)
+									 : (size_t) DDB_FRAME_SIZE * DDB_FRAMES_IN_BUFF * sizeof(i16);
+	memset(pChan->dd.buff, 0, bytes);
+	pChan->dd.inputindex = 0;
+	pChan->dd.outputindex = 0;
+	pChan->dd.skew = pChan->dd.lead = pChan->dd.err = 0;
+	pChan->dd.accum = 0;
+	pChan->dd.z1 = 0;
+	pChan->dd.lock = 0;
+	pChan->dd.b.txlock = pChan->dd.b.rxlock = 0;
+	pChan->dd.b.twiddle = pChan->dd.b.doitnow = 0;
+	pChan->dd.initcnt = 2;
+	pChan->dd.timer = 10000 / 20;
+	pChan->dd.drift = 0;
+	pChan->dd.factor = pChan->dd.x1 = pChan->dd.x0 = pChan->dd.y1 = pChan->dd.y0 = 0;
+	pChan->dd.txframecnt = pChan->dd.rxframecnt = 0;
+}
+
 void dedrift_write(t_pmr_chan *pChan, i16 *src)
 {
 	void *vptr;

--- a/channels/xpmr/xpmr.h
+++ b/channels/xpmr/xpmr.h
@@ -953,6 +953,7 @@ i16 MeasureBlock(t_pmr_sps *mySps);
 
 void dedrift(t_pmr_chan *pChan);
 void dedrift_write(t_pmr_chan *pChan, i16 *src);
+void dedrift_reset(t_pmr_chan *pChan);
 
 void ppspiout(u32 spidata);
 void progdtx(t_pmr_chan *pChan);


### PR DESCRIPTION
## Summary
- Follow-up to #1162 / Mike’s review: reset the XPMR dedrift ring on stream restart so stale TX does not replay after a USB hiccup
- When unkeyed, fill remaining PortAudio room with silence (same idea as #1161) so a late USB read does not underrun
- Keyed TX stays one XPMR frame per 20 ms tick; pumping multiple real TX frames still needs a later `PmrGetTx` split

## Test plan
- [ ] Build/load `chan_usbradio` on a PortAudio USB radio node
- [ ] Confirm RX, COS/CTCSS, DTMF, and TX/PTT still work (including duplex)
- [ ] Yank/replug USB and confirm audio restarts without a burst of old TX
- [ ] Leave the node unkeyed and confirm the stream stays alive (no underflow/chop)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USB radio audio stream recovery when playback or transmission writes fail.
  * Reset audio drift correction state during stream startup and cleanup for more reliable operation.
  * Ensured unkeyed audio output is filled with silence, reducing potential playback gaps or stale audio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->