### PR TITLE
res_usbradio: support mono PortAudio TX for AIOC-class URIs

### DIFF
--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -460,6 +460,11 @@ static int start_stream(struct chan_simpleusb_pvt *pvt)
 
 	ast_assert(pvt->pa.input_channels == 1);
 
+	if (pvt->pa.output_channels == 1 && pvt->pager != PAGER_NONE) {
+		ast_log(LOG_WARNING, "Channel %s: pager=a/b needs stereo TX; device opened with 1 output channel, sending pager and repeater audio together\n",
+			pvt->name);
+	}
+
 	res = ast_radio_pa_start(&pvt->pa);
 	if (res != paNoError) {
 		ast_log(LOG_WARNING, "Failed to start stream - (%d) %s\n", res, Pa_GetErrorText(res));
@@ -2357,8 +2362,11 @@ static void *simpleusb_audio_thread(void *arg)
 								if (f1->src && (!strcmp(f1->src, PAGER_SRC))) {
 									ispager = 1;
 								}
-								/* If pager audio, determine which channel to store audio */
-								if (o->pager != PAGER_NONE) {
+								/* If pager audio, determine which channel to store audio.
+								 * Mono URIs cannot split A/B; keep both sides live so the
+								 * res_usbradio downmix stays full level.
+								 */
+								if (o->pager != PAGER_NONE && o->pa.output_channels > 1) {
 									doleft = (o->pager == PAGER_A) ? ispager : !ispager;
 									doright = (o->pager == PAGER_B) ? ispager : !ispager;
 								}

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -886,6 +886,8 @@ static int load_tune_config(struct chan_usbradio_pvt *o, const struct ast_config
  * XPMR always writes stereo. Default txmixa=composite / txmixb=no zeros
  * the right channel, so the res_usbradio L/R average drops ~6 dB.
  * Duplicate the active mix onto both sides (XPMR monoOut) instead.
+ * Differing voice+tone is left on L/R so the average forms composite;
+ * other differing pairs keep A and disable B.
  */
 static void usbradio_adjust_txmix_for_mono(struct chan_usbradio_pvt *o)
 {
@@ -913,7 +915,19 @@ static void usbradio_adjust_txmix_for_mono(struct chan_usbradio_pvt *o)
 			mono_sps = o->pmrChan->spsTxOutA;
 		}
 	} else if (a != b) {
-		ast_log(LOG_WARNING, "Channel %s: txmixa/txmixb differ on mono TX; using A for both (cannot split sources)\n", o->name);
+		/* Voice+tone on A/B is composite once PortAudio averages L/R. */
+		if ((a == TX_OUT_VOICE && b == TX_OUT_LSD) || (a == TX_OUT_LSD && b == TX_OUT_VOICE)) {
+			ast_log(LOG_WARNING, "Channel %s: mono TX device; voice+tone A/B averaged into composite (both sources kept)\n", o->name);
+			o->txmixa = TX_OUT_COMPOSITE;
+			o->txmixb = TX_OUT_COMPOSITE;
+			if (o->pmrChan) {
+				o->pmrChan->txMixA = TX_OUT_COMPOSITE;
+				o->pmrChan->txMixB = TX_OUT_COMPOSITE;
+			}
+			return;
+		}
+
+		ast_log(LOG_WARNING, "Channel %s: unsupported txmixa/txmixb pair on mono TX; keeping A, disabling B\n", o->name);
 		b = a;
 		if (o->pmrChan) {
 			mono_sps = o->pmrChan->spsTxOutA;

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -880,6 +880,70 @@ static int load_tune_config(struct chan_usbradio_pvt *o, const struct ast_config
 	return 0;
 }
 
+/*!
+ * \brief Keep full TX level on mono PortAudio devices.
+ *
+ * XPMR always writes stereo. Default txmixa=composite / txmixb=no zeros
+ * the right channel, so the res_usbradio L/R average drops ~6 dB.
+ * Duplicate the active mix onto both sides (XPMR monoOut) instead.
+ */
+static void usbradio_adjust_txmix_for_mono(struct chan_usbradio_pvt *o)
+{
+	enum radio_tx_mix a = o->txmixa;
+	enum radio_tx_mix b = o->txmixb;
+	t_pmr_sps *mono_sps = NULL;
+
+	if (o->pa.output_channels != 1) {
+		return;
+	}
+
+	if (a == TX_OUT_OFF && b == TX_OUT_OFF) {
+		return;
+	}
+
+	if (a == TX_OUT_OFF) {
+		/* B holds the configured source; duplicate it to both channels. */
+		a = b;
+		if (o->pmrChan) {
+			mono_sps = o->pmrChan->spsTxOutB;
+		}
+	} else if (b == TX_OUT_OFF) {
+		b = a;
+		if (o->pmrChan) {
+			mono_sps = o->pmrChan->spsTxOutA;
+		}
+	} else if (a != b) {
+		ast_log(LOG_WARNING, "Channel %s: txmixa/txmixb differ on mono TX; using A for both (cannot split sources)\n", o->name);
+		b = a;
+		if (o->pmrChan) {
+			mono_sps = o->pmrChan->spsTxOutA;
+			if (o->pmrChan->spsTxOutB) {
+				o->pmrChan->spsTxOutB->enabled = 0;
+			}
+		}
+	} else if (o->pmrChan) {
+		/* A == B already; createPmrChannel set monoOut, reinforce it. */
+		mono_sps = o->pmrChan->spsTxOutA;
+	}
+
+	if (a != o->txmixa || b != o->txmixb) {
+		ast_log(LOG_WARNING, "Channel %s: mono TX device; forcing equal A/B mix so PortAudio downmix stays full level\n", o->name);
+	}
+
+	o->txmixa = a;
+	o->txmixb = b;
+
+	if (o->pmrChan) {
+		o->pmrChan->txMixA = a;
+		o->pmrChan->txMixB = b;
+	}
+
+	if (mono_sps) {
+		/* Write L and R so (L+R)/2 is full level. */
+		mono_sps->monoOut = 1;
+	}
+}
+
 static int usbradio_start_audio(struct chan_usbradio_pvt *o)
 {
 	PaError res;
@@ -900,6 +964,8 @@ static int usbradio_start_audio(struct chan_usbradio_pvt *o)
 		ast_log(LOG_WARNING, "Channel %s: Unable to open PortAudio stream %s (%s)\n", o->name, o->hw_device, Pa_GetErrorText(res));
 		return -1;
 	}
+
+	usbradio_adjust_txmix_for_mono(o);
 
 	res = ast_radio_pa_start(&o->pa);
 	if (res != paNoError) {

--- a/configs/samples/simpleusb.conf.sample
+++ b/configs/samples/simpleusb.conf.sample
@@ -91,6 +91,7 @@
 ;preemphasis = no           ; Perform standard 6db/octave pre-emphasis
 
 ;pager = no                 ; no,a,b (e.g. pager = b means "put the normal repeat audio on channel A, and the pager audio on channel B")
+                            ; Ignored on mono TX devices (AIOC); pager and repeater audio share the one output.
 
 ;duplex3 = 0                ; duplex 3 gain setting (0 to disable)
 

--- a/configs/samples/usbradio.conf.sample
+++ b/configs/samples/usbradio.conf.sample
@@ -137,6 +137,8 @@
                             ; tone - CTCSS tone only
                             ; composite - voice and tone
                             ; auxvoice - auxiliary voice output at headphone level for monitoring
+                            ; On mono TX devices (AIOC), A/B cannot be split; the inactive
+                            ; side is mirrored so the PortAudio downmix stays full level.
 
 ; Audio filters 
 ;rxlpf = 0                  ; Receiver Audio Low Pass Filter 0,1 2

--- a/configs/samples/usbradio.conf.sample
+++ b/configs/samples/usbradio.conf.sample
@@ -137,8 +137,11 @@
                             ; tone - CTCSS tone only
                             ; composite - voice and tone
                             ; auxvoice - auxiliary voice output at headphone level for monitoring
-                            ; On mono TX devices (AIOC), A/B cannot be split; the inactive
-                            ; side is mirrored so the PortAudio downmix stays full level.
+                            ; On mono TX devices (AIOC), A/B cannot be split:
+                            ; - if one side is no, the active mix is mirrored so the
+                            ;   PortAudio downmix stays full level
+                            ; - voice+tone (either order) is kept and averaged into composite
+                            ; - any other differing pair keeps A and disables B
 
 ; Audio filters 
 ;rxlpf = 0                  ; Receiver Audio Low Pass Filter 0,1 2

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -563,14 +563,17 @@ struct libusb_device *ast_radio_usb_device_from_alsa_card(int cardno);
 /*!
  * \brief PortAudio stream state shared by chan_simpleusb and chan_usbradio.
  *
- * After ast_radio_pa_open(), use ps->input_channels for RX buffer layout.
+ * After ast_radio_pa_open(), use ps->input_channels for RX buffer layout and
+ * ps->output_channels for TX. Callers still pass stereo interleaved TX to
+ * ast_radio_pa_write(); mono hardware is downmixed there (AIOC and similar).
  * ast_radio_pa_read() and ast_radio_pa_write() take frames per channel
- * (typically AST_RADIO_PA_FRAMES_PER_BUFFER). TX is always stereo interleaved.
+ * (typically AST_RADIO_PA_FRAMES_PER_BUFFER).
  */
 struct ast_radio_pa_stream {
 	PaStream *stream;
 	int active;
-	unsigned int input_channels; /*!< Actual RX channel count after ast_radio_pa_open() */
+	unsigned int input_channels;  /*!< Actual RX channel count after ast_radio_pa_open() */
+	unsigned int output_channels; /*!< Actual TX channel count after ast_radio_pa_open() */
 	char hw_device[100];
 };
 

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -1271,6 +1271,24 @@ static void pa_clamp_input_channels(PaDeviceIndex device, unsigned int *input_ch
 	}
 }
 
+/*!
+ * \brief Cap requested TX channels to what PortAudio reports for the device.
+ * Mono URIs (AIOC) advertise maxOutputChannels=1; CM108-class devices report 2.
+ */
+static void pa_clamp_output_channels(PaDeviceIndex device, unsigned int *output_channels)
+{
+	const PaDeviceInfo *out_dev;
+
+	if (!output_channels || device == paNoDevice) {
+		return;
+	}
+
+	out_dev = Pa_GetDeviceInfo(device);
+	if (out_dev && *output_channels > (unsigned int) out_dev->maxOutputChannels) {
+		*output_channels = out_dev->maxOutputChannels ? (unsigned int) out_dev->maxOutputChannels : 1;
+	}
+}
+
 PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
 {
 	PaError res = paInternalError;
@@ -1282,6 +1300,7 @@ PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
 
 	ps->stream = NULL;
 	ps->active = 0;
+	ps->output_channels = AST_RADIO_PA_OUTPUT_CHANNELS;
 
 	if (pa_lib_acquire() < 0) {
 		return paInternalError;
@@ -1289,8 +1308,9 @@ PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
 
 	if (!strcasecmp(ps->hw_device, "default")) {
 		pa_clamp_input_channels(Pa_GetDefaultInputDevice(), &ps->input_channels);
-		res = Pa_OpenDefaultStream(&ps->stream, ps->input_channels, AST_RADIO_PA_OUTPUT_CHANNELS, paInt16,
-			AST_RADIO_PA_SAMPLE_RATE, AST_RADIO_PA_FRAMES_PER_BUFFER, NULL, NULL);
+		pa_clamp_output_channels(Pa_GetDefaultOutputDevice(), &ps->output_channels);
+		res = Pa_OpenDefaultStream(&ps->stream, ps->input_channels, ps->output_channels, paInt16, AST_RADIO_PA_SAMPLE_RATE,
+			AST_RADIO_PA_FRAMES_PER_BUFFER, NULL, NULL);
 	} else {
 		PaStreamParameters input_params = {
 			.channelCount = ps->input_channels,
@@ -1299,7 +1319,7 @@ PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
 			.device = paNoDevice,
 		};
 		PaStreamParameters output_params = {
-			.channelCount = AST_RADIO_PA_OUTPUT_CHANNELS,
+			.channelCount = ps->output_channels,
 			.sampleFormat = paInt16,
 			.suggestedLatency = (1.0 / 50.0),
 			.device = paNoDevice,
@@ -1322,6 +1342,8 @@ PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
 
 		pa_clamp_input_channels(input_params.device, &ps->input_channels);
 		input_params.channelCount = ps->input_channels;
+		pa_clamp_output_channels(output_params.device, &ps->output_channels);
+		output_params.channelCount = ps->output_channels;
 
 		res = Pa_OpenStream(&ps->stream, &input_params, &output_params, AST_RADIO_PA_SAMPLE_RATE, AST_RADIO_PA_FRAMES_PER_BUFFER,
 			paNoFlag, NULL, NULL);
@@ -1341,7 +1363,7 @@ PaError ast_radio_pa_open(struct ast_radio_pa_stream *ps)
 		ast_debug(5, "PortAudio stream latency in %.3f ms out %.3f ms\n", si->inputLatency * 1000.0, si->outputLatency * 1000.0);
 	}
 
-	ast_debug(3, "PortAudio opened '%s' with %u input and %u output channel(s)\n", ps->hw_device, ps->input_channels, AST_RADIO_PA_OUTPUT_CHANNELS);
+	ast_debug(3, "PortAudio opened '%s' with %u input and %u output channel(s)\n", ps->hw_device, ps->input_channels, ps->output_channels);
 
 	return res;
 }
@@ -1423,6 +1445,8 @@ PaError ast_radio_pa_read(struct ast_radio_pa_stream *ps, short *buf, unsigned l
 PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, unsigned long pa_frames)
 {
 	PaError res;
+	const short *tx = data;
+	short mono_buf[AST_RADIO_PA_FRAMES_PER_BUFFER];
 
 	if (!ps || !ps->stream || !data) {
 		return paBadStreamPtr;
@@ -1433,12 +1457,23 @@ PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, un
 		return paBufferTooBig;
 	}
 
-	res = Pa_WriteStream(ps->stream, data, pa_frames);
+	/*
+	 * Callers always pass stereo interleaved samples. Mono URIs (AIOC) open
+	 * with one output channel; average L/R like OSS/ALSA plug conversion did.
+	 */
+	if (ps->output_channels == 1) {
+		unsigned long i;
+
+		for (i = 0; i < pa_frames; i++) {
+			mono_buf[i] = (short) (((int) data[i * 2] + (int) data[i * 2 + 1]) / 2);
+		}
+		tx = mono_buf;
+	}
+
+	res = Pa_WriteStream(ps->stream, tx, pa_frames);
 	if (res == paOutputUnderflowed) {
 		PaError prime_res;
-		/* The data size depends on how many channels are set up in a frame.  We have a max of 2 channels
-		 * If only one channel, the buffer is 2x what is needed
-		 */
+		/* Sized for stereo; unused half is fine when priming mono. */
 		short null_buf[AST_RADIO_PA_FRAMES_PER_BUFFER * AST_RADIO_PA_OUTPUT_CHANNELS] = { 0 };
 		long frames_available;
 
@@ -1449,7 +1484,7 @@ PaError ast_radio_pa_write(struct ast_radio_pa_stream *ps, const short *data, un
 		 */
 		frames_available = ast_radio_pa_write_available(ps);
 
-		if ((frames_available > 0) && (frames_available >= pa_frames)) {
+		if ((frames_available > 0) && (frames_available >= (long) pa_frames)) {
 			ast_debug(6, "PortAudio write stream underflow, priming with %ld silence frames\n", pa_frames);
 			prime_res = Pa_WriteStream(ps->stream, null_buf, pa_frames);
 			if (prime_res != paNoError) {


### PR DESCRIPTION
## Summary
- All-In-One-Cable (and similar URIs) advertise mono playback to PortAudio (`maxOutputChannels=1`); forcing stereo open fails where OSS used to accept stereo and convert
- Clamp TX channel count to the device max on `ast_radio_pa_open()`, and downmix stereo interleaved TX to mono in `ast_radio_pa_write()` when the stream is mono
- CM108-class stereo devices are unchanged (still open and write as 2 channels)

## Test plan
- [ ] Build/load `res_usbradio` + `chan_simpleusb` (or `chan_usbradio`) on an AIOC node (`AllInOneCable` / `hw:N`)
- [ ] Confirm PortAudio opens with 1 output channel (debug: `PortAudio opened ... output channel(s)`)
- [ ] Confirm RX/TX/PTT and tune levels still work
- [ ] Regression: CM108/CM119 stereo URI still opens with 2 output channels and TX is unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USB radio compatibility with devices that support different numbers of audio channels.
  * Correctly reports the actual transmit channel count after opening a radio stream.
  * Automatically downmixes stereo transmit audio for mono-output devices.
  * Preserves existing underflow handling during audio transmission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->