### PR TITLE
app_rpt: park link pchan out of CONF while IAX is down

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4787,6 +4787,20 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 				if (f->subclass.integer == AST_CONTROL_ANSWER) {
 					char lconnected = l->connected;
 
+					/*
+					 * Restore parked pchan before committing connected state.
+					 * On failure leave retries untouched so remote_hangup_helper
+					 * still honors max_retries instead of resetting the budget.
+					 */
+					if (l->pchan && rpt_conf_restore(l->pchan, myrpt, RPT_CONF)) {
+						ast_log(LOG_WARNING, "Unable to restore %s to conference after answer from %s\n", ast_channel_name(l->pchan), l->name);
+						ast_frfree(f);
+						if (remote_hangup_helper(myrpt, l)) {
+							continue;
+						}
+						break;
+					}
+
 					__kickshort(myrpt);
 					myrpt->rxlingertimer = RX_LINGER_TIME;
 					l->connected = 1;
@@ -4811,15 +4825,6 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 						doconpgm(myrpt, l->name);
 					} else
 						l->reconnects++;
-					/* Re-add parked pchan only after the peer has answered. */
-					if (l->pchan && rpt_conf_restore(l->pchan, myrpt, RPT_CONF)) {
-						ast_log(LOG_WARNING, "Unable to restore %s to conference after answer from %s\n", ast_channel_name(l->pchan), l->name);
-						ast_frfree(f);
-						if (remote_hangup_helper(myrpt, l)) {
-							continue;
-						}
-						break;
-					}
 				}
 				/* if RX key */
 				if ((f->subclass.integer == AST_CONTROL_RADIO_KEY) && (l->link_newkey != RADIO_KEY_NOT_ALLOWED)) {

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2569,6 +2569,17 @@ static void *attempt_reconnect(struct rpt *myrpt, struct rpt_link *l)
 		goto retry;
 	}
 
+	if (rpt_conf_restore(l->pchan, myrpt, RPT_CONF)) {
+		ast_log(LOG_WARNING, "Unable to restore %s to conference after reconnect to %s\n", ast_channel_name(l->pchan), l->name);
+		ast_hangup(l->chan);
+		rpt_mutex_lock(&myrpt->lock);
+		l->retrytimer = RETRY_TIMER_MS;
+		l->chan = NULL;
+		rpt_mutex_unlock(&myrpt->lock);
+		ast_autoservice_stop(l->pchan);
+		return NULL;
+	}
+
 	ast_autoservice_stop(l->pchan);
 	ast_log(LOG_NOTICE, "Reconnect Attempt to %s in progress\n", l->name);
 	return NULL;
@@ -4489,8 +4500,12 @@ static inline void safe_hangup(struct ast_channel *chan)
 }
 
 /*! \note myrpt->lock must not be held when calling */
-static inline void hangup_link_chan(struct rpt_link *l)
+static inline void hangup_link_chan(struct rpt *myrpt, struct rpt_link *l)
 {
+	/* Park pchan out of CONF so mix audio cannot fill Announcer/IAXLink while IAX is down. */
+	if (l->pchan) {
+		rpt_conf_remove(l->pchan, myrpt, RPT_CONF);
+	}
 	if (l->chan) {
 		safe_hangup(l->chan);
 		l->chan = NULL;
@@ -4520,16 +4535,16 @@ static int remote_hangup_helper(struct rpt *myrpt, struct rpt_link *l)
 					/* An allstar link node */
 					l->disctime = DISC_TIME;
 				}
-				hangup_link_chan(l);
+				hangup_link_chan(myrpt, l);
 				return 1;
 			}
 
 			if (l->retrytimer) {
-				hangup_link_chan(l);
+				hangup_link_chan(myrpt, l);
 				return 1;
 			}
 			if (l->outbound && (l->retries++ < l->max_retries) && l->hasconnected) {
-				hangup_link_chan(l);
+				hangup_link_chan(myrpt, l);
 				rpt_mutex_lock(&myrpt->lock);
 				l->retrytimer = RETRY_TIMER_MS;
 				l->elaptime = 0;
@@ -4909,7 +4924,7 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 	rpt_frame_queue_free(&l->frame_queue);
 
 	/* hang-up on call to device */
-	hangup_link_chan(l);
+	hangup_link_chan(myrpt, l);
 	ast_hangup(l->pchan);
 
 	if (l->hasconnected) {

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2569,17 +2569,7 @@ static void *attempt_reconnect(struct rpt *myrpt, struct rpt_link *l)
 		goto retry;
 	}
 
-	if (rpt_conf_restore(l->pchan, myrpt, RPT_CONF)) {
-		ast_log(LOG_WARNING, "Unable to restore %s to conference after reconnect to %s\n", ast_channel_name(l->pchan), l->name);
-		ast_hangup(l->chan);
-		rpt_mutex_lock(&myrpt->lock);
-		l->retrytimer = RETRY_TIMER_MS;
-		l->chan = NULL;
-		rpt_mutex_unlock(&myrpt->lock);
-		ast_autoservice_stop(l->pchan);
-		return NULL;
-	}
-
+	/* Leave l->pchan parked until AST_CONTROL_ANSWER restores it to RPT_CONF. */
 	ast_autoservice_stop(l->pchan);
 	ast_log(LOG_NOTICE, "Reconnect Attempt to %s in progress\n", l->name);
 	return NULL;
@@ -4521,7 +4511,7 @@ static int remote_hangup_helper(struct rpt *myrpt, struct rpt_link *l)
 {
 	if (l->chan) {
 		link_process_textq(myrpt, l);
-		ast_safe_sleep(l->chan, MSWAIT * 10);  /* Allow the channel to send the text messages */
+		ast_safe_sleep(l->chan, MSWAIT * 10); /* Allow the channel to send the text messages */
 	}
 
 	if (l->chan && !CHAN_TECH(l->chan, "echolink") && !CHAN_TECH(l->chan, "tlb")) {
@@ -4821,6 +4811,15 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 						doconpgm(myrpt, l->name);
 					} else
 						l->reconnects++;
+					/* Re-add parked pchan only after the peer has answered. */
+					if (l->pchan && rpt_conf_restore(l->pchan, myrpt, RPT_CONF)) {
+						ast_log(LOG_WARNING, "Unable to restore %s to conference after answer from %s\n", ast_channel_name(l->pchan), l->name);
+						ast_frfree(f);
+						if (remote_hangup_helper(myrpt, l)) {
+							continue;
+						}
+						break;
+					}
 				}
 				/* if RX key */
 				if ((f->subclass.integer == AST_CONTROL_RADIO_KEY) && (l->link_newkey != RADIO_KEY_NOT_ALLOWED)) {
@@ -5335,7 +5334,7 @@ static void *rpt(void *this)
 				myrpt->remrx = 1;
 				if (l->voterlink)
 					myrpt->voteremrx = 1;
-				if ((l->name[0] > '0') && (l->name[0] <= '9'))		/* Ignore '0' nodes */
+				if ((l->name[0] > '0') && (l->name[0] <= '9')) /* Ignore '0' nodes */
 					ast_copy_string(myrpt->lastnodewhichkeyedusup, l->name, sizeof(myrpt->lastnodewhichkeyedusup));
 			}
 		}

--- a/apps/app_rpt/rpt_bridging.c
+++ b/apps/app_rpt/rpt_bridging.c
@@ -33,7 +33,7 @@
 #include "asterisk/bridge_channel.h"
 #include "asterisk/core_unreal.h"
 #include "asterisk/channel.h"
-#include "asterisk/timeval.h"
+#include "asterisk/utils.h"
 #include "asterisk/indications.h"
 #include "asterisk/format_cache.h" /* use ast_format_slin */
 

--- a/apps/app_rpt/rpt_bridging.c
+++ b/apps/app_rpt/rpt_bridging.c
@@ -26,12 +26,14 @@
 
 #include "asterisk.h"
 
+#include <unistd.h>
 #include <dahdi/user.h>
 
 #include "asterisk/bridge.h"
 #include "asterisk/bridge_channel.h"
 #include "asterisk/core_unreal.h"
 #include "asterisk/channel.h"
+#include "asterisk/timeval.h"
 #include "asterisk/indications.h"
 #include "asterisk/format_cache.h" /* use ast_format_slin */
 
@@ -406,6 +408,32 @@ static struct ast_bridge_channel *rpt_get_bridge_channel_from_chan(struct ast_ch
 	return bridge_channel;
 }
 
+#define RPT_CONF_UNBRIDGE_TIMEOUT_MS 500
+
+/*!
+ * \brief Wait until the unreal ;2 side has left its bridge.
+ * \retval 0 when no longer bridged
+ * \retval -1 on timeout
+ */
+static int rpt_wait_until_unbridged(struct ast_channel *chan, int timeout_ms)
+{
+	struct timeval start = ast_tvnow();
+
+	for (;;) {
+		struct ast_bridge_channel *bc = rpt_get_bridge_channel_from_chan(chan);
+
+		if (!bc) {
+			return 0;
+		}
+		ao2_ref(bc, -1);
+		if (ast_tvdiff_ms(ast_tvnow(), start) >= timeout_ms) {
+			ast_log(LOG_WARNING, "Timed out waiting for %s to leave the conference bridge\n", ast_channel_name(chan));
+			return -1;
+		}
+		usleep(1000);
+	}
+}
+
 int __rpt_conf_add(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_type type, const char *file, int line)
 {
 	struct ast_bridge *conf = NULL;
@@ -483,7 +511,11 @@ int __rpt_conf_remove(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf
 	res = ast_bridge_remove(conf, p->chan);
 	if (res) {
 		ast_debug(3, "Channel %s was not removed from conference '%s'\n", ast_channel_name(chan), conference_name);
-		return 0;
+	}
+
+	/* ast_bridge_remove() only requests leave; wait until the bridge thread finishes. */
+	if (rpt_wait_until_unbridged(chan, RPT_CONF_UNBRIDGE_TIMEOUT_MS)) {
+		return -1;
 	}
 	return 0;
 }
@@ -491,14 +523,23 @@ int __rpt_conf_remove(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf
 int __rpt_conf_restore(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_type type, const char *file, int line)
 {
 	struct ast_bridge_channel *bc;
+	enum bridge_channel_state state;
 
 	if (!chan) {
 		return -1;
 	}
 	bc = rpt_get_bridge_channel_from_chan(chan);
 	if (bc) {
+		ast_bridge_channel_lock(bc);
+		state = bc->state;
+		ast_bridge_channel_unlock(bc);
 		ao2_ref(bc, -1);
-		return 0;
+		if (state == BRIDGE_CHANNEL_STATE_WAIT) {
+			return 0;
+		}
+		if (rpt_wait_until_unbridged(chan, RPT_CONF_UNBRIDGE_TIMEOUT_MS)) {
+			return -1;
+		}
 	}
 	return __rpt_conf_add(chan, myrpt, type, file, line);
 }

--- a/apps/app_rpt/rpt_bridging.c
+++ b/apps/app_rpt/rpt_bridging.c
@@ -522,19 +522,42 @@ int __rpt_conf_remove(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf
 
 int __rpt_conf_restore(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_type type, const char *file, int line)
 {
+	struct ast_bridge *conf = NULL;
+	struct ast_bridge *bc_bridge;
 	struct ast_bridge_channel *bc;
 	enum bridge_channel_state state;
 
 	if (!chan) {
 		return -1;
 	}
+
+	switch (type) {
+	case RPT_CONF:
+		conf = myrpt->rptconf.conf;
+		break;
+	case RPT_TXCONF:
+		conf = myrpt->rptconf.txconf;
+		break;
+	default:
+		__builtin_unreachable();
+		return -1;
+	}
+	if (!conf) {
+		return -1;
+	}
+
 	bc = rpt_get_bridge_channel_from_chan(chan);
 	if (bc) {
 		ast_bridge_channel_lock(bc);
+		bc_bridge = bc->bridge;
 		state = bc->state;
 		ast_bridge_channel_unlock(bc);
 		ao2_ref(bc, -1);
-		if (state == BRIDGE_CHANNEL_STATE_WAIT) {
+		if (bc_bridge && bc_bridge != conf) {
+			ast_log(LOG_WARNING, "Channel %s is in a different bridge; cannot restore to conference\n", ast_channel_name(chan));
+			return -1;
+		}
+		if (bc_bridge == conf && state == BRIDGE_CHANNEL_STATE_WAIT) {
 			return 0;
 		}
 		if (rpt_wait_until_unbridged(chan, RPT_CONF_UNBRIDGE_TIMEOUT_MS)) {

--- a/apps/app_rpt/rpt_bridging.c
+++ b/apps/app_rpt/rpt_bridging.c
@@ -29,6 +29,7 @@
 #include <dahdi/user.h>
 
 #include "asterisk/bridge.h"
+#include "asterisk/bridge_channel.h"
 #include "asterisk/core_unreal.h"
 #include "asterisk/channel.h"
 #include "asterisk/indications.h"
@@ -378,6 +379,33 @@ int __rpt_conf_create(struct rpt *myrpt, enum rpt_conf_type type, const char *fi
 	return 0;
 }
 
+/*!
+ * \brief Get the bridge channel associated with the underlying Asterisk channel.
+ * \note Returns a ref-counted bridge channel object that must be released with ao2_ref(..., -1).
+ */
+static struct ast_bridge_channel *rpt_get_bridge_channel_from_chan(struct ast_channel *chan)
+{
+	struct ast_unreal_pvt *p;
+	struct ast_channel *pchan;
+	struct ast_bridge_channel *bridge_channel = NULL;
+
+	if (!chan) {
+		return NULL;
+	}
+
+	p = ast_channel_tech_pvt(chan);
+	if (!p || !p->chan) {
+		return NULL;
+	}
+	pchan = ast_channel_ref(p->chan); /* The :2 side of the local channel */
+	ast_channel_lock(pchan);
+	bridge_channel = ast_channel_get_bridge_channel(pchan);
+	ast_channel_unlock(pchan);
+	ast_channel_unref(pchan);
+
+	return bridge_channel;
+}
+
 int __rpt_conf_add(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_type type, const char *file, int line)
 {
 	struct ast_bridge *conf = NULL;
@@ -415,32 +443,64 @@ int __rpt_conf_add(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_ty
 	return res;
 }
 
-/*!
- * \brief Get the bridge channel associated with the underlying Asterisk channel.
- * \note Returns a ref-counted bridge channel object that must be released with ao2_ref(..., -1).
- */
-
-static struct ast_bridge_channel *rpt_get_bridge_channel_from_chan(struct ast_channel *chan)
+int __rpt_conf_remove(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_type type, const char *file, int line)
 {
+	struct ast_bridge *conf = NULL;
+	const char *conference_name = "";
 	struct ast_unreal_pvt *p;
-	struct ast_channel *pchan;
-	struct ast_bridge_channel *bridge_channel = NULL;
+	struct ast_bridge_channel *bc;
+	int res;
 
-	if (!chan) {
-		return NULL;
+	switch (type) {
+	case RPT_CONF:
+		conference_name = RPT_CONF_NAME;
+		conf = myrpt->rptconf.conf;
+		break;
+	case RPT_TXCONF:
+		conference_name = RPT_TXCONF_NAME;
+		conf = myrpt->rptconf.txconf;
+		break;
+	default:
+		__builtin_unreachable();
+		return -1;
 	}
+	if (!chan || !conf) {
+		return 0;
+	}
+
+	bc = rpt_get_bridge_channel_from_chan(chan);
+	if (!bc) {
+		return 0;
+	}
+	ao2_ref(bc, -1);
 
 	p = ast_channel_tech_pvt(chan);
 	if (!p || !p->chan) {
-		return NULL;
+		return 0;
 	}
-	pchan = ast_channel_ref(p->chan); /* The :2 side of the local channel */
-	ast_channel_lock(pchan);
-	bridge_channel = ast_channel_get_bridge_channel(pchan);
-	ast_channel_unlock(pchan);
-	ast_channel_unref(pchan);
 
-	return bridge_channel;
+	ast_debug(3, "Removing channel %s from conference '%s' mixing bridge\n", ast_channel_name(chan), conference_name);
+	res = ast_bridge_remove(conf, p->chan);
+	if (res) {
+		ast_debug(3, "Channel %s was not removed from conference '%s'\n", ast_channel_name(chan), conference_name);
+		return 0;
+	}
+	return 0;
+}
+
+int __rpt_conf_restore(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_type type, const char *file, int line)
+{
+	struct ast_bridge_channel *bc;
+
+	if (!chan) {
+		return -1;
+	}
+	bc = rpt_get_bridge_channel_from_chan(chan);
+	if (bc) {
+		ao2_ref(bc, -1);
+		return 0;
+	}
+	return __rpt_conf_add(chan, myrpt, type, file, line);
 }
 
 int rpt_conf_get_muted(struct ast_channel *chan, struct rpt *myrpt)

--- a/apps/app_rpt/rpt_bridging.c
+++ b/apps/app_rpt/rpt_bridging.c
@@ -381,6 +381,43 @@ int __rpt_conf_create(struct rpt *myrpt, enum rpt_conf_type type, const char *fi
 	return 0;
 }
 
+int __rpt_conf_add(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_type type, const char *file, int line)
+{
+	struct ast_bridge *conf = NULL;
+	const char *conference_name = "";
+	struct ast_unreal_pvt *p;
+	int res;
+
+	switch (type) {
+	case RPT_CONF:
+		conference_name = RPT_CONF_NAME;
+		conf = myrpt->rptconf.conf;
+		break;
+	case RPT_TXCONF:
+		conference_name = RPT_TXCONF_NAME;
+		conf = myrpt->rptconf.txconf;
+		break;
+	default:
+		__builtin_unreachable();
+		return -1;
+	}
+	if (!conf) {
+		ast_log(LOG_ERROR, "Conference '%s' mixing bridge doesn't exist, can't add channel %s\n", conference_name, ast_channel_name(chan));
+		return -1;
+	}
+	ast_debug(3, "Adding channel %s to conference '%s' mixing bridge \n", ast_channel_name(chan), conference_name);
+	res = ast_unreal_channel_push_to_bridge(chan, conf, AST_BRIDGE_CHANNEL_FLAG_IMMOVABLE);
+	if (res) {
+		ast_log(LOG_ERROR, "Failed to add channel %s to conference '%s'\n", ast_channel_name(chan), conference_name);
+		return res;
+	}
+	p = ast_channel_tech_pvt(chan);
+	if (p && p->chan) {
+		ast_raw_answer(p->chan); /* We can not wait 500ms for media to start flowing */
+	}
+	return res;
+}
+
 /*!
  * \brief Get the bridge channel associated with the underlying Asterisk channel.
  * \note Returns a ref-counted bridge channel object that must be released with ao2_ref(..., -1).
@@ -432,43 +469,6 @@ static int rpt_wait_until_unbridged(struct ast_channel *chan, int timeout_ms)
 		}
 		usleep(1000);
 	}
-}
-
-int __rpt_conf_add(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_type type, const char *file, int line)
-{
-	struct ast_bridge *conf = NULL;
-	const char *conference_name = "";
-	struct ast_unreal_pvt *p;
-	int res;
-
-	switch (type) {
-	case RPT_CONF:
-		conference_name = RPT_CONF_NAME;
-		conf = myrpt->rptconf.conf;
-		break;
-	case RPT_TXCONF:
-		conference_name = RPT_TXCONF_NAME;
-		conf = myrpt->rptconf.txconf;
-		break;
-	default:
-		__builtin_unreachable();
-		return -1;
-	}
-	if (!conf) {
-		ast_log(LOG_ERROR, "Conference '%s' mixing bridge doesn't exist, can't add channel %s\n", conference_name, ast_channel_name(chan));
-		return -1;
-	}
-	ast_debug(3, "Adding channel %s to conference '%s' mixing bridge \n", ast_channel_name(chan), conference_name);
-	res = ast_unreal_channel_push_to_bridge(chan, conf, AST_BRIDGE_CHANNEL_FLAG_IMMOVABLE);
-	if (res) {
-		ast_log(LOG_ERROR, "Failed to add channel %s to conference '%s'\n", ast_channel_name(chan), conference_name);
-		return res;
-	}
-	p = ast_channel_tech_pvt(chan);
-	if (p && p->chan) {
-		ast_raw_answer(p->chan); /* We can not wait 500ms for media to start flowing */
-	}
-	return res;
 }
 
 int __rpt_conf_remove(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_type type, const char *file, int line)

--- a/apps/app_rpt/rpt_bridging.h
+++ b/apps/app_rpt/rpt_bridging.h
@@ -90,6 +90,22 @@ int __rpt_conf_add(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_ty
  */
 #define rpt_conf_add(chan, myrpt, type) __rpt_conf_add(chan, myrpt, type, __FILE__, __LINE__)
 
+int __rpt_conf_remove(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_type type, const char *file, int line);
+
+int __rpt_conf_restore(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_type type, const char *file, int line);
+
+/*!
+ * \brief Remove a Local channel from a conference if it is a member.
+ * \retval 0 if removed or already absent, -1 on failure
+ */
+#define rpt_conf_remove(chan, myrpt, type) __rpt_conf_remove(chan, myrpt, type, __FILE__, __LINE__)
+
+/*!
+ * \brief Re-add a Local channel to a conference if it is not already a member.
+ * \retval 0 on success or already a member, -1 on failure
+ */
+#define rpt_conf_restore(chan, myrpt, type) __rpt_conf_restore(chan, myrpt, type, __FILE__, __LINE__)
+
 /*!
  * \param chan Channel to play tone on
  * \param tone tone type (e.g., "dial", "congestion")

--- a/apps/app_rpt/rpt_bridging.h
+++ b/apps/app_rpt/rpt_bridging.h
@@ -75,6 +75,10 @@ int __rpt_conf_create(struct rpt *myrpt, enum rpt_conf_type type, const char *fi
 
 int __rpt_conf_add(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_type type, const char *file, int line);
 
+int __rpt_conf_remove(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_type type, const char *file, int line);
+
+int __rpt_conf_restore(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_type type, const char *file, int line);
+
 /*!
  * \brief Create a conference for repeater channels to join
  * \param myrpt Repeater structure
@@ -89,10 +93,6 @@ int __rpt_conf_add(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_ty
  * \param type Conference type
  */
 #define rpt_conf_add(chan, myrpt, type) __rpt_conf_add(chan, myrpt, type, __FILE__, __LINE__)
-
-int __rpt_conf_remove(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_type type, const char *file, int line);
-
-int __rpt_conf_restore(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_type type, const char *file, int line);
 
 /*!
  * \brief Remove a Local channel from a conference if it is a member.


### PR DESCRIPTION
## Summary
- When an outbound IAX link drops, `Announcer/IAXLink` stayed in CONF and mix audio filled that pchan, then backpressured every conference member (long voice-queue warnings, Allmon CONNECTING, registrations failing)
- Pull `l->pchan` out of CONF on link hangup
- Restore it only after `AST_CONTROL_ANSWER` (not after `rpt_make_call()` / while still CONNECTING)
- Wait until `ast_bridge_remove()` actually finishes before treating the channel as gone; restore only if the channel is in the requested conference (not some other bridge)

Fixes the cascade discussed in https://community.allstarlink.org/t/exceptionally-long-voice-queue-length-error-message-causing-node-to-fail/24807 and complements #1147 / #1164 (autoservice during blocking DNS).

## Test plan
- [ ] Outbound IAX link: yank network / kill peer, confirm no `Exceptionally long voice queue` on `Announcer/IAXLink`, `PChan`, `TXPChan`, or `LocalTX` while reconnecting
- [ ] Confirm reconnect succeeds and audio both ways returns only after answer
- [ ] Inbound link disconnect: pchan parked, thread exits cleanly without restoring
- [ ] Hub with several links: one flapping peer does not stall AMI / IAX registration
- [ ] Permanent (`lconn`) retry still redials after DNS recovery