### PR TITLE
app_rpt: Address incorrect unlock and case switch flow in rpt_tele_thread()

### DIFF
--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -2328,9 +2328,10 @@ treataslocal:
 		} else if (!strcmp(myrpt->remoterig, REMOTE_RIG_RBI) || !strcmp(myrpt->remoterig, REMOTE_RIG_PPP16)) {
 #ifdef HAVE_SYS_IO
 			if (ioperm(myrpt->p.iobase, 1, 1) == -1) {
-				rpt_mutex_unlock(&myrpt->lock);
+				rpt_mutex_unlock(&myrpt->remlock);
 				ast_log(LOG_WARNING, "Can't get io permission on IO port %x hex\n", myrpt->p.iobase);
 				res = -1;
+				break;
 			} else {
 				res = setrbi(myrpt);
 			}

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -2328,6 +2328,7 @@ treataslocal:
 		} else if (!strcmp(myrpt->remoterig, REMOTE_RIG_RBI) || !strcmp(myrpt->remoterig, REMOTE_RIG_PPP16)) {
 #ifdef HAVE_SYS_IO
 			if (ioperm(myrpt->p.iobase, 1, 1) == -1) {
+				myrpt->remsetting = 0;
 				rpt_mutex_unlock(&myrpt->remlock);
 				ast_log(LOG_WARNING, "Can't get io permission on IO port %x hex\n", myrpt->p.iobase);
 				res = -1;

--- a/apps/app_rpt/rpt_telemetry.c
+++ b/apps/app_rpt/rpt_telemetry.c
@@ -2328,11 +2328,8 @@ treataslocal:
 		} else if (!strcmp(myrpt->remoterig, REMOTE_RIG_RBI) || !strcmp(myrpt->remoterig, REMOTE_RIG_PPP16)) {
 #ifdef HAVE_SYS_IO
 			if (ioperm(myrpt->p.iobase, 1, 1) == -1) {
-				myrpt->remsetting = 0;
-				rpt_mutex_unlock(&myrpt->remlock);
 				ast_log(LOG_WARNING, "Can't get io permission on IO port %x hex\n", myrpt->p.iobase);
 				res = -1;
-				break;
 			} else {
 				res = setrbi(myrpt);
 			}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue affecting RBI/PPP16 remote rig setup when permission access fails.
  * Prevented incorrect follow-up processing and ensured remote-operation locking is properly released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->