### PR TITLE
app_rpt: treat an empty "L " linklist update as clearing the stored list

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -1942,7 +1942,7 @@ static void handle_link_data(struct rpt *myrpt, struct rpt_link *mylink, char *s
 		return;
 	}
 	if (*str == 'L') {
-		if (strlen(str) < 3) {
+		if (strlen(str) < 2) {
 			return;
 		}
 		rpt_mutex_lock(&myrpt->lock);

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -600,7 +600,6 @@ struct rpt_link {
 	struct ast_channel *pchan;
 	struct ast_audiohook altaudio;
 	struct ast_str *linklist;
-	time_t linklistreceived;
 	int linklisttimer;
 	int linkunkeytocttimer;
 	struct timeval lastlinktv;


### PR DESCRIPTION
Fixes #1209.

Two commits, separable if you want only one:

1. **`strlen(str) < 3` becomes `< 2` in `handle_link_data()`.** The sender always
   transmits `"L "` plus the list, so a peer with no other links sends exactly the two
   character payload `"L "`. The old guard discarded it, so the last non-empty list a
   permanent link ever sent was kept forever, and non-adjacent nodes showed phantom
   connections in `RPT_LINKS` and `rpt xnode` indefinitely. At length 2, `str + 2`
   points at the NUL terminator and `ast_str_set()` stores the empty list, which is
   what the sender meant. A length 1 payload is still rejected.

2. **Remove the unused `linklistreceived` member** from `struct rpt_link`, as
   requested in the issue discussion. It is declared and never read or written
   anywhere in the tree.

Testing: master is currently the same tree as tag 3.10.4, which is where the A/B in
#1209 ran. Built stock and patched `app_rpt.so` from one tree, swapped them through
the same four radioless lab nodes with module identity checked each arm. Patched: a
non-adjacent node drops the stale entry within ~20s of the transient node detaching,
still clean at t+240s. Stock: the entry is still there at t+240s, and swapping stock
back in brings the ghost back. The member removal in commit 2 was compile-verified
against the same asterisk 22.10.1 overlay build.

Happy to adjust either commit or run any further lab test you want.

73, Ozy **K6OZY**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Link-list messages with the minimum valid length are now accepted correctly.
  * Removed obsolete link-list timestamp data from the application’s link information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->