### PR TITLE
app_rpt: Check bridge state and hangup if no longer bridged.

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4673,6 +4673,8 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 	looptimestart = rpt_tvnow();
 
 	while (ms >= 0 && l->disced == RPT_LINK_DISCONNECT_NONE) {
+		struct ast_unreal_pvt *p;
+
 		ms = MSWAIT;
 		n = 0;
 		cs[n++] = l->pchan;
@@ -4682,7 +4684,12 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 		who = ast_waitfor_n(cs, n, &ms);
 
 		/* Make sure the pchannel is still bridged */
-		if (!ast_channel_is_bridged(l->pchan)) {
+		p = ast_channel_tech_pvt(l->pchan);
+		if (!p || !p->chan) {
+			break;
+		}
+
+		if (!ast_channel_is_bridged(p->chan)) {
 			ast_debug(1, "Link %s pchan %s is no longer bridged, exiting link processing\n", l->name, ast_channel_name(l->pchan));
 			break;
 		}

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4472,8 +4472,11 @@ static int rpt_channel_is_bridged(struct ast_channel *chan)
 		return 0;
 	}
 
-	if (!ast_channel_tech(chan)->type || strcmp(ast_channel_tech(chan)->type, "Local")) {
+	if (!ast_channel_tech(chan)->type || (strcmp(ast_channel_tech(chan)->type, "Local") && strcmp(ast_channel_tech(chan)->type, "Announcer") &&
+											 strcmp(ast_channel_tech(chan)->type, "Recorder"))) {
 		/* Channel is not a Local (unreal) channel */
+		ast_debug(1, "rpt_channel_is_bridged: Channel %s is not a Local channel: type %s\n", ast_channel_name(chan),
+			ast_channel_tech(chan)->type);
 		return 0;
 	}
 
@@ -5131,7 +5134,7 @@ static inline int rxpchannel_read(struct rpt *myrpt)
 	}
 
 	if (!rpt_channel_is_bridged(myrpt->rxpchannel)) {
-		ast_debug(1, "%s rxpchan %s is no longer bridged, exiting repeater processing\n", myrpt->name, ast_channel_name(myrpt->pchannel));
+		ast_debug(1, "%s rxpchan %s is no longer bridged, exiting repeater processing\n", myrpt->name, ast_channel_name(myrpt->rxpchannel));
 		ast_frfree(f);
 		return -1;
 	}
@@ -5157,7 +5160,7 @@ static inline int txpchannel_read(struct rpt *myrpt)
 	}
 
 	if (!rpt_channel_is_bridged(myrpt->txpchannel)) {
-		ast_debug(1, "%s txpchan %s is no longer bridged, exiting repeater processing\n", myrpt->name, ast_channel_name(myrpt->pchannel));
+		ast_debug(1, "%s txpchan %s is no longer bridged, exiting repeater processing\n", myrpt->name, ast_channel_name(myrpt->txpchannel));
 		ast_frfree(f);
 		return -1;
 	}

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4680,6 +4680,13 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 			cs[n++] = l->chan;
 		}
 		who = ast_waitfor_n(cs, n, &ms);
+
+		/* Make sure the pchannel is still bridged */
+		if (!ast_channel_is_bridged(l->pchan)) {
+			ast_debug(1, "Link %s pchan %s is no longer bridged, exiting link processing\n", l->name, ast_channel_name(l->pchan));
+			break;
+		}
+
 		periodic_process_link(myrpt, l, rpt_time_elapsed(&looptimestart));
 		if (!ms) {
 			/* No channels had activity before the timer expired,

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4674,6 +4674,7 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 
 	while (ms >= 0 && l->disced == RPT_LINK_DISCONNECT_NONE) {
 		struct ast_unreal_pvt *p;
+		struct ast_channel *pchan = NULL;
 
 		ms = MSWAIT;
 		n = 0;
@@ -4685,10 +4686,25 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 
 		/* Make sure the pchannel is still bridged */
 		p = ast_channel_tech_pvt(l->pchan);
-		if (!p || !p->chan || !ast_channel_is_bridged(p->chan)) {
+		if (p) {
+			ao2_lock(p);
+			if (p->chan) {
+				pchan = ast_channel_ref(p->chan);
+			}
+			ao2_unlock(p);
+		}
+
+		if (!pchan) {
 			ast_debug(1, "Link %s pchan %s is no longer bridged, exiting link processing\n", l->name, ast_channel_name(l->pchan));
 			break;
 		}
+
+		if (!ast_channel_is_bridged(pchan)) {
+			ast_channel_unref(pchan);
+			ast_debug(1, "Link %s pchan %s is no longer bridged, exiting link processing\n", l->name, ast_channel_name(l->pchan));
+			break;
+		}
+		ast_channel_unref(pchan);
 
 		periodic_process_link(myrpt, l, rpt_time_elapsed(&looptimestart));
 		if (!ms) {

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4458,6 +4458,49 @@ static inline int hangup_frame_helper(struct ast_channel *chan, const char *chan
 	return 0;
 }
 
+/*!
+ * \brief Check if an unreal channel is bridged (helper function)
+ * \param chan The channel to check
+ * \return 1 if bridged, 0 otherwise (including invalid channel, and incorrect channel type)
+ */
+static int rpt_channel_is_bridged(struct ast_channel *chan)
+{
+	struct ast_unreal_pvt *p;
+	struct ast_channel *pchan = NULL;
+
+	if (!chan) {
+		return 0;
+	}
+
+	if (!ast_channel_tech(chan)->type || strcmp(ast_channel_tech(chan)->type, "Local")) {
+		/* Channel is not a Local (unreal) channel */
+		return 0;
+	}
+
+	p = ast_channel_tech_pvt(chan);
+	if (!p) {
+		return 0;
+	}
+
+	ao2_lock(p);
+	if (p->chan) {
+		pchan = ast_channel_ref(p->chan);
+	}
+	ao2_unlock(p);
+
+	if (!pchan) {
+		return 0;
+	}
+
+	if (!ast_channel_is_bridged(pchan)) {
+		ast_channel_unref(pchan);
+		return 0;
+	}
+	ast_channel_unref(pchan);
+
+	return 1;
+}
+
 static inline int pchannel_read(struct rpt *myrpt)
 {
 	struct ast_frame *f = ast_read(myrpt->pchannel);
@@ -4465,6 +4508,13 @@ static inline int pchannel_read(struct rpt *myrpt)
 		ast_debug(1, "@@@@ rpt:Hung Up\n");
 		return -1;
 	}
+
+	if (!rpt_channel_is_bridged(myrpt->pchannel)) {
+		ast_debug(1, "%s pchan %s is no longer bridged, exiting repeater processing\n", myrpt->name, ast_channel_name(myrpt->pchannel));
+		ast_frfree(f);
+		return -1;
+	}
+
 	if (f->frametype == AST_FRAME_VOICE) {
 		if (!myrpt->localoverride && ((myrpt->p.duplex == 2) || (myrpt->p.duplex == 4))) {
 			/* We are in full duplex mode, send pchannel audio to txpchannel
@@ -4673,9 +4723,6 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 	looptimestart = rpt_tvnow();
 
 	while (ms >= 0 && l->disced == RPT_LINK_DISCONNECT_NONE) {
-		struct ast_unreal_pvt *p;
-		struct ast_channel *pchan = NULL;
-
 		ms = MSWAIT;
 		n = 0;
 		cs[n++] = l->pchan;
@@ -4685,26 +4732,10 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 		who = ast_waitfor_n(cs, n, &ms);
 
 		/* Make sure the pchannel is still bridged */
-		p = ast_channel_tech_pvt(l->pchan);
-		if (p) {
-			ao2_lock(p);
-			if (p->chan) {
-				pchan = ast_channel_ref(p->chan);
-			}
-			ao2_unlock(p);
-		}
-
-		if (!pchan) {
+		if (!rpt_channel_is_bridged(l->pchan)) {
 			ast_debug(1, "Link %s pchan %s is no longer bridged, exiting link processing\n", l->name, ast_channel_name(l->pchan));
 			break;
 		}
-
-		if (!ast_channel_is_bridged(pchan)) {
-			ast_channel_unref(pchan);
-			ast_debug(1, "Link %s pchan %s is no longer bridged, exiting link processing\n", l->name, ast_channel_name(l->pchan));
-			break;
-		}
-		ast_channel_unref(pchan);
 
 		periodic_process_link(myrpt, l, rpt_time_elapsed(&looptimestart));
 		if (!ms) {
@@ -5098,6 +5129,13 @@ static inline int rxpchannel_read(struct rpt *myrpt)
 		ast_debug(1, "@@@@ rpt:Hung Up\n");
 		return -1;
 	}
+
+	if (!rpt_channel_is_bridged(myrpt->rxpchannel)) {
+		ast_debug(1, "%s rxpchan %s is no longer bridged, exiting repeater processing\n", myrpt->name, ast_channel_name(myrpt->pchannel));
+		ast_frfree(f);
+		return -1;
+	}
+
 	if (f->frametype == AST_FRAME_VOICE) {
 		if (!myrpt->localoverride && (myrpt->p.duplex != 2) && (myrpt->p.duplex != 4)) {
 			/* We are in 1/2 duplex mode or mode 3, send rxpchannel audio to txpchannel
@@ -5117,6 +5155,13 @@ static inline int txpchannel_read(struct rpt *myrpt)
 		ast_debug(1, "@@@@ rpt:Hung Up\n");
 		return -1;
 	}
+
+	if (!rpt_channel_is_bridged(myrpt->txpchannel)) {
+		ast_debug(1, "%s txpchan %s is no longer bridged, exiting repeater processing\n", myrpt->name, ast_channel_name(myrpt->pchannel));
+		ast_frfree(f);
+		return -1;
+	}
+
 	return hangup_frame_helper(myrpt->txpchannel, "txpchannel", f);
 }
 

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4685,11 +4685,7 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 
 		/* Make sure the pchannel is still bridged */
 		p = ast_channel_tech_pvt(l->pchan);
-		if (!p || !p->chan) {
-			break;
-		}
-
-		if (!ast_channel_is_bridged(p->chan)) {
+		if (!p || !p->chan || !ast_channel_is_bridged(p->chan)) {
 			ast_debug(1, "Link %s pchan %s is no longer bridged, exiting link processing\n", l->name, ast_channel_name(l->pchan));
 			break;
 		}


### PR DESCRIPTION
When a bridge is destroyed or dumps a channel, it simply releases the channel but does not hangup. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of channels that are no longer bridged.
  * Processing now stops cleanly when a bridged connection becomes invalid.
  * Prevented stale or invalid frames from continuing through channel and link processing.
  * Improved connection stability by safely releasing received data when bridging is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->