### PR TITLE
app_rpt.c: check bridge state for repeater channels

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4461,6 +4461,7 @@ static inline int hangup_frame_helper(struct ast_channel *chan, const char *chan
 static inline int pchannel_read(struct rpt *myrpt)
 {
 	struct ast_unreal_pvt *p;
+	struct ast_channel *pchan = NULL;
 	struct ast_frame *f = ast_read(myrpt->pchannel);
 
 	if (!f) {
@@ -4469,11 +4470,27 @@ static inline int pchannel_read(struct rpt *myrpt)
 	}
 
 	p = ast_channel_tech_pvt(myrpt->pchannel);
-	if (!p || !p->chan || !ast_channel_is_bridged(p->chan)) {
+	if (p) {
+		ao2_lock(p);
+		if (p->chan) {
+			pchan = ast_channel_ref(p->chan);
+		}
+		ao2_unlock(p);
+	}
+
+	if (!pchan) {
 		ast_debug(1, "%s pchan %s is no longer bridged, exiting repeater processing\n", myrpt->name, ast_channel_name(myrpt->pchannel));
 		ast_frfree(f);
 		return -1;
 	}
+
+	if (!ast_channel_is_bridged(pchan)) {
+		ast_channel_unref(pchan);
+		ast_debug(1, "%s pchan %s is no longer bridged, exiting repeater processing\n", myrpt->name, ast_channel_name(myrpt->pchannel));
+		ast_frfree(f);
+		return -1;
+	}
+	ast_channel_unref(pchan);
 
 	if (f->frametype == AST_FRAME_VOICE) {
 		if (!myrpt->localoverride && ((myrpt->p.duplex == 2) || (myrpt->p.duplex == 4))) {
@@ -5077,11 +5094,38 @@ static inline int monchannel_read(struct rpt *myrpt)
 
 static inline int rxpchannel_read(struct rpt *myrpt)
 {
+	struct ast_unreal_pvt *p;
+	struct ast_channel *pchan = NULL;
 	struct ast_frame *f = ast_read(myrpt->rxpchannel);
+
 	if (!f) {
 		ast_debug(1, "@@@@ rpt:Hung Up\n");
 		return -1;
 	}
+
+	p = ast_channel_tech_pvt(myrpt->rxpchannel);
+	if (p) {
+		ao2_lock(p);
+		if (p->chan) {
+			pchan = ast_channel_ref(p->chan);
+		}
+		ao2_unlock(p);
+	}
+
+	if (!pchan) {
+		ast_debug(1, "%s rxpchan %s is no longer bridged, exiting repeater processing\n", myrpt->name, ast_channel_name(myrpt->rxpchannel));
+		ast_frfree(f);
+		return -1;
+	}
+
+	if (!ast_channel_is_bridged(pchan)) {
+		ast_channel_unref(pchan);
+		ast_debug(1, "%s rxpchan %s is no longer bridged, exiting repeater processing\n", myrpt->name, ast_channel_name(myrpt->rxpchannel));
+		ast_frfree(f);
+		return -1;
+	}
+	ast_channel_unref(pchan);
+
 	if (f->frametype == AST_FRAME_VOICE) {
 		if (!myrpt->localoverride && (myrpt->p.duplex != 2) && (myrpt->p.duplex != 4)) {
 			/* We are in 1/2 duplex mode or mode 3, send rxpchannel audio to txpchannel
@@ -5097,6 +5141,7 @@ static inline int rxpchannel_read(struct rpt *myrpt)
 static inline int txpchannel_read(struct rpt *myrpt)
 {
 	struct ast_unreal_pvt *p;
+	struct ast_channel *pchan = NULL;
 	struct ast_frame *f = ast_read(myrpt->txpchannel);
 
 	if (!f) {
@@ -5105,11 +5150,27 @@ static inline int txpchannel_read(struct rpt *myrpt)
 	}
 
 	p = ast_channel_tech_pvt(myrpt->txpchannel);
-	if (!p || !p->chan || !ast_channel_is_bridged(p->chan)) {
-		ast_debug(1, "%s pchan %s is no longer bridged, exiting repeater processing\n", myrpt->name, ast_channel_name(myrpt->pchannel));
+	if (p) {
+		ao2_lock(p);
+		if (p->chan) {
+			pchan = ast_channel_ref(p->chan);
+		}
+		ao2_unlock(p);
+	}
+
+	if (!pchan) {
+		ast_debug(1, "%s txpchan %s is no longer bridged, exiting repeater processing\n", myrpt->name, ast_channel_name(myrpt->txpchannel));
 		ast_frfree(f);
 		return -1;
 	}
+
+	if (!ast_channel_is_bridged(pchan)) {
+		ast_channel_unref(pchan);
+		ast_debug(1, "%s txpchan %s is no longer bridged, exiting repeater processing\n", myrpt->name, ast_channel_name(myrpt->txpchannel));
+		ast_frfree(f);
+		return -1;
+	}
+	ast_channel_unref(pchan);
 
 	return hangup_frame_helper(myrpt->txpchannel, "txpchannel", f);
 }

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4460,11 +4460,23 @@ static inline int hangup_frame_helper(struct ast_channel *chan, const char *chan
 
 static inline int pchannel_read(struct rpt *myrpt)
 {
+	struct ast_unreal_pvt *p;
 	struct ast_frame *f = ast_read(myrpt->pchannel);
+
 	if (!f) {
 		ast_debug(1, "@@@@ rpt:Hung Up\n");
 		return -1;
 	}
+	p = ast_channel_tech_pvt(myrpt->pchannel);
+	if (!p || !p->chan) {
+		return -1;
+	}
+
+	if (!ast_channel_is_bridged(p->chan)) {
+		ast_debug(1, "%s pchan %s is no longer bridged, exiting repeater processing\n", myrpt->name, ast_channel_name(myrpt->pchannel));
+		return -1;
+	}
+
 	if (f->frametype == AST_FRAME_VOICE) {
 		if (!myrpt->localoverride && ((myrpt->p.duplex == 2) || (myrpt->p.duplex == 4))) {
 			/* We are in full duplex mode, send pchannel audio to txpchannel
@@ -5086,11 +5098,24 @@ static inline int rxpchannel_read(struct rpt *myrpt)
 
 static inline int txpchannel_read(struct rpt *myrpt)
 {
+	struct ast_unreal_pvt *p;
 	struct ast_frame *f = ast_read(myrpt->txpchannel);
+
 	if (!f) {
 		ast_debug(1, "@@@@ rpt:Hung Up\n");
 		return -1;
 	}
+
+	p = ast_channel_tech_pvt(myrpt->pchannel);
+	if (!p || !p->chan) {
+		return -1;
+	}
+
+	if (!ast_channel_is_bridged(p->chan)) {
+		ast_debug(1, "%s pchan %s is no longer bridged, exiting repeater processing\n", myrpt->name, ast_channel_name(myrpt->pchannel));
+		return -1;
+	}
+
 	return hangup_frame_helper(myrpt->txpchannel, "txpchannel", f);
 }
 

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4467,13 +4467,9 @@ static inline int pchannel_read(struct rpt *myrpt)
 		ast_debug(1, "@@@@ rpt:Hung Up\n");
 		return -1;
 	}
-	p = ast_channel_tech_pvt(myrpt->pchannel);
-	if (!p || !p->chan) {
-		ast_frfree(f);
-		return -1;
-	}
 
-	if (!ast_channel_is_bridged(p->chan)) {
+	p = ast_channel_tech_pvt(myrpt->pchannel);
+	if (!p || !p->chan || !ast_channel_is_bridged(p->chan)) {
 		ast_debug(1, "%s pchan %s is no longer bridged, exiting repeater processing\n", myrpt->name, ast_channel_name(myrpt->pchannel));
 		ast_frfree(f);
 		return -1;
@@ -5109,12 +5105,7 @@ static inline int txpchannel_read(struct rpt *myrpt)
 	}
 
 	p = ast_channel_tech_pvt(myrpt->txpchannel);
-	if (!p || !p->chan) {
-		ast_frfree(f);
-		return -1;
-	}
-
-	if (!ast_channel_is_bridged(p->chan)) {
+	if (!p || !p->chan || !ast_channel_is_bridged(p->chan)) {
 		ast_debug(1, "%s pchan %s is no longer bridged, exiting repeater processing\n", myrpt->name, ast_channel_name(myrpt->pchannel));
 		ast_frfree(f);
 		return -1;

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4469,11 +4469,13 @@ static inline int pchannel_read(struct rpt *myrpt)
 	}
 	p = ast_channel_tech_pvt(myrpt->pchannel);
 	if (!p || !p->chan) {
+		ast_frfree(f);
 		return -1;
 	}
 
 	if (!ast_channel_is_bridged(p->chan)) {
 		ast_debug(1, "%s pchan %s is no longer bridged, exiting repeater processing\n", myrpt->name, ast_channel_name(myrpt->pchannel));
+		ast_frfree(f);
 		return -1;
 	}
 
@@ -5106,13 +5108,15 @@ static inline int txpchannel_read(struct rpt *myrpt)
 		return -1;
 	}
 
-	p = ast_channel_tech_pvt(myrpt->pchannel);
+	p = ast_channel_tech_pvt(myrpt->txpchannel);
 	if (!p || !p->chan) {
+		ast_frfree(f);
 		return -1;
 	}
 
 	if (!ast_channel_is_bridged(p->chan)) {
 		ast_debug(1, "%s pchan %s is no longer bridged, exiting repeater processing\n", myrpt->name, ast_channel_name(myrpt->pchannel));
+		ast_frfree(f);
 		return -1;
 	}
 


### PR DESCRIPTION
CONF is covered with the pchannel, TXCONF is covered with the txpchannel.
Should one of these conferences "die", it appears the only indication the channel is out of the conference is to check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repeater channel handling when a connected peer is unavailable or no longer bridged.
  * Repeater processing now exits cleanly instead of continuing with an invalid channel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->