### PR TITLE
app_rpt: autoservice pchan while draining hangup text

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4513,8 +4513,21 @@ static inline void hangup_link_chan(struct rpt_link *l)
 static int remote_hangup_helper(struct rpt *myrpt, struct rpt_link *l)
 {
 	if (l->chan) {
+		/*
+		 * Flush pending link text, then give IAX a short drain window.
+		 * ast_safe_sleep already autoservices l->chan; also autoservice
+		 * pchan so softmix does not fill Announcer/IAXLink unread while
+		 * this waitfor thread is blocked (key/unkey / periodic work still
+		 * stall for the sleep duration — reconnect DNS is handled elsewhere).
+		 */
 		link_process_textq(myrpt, l);
-		ast_safe_sleep(l->chan, MSWAIT * 10);  /* Allow the channel to send the text messages */
+		if (l->pchan) {
+			ast_autoservice_start(l->pchan);
+		}
+		ast_safe_sleep(l->chan, MSWAIT * 10); /* Allow the channel to send the text messages */
+		if (l->pchan) {
+			ast_autoservice_stop(l->pchan);
+		}
 	}
 
 	if (l->chan && !CHAN_TECH(l->chan, "echolink") && !CHAN_TECH(l->chan, "tlb")) {


### PR DESCRIPTION
## Summary
- `remote_hangup_helper()` flushes the link text queue then waits ~200 ms so IAX can send those TEXT frames before hangup dumps the channel (Mike’s concern on this PR)
- `ast_safe_sleep` already autoservices `l->chan`; also autoservice `l->pchan` during that wait so softmix does not fill `Announcer/IAXLink` unread while the waitfor thread is blocked
- Complements #1190 (async reconnect) for the hang-first approach; park/remove of `pchan` (#1180) stays deferred

## Test plan
- [ ] Outbound permanent link: yank peer / kill network; confirm disconnect/reconnect and link TEXT (NEWKEY / L lists) still behave
- [ ] Confirm hangup no longer produces `Exceptionally long voice queue` on `Announcer/IAXLink` / `PChan` from this ~200 ms window
- [ ] If TEXT is still lost on hangup, next option is hang up `pchan` first then wait on the IAX chan (per Mike)