### PR TITLE
xpmr: preserve CTCSS through repeater hangtime

### DIFF
--- a/channels/xpmr/xpmr.c
+++ b/channels/xpmr/xpmr.c
@@ -2850,7 +2850,7 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 			} else {
 				f = pChan->txctcssdefault_value;
 			}
-			if (f && pChan->spsSigGen0->freq != f * 10 && !pChan->b.txCtcssHangMuted) {
+			if (f && pChan->spsSigGen0->freq != f * 10) {
 				pChan->spsSigGen0->freq = f * 10;
 				pChan->spsSigGen0->option = 1;
 			}
@@ -2871,8 +2871,6 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 				pChan->rxCtcssMap[pChan->rxCtcss->decode]);
 			pChan->dd.b.doitnow = 1;
 			pChan->spsSigGen0->freq = 0;
-			pChan->b.txHadRxCarrier = 0;
-			pChan->b.txCtcssHangMuted = 0;
 			if (pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit) {
 				if (pChan->rxCtcss->decode > CTCSS_NULL) {
 					if (pChan->rxCtcssMap[pChan->rxCtcss->decode] != CTCSS_RXONLY) {
@@ -2936,42 +2934,10 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 			TRACEC(1, "PmrRx() TxOn\n");
 		} else if (pChan->txPttIn && pChan->txState == CHAN_TXSTATE_ACTIVE) {
 			pChan->smodetimer = pChan->smodetime;
-
-			/*
-			 * Full duplex: app_rpt hangtime keeps txPttIn asserted after the user
-			 * unkeys, so classic TOC (which waits for txPttIn to drop) never runs
-			 * until hangtime ends. Start notone/phase turn-off when local COS drops
-			 * so CTCSS ends at the start of hang instead of riding until PTT drops.
-			 * If COS returns while hangtime still holds PTT, restore CTCSS so the
-			 * next keyed period is not left muted until PTT finally drops.
-			 * Half duplex blanks RX while keyed, so COS cannot be used that way.
-			 */
-			if (pChan->radioDuplex && pChan->rxCarrierDetect) {
-				pChan->b.txHadRxCarrier = 1;
-				if (pChan->b.txCtcssHangMuted && pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit && pChan->b.ctcssTxEnable) {
-					pChan->b.txCtcssHangMuted = 0;
-					pChan->spsSigGen0->option = 1;
-					pChan->spsSigGen0->enabled = 1;
-					pChan->spsSigGen0->discounterl = 0;
-					TRACEC(1, "Tx CTCSS restore on COS reassert during hang.\n");
-				}
-			}
-			if (pChan->radioDuplex && pChan->b.txHadRxCarrier && !pChan->rxCarrierDetect && !pChan->b.txCtcssHangMuted &&
-				pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit && pChan->b.ctcssTxEnable && pChan->txTocType != TOC_NONE) {
-				pChan->b.txCtcssHangMuted = 1;
-				if (pChan->txTocType == TOC_NOTONE) {
-					pChan->spsSigGen0->option = 3;
-					TRACEC(1, "Tx CTCSS off on COS drop (notone).\n");
-				} else {
-					pChan->spsSigGen0->option = 2;
-					TRACEC(1, "Tx CTCSS phase turn-off on COS drop.\n");
-				}
-			}
 		} else if (!pChan->txPttIn && pChan->txState == CHAN_TXSTATE_ACTIVE) {
 			TRACEC(1, "txPttIn==0 from CHAN_TXSTATE_ACTIVE\n");
 			if (pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit) {
-				if (pChan->txTocType == TOC_NONE || !pChan->b.ctcssTxEnable || pChan->b.txCtcssHangMuted) {
-					/* Immediate off, or tone already dropped at COS for duplex hang. */
+				if (pChan->txTocType == TOC_NONE || !pChan->b.ctcssTxEnable) {
 					TRACEC(1, "Tx Off Immediate.\n");
 					pChan->spsSigGen0->option = 3;
 					pChan->txBufferClear = 3;
@@ -2996,7 +2962,6 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 			if (pChan->txPttIn && pChan->smode == SMODE_CTCSS) {
 				TRACEC(1, "Tx Key During HangTime\n");
 				pChan->txState = CHAN_TXSTATE_ACTIVE;
-				pChan->b.txCtcssHangMuted = 0;
 				pChan->spsSigGen0->option = 1;
 				pChan->spsSigGen0->enabled = 1;
 				pChan->spsSigGen0->discounterl = 0;
@@ -3023,8 +2988,6 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 		pChan->txPttOut = 0;
 		pChan->spsSigGen0->option = 3;
 		pChan->txrxblankingtimer = pChan->txrxblankingtime;
-		pChan->b.txHadRxCarrier = 0;
-		pChan->b.txCtcssHangMuted = 0;
 		TRACEC(1, "PmrRx() txrxblankingtimer=%i\n", pChan->txrxblankingtimer);
 		pChan->txState = CHAN_TXSTATE_IDLE;
 		if (pChan->spsTxLsdLpf) {

--- a/channels/xpmr/xpmr.h
+++ b/channels/xpmr/xpmr.h
@@ -843,9 +843,6 @@ typedef struct t_pmr_chan {
 		unsigned txCtcssInhibit:1;
 		unsigned txCtcssReady:1;
 		unsigned txCtcssOff:1;
-		unsigned txHadRxCarrier:1;	 /*!< Saw local RX carrier during this TX cycle */
-		unsigned txCtcssHangMuted:1; /*!< CTCSS already turned off on COS drop (duplex hang) */
-
 		unsigned rxkeyed:1;
 		unsigned rxhalted:1;
 		unsigned txhalted:1;


### PR DESCRIPTION
## Summary

Remove the XPMR state that terminates transmit CTCSS when local COR drops while PTT remains asserted.

With CTCSS-on-input-only disabled, CTCSS should remain encoded for the entire keyed period, including repeater hang time, and phase/notone termination should occur only at actual transmitter release.

Fixes #1182.

## Root cause

The COR-drop logic used only `rxCarrierDetect` to decide when to terminate CTCSS. It could not distinguish ordinary repeater hang time from linked audio, telemetry, or another source holding the transmitter. Once `txCtcssHangMuted` was set, linked activity could not restore CTCSS because the restore path also depended on local receiver carrier.

## Changes

- Remove the local-COR-driven CTCSS termination block.
- Remove `txHadRxCarrier` and `txCtcssHangMuted`.
- Restore the normal frequency update and transmitter-release paths.
- Preserve configured phase/notone termination immediately before PTT drops.

## Validation

Built against Asterisk/app_rpt 22.10.1+asl3-3.10.1 on aarch64 and installed on a full-duplex ASL3 repeater using chan_usbradio.

Validated with CTCSS-on-input-only disabled:

- CTCSS remains present after local COR drops and throughout hang time.
- Courtesy tone audio remains decodable during hang time.
- Linked and local receiver activity continue to transmit with CTCSS.
- Configured reverse burst occurs immediately before transmitter release.
- Multi-day on-air testing has not reproduced the prior intermittent CTCSS loss.

Tested by Chris Peterson, KG0BP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CTCSS tone handling when releasing and re-keying the transmitter.
  * Ensured configured no-tone and phase-shift shutdown behavior is applied consistently.
  * Improved transmitter restart behavior during tone-off periods.
  * Prevented unnecessary interruption of frequency updates during CTCSS operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->