### PR TITLE
app_rpt.c: Cleanup bridges on shutdown

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -6017,6 +6017,19 @@ static void *rpt(void *this)
 
 	ao2_cleanup(myrpt->links);
 	myrpt->links = NULL;
+
+	if (myrpt->rptconf.conf) {
+		ast_bridge_destroy(myrpt->rptconf.conf, 0);
+		ao2_cleanup(myrpt->rptconf.conf);
+		myrpt->rptconf.conf = NULL;
+	}
+
+	if (myrpt->rptconf.txconf) {
+		ast_bridge_destroy(myrpt->rptconf.txconf, 0);
+		ao2_cleanup(myrpt->rptconf.txconf);
+		myrpt->rptconf.txconf = NULL;
+	}
+
 	rpt_mutex_unlock(&myrpt->lock);
 
 	ast_debug(1, "%s thread now exiting...\n", myrpt->name);

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -6018,15 +6018,8 @@ static void *rpt(void *this)
 	ao2_cleanup(myrpt->links);
 	myrpt->links = NULL;
 
-	if (myrpt->rptconf.conf) {
-		ast_bridge_destroy(myrpt->rptconf.conf, 0);
-		myrpt->rptconf.conf = NULL;
-	}
-
-	if (myrpt->rptconf.txconf) {
-		ast_bridge_destroy(myrpt->rptconf.txconf, 0);
-		myrpt->rptconf.txconf = NULL;
-	}
+	rpt_conf_destroy(myrpt, RPT_CONF);
+	rpt_conf_destroy(myrpt, RPT_TXCONF);
 
 	rpt_mutex_unlock(&myrpt->lock);
 

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -6020,13 +6020,11 @@ static void *rpt(void *this)
 
 	if (myrpt->rptconf.conf) {
 		ast_bridge_destroy(myrpt->rptconf.conf, 0);
-		ao2_cleanup(myrpt->rptconf.conf);
 		myrpt->rptconf.conf = NULL;
 	}
 
 	if (myrpt->rptconf.txconf) {
 		ast_bridge_destroy(myrpt->rptconf.txconf, 0);
-		ao2_cleanup(myrpt->rptconf.txconf);
 		myrpt->rptconf.txconf = NULL;
 	}
 

--- a/apps/app_rpt/rpt_bridging.c
+++ b/apps/app_rpt/rpt_bridging.c
@@ -349,6 +349,27 @@ int __rpt_request_local(void *data, struct ast_format_cap *cap, enum rpt_chan_ty
 	return 0;
 }
 
+void __rpt_conf_destroy(struct rpt *myrpt, enum rpt_conf_type type, const char *file, int line)
+{
+	switch (type) {
+	case RPT_CONF:
+		if (myrpt->rptconf.conf) {
+			ast_bridge_destroy(myrpt->rptconf.conf, 0);
+			myrpt->rptconf.conf = NULL;
+		}
+		break;
+	case RPT_TXCONF:
+		if (myrpt->rptconf.txconf) {
+			ast_bridge_destroy(myrpt->rptconf.txconf, 0);
+			myrpt->rptconf.txconf = NULL;
+		}
+		break;
+	default:
+		__builtin_unreachable();
+		break;
+	}
+}
+
 int __rpt_conf_create(struct rpt *myrpt, enum rpt_conf_type type, const char *file, int line)
 {
 	struct ast_bridge *conf = NULL, **confptr;

--- a/apps/app_rpt/rpt_bridging.h
+++ b/apps/app_rpt/rpt_bridging.h
@@ -71,9 +71,19 @@ int __rpt_request_local(void *data, struct ast_format_cap *cap, enum rpt_chan_ty
 
 #define rpt_request_local(data, cap, chantype, exten) __rpt_request_local(data, cap, chantype, 0, exten)
 
+void __rpt_conf_destroy(struct rpt *myrpt, enum rpt_conf_type type, const char *file, int line);
+
 int __rpt_conf_create(struct rpt *myrpt, enum rpt_conf_type type, const char *file, int line);
 
 int __rpt_conf_add(struct ast_channel *chan, struct rpt *myrpt, enum rpt_conf_type type, const char *file, int line);
+
+/*!
+ * \brief Destroy a conference
+ * \param myrpt Repeater structure
+ * \param type Conference type
+ * \note myrpt->lock must be held when calling
+ */
+#define rpt_conf_destroy(myrpt, type) __rpt_conf_destroy(myrpt, type, __FILE__, __LINE__)
 
 /*!
  * \brief Create a conference for repeater channels to join


### PR DESCRIPTION
Need to release the bridges on shutdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repeater shutdown by properly releasing conference bridge resources.
  * Cleared bridge references after shutdown to help prevent stale connections and resource leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->