### PR TITLE
app_rpt: Clear linklist on disconnect

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4528,7 +4528,10 @@ static int remote_hangup_helper(struct rpt *myrpt, struct rpt_link *l)
 	 * This is done to prevent any stale links from being shared while the node
 	 * is attempting to reconnect (and is not "really" connected)
 	 */
-	ast_str_reset(l->linklist);
+	if (ast_str_len(l->linklist) > 0) {
+		ast_str_reset(l->linklist);
+		rpt_update_links(myrpt);
+	}
 
 	if (l->chan && !CHAN_TECH(l->chan, "echolink") && !CHAN_TECH(l->chan, "tlb")) {
 		/* If neither echolink nor tlb */

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4520,7 +4520,7 @@ static int remote_hangup_helper(struct rpt *myrpt, struct rpt_link *l)
 		 */
 		ast_autoservice_start(l->pchan);
 		link_process_textq(myrpt, l);
-		ast_safe_sleep(l->chan, MSWAIT * 10);  /* Allow the channel to send the text messages */
+		ast_safe_sleep(l->chan, MSWAIT * 10); /* Allow the channel to send the text messages */
 		ast_autoservice_stop(l->pchan);
 	}
 

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4529,7 +4529,9 @@ static int remote_hangup_helper(struct rpt *myrpt, struct rpt_link *l)
 	 * is attempting to reconnect (and is not "really" connected)
 	 */
 	if (ast_str_len(l->linklist) > 0) {
+		rpt_mutex_lock(&myrpt->lock);
 		ast_str_reset(l->linklist);
+		rpt_mutex_unlock(&myrpt->lock);
 		rpt_update_links(myrpt);
 	}
 

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4528,7 +4528,7 @@ static int remote_hangup_helper(struct rpt *myrpt, struct rpt_link *l)
 	 * This is done to prevent any stale links from being shared while the node
 	 * is attempting to reconnect (and is not "really" connected)
 	 */
-	if (ast_str_len(l->linklist) > 0) {
+	if (ast_str_strlen(l->linklist) > 0) {
 		rpt_mutex_lock(&myrpt->lock);
 		ast_str_reset(l->linklist);
 		rpt_mutex_unlock(&myrpt->lock);

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4524,6 +4524,12 @@ static int remote_hangup_helper(struct rpt *myrpt, struct rpt_link *l)
 		ast_autoservice_stop(l->pchan);
 	}
 
+	/* When the node is disconnected we need to clear the list of links.
+	 * This is done to prevent any stale links from being shared while the node
+	 * is attempting to reconnect (and is not "really" connected)
+	 */
+	ast_str_reset(l->linklist);
+
 	if (l->chan && !CHAN_TECH(l->chan, "echolink") && !CHAN_TECH(l->chan, "tlb")) {
 		/* If neither echolink nor tlb */
 		if (l->disced == RPT_LINK_DISCONNECT_NONE && !ast_shutting_down()) {


### PR DESCRIPTION
Fixes #1197 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when a link is disconnected by clearing stale link information before reconnection or cleanup actions are evaluated.
  * Helps ensure link state remains accurate after remote hangups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->