### PR TITLE
app_rpt.c: Optimize calculation of remrx, reducing locking requirements.

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -3422,6 +3422,23 @@ static inline void link_process_textq(struct rpt *myrpt, struct rpt_link *l)
 	rpt_mutex_unlock(&myrpt->lock);
 }
 
+static inline void rpt_update_link_rx_state(struct rpt *myrpt, struct rpt_link *l, int new_lastrx)
+{
+	if (l->lastrx == new_lastrx) {
+		return;
+	}
+
+	/* Only count links with mode < 2 (MODE_MONITOR & MODE_TRANSCEIVE) */
+	if (l->mode < 2) {
+		if (new_lastrx) {
+			ast_atomic_fetchadd_int(&myrpt->eligible_remrx_cnt, 1);
+		} else {
+			ast_atomic_fetchadd_int(&myrpt->eligible_remrx_cnt, -1);
+		}
+	}
+	l->lastrx = new_lastrx;
+}
+
 static inline void periodic_process_link(struct rpt *myrpt, struct rpt_link *l, const int elap)
 {
 	int newkeytimer_last, max_retries;
@@ -3537,7 +3554,7 @@ static inline void periodic_process_link(struct rpt *myrpt, struct rpt_link *l, 
 		if (!l->voxtostate)
 			myrx = myrx || l->wasvox;
 	}
-	l->lastrx = myrx;
+	rpt_update_link_rx_state(myrpt, l, myrx);
 
 	update_timer(&l->linklisttimer, elap, 0);
 
@@ -4657,14 +4674,12 @@ static inline void rxkey_helper(struct rpt *myrpt, struct rpt_link *l)
 void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 {
 	struct ast_channel *who;
-	struct rpt_link *m;
 	int n = 0, ms = MSWAIT, myfirst = 0;
 	struct ast_channel *cs[2];
 	struct ast_frame wf = {
 		.frametype = AST_FRAME_CNG,
 		.src = __PRETTY_FUNCTION__,
 	};
-	struct ao2_iterator l_it;
 	int totx;
 	int remnomute, remrx;
 	struct timeval now;
@@ -4673,6 +4688,7 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 	looptimestart = rpt_tvnow();
 
 	while (ms >= 0 && l->disced == RPT_LINK_DISCONNECT_NONE) {
+		int active_rx_count;
 		ms = MSWAIT;
 		n = 0;
 		cs[n++] = l->pchan;
@@ -4689,24 +4705,12 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 
 		remrx = 0;
 		/* see if any other links are receiving */
-		if (myrpt->remrx) {
-			if (!l->lastrx) {
-				/* myrpt->remrx is true and this link is NOT receiving,
-				 * so another link MUST be receiving. No lock needed! */
-				remrx = 1;
-			} else {
-				/* Only lock if THIS link is receiving and we need to verify
-				 * whether a SECOND link is also receiving. */
-				rpt_mutex_lock(&myrpt->lock);
-				RPT_LIST_TRAVERSE(myrpt->links, m, l_it) {
-					/* if not the link we are currently processing, and not localonly count it */
-					if ((m != l) && (m->lastrx) && (m->mode < 2)) {
-						remrx = 1;
-					}
-				}
-				ao2_iterator_destroy(&l_it);
-				rpt_mutex_unlock(&myrpt->lock);
-			}
+		active_rx_count = ast_atomic_fetchadd_int(&myrpt->eligible_remrx_cnt, 0);
+		/* If this current link is active and eligible, subtract 1 to check if ANOTHER eligible link is receiving */
+		if (l->lastrx && l->mode < 2) {
+			remrx = (active_rx_count > 1);
+		} else {
+			remrx = (active_rx_count > 0);
 		}
 
 		now = rpt_tvnow();
@@ -4993,6 +4997,7 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 		continue;
 	}
 	/* Link is done: Cleanup channels and link structure */
+	rpt_update_link_rx_state(myrpt, l, 0);
 	rpt_mutex_lock(&myrpt->lock);
 	ao2_ref(l, +1);					  /* prevent freeing while we finish up */
 	rpt_link_remove(myrpt->links, l); /* remove from queue */

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -3225,7 +3225,7 @@ static inline void dump_rpt(struct rpt *myrpt, const int lasttx, const int laste
 	ast_debug(2, "lastexttx = %d\n", lastexttx);
 	ast_debug(2, "elap = %d\n", elap);
 	ast_debug(2, "totx = %d\n", totx);
-
+	ast_debug(2, "myrpt->eligible_remrx_cnt = %d\n", myrpt->eligible_remrx_cnt);
 	ast_debug(2, "myrpt->keyed = %d\n", myrpt->keyed);
 	ast_debug(2, "myrpt->localtx = %d\n", myrpt->localtx);
 	ast_debug(2, "myrpt->callmode = %d\n", myrpt->callmode);

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -3422,6 +3422,21 @@ static inline void link_process_textq(struct rpt *myrpt, struct rpt_link *l)
 	rpt_mutex_unlock(&myrpt->lock);
 }
 
+static inline void rpt_update_link_mode(struct rpt *myrpt, struct rpt_link *l, int new_mode)
+{
+	if (l->last_mode == new_mode) {
+		return;
+	}
+	if (l->lastrx) {
+		if (l->last_mode < 2 && new_mode >= 2) {
+			ast_atomic_fetchadd_int(&myrpt->eligible_remrx_cnt, -1);
+		} else if (l->last_mode >= 2 && new_mode < 2) {
+			ast_atomic_fetchadd_int(&myrpt->eligible_remrx_cnt, 1);
+		}
+	}
+	l->last_mode = new_mode;
+}
+
 static inline void rpt_update_link_rx_state(struct rpt *myrpt, struct rpt_link *l, int new_lastrx)
 {
 	if (l->lastrx == new_lastrx) {
@@ -3554,6 +3569,7 @@ static inline void periodic_process_link(struct rpt *myrpt, struct rpt_link *l, 
 		if (!l->voxtostate)
 			myrx = myrx || l->wasvox;
 	}
+	rpt_update_link_mode(myrpt, l, l->mode);
 	rpt_update_link_rx_state(myrpt, l, myrx);
 
 	update_timer(&l->linklisttimer, elap, 0);

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -4689,15 +4689,25 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 
 		remrx = 0;
 		/* see if any other links are receiving */
-		rpt_mutex_lock(&myrpt->lock);
-		RPT_LIST_TRAVERSE(myrpt->links, m, l_it) {
-			/* if not the link we are currently processing, and not localonly count it */
-			if ((m != l) && (m->lastrx) && (m->mode < 2)) {
+		if (myrpt->remrx) {
+			if (!l->lastrx) {
+				/* myrpt->remrx is true and this link is NOT receiving,
+				 * so another link MUST be receiving. No lock needed! */
 				remrx = 1;
+			} else {
+				/* Only lock if THIS link is receiving and we need to verify
+				 * whether a SECOND link is also receiving. */
+				rpt_mutex_lock(&myrpt->lock);
+				RPT_LIST_TRAVERSE(myrpt->links, m, l_it) {
+					/* if not the link we are currently processing, and not localonly count it */
+					if ((m != l) && (m->lastrx) && (m->mode < 2)) {
+						remrx = 1;
+					}
+				}
+				ao2_iterator_destroy(&l_it);
+				rpt_mutex_unlock(&myrpt->lock);
 			}
 		}
-		ao2_iterator_destroy(&l_it);
-		rpt_mutex_unlock(&myrpt->lock);
 
 		now = rpt_tvnow();
 		if ((who == l->chan) || (!l->lastlinktv.tv_sec) || (ast_tvdiff_ms(now, l->lastlinktv) >= 19)) {

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -1126,6 +1126,7 @@ struct rpt {
 	rpt_bool deferid:1;
 	rpt_bool last_statpost_failed:1;
 	struct timeval lastlinktime;
+	volatile int eligible_remrx_cnt; /* Count of receiving links with mode < 2 */
 };
 
 struct nodelog {

--- a/apps/app_rpt/app_rpt.h
+++ b/apps/app_rpt/app_rpt.h
@@ -564,6 +564,7 @@ struct rpt_link {
 	struct rpt_link *next;
 	struct rpt_link *prev;
 	enum link_mode mode;
+	enum link_mode last_mode;
 	char isremote;
 	enum rpt_phone_mode phonemode;
 	char phonevox;		   /* vox the phone */

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -774,7 +774,7 @@ void *rpt_link_connect(void *data)
 		if ((CHAN_TECH(l->chan, "echolink")) || (CHAN_TECH(l->chan, "tlb"))) {
 			ast_copy_string(myrpt->lastlinknode, node, sizeof(myrpt->lastlinknode));
 			rpt_mutex_unlock(&myrpt->lock);
-			l->mode = connect_data->mode;
+			rpt_update_link_mode(myrpt, l, connect_data->mode);
 			ao2_ref(l, -1);
 			goto cleanup;
 		}

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -697,6 +697,21 @@ void rpt_update_links(struct rpt *myrpt)
 	ast_free(obuf);
 }
 
+static inline void rpt_update_link_mode(struct rpt *myrpt, struct rpt_link *l, int new_mode)
+{
+	if (l->mode == new_mode) {
+		return;
+	}
+	if (l->lastrx) {
+		if (l->mode < 2 && new_mode >= 2) {
+			ast_atomic_fetchadd_int(&myrpt->eligible_remrx_cnt, -1);
+		} else if (l->mode >= 2 && new_mode < 2) {
+			ast_atomic_fetchadd_int(&myrpt->eligible_remrx_cnt, 1);
+		}
+	}
+	l->mode = new_mode;
+}
+
 void *rpt_link_connect(void *data)
 {
 	char *s, *s1, *tele, *cp;
@@ -812,7 +827,7 @@ void *rpt_link_connect(void *data)
 		ao2_ref(l, -1);
 		goto cleanup;
 	}
-	l->mode = connect_data->mode;
+	rpt_update_link_mode(myrpt, l, connect_data->mode);
 	l->outbound = 1;
 	l->thisconnected = 0;
 	voxinit_link(l, 1);

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -697,21 +697,6 @@ void rpt_update_links(struct rpt *myrpt)
 	ast_free(obuf);
 }
 
-static inline void rpt_update_link_mode(struct rpt *myrpt, struct rpt_link *l, int new_mode)
-{
-	if (l->mode == new_mode) {
-		return;
-	}
-	if (l->lastrx) {
-		if (l->mode < 2 && new_mode >= 2) {
-			ast_atomic_fetchadd_int(&myrpt->eligible_remrx_cnt, -1);
-		} else if (l->mode >= 2 && new_mode < 2) {
-			ast_atomic_fetchadd_int(&myrpt->eligible_remrx_cnt, 1);
-		}
-	}
-	l->mode = new_mode;
-}
-
 void *rpt_link_connect(void *data)
 {
 	char *s, *s1, *tele, *cp;
@@ -774,7 +759,7 @@ void *rpt_link_connect(void *data)
 		if ((CHAN_TECH(l->chan, "echolink")) || (CHAN_TECH(l->chan, "tlb"))) {
 			ast_copy_string(myrpt->lastlinknode, node, sizeof(myrpt->lastlinknode));
 			rpt_mutex_unlock(&myrpt->lock);
-			rpt_update_link_mode(myrpt, l, connect_data->mode);
+			l->mode = connect_data->mode;
 			ao2_ref(l, -1);
 			goto cleanup;
 		}
@@ -822,12 +807,14 @@ void *rpt_link_connect(void *data)
 	if (!l) {
 		goto cleanup;
 	}
+
 	l->linklist = ast_str_create(RPT_AST_STR_INIT_SIZE);
 	if (!l->linklist) {
 		ao2_ref(l, -1);
 		goto cleanup;
 	}
-	rpt_update_link_mode(myrpt, l, connect_data->mode);
+
+	l->mode = connect_data->mode;
 	l->outbound = 1;
 	l->thisconnected = 0;
 	voxinit_link(l, 1);


### PR DESCRIPTION
Reduce locking by determining `remrx` with `myrpt->remrx`.  Only search other links IF the link is receiving to find if some other link is also receiving.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved link status processing by replacing repeated link-list scans with more efficient tracking.
  * Updated receive-state handling to provide faster, more consistent channel status updates.

* **Bug Fixes**
  * Improved cleanup when link connection setup cannot allocate required resources.

* **Diagnostics**
  * Added the tracked eligible receive-link count to diagnostic output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->