### PR TITLE
app_rpt: do not send TXCTCSS to chan_simpleusb

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -5719,7 +5719,7 @@ static void *rpt(void *this)
 				if (myrpt->p.itxctcss) {
 					dahdi_radio_set_ctcss_encode(myrpt->localrxchannel, !x);
 				}
-			} else if (CHAN_TECH(myrpt->rxchannel, "radio") || CHAN_TECH(myrpt->rxchannel, "simpleusb")) {
+			} else if (CHAN_TECH(myrpt->rxchannel, "radio")) {
 				/* Disabled input-only mode always means CTCSS enabled. */
 				snprintf(str, sizeof(str), "TXCTCSS %d", !myrpt->p.itxctcss || !!x);
 				ast_sendtext(myrpt->rxchannel, str);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CTCSS control commands are now sent only for supported radio channels.
  * SimpleUSB channels no longer receive inappropriate CTCSS commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->