### PR TITLE
app_rpt: Don't put outbound link pchan on conference until channel is up

### DIFF
--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -718,7 +718,7 @@ static int rpt_wait_for_link_up(struct ast_channel *chan, int timeout_ms)
 		if (ast_channel_state(chan) == AST_STATE_UP) {
 			return 0;
 		}
-		if (ast_waitfor(chan, poll_ms) == chan) {
+		if (ast_waitfor(chan, poll_ms) > 0) {
 			f = ast_read(chan);
 			if (!f) {
 				return -1;

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -701,7 +701,8 @@ void rpt_update_links(struct rpt *myrpt)
  * \brief Wait for an outbound link channel to reach AST_STATE_UP.
  *
  * Outbound Echolink and TLB calls return from ast_call while still ringing;
- * the remote answer arrives asynchronously via channel read processing.
+ * the remote answer arrives asynchronously via AST_CONTROL_ANSWER.  That
+ * frame is re-queued so process_link_channel() can perform link setup.
  *
  * \return 0 if the channel is up, -1 on hangup or timeout.
  */
@@ -710,6 +711,11 @@ static int rpt_wait_for_link_up(struct ast_channel *chan, int timeout_ms)
 	int elapsed = 0;
 	const int poll_ms = 50;
 	struct ast_frame *f;
+	struct ast_frame answer = {
+		.frametype = AST_FRAME_CONTROL,
+		.subclass.integer = AST_CONTROL_ANSWER,
+		.src = __PRETTY_FUNCTION__,
+	};
 
 	while (elapsed < timeout_ms) {
 		if (ast_check_hangup(chan)) {
@@ -721,6 +727,15 @@ static int rpt_wait_for_link_up(struct ast_channel *chan, int timeout_ms)
 		if (ast_waitfor(chan, poll_ms) > 0) {
 			f = ast_read(chan);
 			if (!f) {
+				return -1;
+			}
+			if (f->frametype == AST_FRAME_CONTROL && f->subclass.integer == AST_CONTROL_ANSWER) {
+				ast_frfree(f);
+				ast_queue_frame(chan, &answer);
+				return 0;
+			}
+			if (f->frametype == AST_FRAME_CONTROL && f->subclass.integer == AST_CONTROL_HANGUP) {
+				ast_frfree(f);
 				return -1;
 			}
 			ast_frfree(f);

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -697,6 +697,43 @@ void rpt_update_links(struct rpt *myrpt)
 	ast_free(obuf);
 }
 
+/*!
+ * \brief Wait for an outbound link channel to reach AST_STATE_UP.
+ *
+ * Outbound Echolink and TLB calls return from ast_call while still ringing;
+ * the remote answer arrives asynchronously via channel read processing.
+ *
+ * \return 0 if the channel is up, -1 on hangup or timeout.
+ */
+static int rpt_wait_for_link_up(struct ast_channel *chan, int timeout_ms)
+{
+	int elapsed = 0;
+	const int poll_ms = 50;
+	struct ast_frame *f;
+
+	while (elapsed < timeout_ms) {
+		if (ast_check_hangup(chan)) {
+			return -1;
+		}
+		if (ast_channel_state(chan) == AST_STATE_UP) {
+			return 0;
+		}
+		if (ast_waitfor(chan, poll_ms) == chan) {
+			f = ast_read(chan);
+			if (!f) {
+				return -1;
+			}
+			ast_frfree(f);
+			if (ast_channel_state(chan) == AST_STATE_UP) {
+				return 0;
+			}
+		}
+		elapsed += poll_ms;
+	}
+
+	return ast_channel_state(chan) == AST_STATE_UP ? 0 : -1;
+}
+
 void *rpt_link_connect(void *data)
 {
 	char *s, *s1, *tele, *cp;
@@ -902,8 +939,8 @@ void *rpt_link_connect(void *data)
 	ao2_ref(cap, -1);
 
 	if (ast_channel_state(l->chan) != AST_STATE_UP) {
-		if (ast_answer(l->chan) < 0) {
-			ast_log(LOG_WARNING, "Cannot answer channel %s\n", ast_channel_name(l->chan));
+		if (rpt_wait_for_link_up(l->chan, MAXCONNECTTIME) < 0) {
+			ast_log(LOG_WARNING, "Link channel %s not up after dial\n", ast_channel_name(l->chan));
 			rpt_telem_select(myrpt, connect_data->command_source, connect_data->mylink);
 			rpt_telemetry(myrpt, CONNFAIL, NULL);
 			ast_hangup(l->pchan);
@@ -921,15 +958,6 @@ void *rpt_link_connect(void *data)
 				ao2_ref(l, -1);
 				goto cleanup;
 			}
-		}
-		if (ast_channel_state(l->chan) != AST_STATE_UP) {
-			ast_log(LOG_WARNING, "Link channel %s not up after dial\n", ast_channel_name(l->chan));
-			rpt_telem_select(myrpt, connect_data->command_source, connect_data->mylink);
-			rpt_telemetry(myrpt, CONNFAIL, NULL);
-			ast_hangup(l->pchan);
-			ast_hangup(l->chan);
-			ao2_ref(l, -1);
-			goto cleanup;
 		}
 	}
 

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -901,6 +901,38 @@ void *rpt_link_connect(void *data)
 
 	ao2_ref(cap, -1);
 
+	if (ast_channel_state(l->chan) != AST_STATE_UP) {
+		if (ast_answer(l->chan) < 0) {
+			ast_log(LOG_WARNING, "Cannot answer channel %s\n", ast_channel_name(l->chan));
+			rpt_telem_select(myrpt, connect_data->command_source, connect_data->mylink);
+			rpt_telemetry(myrpt, CONNFAIL, NULL);
+			ast_hangup(l->pchan);
+			ast_hangup(l->chan);
+			ao2_ref(l, -1);
+			goto cleanup;
+		}
+		if (l->name[0] > '9') {
+			if (ast_safe_sleep(l->chan, 500) == -1) {
+				ast_debug(3, "Channel %s hung up\n", ast_channel_name(l->chan));
+				rpt_telem_select(myrpt, connect_data->command_source, connect_data->mylink);
+				rpt_telemetry(myrpt, CONNFAIL, NULL);
+				ast_hangup(l->pchan);
+				ast_hangup(l->chan);
+				ao2_ref(l, -1);
+				goto cleanup;
+			}
+		}
+		if (ast_channel_state(l->chan) != AST_STATE_UP) {
+			ast_log(LOG_WARNING, "Link channel %s not up after dial\n", ast_channel_name(l->chan));
+			rpt_telem_select(myrpt, connect_data->command_source, connect_data->mylink);
+			rpt_telemetry(myrpt, CONNFAIL, NULL);
+			ast_hangup(l->pchan);
+			ast_hangup(l->chan);
+			ao2_ref(l, -1);
+			goto cleanup;
+		}
+	}
+
 	if (rpt_conf_add(l->pchan, myrpt, RPT_CONF)) {
 		rpt_telem_select(myrpt, connect_data->command_source, connect_data->mylink);
 		rpt_telemetry(myrpt, CONNFAIL, NULL);


### PR DESCRIPTION
## Summary
- Extend the #1196 inbound link fix to outbound `rpt_link_connect()` so hub-initiated IAX links do not add `pchan` to the TX conference until the link channel is `AST_STATE_UP`.
- Mirror inbound behavior: answer if needed, optional 500 ms settle for non-numeric node names, then fail with CONNFAIL if the channel still is not up.
- Addresses the asymmetric link-setup path suspected in [forum reports of intermittent congestion/reorder tones](https://community.allstarlink.org/t/unwanted-reorder-or-fast-busy-tone/24944) when a voter hub links out to a SimpleUSB node (`ilink` / `linktolink`).

## Test plan
- [ ] Build/install package with this branch on a test node
- [ ] Hub-initiated link: `rpt cmd <hub> ilink 3 <remote>` — confirm link comes up cleanly and audio is normal
- [ ] Repeat several connect/disconnect cycles; verify no stuck 480/620 Hz congestion tone on the linked pair
- [ ] Confirm inbound links (remote initiates) still work as before (#1196 path unchanged)
- [ ] Echolink/non-numeric outbound link names: verify 500 ms settle path does not regress connect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link connection reliability by verifying the channel is active before continuing.
  * Added recovery handling for channels that are not immediately ready.
  * Connections that remain unavailable now fail cleanly with appropriate reporting and teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->