### PR TITLE
app_rpt: use talkover ID for active transmissions

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2765,11 +2765,19 @@ static void local_dtmf_helper(struct rpt *myrpt, char c_in)
 
 static void queue_id(struct rpt *myrpt)
 {
+	enum rpt_tele_mode mode = ID;
+	const char *idtalkover;
+
 	myrpt->mustid = myrpt->tailid = 0;
 	if (myrpt->p.idtime) {				  /* ID time must be non-zero */
+		idtalkover = ast_variable_retrieve(myrpt->cfg, myrpt->name, "idtalkover");
+		if ((myrpt->keyed || myrpt->remrx || myrpt->localoverride) && !ast_strlen_zero(idtalkover)) {
+			mode = IDTALKOVER;
+		}
+
 		myrpt->idtimer = myrpt->p.idtime; /* Reset our ID timer */
 		rpt_mutex_unlock(&myrpt->lock);
-		rpt_telemetry(myrpt, ID, NULL);
+		rpt_telemetry(myrpt, mode, NULL);
 		rpt_mutex_lock(&myrpt->lock);
 	}
 }


### PR DESCRIPTION
## Summary

Select `IDTALKOVER` directly when a periodic ID becomes due while receiver, linked-node, or local-override traffic is already active.

Fixes #1183.

## Root cause

The main repeater loop checks whether an already-queued normal `ID` should be replaced before it checks whether the periodic ID timer has expired. When traffic is already active, no ID exists during that replacement check. `queue_id()` subsequently queues the normal `ID` unconditionally, resulting in the complete voice ID followed by the talk-over ID.

## Change

`queue_id()` now selects:

- `IDTALKOVER` when `idtalkover` is configured and `keyed`, `remrx`, or `localoverride` is active.
- The normal `ID` in all other cases.

The existing path that interrupts a normal ID when traffic begins during playback is unchanged.

## Validation

Built against Asterisk/app_rpt 22.10.1+asl3-3.10.1 on aarch64 and installed on a full-duplex ASL3 repeater.

On-air testing confirmed:

- A Morse talk-over ID plays when the periodic ID becomes due during an active transmission.
- The normal voice ID plays when the node is idle.
- The previously observed voice-ID-then-Morse-ID sequence no longer occurs.

Tested by Chris Peterson, KG0BP.

## Test coverage

The current app_rpt automated suite does not cover periodic ID mode selection or the `idrecording`/`idtalkover` transition paths. Automated coverage should be added for idle, local receiver, linked receiver, local override, missing-`idtalkover`, and mid-ID key-up cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repeater identification announcements during keyed, remote-audio, or locally overridden operation.
  * Uses the configured talkover identification when available; otherwise, standard identification telemetry continues as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->