### PR TITLE
xpmr: drive hang CTCSS TOC from itxctcss, not local COS

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -5706,13 +5706,15 @@ static void *rpt(void *this)
 			char str[16];
 
 			myrpt->lastitx = x;
-			if (myrpt->p.itxctcss) {
-				if (IS_DAHDI_CHAN(myrpt->rxchannel)) {
+			if (IS_DAHDI_CHAN(myrpt->rxchannel)) {
+				/* Preserve the existing legacy DAHDI behavior. */
+				if (myrpt->p.itxctcss) {
 					dahdi_radio_set_ctcss_encode(myrpt->localrxchannel, !x);
-				} else if (CHAN_TECH(myrpt->rxchannel, "radio") || CHAN_TECH(myrpt->rxchannel, "simpleusb")) {
-					snprintf(str, sizeof(str), "TXCTCSS %d", !(!x));
-					ast_sendtext(myrpt->rxchannel, str);
 				}
+			} else if (CHAN_TECH(myrpt->rxchannel, "radio") || CHAN_TECH(myrpt->rxchannel, "simpleusb")) {
+				/* Disabled input-only mode always means CTCSS enabled. */
+				snprintf(str, sizeof(str), "TXCTCSS %d", !myrpt->p.itxctcss || !!x);
+				ast_sendtext(myrpt->rxchannel, str);
 			}
 		}
 		/* If we have a new active telemetry message and a channel */

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -1867,6 +1867,8 @@ enum rpt_function_response function_cop(struct rpt *myrpt, char *param, char *di
 	case 58: /* TX CTCSS on input only Enable */
 		rpt_mutex_lock(&myrpt->lock);
 		myrpt->p.itxctcss = 1;
+		/* Force the main loop to publish the current aggregate input state. */
+		myrpt->lastitx = -1;
 		rpt_mutex_unlock(&myrpt->lock);
 		rpt_telem_select(myrpt, command_source, mylink);
 		rpt_telemetry(myrpt, ARB_ALPHA, (void *) "TXIPLENA");
@@ -1874,6 +1876,8 @@ enum rpt_function_response function_cop(struct rpt *myrpt, char *param, char *di
 	case 59: /* TX CTCSS on input only Disable */
 		rpt_mutex_lock(&myrpt->lock);
 		myrpt->p.itxctcss = 0;
+		/* Force an explicit CTCSS enable to clear a prior input-only request. */
+		myrpt->lastitx = -1;
 		rpt_mutex_unlock(&myrpt->lock);
 		rpt_telem_select(myrpt, command_source, mylink);
 		rpt_telemetry(myrpt, ARB_ALPHA, (void *) "TXIPLDIS");

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -1858,15 +1858,8 @@ static int usbradio_text(struct ast_channel *c, const char *text)
 		u8 x;
 		x = strtod(rxs, NULL);
 		if (o && o->pmrChan) {
-			if (x) {
-				/* Input activity present — restore encode if muted for hang. */
-				o->pmrChan->b.txCtcssInputOnReq = 1;
-				o->pmrChan->b.txCtcssInputOffReq = 0;
-			} else {
-				/* No remrx/localtx/call/parrot — TOC or mute while PTT may still be held. */
-				o->pmrChan->b.txCtcssInputOffReq = 1;
-				o->pmrChan->b.txCtcssInputOnReq = 0;
-			}
+			/* Single atomic replaces paired on/off bits so PmrRx cannot see a torn pair. */
+			__atomic_store_n(&o->pmrChan->txCtcssInputReq, x ? TXCTCSS_INPUT_REQ_ON : TXCTCSS_INPUT_REQ_OFF, __ATOMIC_RELEASE);
 		}
 		ast_debug(3, "Channel %s: TXCTCSS cmd: %s\n", o->name, text);
 		return 0;

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -1853,12 +1853,20 @@ static int usbradio_text(struct ast_channel *c, const char *text)
 		return 0;
 	}
 
-	/* set transmit CTCSS */
+	/* set transmit CTCSS (app_rpt itxctcss → TXCTCSS 0/1) */
 	if (strcmp(cmd, "TXCTCSS") == 0) {
 		u8 x;
 		x = strtod(rxs, NULL);
 		if (o && o->pmrChan) {
-			o->pmrChan->b.txCtcssOff = !x;
+			if (x) {
+				/* Input activity present — restore encode if muted for hang. */
+				o->pmrChan->b.txCtcssInputOnReq = 1;
+				o->pmrChan->b.txCtcssInputOffReq = 0;
+			} else {
+				/* No remrx/localtx/call/parrot — TOC or mute while PTT may still be held. */
+				o->pmrChan->b.txCtcssInputOffReq = 1;
+				o->pmrChan->b.txCtcssInputOnReq = 0;
+			}
 		}
 		ast_debug(3, "Channel %s: TXCTCSS cmd: %s\n", o->name, text);
 		return 0;

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -1855,11 +1855,13 @@ static int usbradio_text(struct ast_channel *c, const char *text)
 
 	/* set transmit CTCSS (app_rpt itxctcss → TXCTCSS 0/1) */
 	if (strcmp(cmd, "TXCTCSS") == 0) {
-		u8 x;
-		x = strtod(rxs, NULL);
+		if (cnt < 2 || (strcmp(rxs, "0") && strcmp(rxs, "1"))) {
+			ast_log(LOG_WARNING, "Channel %s: Invalid TXCTCSS command: %s\n", o->name, text);
+			return 0;
+		}
 		if (o && o->pmrChan) {
 			/* Single atomic replaces paired on/off bits so PmrRx cannot see a torn pair. */
-			__atomic_store_n(&o->pmrChan->txCtcssInputReq, x ? TXCTCSS_INPUT_REQ_ON : TXCTCSS_INPUT_REQ_OFF, __ATOMIC_RELEASE);
+			__atomic_store_n(&o->pmrChan->txCtcssInputReq, rxs[0] == '1' ? TXCTCSS_INPUT_REQ_ON : TXCTCSS_INPUT_REQ_OFF, __ATOMIC_RELEASE);
 		}
 		ast_debug(3, "Channel %s: TXCTCSS cmd: %s\n", o->name, text);
 		return 0;

--- a/channels/xpmr/xpmr.c
+++ b/channels/xpmr/xpmr.c
@@ -2914,6 +2914,23 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 			pChan->txState = CHAN_TXSTATE_ACTIVE;
 			pChan->txPttOut = 1;
 
+			/*
+			 * Consume an input-only request that arrived while TX was idle.
+			 * An OFF request here suppresses CTCSS without a TOC because no
+			 * tone has yet been transmitted in this keyed period.
+			 */
+			{
+				sig_atomic_t input_req = __atomic_exchange_n(&pChan->txCtcssInputReq, TXCTCSS_INPUT_REQ_NONE, __ATOMIC_ACQ_REL);
+
+				if (input_req == TXCTCSS_INPUT_REQ_OFF) {
+					pChan->b.txCtcssHangMuted = 1;
+					pChan->b.txCtcssOff = 1;
+					pChan->spsSigGen0->option = 3;
+				} else if (input_req == TXCTCSS_INPUT_REQ_ON) {
+					pChan->b.txCtcssOff = 0;
+				}
+			}
+
 			pChan->txsettletimer = pChan->txsettletime;
 
 			if (pChan->spsTxOutA) {
@@ -2959,16 +2976,18 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 							} else {
 								f = pChan->txctcssdefault_value;
 							}
-							if (!f) {
+							if (f <= 0) {
 								f = pChan->txctcssdefault_value;
 							}
-							if (f) {
+							if (f > 0) {
 								pChan->spsSigGen0->freq = f * 10;
+								pChan->spsSigGen0->option = 1;
+								pChan->spsSigGen0->enabled = 1;
+								pChan->spsSigGen0->discounterl = 0;
+								TRACEC(1, "Tx CTCSS restore on TXCTCSS on during hang.\n");
+							} else {
+								TRACEC(1, "Tx CTCSS restore skipped: no valid frequency.\n");
 							}
-							pChan->spsSigGen0->option = 1;
-							pChan->spsSigGen0->enabled = 1;
-							pChan->spsSigGen0->discounterl = 0;
-							TRACEC(1, "Tx CTCSS restore on TXCTCSS on during hang.\n");
 						}
 					}
 				} else if (input_req == TXCTCSS_INPUT_REQ_OFF) {

--- a/channels/xpmr/xpmr.c
+++ b/channels/xpmr/xpmr.c
@@ -2871,7 +2871,6 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 				pChan->rxCtcssMap[pChan->rxCtcss->decode]);
 			pChan->dd.b.doitnow = 1;
 			pChan->spsSigGen0->freq = 0;
-			pChan->b.txHadRxCarrier = 0;
 			pChan->b.txCtcssHangMuted = 0;
 			if (pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit) {
 				if (pChan->rxCtcss->decode > CTCSS_NULL) {
@@ -2938,40 +2937,51 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 			pChan->smodetimer = pChan->smodetime;
 
 			/*
-			 * Full duplex: app_rpt hangtime keeps txPttIn asserted after the user
-			 * unkeys, so classic TOC (which waits for txPttIn to drop) never runs
-			 * until hangtime ends. Start notone/phase turn-off when local COS drops
-			 * so CTCSS ends at the start of hang instead of riding until PTT drops.
-			 * If COS returns while hangtime still holds PTT, restore CTCSS so the
-			 * next keyed period is not left muted until PTT finally drops.
-			 * Half duplex blanks RX while keyed, so COS cannot be used that way.
+			 * Input-only CTCSS (app_rpt itxctcss → TXCTCSS): end or restore
+			 * encode while PTT is still held for hangtime. Do not watch local
+			 * COS — that cannot tell hangtime apart from linked/telemetry hold.
+			 * Classic mode (itxctcss off) never sends these requests; TOC runs
+			 * at actual txPttIn drop below.
 			 */
-			if (pChan->radioDuplex && pChan->rxCarrierDetect) {
-				pChan->b.txHadRxCarrier = 1;
-				if (pChan->b.txCtcssHangMuted && pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit && pChan->b.ctcssTxEnable) {
+			if (pChan->b.txCtcssInputOnReq) {
+				pChan->b.txCtcssInputOnReq = 0;
+				if (pChan->b.txCtcssHangMuted || pChan->b.txCtcssOff) {
 					pChan->b.txCtcssHangMuted = 0;
-					pChan->spsSigGen0->option = 1;
-					pChan->spsSigGen0->enabled = 1;
-					pChan->spsSigGen0->discounterl = 0;
-					TRACEC(1, "Tx CTCSS restore on COS reassert during hang.\n");
+					pChan->b.txCtcssOff = 0;
+					if (pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit && pChan->b.ctcssTxEnable) {
+						pChan->spsSigGen0->option = 1;
+						pChan->spsSigGen0->enabled = 1;
+						pChan->spsSigGen0->discounterl = 0;
+						TRACEC(1, "Tx CTCSS restore on TXCTCSS on during hang.\n");
+					}
 				}
 			}
-			if (pChan->radioDuplex && pChan->b.txHadRxCarrier && !pChan->rxCarrierDetect && !pChan->b.txCtcssHangMuted &&
-				pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit && pChan->b.ctcssTxEnable && pChan->txTocType != TOC_NONE) {
-				pChan->b.txCtcssHangMuted = 1;
-				if (pChan->txTocType == TOC_NOTONE) {
-					pChan->spsSigGen0->option = 3;
-					TRACEC(1, "Tx CTCSS off on COS drop (notone).\n");
-				} else {
-					pChan->spsSigGen0->option = 2;
-					TRACEC(1, "Tx CTCSS phase turn-off on COS drop.\n");
+			if (pChan->b.txCtcssInputOffReq) {
+				pChan->b.txCtcssInputOffReq = 0;
+				if (!pChan->b.txCtcssHangMuted && pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit && pChan->b.ctcssTxEnable) {
+					pChan->b.txCtcssHangMuted = 1;
+					if (pChan->txTocType == TOC_NOTONE) {
+						/* Keep mute clear so chicken-burst silence is clean. */
+						pChan->b.txCtcssOff = 0;
+						pChan->spsSigGen0->option = 3;
+						TRACEC(1, "Tx CTCSS notone on TXCTCSS off.\n");
+					} else if (pChan->txTocType == TOC_PHASE) {
+						pChan->b.txCtcssOff = 0;
+						pChan->spsSigGen0->option = 2;
+						TRACEC(1, "Tx CTCSS phase turn-off on TXCTCSS off.\n");
+					} else {
+						pChan->b.txCtcssOff = 1;
+						TRACEC(1, "Tx CTCSS mute on TXCTCSS off.\n");
+					}
+				} else if (!pChan->b.txCtcssHangMuted) {
+					pChan->b.txCtcssOff = 1;
 				}
 			}
 		} else if (!pChan->txPttIn && pChan->txState == CHAN_TXSTATE_ACTIVE) {
 			TRACEC(1, "txPttIn==0 from CHAN_TXSTATE_ACTIVE\n");
 			if (pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit) {
 				if (pChan->txTocType == TOC_NONE || !pChan->b.ctcssTxEnable || pChan->b.txCtcssHangMuted) {
-					/* Immediate off, or tone already dropped at COS for duplex hang. */
+					/* Immediate off, or tone already ended for input-only. */
 					TRACEC(1, "Tx Off Immediate.\n");
 					pChan->spsSigGen0->option = 3;
 					pChan->txBufferClear = 3;
@@ -2997,6 +3007,7 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 				TRACEC(1, "Tx Key During HangTime\n");
 				pChan->txState = CHAN_TXSTATE_ACTIVE;
 				pChan->b.txCtcssHangMuted = 0;
+				pChan->b.txCtcssOff = 0;
 				pChan->spsSigGen0->option = 1;
 				pChan->spsSigGen0->enabled = 1;
 				pChan->spsSigGen0->discounterl = 0;
@@ -3023,8 +3034,9 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 		pChan->txPttOut = 0;
 		pChan->spsSigGen0->option = 3;
 		pChan->txrxblankingtimer = pChan->txrxblankingtime;
-		pChan->b.txHadRxCarrier = 0;
 		pChan->b.txCtcssHangMuted = 0;
+		pChan->b.txCtcssInputOffReq = 0;
+		pChan->b.txCtcssInputOnReq = 0;
 		TRACEC(1, "PmrRx() txrxblankingtimer=%i\n", pChan->txrxblankingtimer);
 		pChan->txState = CHAN_TXSTATE_IDLE;
 		if (pChan->spsTxLsdLpf) {

--- a/channels/xpmr/xpmr.c
+++ b/channels/xpmr/xpmr.c
@@ -2951,6 +2951,20 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 						pChan->b.txCtcssHangMuted = 0;
 						pChan->b.txCtcssOff = 0;
 						if (pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit && pChan->b.ctcssTxEnable) {
+							f = 0;
+							if (pChan->rxCtcss->decode > CTCSS_NULL) {
+								if (pChan->rxCtcssMap[pChan->rxCtcss->decode] != CTCSS_RXONLY) {
+									f = freq_ctcss[pChan->rxCtcssMap[pChan->rxCtcss->decode]];
+								}
+							} else {
+								f = pChan->txctcssdefault_value;
+							}
+							if (!f) {
+								f = pChan->txctcssdefault_value;
+							}
+							if (f) {
+								pChan->spsSigGen0->freq = f * 10;
+							}
 							pChan->spsSigGen0->option = 1;
 							pChan->spsSigGen0->enabled = 1;
 							pChan->spsSigGen0->discounterl = 0;

--- a/channels/xpmr/xpmr.c
+++ b/channels/xpmr/xpmr.c
@@ -2943,38 +2943,39 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 			 * Classic mode (itxctcss off) never sends these requests; TOC runs
 			 * at actual txPttIn drop below.
 			 */
-			if (pChan->b.txCtcssInputOnReq) {
-				pChan->b.txCtcssInputOnReq = 0;
-				if (pChan->b.txCtcssHangMuted || pChan->b.txCtcssOff) {
-					pChan->b.txCtcssHangMuted = 0;
-					pChan->b.txCtcssOff = 0;
-					if (pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit && pChan->b.ctcssTxEnable) {
-						pChan->spsSigGen0->option = 1;
-						pChan->spsSigGen0->enabled = 1;
-						pChan->spsSigGen0->discounterl = 0;
-						TRACEC(1, "Tx CTCSS restore on TXCTCSS on during hang.\n");
+			{
+				sig_atomic_t input_req = __atomic_exchange_n(&pChan->txCtcssInputReq, TXCTCSS_INPUT_REQ_NONE, __ATOMIC_ACQ_REL);
+
+				if (input_req == TXCTCSS_INPUT_REQ_ON) {
+					if (pChan->b.txCtcssHangMuted || pChan->b.txCtcssOff) {
+						pChan->b.txCtcssHangMuted = 0;
+						pChan->b.txCtcssOff = 0;
+						if (pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit && pChan->b.ctcssTxEnable) {
+							pChan->spsSigGen0->option = 1;
+							pChan->spsSigGen0->enabled = 1;
+							pChan->spsSigGen0->discounterl = 0;
+							TRACEC(1, "Tx CTCSS restore on TXCTCSS on during hang.\n");
+						}
 					}
-				}
-			}
-			if (pChan->b.txCtcssInputOffReq) {
-				pChan->b.txCtcssInputOffReq = 0;
-				if (!pChan->b.txCtcssHangMuted && pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit && pChan->b.ctcssTxEnable) {
-					pChan->b.txCtcssHangMuted = 1;
-					if (pChan->txTocType == TOC_NOTONE) {
-						/* Keep mute clear so chicken-burst silence is clean. */
-						pChan->b.txCtcssOff = 0;
-						pChan->spsSigGen0->option = 3;
-						TRACEC(1, "Tx CTCSS notone on TXCTCSS off.\n");
-					} else if (pChan->txTocType == TOC_PHASE) {
-						pChan->b.txCtcssOff = 0;
-						pChan->spsSigGen0->option = 2;
-						TRACEC(1, "Tx CTCSS phase turn-off on TXCTCSS off.\n");
-					} else {
+				} else if (input_req == TXCTCSS_INPUT_REQ_OFF) {
+					if (!pChan->b.txCtcssHangMuted && pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit && pChan->b.ctcssTxEnable) {
+						pChan->b.txCtcssHangMuted = 1;
+						if (pChan->txTocType == TOC_NOTONE) {
+							/* Keep mute clear so chicken-burst silence is clean. */
+							pChan->b.txCtcssOff = 0;
+							pChan->spsSigGen0->option = 3;
+							TRACEC(1, "Tx CTCSS notone on TXCTCSS off.\n");
+						} else if (pChan->txTocType == TOC_PHASE) {
+							pChan->b.txCtcssOff = 0;
+							pChan->spsSigGen0->option = 2;
+							TRACEC(1, "Tx CTCSS phase turn-off on TXCTCSS off.\n");
+						} else {
+							pChan->b.txCtcssOff = 1;
+							TRACEC(1, "Tx CTCSS mute on TXCTCSS off.\n");
+						}
+					} else if (!pChan->b.txCtcssHangMuted) {
 						pChan->b.txCtcssOff = 1;
-						TRACEC(1, "Tx CTCSS mute on TXCTCSS off.\n");
 					}
-				} else if (!pChan->b.txCtcssHangMuted) {
-					pChan->b.txCtcssOff = 1;
 				}
 			}
 		} else if (!pChan->txPttIn && pChan->txState == CHAN_TXSTATE_ACTIVE) {
@@ -3035,8 +3036,8 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 		pChan->spsSigGen0->option = 3;
 		pChan->txrxblankingtimer = pChan->txrxblankingtime;
 		pChan->b.txCtcssHangMuted = 0;
-		pChan->b.txCtcssInputOffReq = 0;
-		pChan->b.txCtcssInputOnReq = 0;
+		pChan->b.txCtcssOff = 0;
+		__atomic_store_n(&pChan->txCtcssInputReq, TXCTCSS_INPUT_REQ_NONE, __ATOMIC_RELEASE);
 		TRACEC(1, "PmrRx() txrxblankingtimer=%i\n", pChan->txrxblankingtimer);
 		pChan->txState = CHAN_TXSTATE_IDLE;
 		if (pChan->spsTxLsdLpf) {

--- a/channels/xpmr/xpmr.c
+++ b/channels/xpmr/xpmr.c
@@ -2706,6 +2706,7 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 {
 	int i, hit;
 	float f = 0;
+	sig_atomic_t input_req;
 	t_pmr_sps *pmr_sps;
 
 	TRACEC(5, "PmrRx(%p %p %p %p)\n", pChan, input, outputrx, outputtx);
@@ -2919,16 +2920,14 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 			 * An OFF request here suppresses CTCSS without a TOC because no
 			 * tone has yet been transmitted in this keyed period.
 			 */
-			{
-				sig_atomic_t input_req = __atomic_exchange_n(&pChan->txCtcssInputReq, TXCTCSS_INPUT_REQ_NONE, __ATOMIC_ACQ_REL);
+			input_req = __atomic_exchange_n(&pChan->txCtcssInputReq, TXCTCSS_INPUT_REQ_NONE, __ATOMIC_ACQ_REL);
 
-				if (input_req == TXCTCSS_INPUT_REQ_OFF) {
-					pChan->b.txCtcssHangMuted = 1;
-					pChan->b.txCtcssOff = 1;
-					pChan->spsSigGen0->option = 3;
-				} else if (input_req == TXCTCSS_INPUT_REQ_ON) {
-					pChan->b.txCtcssOff = 0;
-				}
+			if (input_req == TXCTCSS_INPUT_REQ_OFF) {
+				pChan->b.txCtcssHangMuted = 1;
+				pChan->b.txCtcssOff = 1;
+				pChan->spsSigGen0->option = 3;
+			} else if (input_req == TXCTCSS_INPUT_REQ_ON) {
+				pChan->b.txCtcssOff = 0;
 			}
 
 			pChan->txsettletimer = pChan->txsettletime;
@@ -2960,54 +2959,52 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 			 * Classic mode (itxctcss off) never sends these requests; TOC runs
 			 * at actual txPttIn drop below.
 			 */
-			{
-				sig_atomic_t input_req = __atomic_exchange_n(&pChan->txCtcssInputReq, TXCTCSS_INPUT_REQ_NONE, __ATOMIC_ACQ_REL);
+			input_req = __atomic_exchange_n(&pChan->txCtcssInputReq, TXCTCSS_INPUT_REQ_NONE, __ATOMIC_ACQ_REL);
 
-				if (input_req == TXCTCSS_INPUT_REQ_ON) {
-					if (pChan->b.txCtcssHangMuted || pChan->b.txCtcssOff) {
-						pChan->b.txCtcssHangMuted = 0;
-						pChan->b.txCtcssOff = 0;
-						if (pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit && pChan->b.ctcssTxEnable) {
-							f = 0;
-							if (pChan->rxCtcss->decode > CTCSS_NULL) {
-								/* RX-only codes leave f unset — do not encode. */
-								if (pChan->rxCtcssMap[pChan->rxCtcss->decode] != CTCSS_RXONLY) {
-									f = freq_ctcss[pChan->rxCtcssMap[pChan->rxCtcss->decode]];
-								}
-							} else {
-								/* No decoded code — use the configured default TX tone. */
-								f = pChan->txctcssdefault_value;
+			if (input_req == TXCTCSS_INPUT_REQ_ON) {
+				if (pChan->b.txCtcssHangMuted || pChan->b.txCtcssOff) {
+					pChan->b.txCtcssHangMuted = 0;
+					pChan->b.txCtcssOff = 0;
+					if (pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit && pChan->b.ctcssTxEnable) {
+						f = 0;
+						if (pChan->rxCtcss->decode > CTCSS_NULL) {
+							/* RX-only codes leave f unset — do not encode. */
+							if (pChan->rxCtcssMap[pChan->rxCtcss->decode] != CTCSS_RXONLY) {
+								f = freq_ctcss[pChan->rxCtcssMap[pChan->rxCtcss->decode]];
 							}
-							if (f > 0) {
-								pChan->spsSigGen0->freq = f * 10;
-								pChan->spsSigGen0->option = 1;
-								pChan->spsSigGen0->enabled = 1;
-								pChan->spsSigGen0->discounterl = 0;
-								TRACEC(1, "Tx CTCSS restore on TXCTCSS on during hang.\n");
-							} else {
-								TRACEC(1, "Tx CTCSS restore skipped: no valid frequency.\n");
-							}
-						}
-					}
-				} else if (input_req == TXCTCSS_INPUT_REQ_OFF) {
-					if (!pChan->b.txCtcssHangMuted && pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit && pChan->b.ctcssTxEnable) {
-						pChan->b.txCtcssHangMuted = 1;
-						if (pChan->txTocType == TOC_NOTONE) {
-							/* Keep mute clear so chicken-burst silence is clean. */
-							pChan->b.txCtcssOff = 0;
-							pChan->spsSigGen0->option = 3;
-							TRACEC(1, "Tx CTCSS notone on TXCTCSS off.\n");
-						} else if (pChan->txTocType == TOC_PHASE) {
-							pChan->b.txCtcssOff = 0;
-							pChan->spsSigGen0->option = 2;
-							TRACEC(1, "Tx CTCSS phase turn-off on TXCTCSS off.\n");
 						} else {
-							pChan->b.txCtcssOff = 1;
-							TRACEC(1, "Tx CTCSS mute on TXCTCSS off.\n");
+							/* No decoded code — use the configured default TX tone. */
+							f = pChan->txctcssdefault_value;
 						}
-					} else if (!pChan->b.txCtcssHangMuted) {
-						pChan->b.txCtcssOff = 1;
+						if (f > 0) {
+							pChan->spsSigGen0->freq = f * 10;
+							pChan->spsSigGen0->option = 1;
+							pChan->spsSigGen0->enabled = 1;
+							pChan->spsSigGen0->discounterl = 0;
+							TRACEC(1, "Tx CTCSS restore on TXCTCSS on during hang.\n");
+						} else {
+							TRACEC(1, "Tx CTCSS restore skipped: no valid frequency.\n");
+						}
 					}
+				}
+			} else if (input_req == TXCTCSS_INPUT_REQ_OFF) {
+				if (!pChan->b.txCtcssHangMuted && pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit && pChan->b.ctcssTxEnable) {
+					pChan->b.txCtcssHangMuted = 1;
+					if (pChan->txTocType == TOC_NOTONE) {
+						/* Keep mute clear so chicken-burst silence is clean. */
+						pChan->b.txCtcssOff = 0;
+						pChan->spsSigGen0->option = 3;
+						TRACEC(1, "Tx CTCSS notone on TXCTCSS off.\n");
+					} else if (pChan->txTocType == TOC_PHASE) {
+						pChan->b.txCtcssOff = 0;
+						pChan->spsSigGen0->option = 2;
+						TRACEC(1, "Tx CTCSS phase turn-off on TXCTCSS off.\n");
+					} else {
+						pChan->b.txCtcssOff = 1;
+						TRACEC(1, "Tx CTCSS mute on TXCTCSS off.\n");
+					}
+				} else if (!pChan->b.txCtcssHangMuted) {
+					pChan->b.txCtcssOff = 1;
 				}
 			}
 		} else if (!pChan->txPttIn && pChan->txState == CHAN_TXSTATE_ACTIVE) {

--- a/channels/xpmr/xpmr.c
+++ b/channels/xpmr/xpmr.c
@@ -2970,13 +2970,12 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 						if (pChan->smode == SMODE_CTCSS && !pChan->b.txCtcssInhibit && pChan->b.ctcssTxEnable) {
 							f = 0;
 							if (pChan->rxCtcss->decode > CTCSS_NULL) {
+								/* RX-only codes leave f unset — do not encode. */
 								if (pChan->rxCtcssMap[pChan->rxCtcss->decode] != CTCSS_RXONLY) {
 									f = freq_ctcss[pChan->rxCtcssMap[pChan->rxCtcss->decode]];
 								}
 							} else {
-								f = pChan->txctcssdefault_value;
-							}
-							if (f <= 0) {
+								/* No decoded code — use the configured default TX tone. */
 								f = pChan->txctcssdefault_value;
 							}
 							if (f > 0) {

--- a/channels/xpmr/xpmr.c
+++ b/channels/xpmr/xpmr.c
@@ -3037,7 +3037,6 @@ i16 PmrRx(t_pmr_chan *pChan, i16 *input, i16 *outputrx, i16 *outputtx)
 		pChan->txrxblankingtimer = pChan->txrxblankingtime;
 		pChan->b.txCtcssHangMuted = 0;
 		pChan->b.txCtcssOff = 0;
-		__atomic_store_n(&pChan->txCtcssInputReq, TXCTCSS_INPUT_REQ_NONE, __ATOMIC_RELEASE);
 		TRACEC(1, "PmrRx() txrxblankingtimer=%i\n", pChan->txrxblankingtimer);
 		pChan->txState = CHAN_TXSTATE_IDLE;
 		if (pChan->spsTxLsdLpf) {

--- a/channels/xpmr/xpmr.h
+++ b/channels/xpmr/xpmr.h
@@ -843,8 +843,9 @@ typedef struct t_pmr_chan {
 		unsigned txCtcssInhibit:1;
 		unsigned txCtcssReady:1;
 		unsigned txCtcssOff:1;
-		unsigned txHadRxCarrier:1;	 /*!< Saw local RX carrier during this TX cycle */
-		unsigned txCtcssHangMuted:1; /*!< CTCSS already turned off on COS drop (duplex hang) */
+		unsigned txCtcssHangMuted:1;   /*!< CTCSS already TOC'd/muted for input-only end */
+		unsigned txCtcssInputOffReq:1; /*!< app_rpt TXCTCSS off — run TOC or mute while PTT held */
+		unsigned txCtcssInputOnReq:1;  /*!< app_rpt TXCTCSS on — restore encode while PTT held */
 
 		unsigned rxkeyed:1;
 		unsigned rxhalted:1;

--- a/channels/xpmr/xpmr.h
+++ b/channels/xpmr/xpmr.h
@@ -38,6 +38,13 @@
 #ifndef XPMR_H
 #define XPMR_H 1
 
+#include <signal.h>
+
+/*! Cross-thread TXCTCSS request values for t_pmr_chan::txCtcssInputReq */
+#define TXCTCSS_INPUT_REQ_NONE 0
+#define TXCTCSS_INPUT_REQ_ON 1
+#define TXCTCSS_INPUT_REQ_OFF 2
+
 #define XPMR_DEV 0 /* when running in test mode */
 
 #define XPMR_TRACE_OVFLW 0
@@ -843,9 +850,7 @@ typedef struct t_pmr_chan {
 		unsigned txCtcssInhibit:1;
 		unsigned txCtcssReady:1;
 		unsigned txCtcssOff:1;
-		unsigned txCtcssHangMuted:1;   /*!< CTCSS already TOC'd/muted for input-only end */
-		unsigned txCtcssInputOffReq:1; /*!< app_rpt TXCTCSS off — run TOC or mute while PTT held */
-		unsigned txCtcssInputOnReq:1;  /*!< app_rpt TXCTCSS on — restore encode while PTT held */
+		unsigned txCtcssHangMuted:1; /*!< CTCSS already TOC'd/muted for input-only end */
 
 		unsigned rxkeyed:1;
 		unsigned rxhalted:1;
@@ -856,6 +861,13 @@ typedef struct t_pmr_chan {
 		unsigned pttwas:1;
 		unsigned txboost:1;
 	} b;
+
+	/*!
+	 * \brief Cross-thread TXCTCSS request from app_rpt itxctcss.
+	 * Written by chan_usbradio text path; consumed in PmrRx via atomic exchange.
+	 * Values: TXCTCSS_INPUT_REQ_NONE / _ON / _OFF.
+	 */
+	volatile sig_atomic_t txCtcssInputReq;
 
 	i16 *pRxDemod; /* buffers */
 	i16 *pRxBase;  /* decimated lpf input */

--- a/configs/rpt/rpt.conf
+++ b/configs/rpt/rpt.conf
@@ -142,6 +142,11 @@ accountcode = RADIO                 ; account code (optional)
 
 hangtime = 2000                     ; squelch tail hang time (in ms) (optional, default 5 seconds, 5000 ms)
 althangtime = 4000                  ; longer squelch tail
+;itxctcss = no                      ; TX CTCSS on input only (optional, default no). When yes, encode
+                                    ; only while local RX, link RX, autopatch, or parrot is active.
+                                    ; Ends CTCSS (with usbradio txtoctype phase/notone) when that
+                                    ; activity stops, even if hangtime still holds PTT. See also
+                                    ; cop,58 / cop,59 and usbradio.conf txtoctype.
 totime = 180000                     ; transmit time-out time (in ms) (optional, default to 180000 ms (3 minutes), maximum 9999999 ms (166 minutes))
 time_out_reset_unkey_interval = 0   ; The minimum time for no carrier detect after the transmitter drops in a time out condition (optional).
 									; This can be used to filter for noise and picket fencing during a time out condition.
@@ -465,7 +470,13 @@ parrottime = 1000                   ; Set the amount of time in milliseconds
 ; 957 = cop,57                      ; RX CTCSS Disable
 
 ; 958 = cop,58                      ; TX CTCSS On Input only Enable
+                                    ; Encode CTCSS only while local RX, link RX, autopatch,
+                                    ; or parrot is active. When activity ends, chan_usbradio
+                                    ; runs txtoctype phase/notone (or mutes if txtoctype=no)
+                                    ; even if hangtime still holds PTT; encode restores if
+                                    ; activity returns during hang. See usbradio.conf txtoctype.
 ; 959 = cop,59                      ; TX CTCSS On Input only Disable
+                                    ; Classic: CTCSS rides hangtime; phase/notone at PTT drop.
 
 ; 960 = cop,60                      ; Send MDC-1200 Burst (cop,60,type,UnitID[,DestID,SubCode])
                                     ; Type is 'I' for PttID, 'E' for Emergency, and 'C' for Call

--- a/configs/samples/usbradio.conf.sample
+++ b/configs/samples/usbradio.conf.sample
@@ -120,9 +120,12 @@
                             ; AKA ("reverse burst") before unkeying TX
                             ; notone - encode CTCSS and stop sending tone before unkeying TX
                             ; AKA ("chicken burst")
-                            ; With duplex=1 (full duplex), notone/phase begin when local
-                            ; COS drops so CTCSS does not ride app_rpt hangtime. Half duplex
-                            ; still applies the burst when PTT is released (fixed ~600ms).
+                            ; Classic (rpt.conf itxctcss=no, default): CTCSS rides app_rpt
+                            ; hangtime; phase/notone runs at actual PTT release.
+                            ; With itxctcss=yes (or cop,58): encode only while local RX,
+                            ; link RX, autopatch, or parrot is active. When that activity
+                            ; ends, phase/notone runs immediately even if hangtime still
+                            ; holds PTT; encode restores if activity returns during hang.
 
 ;txmixa = composite         ; Left channel output: no,voice,tone,composite,auxvoice
                             ; no - Do not output anything


### PR DESCRIPTION
## Summary
- Remove the #1113 duplex COS hang-mute path that ended TX CTCSS when local COR dropped while PTT was still held (cannot tell hangtime from linked/telemetry hold; #1182)
- Classic mode (`itxctcss` off): CTCSS rides app_rpt hangtime; phase/notone runs at actual PTT release
- With `itxctcss` (or cop,58): `TXCTCSS` off/on drives TOC or mute and restores encode from real TX sources (`remrx` / localtx / autopatch / parrot), using a single atomic request between the text and audio paths

This is an alternative to #1184’s full revert: keep classic hang behavior by default, and put early TOC where app_rpt already knows why PTT is held.

Fixes #1182. Addresses the regression from #1024 / #1113 without losing a supported early-TOC path for operators who want it via `itxctcss`.

## Test plan
- [ ] Classic (`itxctcss=no`, `txtoctype=phase` or `notone`): CTCSS present through hangtime; reverse/chicken burst at TX release
- [ ] `itxctcss=yes`: CTCSS ends (with configured TOC) when local/link/patch/parrot activity stops even if hangtime holds PTT
- [ ] `itxctcss=yes`: linked or local activity returning during hang restores CTCSS
- [ ] Half-duplex / no early request path unchanged for non-itxctcss
- [ ] Stereo/default usbradio configs unaffected when `itxctcss` is off

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transmit CTCSS handling during receive hangtime and retransmission.
  * CTCSS requests now reliably support explicit ON and OFF states; invalid commands are ignored.
  * Corrected tone muting, restoration, and phase behavior across local and linked activity.
  * Improved CTCSS state updates for radio, autopatch, and parrot operation.

* **Documentation**
  * Clarified configuration options and command behavior for transmitting CTCSS during input, autopatch, parrot, and hangtime operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->