### PR TITLE
chan_voter: Now requires res_usbradio

### DIFF
--- a/channels/chan_voter.c
+++ b/channels/chan_voter.c
@@ -6531,4 +6531,5 @@ AST_MODULE_INFO(ASTERISK_GPL_KEY, AST_MODFLAG_DEFAULT, "Voter Radio Channel Driv
 	.load = load_module,
 	.unload = unload_module,
 	.reload = reload_module,
+	.requires = "res_usbradio",
 );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added the required radio resource dependency for the voter channel module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->