### PR TITLE
res_usbradio: drop inert OSS fragment and /dev/dsp leftovers

### DIFF
--- a/channels/chan_simpleusb.c
+++ b/channels/chan_simpleusb.c
@@ -123,8 +123,6 @@ static struct ast_jb_conf global_jbconf;
 #define ZEROVAL AMPVAL
 #define DIVSAMP (DIVLCM / AST_SAMPLE_RATE)
 
-#define QUEUE_SIZE 5 /* 100 milliseconds of sound card output buffer */
-
 #define CONFIG "simpleusb.conf"				   /* default config file */
 #define RX_ON_DELAY_MAX 60000				   /* in ms, 60000ms, 60 seconds, 1 minute */
 #define TX_OFF_DELAY_MAX 60000				   /* in ms, 60000ms, 60 seconds, 1 minute */

--- a/channels/chan_usbradio.c
+++ b/channels/chan_usbradio.c
@@ -132,8 +132,6 @@ static struct ast_jb_conf default_jbconf = {
 
 static struct ast_jb_conf global_jbconf;
 
-#define QUEUE_SIZE 20 /* 400 milliseconds of sound card output buffer */
-
 #define CONFIG "usbradio.conf" /* default config file */
 
 /* file handles for writing debug audio packets */
@@ -191,8 +189,6 @@ struct chan_usbradio_pvt {
 		M_WRITE
 	} duplex;
 	int hookstate;
-	unsigned int queuesize; /* max fragments in queue */
-	unsigned int frags;		/* parameter for SETFRAGMENT */
 
 	char devicenum;
 	char devstr[128];
@@ -429,8 +425,6 @@ struct chan_usbradio_pvt {
  */
 static struct chan_usbradio_pvt usbradio_default = {
 	.duplex = M_UNSET,
-	.queuesize = QUEUE_SIZE,
-	.frags = FRAGS,
 	.readpos = AST_FRIENDLY_OFFSET, /* start here on reads */
 	.wanteeprom = 1,
 	.usedtmf = 1,
@@ -5142,8 +5136,6 @@ static struct chan_usbradio_pvt *store_config(struct ast_config *cfg, const char
 			continue;
 		}
 
-		CV_UINT("frags", o->frags);
-		CV_UINT("queuesize", o->queuesize);
 		CV_BOOL("rxcpusaver", o->rxcpusaver);
 		CV_BOOL("txcpusaver", o->txcpusaver);
 		CV_BOOL("invertptt", o->invertptt);

--- a/include/asterisk/res_usbradio.h
+++ b/include/asterisk/res_usbradio.h
@@ -132,38 +132,9 @@
  *
  *  FRAME_SIZE	the size of an audio frame, in samples.
  *		160 is used almost universally, so you should not change it.
- *
- *  FRAGS	the argument for the SETFRAGMENT ioctl.
- *		Overridden by the 'frags' parameter.
- *
- *		Bits 0-7 are the base-2 log of the device's block size,
- *		bits 16-31 are the number of blocks in the driver's queue.
- *		There are a lot of differences in the way this parameter
- *		is supported by different drivers, so you may need to
- *		experiment a bit with the value.
- *		A good default for linux is 30 blocks of 64 bytes, which
- *		results in 6 frames of 320 bytes (160 samples).
- *		FreeBSD works decently with blocks of 256 or 512 bytes,
- *		leaving the number unspecified.
- *		Note that this only refers to the device buffer size,
- *		this module will then try to keep the length of audio
- *		buffered within small constraints.
- *
- *  QUEUE_SIZE	The max number of blocks actually allowed in the device
- *		driver's buffer, irrespective of the available number.
- *		Overridden by the 'queuesize' parameter.
- *
- *		Should be >=2, and at most as large as the hw queue above
- *		(otherwise it will never be full).
  */
 
 #define FRAME_SIZE 160 /* Samples per Asterisk Frame */
-
-#if defined(__FreeBSD__)
-#define FRAGS 0x8
-#else
-#define FRAGS (((6 * 5) << 16) | 0xc)
-#endif
 
 /*
  * XXX text message sizes are probably 256 chars, but i am
@@ -172,12 +143,6 @@
 #define TEXT_SIZE 256
 
 #define O_CLOSE 0x444 /* special 'close' mode for device */
-/* Which sound device to use */
-#if defined(__OpenBSD__) || defined(__NetBSD__)
-#define DEV_DSP "/dev/audio"
-#else
-#define DEV_DSP "/dev/dsp"
-#endif
 
 struct usbecho {
 	struct qelem *q_forw;

--- a/res/res_usbradio.c
+++ b/res/res_usbradio.c
@@ -57,14 +57,6 @@
 #include <sys/io.h>
 #endif
 
-#ifdef __linux
-#include <linux/soundcard.h>
-#elif defined(__FreeBSD__)
-#include <sys/soundcard.h>
-#else
-#include <soundcard.h>
-#endif
-
 #include "asterisk/lock.h"
 #include "asterisk/logger.h"
 #include "asterisk/module.h"


### PR DESCRIPTION
## Summary
- Remove unused OSS-era `FRAGS` / `DEV_DSP` defines and docs from `res_usbradio.h`
- Drop unused `soundcard.h` includes from `res_usbradio.c` (PCM is PortAudio-only)
- Remove inert `frags` / `queuesize` config fields from `chan_usbradio` and unused `QUEUE_SIZE` defines in usbradio/simpleusb

No behavior change for the PortAudio path; these knobs no longer affect buffering after the OSS → PA migration.

## Test plan
- [ ] Build `res_usbradio`, `chan_usbradio`, and `chan_simpleusb`
- [ ] Load modules and confirm a stereo CM108-class URI still opens RX/TX
- [ ] Confirm legacy `frags=` / `queuesize=` lines in an old `usbradio.conf` are ignored (unknown/unused) without affecting audio

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed obsolete sound-card buffer and device-selection configuration.
  * Simplified USB radio configuration by eliminating unused queue and fragment settings.
  * Removed legacy platform-specific sound-card integration references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->