### PR TITLE
app_rpt: autoservice channels on startup and shutdown 

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -3002,6 +3002,31 @@ static void rpt_stop_channel_autoservice(struct rpt *myrpt)
 	}
 }
 
+static void rpt_start_channel_autoservice(struct rpt *myrpt)
+{
+	if (myrpt->rxchannel) {
+		ast_autoservice_start(myrpt->rxchannel);
+	}
+	if (myrpt->txchannel && myrpt->txchannel != myrpt->rxchannel) {
+		ast_autoservice_start(myrpt->txchannel);
+	}
+	if (myrpt->pchannel) {
+		ast_autoservice_start(myrpt->pchannel);
+	}
+	if (myrpt->localtxchannel && myrpt->localtxchannel != myrpt->txchannel) {
+		ast_autoservice_start(myrpt->localtxchannel);
+	}
+	if (myrpt->monchannel) {
+		ast_autoservice_start(myrpt->monchannel);
+	}
+	if (myrpt->rxpchannel) {
+		ast_autoservice_start(myrpt->rxpchannel);
+	}
+	if (myrpt->txpchannel) {
+		ast_autoservice_start(myrpt->txpchannel);
+	}
+}
+
 static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 {
 	int res = 0;
@@ -5915,6 +5940,7 @@ static void *rpt(void *this)
 	ast_debug(1, "%s disconnected, cleaning up...\n", myrpt->name);
 
 	myrpt->ready = 0;
+	rpt_start_channel_autoservice(myrpt);
 	usleep(100000);
 	while (myrpt->tele.next != &myrpt->tele) {
 		/* wait for telem to be done */
@@ -5928,6 +5954,7 @@ static void *rpt(void *this)
 	ao2_iterator_destroy(&l_it);
 	rpt_mutex_unlock(&myrpt->lock);
 
+	rpt_stop_channel_autoservice(myrpt);
 	rpt_hangup(myrpt, RPT_PCHAN);
 	if (myrpt->monchannel) {
 		rpt_hangup(myrpt, RPT_MONCHAN);

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2965,10 +2965,6 @@ static void _load_rpt_vars_by_rpt(struct rpt *myrpt, int force)
 }
 
 #define rpt_hangup_rx_tx(myrpt) \
-	ast_autoservice_stop(myrpt->rxchannel); \
-	if (myrpt->txchannel && myrpt->txchannel != myrpt->rxchannel) { \
-		ast_autoservice_stop(myrpt->txchannel); \
-	} \
 	rpt_hangup(myrpt, RPT_RXCHAN); \
 	if (myrpt->txchannel) { \
 		rpt_hangup(myrpt, RPT_TXCHAN); \

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2966,6 +2966,9 @@ static void _load_rpt_vars_by_rpt(struct rpt *myrpt, int force)
 
 #define rpt_hangup_rx_tx(myrpt) \
 	ast_autoservice_stop(myrpt->rxchannel); \
+	if (myrpt->txchannel && myrpt->txchannel != myrpt->rxchannel) { \
+		ast_autoservice_stop(myrpt->txchannel); \
+	} \
 	rpt_hangup(myrpt, RPT_RXCHAN); \
 	if (myrpt->txchannel) { \
 		rpt_hangup(myrpt, RPT_TXCHAN); \
@@ -2973,6 +2976,31 @@ static void _load_rpt_vars_by_rpt(struct rpt *myrpt, int force)
 
 #define IS_DAHDI_CHAN(c) (CHAN_TECH(c, "DAHDI"))
 #define IS_DAHDI_CHAN_NAME(s) (!strncasecmp(s, "DAHDI", 5))
+
+static void rpt_stop_channel_autoservice(struct rpt *myrpt)
+{
+	if (myrpt->rxchannel) {
+		ast_autoservice_stop(myrpt->rxchannel);
+	}
+	if (myrpt->txchannel && myrpt->txchannel != myrpt->rxchannel) {
+		ast_autoservice_stop(myrpt->txchannel);
+	}
+	if (myrpt->pchannel) {
+		ast_autoservice_stop(myrpt->pchannel);
+	}
+	if (myrpt->localtxchannel && myrpt->localtxchannel != myrpt->txchannel) {
+		ast_autoservice_stop(myrpt->localtxchannel);
+	}
+	if (myrpt->monchannel) {
+		ast_autoservice_stop(myrpt->monchannel);
+	}
+	if (myrpt->rxpchannel) {
+		ast_autoservice_stop(myrpt->rxpchannel);
+	}
+	if (myrpt->txpchannel) {
+		ast_autoservice_stop(myrpt->txpchannel);
+	}
+}
 
 static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 {
@@ -3002,9 +3030,12 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 	ast_autoservice_start(myrpt->rxchannel);
 	if (myrpt->txchanname) {
 		if (rpt_request(myrpt, cap, RPT_TXCHAN)) {
-			ast_autoservice_stop(myrpt->rxchannel);
+			rpt_stop_channel_autoservice(myrpt);
 			rpt_hangup(myrpt, RPT_RXCHAN);
 			return -1;
+		}
+		if (myrpt->txchannel != myrpt->rxchannel) {
+			ast_autoservice_start(myrpt->txchannel);
 		}
 	} else {
 		myrpt->txchannel = myrpt->rxchannel;
@@ -3013,9 +3044,11 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 	}
 
 	if (rpt_request_local(myrpt, cap, RPT_PCHAN, "PChan")) {
+		rpt_stop_channel_autoservice(myrpt);
 		rpt_hangup_rx_tx(myrpt);
 		return -1;
 	}
+	ast_autoservice_start(myrpt->pchannel);
 
 	if (IS_LOCAL_NAME(ast_channel_name(myrpt->txchannel))) {
 		/* IF we have a local channel setup in txchannel this is a hub
@@ -3025,6 +3058,7 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 		struct ast_unreal_pvt *p = ast_channel_tech_pvt(myrpt->txchannel);
 		if (!p || !p->chan) {
 			ast_log(LOG_WARNING, "Local channel %s missing endpoints\n", ast_channel_name(myrpt->txchannel));
+			rpt_stop_channel_autoservice(myrpt);
 			rpt_hangup_rx_tx(myrpt);
 			rpt_hangup(myrpt, RPT_PCHAN);
 			return -1;
@@ -3035,13 +3069,16 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 
 	if (!myrpt->localtxchannel) {
 		if (rpt_request_local(myrpt, cap, RPT_LOCALTXCHAN, "LocalTX")) { /* Listen only link */
+			rpt_stop_channel_autoservice(myrpt);
 			rpt_hangup_rx_tx(myrpt);
 			rpt_hangup(myrpt, RPT_PCHAN);
 			return -1;
 		}
+		ast_autoservice_start(myrpt->localtxchannel);
 	}
 
 	if (rpt_conf_add(myrpt->localtxchannel, myrpt, RPT_TXCONF)) {
+		rpt_stop_channel_autoservice(myrpt);
 		rpt_hangup_rx_tx(myrpt);
 		rpt_hangup(myrpt, RPT_PCHAN);
 		rpt_hangup(myrpt, RPT_LOCALTXCHAN);
@@ -3049,13 +3086,16 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 	}
 
 	if (rpt_request_local(myrpt, cap, RPT_MONCHAN, "MonChan")) {
+		rpt_stop_channel_autoservice(myrpt);
 		rpt_hangup_rx_tx(myrpt);
 		rpt_hangup(myrpt, RPT_PCHAN);
 		rpt_hangup(myrpt, RPT_LOCALTXCHAN);
 		return -1;
 	}
+	ast_autoservice_start(myrpt->monchannel);
 
 	if (rpt_request_local(myrpt, cap, RPT_RXPCHAN, "RXPChan")) {
+		rpt_stop_channel_autoservice(myrpt);
 		rpt_hangup_rx_tx(myrpt);
 		rpt_hangup(myrpt, RPT_PCHAN);
 		rpt_hangup(myrpt, RPT_MONCHAN);
@@ -3064,8 +3104,10 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 		}
 		return -1;
 	}
+	ast_autoservice_start(myrpt->rxpchannel);
 
 	if (rpt_conf_add(myrpt->pchannel, myrpt, RPT_CONF)) {
+		rpt_stop_channel_autoservice(myrpt);
 		rpt_hangup_rx_tx(myrpt);
 		rpt_hangup(myrpt, RPT_PCHAN);
 		rpt_hangup(myrpt, RPT_MONCHAN);
@@ -3077,6 +3119,7 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 	}
 
 	if (rpt_conf_add(myrpt->rxpchannel, myrpt, RPT_CONF)) {
+		rpt_stop_channel_autoservice(myrpt);
 		rpt_hangup_rx_tx(myrpt);
 		rpt_hangup(myrpt, RPT_PCHAN);
 		rpt_hangup(myrpt, RPT_MONCHAN);
@@ -3084,13 +3127,11 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 		if (myrpt->localtxchannel != myrpt->txchannel) {
 			rpt_hangup(myrpt, RPT_LOCALTXCHAN);
 		}
-
 		return -1;
 	}
 
-	/*! \todo Need to verify always setting MONCHAN to TXCONF is "ok" or how to deal at dialtime*/
-
 	if (rpt_conf_add(myrpt->monchannel, myrpt, RPT_TXCONF)) {
+		rpt_stop_channel_autoservice(myrpt);
 		rpt_hangup_rx_tx(myrpt);
 		rpt_hangup(myrpt, RPT_PCHAN);
 		rpt_hangup(myrpt, RPT_MONCHAN);
@@ -3102,6 +3143,7 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 	}
 
 	if (rpt_request_local(myrpt, cap, RPT_TXPCHAN, "TXPChan")) {
+		rpt_stop_channel_autoservice(myrpt);
 		rpt_hangup_rx_tx(myrpt);
 		rpt_hangup(myrpt, RPT_PCHAN);
 		rpt_hangup(myrpt, RPT_MONCHAN);
@@ -3111,7 +3153,10 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 		}
 		return -1;
 	}
+	ast_autoservice_start(myrpt->txpchannel);
+
 	if (rpt_conf_add(myrpt->txpchannel, myrpt, RPT_TXCONF)) {
+		rpt_stop_channel_autoservice(myrpt);
 		rpt_hangup_rx_tx(myrpt);
 		rpt_hangup(myrpt, RPT_PCHAN);
 		rpt_hangup(myrpt, RPT_MONCHAN);
@@ -5100,6 +5145,7 @@ static void *rpt(void *this)
 	if (myrpt->p.ioport && ((myrpt->iofd = openserial(myrpt, myrpt->p.ioport)) == -1)) {
 		ast_log(LOG_ERROR, "Unable to open %s\n", myrpt->p.ioport);
 		rpt_mutex_unlock(&myrpt->lock);
+		rpt_stop_channel_autoservice(myrpt);
 		rpt_hangup_rx_tx(myrpt);
 		rpt_hangup(myrpt, RPT_PCHAN);
 		rpt_hangup(myrpt, RPT_MONCHAN);
@@ -5115,6 +5161,7 @@ static void *rpt(void *this)
 		myrpt->macrobuf = ast_str_create(MAXMACRO);
 		if (!myrpt->macrobuf) {
 			rpt_mutex_unlock(&myrpt->lock);
+			rpt_stop_channel_autoservice(myrpt);
 			rpt_hangup_rx_tx(myrpt);
 			rpt_hangup(myrpt, RPT_PCHAN);
 			rpt_hangup(myrpt, RPT_MONCHAN);
@@ -5135,6 +5182,7 @@ static void *rpt(void *this)
 
 	if (!myrpt->links) {
 		rpt_mutex_unlock(&myrpt->lock);
+		rpt_stop_channel_autoservice(myrpt);
 		rpt_hangup_rx_tx(myrpt);
 		rpt_hangup(myrpt, RPT_PCHAN);
 		rpt_hangup(myrpt, RPT_MONCHAN);
@@ -5209,6 +5257,7 @@ static void *rpt(void *this)
 #ifdef NATIVE_DSP
 		if (!(myrpt->dsp = ast_dsp_new())) {
 			rpt_mutex_unlock(&myrpt->lock);
+			rpt_stop_channel_autoservice(myrpt);
 			rpt_hangup_rx_tx(myrpt);
 			rpt_hangup(myrpt, RPT_PCHAN);
 			rpt_hangup(myrpt, RPT_MONCHAN);
@@ -5262,7 +5311,7 @@ static void *rpt(void *this)
 	myrpt->ready = 1;
 
 	looptimestart = rpt_tvnow();
-	ast_autoservice_stop(myrpt->rxchannel);
+	rpt_stop_channel_autoservice(myrpt);
 	while (ms >= 0) {
 		struct ast_channel *who;
 		struct ast_channel *cs[8];

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -2977,32 +2977,7 @@ static void _load_rpt_vars_by_rpt(struct rpt *myrpt, int force)
 #define IS_DAHDI_CHAN(c) (CHAN_TECH(c, "DAHDI"))
 #define IS_DAHDI_CHAN_NAME(s) (!strncasecmp(s, "DAHDI", 5))
 
-static void rpt_stop_channel_autoservice(struct rpt *myrpt)
-{
-	if (myrpt->rxchannel) {
-		ast_autoservice_stop(myrpt->rxchannel);
-	}
-	if (myrpt->txchannel && myrpt->txchannel != myrpt->rxchannel) {
-		ast_autoservice_stop(myrpt->txchannel);
-	}
-	if (myrpt->pchannel) {
-		ast_autoservice_stop(myrpt->pchannel);
-	}
-	if (myrpt->localtxchannel && myrpt->localtxchannel != myrpt->txchannel) {
-		ast_autoservice_stop(myrpt->localtxchannel);
-	}
-	if (myrpt->monchannel) {
-		ast_autoservice_stop(myrpt->monchannel);
-	}
-	if (myrpt->rxpchannel) {
-		ast_autoservice_stop(myrpt->rxpchannel);
-	}
-	if (myrpt->txpchannel) {
-		ast_autoservice_stop(myrpt->txpchannel);
-	}
-}
-
-static void rpt_start_channel_autoservice(struct rpt *myrpt)
+static void rpt_autoservice_start(struct rpt *myrpt)
 {
 	if (myrpt->rxchannel) {
 		ast_autoservice_start(myrpt->rxchannel);
@@ -3024,6 +2999,31 @@ static void rpt_start_channel_autoservice(struct rpt *myrpt)
 	}
 	if (myrpt->txpchannel) {
 		ast_autoservice_start(myrpt->txpchannel);
+	}
+}
+
+static void rpt_autoservice_stop(struct rpt *myrpt)
+{
+	if (myrpt->rxchannel) {
+		ast_autoservice_stop(myrpt->rxchannel);
+	}
+	if (myrpt->txchannel && myrpt->txchannel != myrpt->rxchannel) {
+		ast_autoservice_stop(myrpt->txchannel);
+	}
+	if (myrpt->pchannel) {
+		ast_autoservice_stop(myrpt->pchannel);
+	}
+	if (myrpt->localtxchannel && myrpt->localtxchannel != myrpt->txchannel) {
+		ast_autoservice_stop(myrpt->localtxchannel);
+	}
+	if (myrpt->monchannel) {
+		ast_autoservice_stop(myrpt->monchannel);
+	}
+	if (myrpt->rxpchannel) {
+		ast_autoservice_stop(myrpt->rxpchannel);
+	}
+	if (myrpt->txpchannel) {
+		ast_autoservice_stop(myrpt->txpchannel);
 	}
 }
 
@@ -3055,7 +3055,7 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 	ast_autoservice_start(myrpt->rxchannel);
 	if (myrpt->txchanname) {
 		if (rpt_request(myrpt, cap, RPT_TXCHAN)) {
-			rpt_stop_channel_autoservice(myrpt);
+			rpt_autoservice_stop(myrpt);
 			rpt_hangup(myrpt, RPT_RXCHAN);
 			return -1;
 		}
@@ -3069,7 +3069,7 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 	}
 
 	if (rpt_request_local(myrpt, cap, RPT_PCHAN, "PChan")) {
-		rpt_stop_channel_autoservice(myrpt);
+		rpt_autoservice_stop(myrpt);
 		rpt_hangup_rx_tx(myrpt);
 		return -1;
 	}
@@ -3083,7 +3083,7 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 		struct ast_unreal_pvt *p = ast_channel_tech_pvt(myrpt->txchannel);
 		if (!p || !p->chan) {
 			ast_log(LOG_WARNING, "Local channel %s missing endpoints\n", ast_channel_name(myrpt->txchannel));
-			rpt_stop_channel_autoservice(myrpt);
+			rpt_autoservice_stop(myrpt);
 			rpt_hangup_rx_tx(myrpt);
 			rpt_hangup(myrpt, RPT_PCHAN);
 			return -1;
@@ -3094,7 +3094,7 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 
 	if (!myrpt->localtxchannel) {
 		if (rpt_request_local(myrpt, cap, RPT_LOCALTXCHAN, "LocalTX")) { /* Listen only link */
-			rpt_stop_channel_autoservice(myrpt);
+			rpt_autoservice_stop(myrpt);
 			rpt_hangup_rx_tx(myrpt);
 			rpt_hangup(myrpt, RPT_PCHAN);
 			return -1;
@@ -3103,7 +3103,7 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 	}
 
 	if (rpt_conf_add(myrpt->localtxchannel, myrpt, RPT_TXCONF)) {
-		rpt_stop_channel_autoservice(myrpt);
+		rpt_autoservice_stop(myrpt);
 		rpt_hangup_rx_tx(myrpt);
 		rpt_hangup(myrpt, RPT_PCHAN);
 		rpt_hangup(myrpt, RPT_LOCALTXCHAN);
@@ -3111,7 +3111,7 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 	}
 
 	if (rpt_request_local(myrpt, cap, RPT_MONCHAN, "MonChan")) {
-		rpt_stop_channel_autoservice(myrpt);
+		rpt_autoservice_stop(myrpt);
 		rpt_hangup_rx_tx(myrpt);
 		rpt_hangup(myrpt, RPT_PCHAN);
 		rpt_hangup(myrpt, RPT_LOCALTXCHAN);
@@ -3120,7 +3120,7 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 	ast_autoservice_start(myrpt->monchannel);
 
 	if (rpt_request_local(myrpt, cap, RPT_RXPCHAN, "RXPChan")) {
-		rpt_stop_channel_autoservice(myrpt);
+		rpt_autoservice_stop(myrpt);
 		rpt_hangup_rx_tx(myrpt);
 		rpt_hangup(myrpt, RPT_PCHAN);
 		rpt_hangup(myrpt, RPT_MONCHAN);
@@ -3132,7 +3132,7 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 	ast_autoservice_start(myrpt->rxpchannel);
 
 	if (rpt_conf_add(myrpt->pchannel, myrpt, RPT_CONF)) {
-		rpt_stop_channel_autoservice(myrpt);
+		rpt_autoservice_stop(myrpt);
 		rpt_hangup_rx_tx(myrpt);
 		rpt_hangup(myrpt, RPT_PCHAN);
 		rpt_hangup(myrpt, RPT_MONCHAN);
@@ -3144,7 +3144,7 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 	}
 
 	if (rpt_conf_add(myrpt->rxpchannel, myrpt, RPT_CONF)) {
-		rpt_stop_channel_autoservice(myrpt);
+		rpt_autoservice_stop(myrpt);
 		rpt_hangup_rx_tx(myrpt);
 		rpt_hangup(myrpt, RPT_PCHAN);
 		rpt_hangup(myrpt, RPT_MONCHAN);
@@ -3156,7 +3156,7 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 	}
 
 	if (rpt_conf_add(myrpt->monchannel, myrpt, RPT_TXCONF)) {
-		rpt_stop_channel_autoservice(myrpt);
+		rpt_autoservice_stop(myrpt);
 		rpt_hangup_rx_tx(myrpt);
 		rpt_hangup(myrpt, RPT_PCHAN);
 		rpt_hangup(myrpt, RPT_MONCHAN);
@@ -3168,7 +3168,7 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 	}
 
 	if (rpt_request_local(myrpt, cap, RPT_TXPCHAN, "TXPChan")) {
-		rpt_stop_channel_autoservice(myrpt);
+		rpt_autoservice_stop(myrpt);
 		rpt_hangup_rx_tx(myrpt);
 		rpt_hangup(myrpt, RPT_PCHAN);
 		rpt_hangup(myrpt, RPT_MONCHAN);
@@ -3181,7 +3181,7 @@ static int rpt_setup_channels(struct rpt *myrpt, struct ast_format_cap *cap)
 	ast_autoservice_start(myrpt->txpchannel);
 
 	if (rpt_conf_add(myrpt->txpchannel, myrpt, RPT_TXCONF)) {
-		rpt_stop_channel_autoservice(myrpt);
+		rpt_autoservice_stop(myrpt);
 		rpt_hangup_rx_tx(myrpt);
 		rpt_hangup(myrpt, RPT_PCHAN);
 		rpt_hangup(myrpt, RPT_MONCHAN);
@@ -5170,7 +5170,7 @@ static void *rpt(void *this)
 	if (myrpt->p.ioport && ((myrpt->iofd = openserial(myrpt, myrpt->p.ioport)) == -1)) {
 		ast_log(LOG_ERROR, "Unable to open %s\n", myrpt->p.ioport);
 		rpt_mutex_unlock(&myrpt->lock);
-		rpt_stop_channel_autoservice(myrpt);
+		rpt_autoservice_stop(myrpt);
 		rpt_hangup_rx_tx(myrpt);
 		rpt_hangup(myrpt, RPT_PCHAN);
 		rpt_hangup(myrpt, RPT_MONCHAN);
@@ -5186,7 +5186,7 @@ static void *rpt(void *this)
 		myrpt->macrobuf = ast_str_create(MAXMACRO);
 		if (!myrpt->macrobuf) {
 			rpt_mutex_unlock(&myrpt->lock);
-			rpt_stop_channel_autoservice(myrpt);
+			rpt_autoservice_stop(myrpt);
 			rpt_hangup_rx_tx(myrpt);
 			rpt_hangup(myrpt, RPT_PCHAN);
 			rpt_hangup(myrpt, RPT_MONCHAN);
@@ -5207,7 +5207,7 @@ static void *rpt(void *this)
 
 	if (!myrpt->links) {
 		rpt_mutex_unlock(&myrpt->lock);
-		rpt_stop_channel_autoservice(myrpt);
+		rpt_autoservice_stop(myrpt);
 		rpt_hangup_rx_tx(myrpt);
 		rpt_hangup(myrpt, RPT_PCHAN);
 		rpt_hangup(myrpt, RPT_MONCHAN);
@@ -5282,7 +5282,7 @@ static void *rpt(void *this)
 #ifdef NATIVE_DSP
 		if (!(myrpt->dsp = ast_dsp_new())) {
 			rpt_mutex_unlock(&myrpt->lock);
-			rpt_stop_channel_autoservice(myrpt);
+			rpt_autoservice_stop(myrpt);
 			rpt_hangup_rx_tx(myrpt);
 			rpt_hangup(myrpt, RPT_PCHAN);
 			rpt_hangup(myrpt, RPT_MONCHAN);
@@ -5336,7 +5336,7 @@ static void *rpt(void *this)
 	myrpt->ready = 1;
 
 	looptimestart = rpt_tvnow();
-	rpt_stop_channel_autoservice(myrpt);
+	rpt_autoservice_stop(myrpt);
 	while (ms >= 0) {
 		struct ast_channel *who;
 		struct ast_channel *cs[8];
@@ -5940,7 +5940,7 @@ static void *rpt(void *this)
 	ast_debug(1, "%s disconnected, cleaning up...\n", myrpt->name);
 
 	myrpt->ready = 0;
-	rpt_start_channel_autoservice(myrpt);
+	rpt_autoservice_start(myrpt);
 	usleep(100000);
 	while (myrpt->tele.next != &myrpt->tele) {
 		/* wait for telem to be done */
@@ -5954,7 +5954,7 @@ static void *rpt(void *this)
 	ao2_iterator_destroy(&l_it);
 	rpt_mutex_unlock(&myrpt->lock);
 
-	rpt_stop_channel_autoservice(myrpt);
+	rpt_autoservice_stop(myrpt);
 	rpt_hangup(myrpt, RPT_PCHAN);
 	if (myrpt->monchannel) {
 		rpt_hangup(myrpt, RPT_MONCHAN);


### PR DESCRIPTION
Address areas where channels are on conferences but not being processed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved repeater channel startup and shutdown reliability.
  - Ensured channels are consistently stopped and cleaned up when setup or initialization encounters an error.
  - Improved recovery during repeater shutdown to prevent channels from remaining active unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->