### PR TITLE
app_rpt: run outbound link reconnect off the waitfor thread

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2065,9 +2065,11 @@ static void handle_link_data(struct rpt *myrpt, struct rpt_link *mylink, char *s
 			snprintf(tmp1, sizeof(tmp1), "K %s %s %d %d", src, myrpt->name, myrpt->keyed, n);
 			wf.data.ptr = tmp1;
 			wf.datalen = strlen(tmp1) + 1;
+			rpt_mutex_lock(&myrpt->lock);
 			if (mylink->chan) {
 				rpt_qwrite(mylink, &wf);
 			}
+			rpt_mutex_unlock(&myrpt->lock);
 			return;
 		}
 		if (myrpt->topkeystate != 1) {
@@ -2500,16 +2502,109 @@ static char *parse_node_format(char *s, char **restrict s1, char *buf, size_t le
 	return s2;
 }
 
-/*! \brief Detached reconnect worker context (takes ownership of link ref) */
+/*! \brief Joinable reconnect worker context (takes ownership of link ref until thread exits) */
 struct rpt_reconnect_data {
 	struct rpt *myrpt;
 	struct rpt_link *l;
+	pthread_t thread;
+	AST_LIST_ENTRY(rpt_reconnect_data) entry;
 };
+
+static AST_LIST_HEAD_STATIC(reconnect_threads, rpt_reconnect_data);
+
+/*!
+ * \brief Join and free one reconnect worker removed from the tracking list.
+ * \note Caller must not hold reconnect_threads.lock. rd must not be on the list.
+ */
+static void rpt_join_reconnect_data(struct rpt_reconnect_data *rd)
+{
+	if (!rd) {
+		return;
+	}
+	pthread_join(rd->thread, NULL);
+	ast_free(rd);
+}
+
+/*!
+ * \brief Join every reconnect worker tracked for a link.
+ * \note Safe if none are running. Blocks until DNS/dial finishes for each match.
+ */
+static void rpt_join_link_reconnect(struct rpt_link *l)
+{
+	struct rpt_reconnect_data *rd;
+	struct rpt_reconnect_data *cur;
+	AST_LIST_HEAD_NOLOCK(, rpt_reconnect_data)
+	local = {
+		0,
+	};
+
+	AST_LIST_LOCK(&reconnect_threads);
+	AST_LIST_TRAVERSE_SAFE_BEGIN(&reconnect_threads, cur, entry) {
+		if (cur->l == l) {
+			AST_LIST_REMOVE_CURRENT(entry);
+			AST_LIST_INSERT_TAIL(&local, cur, entry);
+		}
+	}
+	AST_LIST_TRAVERSE_SAFE_END;
+	AST_LIST_UNLOCK(&reconnect_threads);
+
+	while ((rd = AST_LIST_REMOVE_HEAD(&local, entry))) {
+		rpt_join_reconnect_data(rd);
+	}
+}
+
+/*!
+ * \brief Join all outstanding reconnect workers.
+ * \note Call before destroying any struct rpt locks or name used by workers.
+ */
+static void rpt_wait_reconnect_threads(void)
+{
+	struct rpt_reconnect_data *rd;
+
+	for (;;) {
+		AST_LIST_LOCK(&reconnect_threads);
+		rd = AST_LIST_REMOVE_HEAD(&reconnect_threads, entry);
+		AST_LIST_UNLOCK(&reconnect_threads);
+		if (!rd) {
+			break;
+		}
+		rpt_join_reconnect_data(rd);
+	}
+}
+
+/*!
+ * \brief Join reconnect workers that reference a specific repeater.
+ * \note Used when reloading/reusing a deleted rpt slot before destroying its locks.
+ */
+static void rpt_wait_reconnect_threads_for_rpt(struct rpt *myrpt)
+{
+	struct rpt_reconnect_data *rd;
+	struct rpt_reconnect_data *cur;
+	AST_LIST_HEAD_NOLOCK(, rpt_reconnect_data)
+	local = {
+		0,
+	};
+
+	AST_LIST_LOCK(&reconnect_threads);
+	AST_LIST_TRAVERSE_SAFE_BEGIN(&reconnect_threads, cur, entry) {
+		if (cur->myrpt == myrpt) {
+			AST_LIST_REMOVE_CURRENT(entry);
+			AST_LIST_INSERT_TAIL(&local, cur, entry);
+		}
+	}
+	AST_LIST_TRAVERSE_SAFE_END;
+	AST_LIST_UNLOCK(&reconnect_threads);
+
+	while ((rd = AST_LIST_REMOVE_HEAD(&local, entry))) {
+		rpt_join_reconnect_data(rd);
+	}
+}
 
 /*!
  * \brief Blocking DNS/dial for an outbound link reconnect.
- * \note Runs on a detached thread so process_link_channel can stay on waitfor.
+ * \note Runs on a joinable worker so process_link_channel can stay on waitfor.
  *       Do not autoservice pchan here — the link waitfor thread keeps reading it.
+ *       Caller tracks rd on reconnect_threads and joins/frees it; do not free rd here.
  */
 static void *attempt_reconnect(void *data)
 {
@@ -2612,17 +2707,15 @@ done:
 
 cleanup:
 	ao2_ref(l, -1);
-	ast_free(rd);
 	return NULL;
 }
 
 /*!
- * \brief Start a detached reconnect worker if one is not already running.
+ * \brief Start a joinable reconnect worker if one is not already running.
  * \retval 0 if worker started or already running, -1 if thread create failed
  */
 static int schedule_reconnect(struct rpt *myrpt, struct rpt_link *l)
 {
-	pthread_t tid;
 	struct rpt_reconnect_data *rd;
 
 	rpt_mutex_lock(&myrpt->lock);
@@ -2645,7 +2738,15 @@ static int schedule_reconnect(struct rpt *myrpt, struct rpt_link *l)
 	rd->l = l;
 	ao2_ref(l, +1);
 
-	if (ast_pthread_create_detached(&tid, NULL, attempt_reconnect, rd)) {
+	/*
+	 * Hold the list lock across create so a concurrent join either sees a
+	 * valid pthread_t or finds no entry (create failed and removed).
+	 */
+	AST_LIST_LOCK(&reconnect_threads);
+	AST_LIST_INSERT_TAIL(&reconnect_threads, rd, entry);
+	if (ast_pthread_create(&rd->thread, NULL, attempt_reconnect, rd)) {
+		AST_LIST_REMOVE(&reconnect_threads, rd, entry);
+		AST_LIST_UNLOCK(&reconnect_threads);
 		ast_log(LOG_WARNING, "Unable to start reconnect thread for %s\n", l->name);
 		rpt_mutex_lock(&myrpt->lock);
 		l->reconnecting = 0;
@@ -2655,6 +2756,7 @@ static int schedule_reconnect(struct rpt *myrpt, struct rpt_link *l)
 		ast_free(rd);
 		return -1;
 	}
+	AST_LIST_UNLOCK(&reconnect_threads);
 	return 0;
 }
 
@@ -3557,7 +3659,6 @@ static inline void periodic_process_link(struct rpt *myrpt, struct rpt_link *l, 
 		ast_str_set(&lstr, 0, "%s", "L ");
 		rpt_mutex_lock(&myrpt->lock);
 		__mklinklist(myrpt, l, &lstr, USE_FORMAT_RPT_LINK);
-		rpt_mutex_unlock(&myrpt->lock);
 		if (l->chan) {
 			struct ast_frame lf = {
 				.frametype = AST_FRAME_TEXT,
@@ -3566,9 +3667,11 @@ static inline void periodic_process_link(struct rpt *myrpt, struct rpt_link *l, 
 				.src = __PRETTY_FUNCTION__,
 			};
 
+			/* Hold myrpt->lock so textq insert stays synchronized with reconnect cleanup. */
 			rpt_qwrite(l, &lf);
 			ast_debug(7, "@@@@ node %s sent node string %s to node %s\n", myrpt->name, ast_str_buffer(lstr), l->name);
 		}
+		rpt_mutex_unlock(&myrpt->lock);
 		ast_free(lstr);
 	}
 	if (l->link_newkey == RADIO_KEY_ALLOWED_REDUNDANT) {
@@ -4993,16 +5096,19 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 	}
 	rpt_frame_queue_free(&l->frame_queue);
 
-	/* Ensure any detached reconnect worker has finished before we hang up. */
+	/* Ensure any reconnect worker has finished before we hang up / free link state. */
 	rpt_mutex_lock(&myrpt->lock);
 	l->killme = 1;
 	rpt_mutex_unlock(&myrpt->lock);
 	{
 		int waited_ms = 0;
+		int still_reconnecting = 0;
 
+		rpt_join_link_reconnect(l);
 		while (waited_ms < 30000) {
 			rpt_mutex_lock(&myrpt->lock);
-			if (!l->reconnecting) {
+			still_reconnecting = l->reconnecting;
+			if (!still_reconnecting) {
 				rpt_mutex_unlock(&myrpt->lock);
 				break;
 			}
@@ -5010,7 +5116,7 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 			usleep(10000);
 			waited_ms += 10;
 		}
-		if (l->reconnecting) {
+		if (still_reconnecting) {
 			ast_log(LOG_WARNING, "Timed out waiting for reconnect thread for node %s\n", l->name);
 		}
 	}
@@ -6132,6 +6238,8 @@ static int load_config(int reload)
 		 * when it's time to reuse the rpt_var, clean up any left over strings.
 		 */
 		if (reload && rpt_vars[n].deleted == RPT_DELETED_COMPLETE) {
+			/* Join workers that still reference this repeater before destroying locks/name. */
+			rpt_wait_reconnect_threads_for_rpt(&rpt_vars[n]);
 			ast_mutex_destroy(&rpt_vars[n].lock);
 			ast_mutex_destroy(&rpt_vars[n].remlock);
 			ast_mutex_destroy(&rpt_vars[n].statpost_lock);
@@ -8111,6 +8219,9 @@ static int unload_module(void)
 	ast_debug(1, "Waiting for master thread to exit\n");
 	pthread_join(rpt_master_thread, NULL); /* All pseudo channels need to be hung up before we can unload the Rpt() application */
 	ast_debug(1, "Master thread has now exited\n");
+
+	/* Join reconnect workers before destroying locks/name they may still reference. */
+	rpt_wait_reconnect_threads();
 
 	/* Destroy the locks subsequently, after repeater threads have exited. Otherwise they will still be in use. */
 	for (i = 0; i < nrpts; i++) {

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2726,6 +2726,9 @@ static int schedule_reconnect(struct rpt *myrpt, struct rpt_link *l)
 	l->reconnecting = 1;
 	rpt_mutex_unlock(&myrpt->lock);
 
+	/* Reap any finished worker for this link before starting another. */
+	rpt_join_link_reconnect(l);
+
 	rd = ast_calloc(1, sizeof(*rd));
 	if (!rd) {
 		rpt_mutex_lock(&myrpt->lock);
@@ -5100,26 +5103,7 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 	rpt_mutex_lock(&myrpt->lock);
 	l->killme = 1;
 	rpt_mutex_unlock(&myrpt->lock);
-	{
-		int waited_ms = 0;
-		int still_reconnecting = 0;
-
-		rpt_join_link_reconnect(l);
-		while (waited_ms < 30000) {
-			rpt_mutex_lock(&myrpt->lock);
-			still_reconnecting = l->reconnecting;
-			if (!still_reconnecting) {
-				rpt_mutex_unlock(&myrpt->lock);
-				break;
-			}
-			rpt_mutex_unlock(&myrpt->lock);
-			usleep(10000);
-			waited_ms += 10;
-		}
-		if (still_reconnecting) {
-			ast_log(LOG_WARNING, "Timed out waiting for reconnect thread for node %s\n", l->name);
-		}
-	}
+	rpt_join_link_reconnect(l);
 
 	/* hang-up on call to device */
 	hangup_link_chan(l);

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2500,19 +2500,31 @@ static char *parse_node_format(char *s, char **restrict s1, char *buf, size_t le
 	return s2;
 }
 
-static void *attempt_reconnect(struct rpt *myrpt, struct rpt_link *l)
+/*! \brief Detached reconnect worker context (takes ownership of link ref) */
+struct rpt_reconnect_data {
+	struct rpt *myrpt;
+	struct rpt_link *l;
+};
+
+/*!
+ * \brief Blocking DNS/dial for an outbound link reconnect.
+ * \note Runs on a detached thread so process_link_channel can stay on waitfor.
+ *       Do not autoservice pchan here — the link waitfor thread keeps reading it.
+ */
+static void *attempt_reconnect(void *data)
 {
+	struct rpt_reconnect_data *rd = data;
+	struct rpt *myrpt = rd->myrpt;
+	struct rpt_link *l = rd->l;
 	char *s1, *tele;
 	char tmp[300], deststr[325] = "";
 	char sx[320];
 	struct ast_frame *f1;
 	struct ast_format_cap *cap;
+	struct ast_channel *newchan = NULL;
 
-	ast_debug(1, "Attempting Reconnect");
-	/* rpt_make_call and node_lookup are blocking, long dns lookups result in exceptionally long queue warnings
-	 * autoservice handles "eating" the frames and eliminating the warning.
-	 */
-	ast_autoservice_start(l->pchan);
+	ast_debug(1, "Attempting Reconnect (async) to %s\n", l->name);
+
 	if (node_lookup(myrpt, l->name, tmp, sizeof(tmp), 1)) {
 		ast_log(LOG_WARNING, "attempt_reconnect: cannot find node %s\n", l->name);
 		goto retry;
@@ -2537,6 +2549,13 @@ static void *attempt_reconnect(struct rpt *myrpt, struct rpt_link *l)
 	tele = strchr(deststr, '/');
 	/* tele must be non-NULL here since deststr always contains at least 'IAX2/' */
 	*tele++ = 0;
+
+	rpt_mutex_lock(&myrpt->lock);
+	if (l->killme || l->chan || (l->disced != RPT_LINK_DISCONNECT_NONE)) {
+		rpt_mutex_unlock(&myrpt->lock);
+		ao2_ref(cap, -1);
+		goto done;
+	}
 	l->elaptime = 0;
 	l->connecttime = ast_tv(0, 0); /* not connected */
 	l->lastkeytime = 0;
@@ -2548,37 +2567,95 @@ static void *attempt_reconnect(struct rpt *myrpt, struct rpt_link *l)
 	l->rxlingertimer = RX_LINGER_TIME;
 	l->newkeytimer = NEWKEYTIME;
 	l->link_newkey = RADIO_KEY_NOT_ALLOWED;
-	l->chan = ast_request(deststr, cap, NULL, NULL, tele, NULL);
-	ao2_ref(cap, -1);
 	while ((f1 = AST_LIST_REMOVE_HEAD(&l->textq, frame_list))) {
 		ast_frfree(f1);
 	}
-	if (l->chan) {
-		if (rpt_make_call(l->chan, tele, 999, deststr, "Remote Rx", "attempt_reconnect", myrpt->name, l->name)) {
-			ast_log(LOG_WARNING, "Unable to place call to %s/%s\n", deststr, tele);
-			ast_hangup(l->chan);
-			rpt_mutex_lock(&myrpt->lock);
-			l->retrytimer = RETRY_TIMER_MS;
-			l->chan = NULL;
-			rpt_mutex_unlock(&myrpt->lock);
-			ast_autoservice_stop(l->pchan);
-			return NULL;
-		}
-	} else {
+	rpt_mutex_unlock(&myrpt->lock);
+
+	newchan = ast_request(deststr, cap, NULL, NULL, tele, NULL);
+	ao2_ref(cap, -1);
+	if (!newchan) {
 		ast_verb(3, "Unable to place call to %s/%s\n", deststr, tele);
 		goto retry;
 	}
+	if (rpt_make_call(newchan, tele, 999, deststr, "Remote Rx", "attempt_reconnect", myrpt->name, l->name)) {
+		ast_log(LOG_WARNING, "Unable to place call to %s/%s\n", deststr, tele);
+		ast_hangup(newchan);
+		goto retry;
+	}
 
-	ast_autoservice_stop(l->pchan);
+	rpt_mutex_lock(&myrpt->lock);
+	if (l->killme || l->chan || (l->disced != RPT_LINK_DISCONNECT_NONE)) {
+		rpt_mutex_unlock(&myrpt->lock);
+		ast_hangup(newchan);
+		goto done;
+	}
+	l->chan = newchan;
+	l->reconnecting = 0;
+	rpt_mutex_unlock(&myrpt->lock);
 	ast_log(LOG_NOTICE, "Reconnect Attempt to %s in progress\n", l->name);
-	return NULL;
+	goto cleanup;
 
 retry:
 	rpt_mutex_lock(&myrpt->lock);
-	l->retrytimer = RETRY_TIMER_MS;
+	if (!l->killme && (l->disced == RPT_LINK_DISCONNECT_NONE)) {
+		l->retrytimer = RETRY_TIMER_MS;
+	}
+	l->reconnecting = 0;
 	rpt_mutex_unlock(&myrpt->lock);
-	ast_autoservice_stop(l->pchan);
+	goto cleanup;
+
+done:
+	rpt_mutex_lock(&myrpt->lock);
+	l->reconnecting = 0;
+	rpt_mutex_unlock(&myrpt->lock);
+
+cleanup:
+	ao2_ref(l, -1);
+	ast_free(rd);
 	return NULL;
+}
+
+/*!
+ * \brief Start a detached reconnect worker if one is not already running.
+ * \retval 0 if worker started or already running, -1 if thread create failed
+ */
+static int schedule_reconnect(struct rpt *myrpt, struct rpt_link *l)
+{
+	pthread_t tid;
+	struct rpt_reconnect_data *rd;
+
+	rpt_mutex_lock(&myrpt->lock);
+	if (l->reconnecting || l->chan) {
+		rpt_mutex_unlock(&myrpt->lock);
+		return 0;
+	}
+	l->reconnecting = 1;
+	rpt_mutex_unlock(&myrpt->lock);
+
+	rd = ast_calloc(1, sizeof(*rd));
+	if (!rd) {
+		rpt_mutex_lock(&myrpt->lock);
+		l->reconnecting = 0;
+		l->retrytimer = RETRY_TIMER_MS;
+		rpt_mutex_unlock(&myrpt->lock);
+		return -1;
+	}
+	rd->myrpt = myrpt;
+	rd->l = l;
+	ao2_ref(l, +1);
+
+	if (ast_pthread_create_detached(&tid, NULL, attempt_reconnect, rd)) {
+		ast_log(LOG_WARNING, "Unable to start reconnect thread for %s\n", l->name);
+		rpt_mutex_lock(&myrpt->lock);
+		l->reconnecting = 0;
+		l->retrytimer = RETRY_TIMER_MS;
+		rpt_mutex_unlock(&myrpt->lock);
+		ao2_ref(l, -1);
+		ast_free(rd);
+		return -1;
+	}
+	return 0;
 }
 
 /* 0 return=continue, 1 return = break, -1 return = error */
@@ -3548,16 +3625,16 @@ static inline void periodic_process_link(struct rpt *myrpt, struct rpt_link *l, 
 			return;
 		}
 
-		if (!l->chan && !l->retrytimer && !max_retries && l->hasconnected) {
+		if (!l->chan && !l->retrytimer && !l->reconnecting && !max_retries && l->hasconnected) {
 			if ((l->name[0] > '0') && (l->name[0] <= '9') && (!l->isremote)) {
-				attempt_reconnect(myrpt, l);
+				schedule_reconnect(myrpt, l);
 			} else {
 				/* We should not retry this node type */
 				l->retries = l->max_retries + 1;
 			}
 			return;
 		}
-		if (!l->chan && !l->retrytimer && max_retries) {
+		if (!l->chan && !l->retrytimer && !l->reconnecting && max_retries) {
 			l->disced = RPT_LINK_DISCONNECT;
 			if (!strcmp(myrpt->cmdnode, l->name))
 				myrpt->cmdnode[0] = 0;
@@ -4915,6 +4992,28 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 		donodelog_fmt(myrpt, l->hasconnected ? "LINKDISC,%s" : "LINKFAIL,%s", l->name);
 	}
 	rpt_frame_queue_free(&l->frame_queue);
+
+	/* Ensure any detached reconnect worker has finished before we hang up. */
+	rpt_mutex_lock(&myrpt->lock);
+	l->killme = 1;
+	rpt_mutex_unlock(&myrpt->lock);
+	{
+		int waited_ms = 0;
+
+		while (waited_ms < 30000) {
+			rpt_mutex_lock(&myrpt->lock);
+			if (!l->reconnecting) {
+				rpt_mutex_unlock(&myrpt->lock);
+				break;
+			}
+			rpt_mutex_unlock(&myrpt->lock);
+			usleep(10000);
+			waited_ms += 10;
+		}
+		if (l->reconnecting) {
+			ast_log(LOG_WARNING, "Timed out waiting for reconnect thread for node %s\n", l->name);
+		}
+	}
 
 	/* hang-up on call to device */
 	hangup_link_chan(l);

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -588,6 +588,8 @@ struct rpt_link {
 	long elaptime;
 	int disctime;
 	int retrytimer;
+	/*! \brief Non-zero while a detached reconnect worker owns outbound dial for this link */
+	int reconnecting;
 	int retxtimer;
 	int rerxtimer;
 	int rxlingertimer;

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -588,7 +588,7 @@ struct rpt_link {
 	long elaptime;
 	int disctime;
 	int retrytimer;
-	/*! \brief Non-zero while a detached reconnect worker owns outbound dial for this link */
+	/*! \brief Non-zero while a joinable reconnect worker owns outbound dial for this link */
 	int reconnecting;
 	int retxtimer;
 	int rerxtimer;

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -392,8 +392,8 @@ void send_link_keyquery(struct rpt *myrpt)
 		return;
 	}
 
-	rpt_mutex_unlock(&myrpt->lock);
 	ao2_callback(myrpt->links, OBJ_MULTIPLE | OBJ_NODATA, link_qwrite_cb, &wf);
+	rpt_mutex_unlock(&myrpt->lock);
 }
 
 void rpt_link_add(struct ao2_container *links, struct rpt_link *l)

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -195,6 +195,11 @@ int altlink1(struct rpt *myrpt, struct rpt_link *mylink)
 	return 0;
 }
 
+/*!
+ * \brief Queue a TEXT frame onto a link for later write.
+ * \note Caller must hold myrpt->lock so inserts stay synchronized with
+ *       link_process_textq removal and reconnect worker textq cleanup.
+ */
 void rpt_qwrite(struct rpt_link *l, struct ast_frame *f)
 {
 	struct ast_frame *f1;

--- a/apps/app_rpt/rpt_link.h
+++ b/apps/app_rpt/rpt_link.h
@@ -27,6 +27,11 @@ void tele_link_remove(struct rpt *myrpt, struct rpt_tele *t);
 
 int altlink1(struct rpt *myrpt, struct rpt_link *mylink);
 
+/*!
+ * \brief Queue a TEXT frame onto a link for later write.
+ * \note Caller must hold the owning repeater's myrpt->lock so inserts stay
+ *       synchronized with link_process_textq removal and reconnect cleanup.
+ */
 void rpt_qwrite(struct rpt_link *l, struct ast_frame *f);
 
 int linkcount(struct rpt *myrpt);


### PR DESCRIPTION
## Summary
- Outbound reconnect (`node_lookup` DNS + `rpt_make_call`) no longer runs inline on `process_link_channel`
- A detached worker does the blocking work; the link waitfor thread keeps reading/tossing `l->pchan` (no autoservice needed on this path)
- `l->reconnecting` prevents duplicate workers and the max-retries teardown race; link exit waits for the worker and sets `killme` so dial aborts cleanly

Complements #1189 (hangup sleep removal). Together these are the hang-first alternative to parking `pchan` out of CONF (#1180, draft).

## Test plan
- [ ] Permanent outbound IAX link: yank peer / block network; confirm reconnect succeeds and audio returns
- [ ] During DNS/reconnect, no `Exceptionally long voice queue` on `Announcer/IAXLink` / `PChan` / `LocalTX` from that stall
- [ ] Key/unkey / link timers continue during reconnect (waitfor cadence intact)
- [ ] Tear down a link while reconnect is in flight (no crash / orphaned IAX channel)
- [ ] Non-IAX / echolink / tlb names still skip reconnect as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved outbound reconnection handling so link processing remains responsive during connection attempts.
  * Prevented duplicate reconnect attempts and improved cancellation, retry, and cleanup behavior.
  * Improved synchronization during reconnect activity and key-response transmission.
* **Reliability**
  * Ensured active reconnect operations are properly completed during link cleanup, repeater reloads, and module shutdown.
  * Improved deferred text-message queue handling during link operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->