### PR TITLE
app_rpt: Address thread creation failure leaks

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -1527,7 +1527,7 @@ void *rpt_call(void *this)
 	patch_thread_data->myrpt = myrpt;
 	patch_thread_data->mychannel = mychannel;
 	res = ast_pthread_create(&threadid, NULL, rpt_pbx_autopatch_run, patch_thread_data);
-	if (res < 0) {
+	if (res) {
 		ast_log(LOG_ERROR, "Unable to start PBX!\n");
 		ast_free(patch_thread_data);
 		goto cleanup;

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -3935,7 +3935,7 @@ void rpt_telemetry(struct rpt *myrpt, enum rpt_tele_mode mode, void *data)
 	rpt_mutex_unlock(&myrpt->lock);
 	res = ast_pthread_create_detached(&tele->threadid, NULL, rpt_tele_thread, (void *) tele);
 
-	if (res < 0) {
+	if (res) {
 		rpt_mutex_lock(&myrpt->lock);
 		tele_link_remove(myrpt, tele); /* We don't like stuck transmitters, remove it from the queue */
 		rpt_mutex_unlock(&myrpt->lock);


### PR DESCRIPTION
Non 0 is considered a failure.  Any >0 failures were not handled.