### PR TITLE
app_rpt: Flush !!DISCONNECT!! before softhangup

### DIFF
--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -1914,8 +1914,7 @@ static void handle_link_data(struct rpt *myrpt, struct rpt_link *mylink, char *s
 
 	if (!strcmp(str, DISCSTR)) {
 		/* Peer asked us to drop this link; demote permalinks so #574 infinite
-		 * retry cannot resurrect it. stop_retries softhangups so teardown
-		 * runs through remote_hangup_helper (textq flush).
+		 * retry cannot resurrect it. Link thread softhangups after textq flush (#1236).
 		 */
 		rpt_link_stop_retries(mylink);
 		return;
@@ -3646,6 +3645,17 @@ static inline int periodic_process_link(struct rpt *myrpt, struct rpt_link *l, c
 		}
 
 		/*
+		 * Channel already gone and disconnect was requested (demote during reconnect
+		 * wait, unsupported-type stop_retries, etc.): finish so the link thread exits
+		 * and tears down pchan — do not leave the link stranded without l->chan.
+		 */
+		if (!l->chan && l->disced != RPT_LINK_DISCONNECT_NONE) {
+			if (!strcmp(myrpt->cmdnode, l->name)) {
+				myrpt->cmdnode[0] = 0;
+			}
+			return -1;
+		}
+		/*
 		 * Reconnect only while the channel is down. Count attempts here — not on every
 		 * tick while connected (that exhausted MAX_RETRIES within ~100ms after ANSWER).
 		 * Permanent links keep trying unless rpt_link_stop_retries() demoted them.
@@ -4732,9 +4742,10 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 	looptimestart = rpt_tvnow();
 
 	/*
-	 * Do not exit on disced or !chan. softhangup must reach remote_hangup_helper.
-	 * Unexpected inbound loss keeps ticking until disctime expires (LINKDISC AA);
-	 * intentional inbound DISCSTR finishes immediately in remote_hangup_helper.
+	 * Do not exit on disced or !chan alone.
+	 * Intentional disconnect: periodic flushes textq, then we softhangup so
+	 * !!DISCONNECT!! goes out before hangup (#1236). Unexpected inbound loss
+	 * keeps ticking until disctime expires (LINKDISC AA).
 	 * periodic_process_link returns -1 when that timeout/give-up path finishes.
 	 */
 	while (ms >= 0) {
@@ -4752,6 +4763,23 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 		who = ast_waitfor_n(cs, n, &ms);
 		if (periodic_process_link(myrpt, l, rpt_time_elapsed(&looptimestart))) {
 			break;
+		}
+		/*
+		 * After demote/disced, flush any remaining textq (incl. !!DISCONNECT!!)
+		 * on a live channel, wait briefly for TX, then softhangup (#1236).
+		 */
+		if (l->disced != RPT_LINK_DISCONNECT_NONE && l->chan && !ast_check_hangup(l->chan)) {
+			if (l->pchan) {
+				ast_autoservice_start(l->pchan);
+			}
+			link_process_textq(myrpt, l);
+			ast_safe_sleep(l->chan, MSWAIT * 10);
+			if (l->pchan) {
+				ast_autoservice_stop(l->pchan);
+			}
+			if (l->chan) {
+				ast_softhangup(l->chan, AST_SOFTHANGUP_DEV);
+			}
 		}
 		if (!ms) {
 			/* No channels had activity before the timer expired,

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -1913,9 +1913,9 @@ static void handle_link_data(struct rpt *myrpt, struct rpt_link *mylink, char *s
 	ast_debug(5, "Received text over link: '%s'\n", str);
 
 	if (!strcmp(str, DISCSTR)) {
-		/* Peer asked us to drop this link; demote permalinks so #574 infinite
-		 * retry cannot resurrect it. Arms disctime; link thread waits for peer
-		 * hangup / expiry before teardown (#1236 / #1218).
+		/* Peer asked us to drop this link. Demote permalinks, but do not arm
+		 * disctime — the receiver must close promptly so a peer that is waiting
+		 * its own grace window is not stuck until both timers expire (#1236).
 		 */
 		rpt_link_stop_retries(mylink);
 		return;
@@ -3622,11 +3622,12 @@ static inline int periodic_process_link(struct rpt *myrpt, struct rpt_link *l, c
 	update_timer(&l->retrytimer, elap, 0);
 
 	/*
-	 * Intentional disconnect (#1218): after !!DISCONNECT!! was flushed via textq,
-	 * wait for the peer to drop during disctime. Force softhangup only if still up.
+	 * Force hangup when disced is set and disctime is not running:
+	 * - received !!DISCONNECT!! never arms grace, so this closes promptly;
+	 * - a local initiator only reaches here after the armed grace expires.
 	 */
 	if (l->disced == RPT_LINK_DISCONNECT && !l->disctime && l->chan && !ast_check_hangup(l->chan)) {
-		ast_debug(1, "disctime expired on %s, forcing hangup\n", l->name);
+		ast_debug(1, "disconnect on %s: hanging up (grace not running)\n", l->name);
 		ast_softhangup(l->chan, AST_SOFTHANGUP_DEV);
 	}
 
@@ -4695,10 +4696,20 @@ static int remote_hangup_helper(struct rpt *myrpt, struct rpt_link *l)
 	}
 
 	/*
-	 * Inbound: park on disctime (unexpected, or intentional after DISCSTR/stop_retries
-	 * armed it) so periodic LINKDISC AA runs on expiry. Do not finish early on disced.
+	 * Inbound unexpected loss parks on disctime. A local initiator that already
+	 * armed grace keeps that timer (do not start a second one). Received DISCSTR
+	 * or a grace timer that already expired must not be rearmed.
 	 */
 	if (!l->outbound) {
+		if (l->disced == RPT_LINK_DISCONNECT && l->disctime) {
+			hangup_link_chan(l);
+			return 1;
+		}
+		if (l->disced != RPT_LINK_DISCONNECT_NONE && !l->disctime) {
+			hangup_link_chan(l);
+			inbound_link_finished(myrpt, l);
+			return 0;
+		}
 		if (!l->disctime) {
 			if ((l->name[0] <= '0') || (l->name[0] > '9') || l->isremote) {
 				l->disctime = 1;
@@ -4710,10 +4721,14 @@ static int remote_hangup_helper(struct rpt *myrpt, struct rpt_link *l)
 		return 1;
 	}
 
-	/* Intentional outbound disconnect: do not redial; wait for disctime expiry. */
-	if (l->disced == RPT_LINK_DISCONNECT) {
+	/* Local outbound disconnect: do not redial; wait out armed grace. */
+	if (l->disced == RPT_LINK_DISCONNECT && l->disctime) {
 		hangup_link_chan(l);
 		return 1;
+	}
+	if (l->disced == RPT_LINK_DISCONNECT) {
+		hangup_link_chan(l);
+		return 0;
 	}
 	if (l->disced == RPT_LINK_DISCONNECT_SILENT) {
 		hangup_link_chan(l);

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -1914,7 +1914,8 @@ static void handle_link_data(struct rpt *myrpt, struct rpt_link *mylink, char *s
 
 	if (!strcmp(str, DISCSTR)) {
 		/* Peer asked us to drop this link; demote permalinks so #574 infinite
-		 * retry cannot resurrect it. Link thread softhangups after textq flush (#1236).
+		 * retry cannot resurrect it. Arms disctime; link thread waits for peer
+		 * hangup / expiry before teardown (#1236 / #1218).
 		 */
 		rpt_link_stop_retries(mylink);
 		return;
@@ -3426,7 +3427,7 @@ static inline void link_process_textq(struct rpt *myrpt, struct rpt_link *l)
 
 /*!
  * \brief Finish an inbound link after chan is gone (LINKDISC AA side effects).
- * Used after disctime expires, or immediately on intentional inbound DISCSTR.
+ * Used after disctime expires (unexpected loss or intentional disconnect grace).
  */
 static void inbound_link_finished(struct rpt *myrpt, struct rpt_link *l)
 {
@@ -3620,6 +3621,15 @@ static inline int periodic_process_link(struct rpt *myrpt, struct rpt_link *l, c
 
 	update_timer(&l->retrytimer, elap, 0);
 
+	/*
+	 * Intentional disconnect (#1218): after !!DISCONNECT!! was flushed via textq,
+	 * wait for the peer to drop during disctime. Force softhangup only if still up.
+	 */
+	if (l->disced == RPT_LINK_DISCONNECT && !l->disctime && l->chan && !ast_check_hangup(l->chan)) {
+		ast_debug(1, "disctime expired on %s, forcing hangup\n", l->name);
+		ast_softhangup(l->chan, AST_SOFTHANGUP_DEV);
+	}
+
 	/* start tracking connect time */
 	if (ast_tvzero(l->connecttime)) {
 		l->connecttime = rpt_tvnow();
@@ -3645,13 +3655,23 @@ static inline int periodic_process_link(struct rpt *myrpt, struct rpt_link *l, c
 		}
 
 		/*
-		 * Channel already gone and disconnect was requested (demote during reconnect
-		 * wait, unsupported-type stop_retries, etc.): finish so the link thread exits
-		 * and tears down pchan — do not leave the link stranded without l->chan.
+		 * Intentional disconnect with channel already gone: wait out disctime so
+		 * LINKDISC AA / telem still run on expiry (#1218). Then finish.
 		 */
 		if (!l->chan && l->disced != RPT_LINK_DISCONNECT_NONE) {
+			if (l->disctime) {
+				return 0;
+			}
 			if (!strcmp(myrpt->cmdnode, l->name)) {
 				myrpt->cmdnode[0] = 0;
+			}
+			if (l->disced == RPT_LINK_DISCONNECT && l->hasconnected) {
+				if (l->name[0] != '0') {
+					rpt_telemetry(myrpt, REMDISC, l);
+				}
+				rpt_update_links(myrpt);
+				dodispgm(myrpt, l->name);
+				donodelog_fmt(myrpt, "LINKDISC,%s", l->name);
 			}
 			return -1;
 		}
@@ -4660,33 +4680,42 @@ static int remote_hangup_helper(struct rpt *myrpt, struct rpt_link *l)
 		rpt_update_links(myrpt);
 	}
 
-	if (!l->chan || CHAN_TECH(l->chan, "echolink") || CHAN_TECH(l->chan, "tlb") || ast_shutting_down()) {
+	if (!l->chan) {
+		/*
+		 * Intentional disconnect: peer already gone — keep the link thread alive on
+		 * pchan until disctime expires so LINKDISC AA still runs (#1218).
+		 */
+		if (l->disced == RPT_LINK_DISCONNECT && l->disctime) {
+			return 1;
+		}
+		return 0;
+	}
+	if (CHAN_TECH(l->chan, "echolink") || CHAN_TECH(l->chan, "tlb") || ast_shutting_down()) {
 		return 0;
 	}
 
 	/*
-	 * Unexpected inbound loss parks on disctime so periodic LINKDISC AA can run.
-	 * Intentional inbound disconnect (disced already set) skips that grace period.
+	 * Inbound: park on disctime (unexpected, or intentional after DISCSTR/stop_retries
+	 * armed it) so periodic LINKDISC AA runs on expiry. Do not finish early on disced.
 	 */
 	if (!l->outbound) {
-		if (l->disced != RPT_LINK_DISCONNECT_NONE) {
-			hangup_link_chan(l);
-			inbound_link_finished(myrpt, l);
-			return 0;
-		}
-		if ((l->name[0] <= '0') || (l->name[0] > '9') || l->isremote) {
-			/* Not an allstar link node */
-			l->disctime = 1;
-		} else {
-			/* An allstar link node */
-			l->disctime = DISC_TIME;
+		if (!l->disctime) {
+			if ((l->name[0] <= '0') || (l->name[0] > '9') || l->isremote) {
+				l->disctime = 1;
+			} else {
+				l->disctime = DISC_TIME;
+			}
 		}
 		hangup_link_chan(l);
 		return 1;
 	}
 
-	/* Intentional outbound disconnect: do not redial. */
-	if (l->disced != RPT_LINK_DISCONNECT_NONE) {
+	/* Intentional outbound disconnect: do not redial; wait for disctime expiry. */
+	if (l->disced == RPT_LINK_DISCONNECT) {
+		hangup_link_chan(l);
+		return 1;
+	}
+	if (l->disced == RPT_LINK_DISCONNECT_SILENT) {
 		hangup_link_chan(l);
 		return 0;
 	}
@@ -4743,9 +4772,10 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 
 	/*
 	 * Do not exit on disced or !chan alone.
-	 * Intentional disconnect: periodic flushes textq, then we softhangup so
-	 * !!DISCONNECT!! goes out before hangup (#1236). Unexpected inbound loss
-	 * keeps ticking until disctime expires (LINKDISC AA).
+	 * Intentional DISCONNECT: textq flush (periodic) sends !!DISCONNECT!!, then we
+	 * wait for the peer during disctime and force softhangup only if still up (#1218).
+	 * SILENT: softhangup promptly (no DISCSTR / no grace wait).
+	 * Unexpected inbound loss parks on disctime until LINKDISC AA.
 	 * periodic_process_link returns -1 when that timeout/give-up path finishes.
 	 */
 	while (ms >= 0) {
@@ -4764,22 +4794,9 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 		if (periodic_process_link(myrpt, l, rpt_time_elapsed(&looptimestart))) {
 			break;
 		}
-		/*
-		 * After demote/disced, flush any remaining textq (incl. !!DISCONNECT!!)
-		 * on a live channel, wait briefly for TX, then softhangup (#1236).
-		 */
-		if (l->disced != RPT_LINK_DISCONNECT_NONE && l->chan && !ast_check_hangup(l->chan)) {
-			if (l->pchan) {
-				ast_autoservice_start(l->pchan);
-			}
-			link_process_textq(myrpt, l);
-			ast_safe_sleep(l->chan, MSWAIT * 10);
-			if (l->pchan) {
-				ast_autoservice_stop(l->pchan);
-			}
-			if (l->chan) {
-				ast_softhangup(l->chan, AST_SOFTHANGUP_DEV);
-			}
+		/* Silent teardown: no DISCSTR grace period — hang up now. */
+		if (l->disced == RPT_LINK_DISCONNECT_SILENT && l->chan && !ast_check_hangup(l->chan)) {
+			ast_softhangup(l->chan, AST_SOFTHANGUP_DEV);
 		}
 		if (!ms) {
 			/* No channels had activity before the timer expired,

--- a/apps/app_rpt.c
+++ b/apps/app_rpt.c
@@ -1913,9 +1913,8 @@ static void handle_link_data(struct rpt *myrpt, struct rpt_link *mylink, char *s
 	ast_debug(5, "Received text over link: '%s'\n", str);
 
 	if (!strcmp(str, DISCSTR)) {
-		/* Peer asked us to drop this link. Demote permalinks, but do not arm
-		 * disctime — the receiver must close promptly so a peer that is waiting
-		 * its own grace window is not stuck until both timers expire (#1236).
+		/* Peer asked us to drop this link; demote permalinks so #574 infinite
+		 * retry cannot resurrect it. Link thread softhangups after textq flush (#1236).
 		 */
 		rpt_link_stop_retries(mylink);
 		return;
@@ -3427,7 +3426,7 @@ static inline void link_process_textq(struct rpt *myrpt, struct rpt_link *l)
 
 /*!
  * \brief Finish an inbound link after chan is gone (LINKDISC AA side effects).
- * Used after disctime expires (unexpected loss or intentional disconnect grace).
+ * Used after disctime expires, or immediately on intentional inbound DISCSTR.
  */
 static void inbound_link_finished(struct rpt *myrpt, struct rpt_link *l)
 {
@@ -3621,16 +3620,6 @@ static inline int periodic_process_link(struct rpt *myrpt, struct rpt_link *l, c
 
 	update_timer(&l->retrytimer, elap, 0);
 
-	/*
-	 * Force hangup when disced is set and disctime is not running:
-	 * - received !!DISCONNECT!! never arms grace, so this closes promptly;
-	 * - a local initiator only reaches here after the armed grace expires.
-	 */
-	if (l->disced == RPT_LINK_DISCONNECT && !l->disctime && l->chan && !ast_check_hangup(l->chan)) {
-		ast_debug(1, "disconnect on %s: hanging up (grace not running)\n", l->name);
-		ast_softhangup(l->chan, AST_SOFTHANGUP_DEV);
-	}
-
 	/* start tracking connect time */
 	if (ast_tvzero(l->connecttime)) {
 		l->connecttime = rpt_tvnow();
@@ -3656,23 +3645,12 @@ static inline int periodic_process_link(struct rpt *myrpt, struct rpt_link *l, c
 		}
 
 		/*
-		 * Intentional disconnect with channel already gone: wait out disctime so
-		 * LINKDISC AA / telem still run on expiry (#1218). Then finish.
+		 * Intentional disconnect and channel already gone: finish so the link
+		 * thread exits and tears down pchan (no disctime wait on local disconnect).
 		 */
 		if (!l->chan && l->disced != RPT_LINK_DISCONNECT_NONE) {
-			if (l->disctime) {
-				return 0;
-			}
 			if (!strcmp(myrpt->cmdnode, l->name)) {
 				myrpt->cmdnode[0] = 0;
-			}
-			if (l->disced == RPT_LINK_DISCONNECT && l->hasconnected) {
-				if (l->name[0] != '0') {
-					rpt_telemetry(myrpt, REMDISC, l);
-				}
-				rpt_update_links(myrpt);
-				dodispgm(myrpt, l->name);
-				donodelog_fmt(myrpt, "LINKDISC,%s", l->name);
 			}
 			return -1;
 		}
@@ -4681,56 +4659,33 @@ static int remote_hangup_helper(struct rpt *myrpt, struct rpt_link *l)
 		rpt_update_links(myrpt);
 	}
 
-	if (!l->chan) {
-		/*
-		 * Intentional disconnect: peer already gone — keep the link thread alive on
-		 * pchan until disctime expires so LINKDISC AA still runs (#1218).
-		 */
-		if (l->disced == RPT_LINK_DISCONNECT && l->disctime) {
-			return 1;
-		}
-		return 0;
-	}
-	if (CHAN_TECH(l->chan, "echolink") || CHAN_TECH(l->chan, "tlb") || ast_shutting_down()) {
+	if (!l->chan || CHAN_TECH(l->chan, "echolink") || CHAN_TECH(l->chan, "tlb") || ast_shutting_down()) {
 		return 0;
 	}
 
 	/*
-	 * Inbound unexpected loss parks on disctime. A local initiator that already
-	 * armed grace keeps that timer (do not start a second one). Received DISCSTR
-	 * or a grace timer that already expired must not be rearmed.
+	 * Unexpected inbound loss parks on disctime so periodic LINKDISC AA can run.
+	 * Intentional inbound DISCSTR (disced already set) finishes immediately.
 	 */
 	if (!l->outbound) {
-		if (l->disced == RPT_LINK_DISCONNECT && l->disctime) {
-			hangup_link_chan(l);
-			return 1;
-		}
-		if (l->disced != RPT_LINK_DISCONNECT_NONE && !l->disctime) {
+		if (l->disced != RPT_LINK_DISCONNECT_NONE) {
 			hangup_link_chan(l);
 			inbound_link_finished(myrpt, l);
 			return 0;
 		}
-		if (!l->disctime) {
-			if ((l->name[0] <= '0') || (l->name[0] > '9') || l->isremote) {
-				l->disctime = 1;
-			} else {
-				l->disctime = DISC_TIME;
-			}
+		if ((l->name[0] <= '0') || (l->name[0] > '9') || l->isremote) {
+			/* Not an allstar link node */
+			l->disctime = 1;
+		} else {
+			/* An allstar link node */
+			l->disctime = DISC_TIME;
 		}
 		hangup_link_chan(l);
 		return 1;
 	}
 
-	/* Local outbound disconnect: do not redial; wait out armed grace. */
-	if (l->disced == RPT_LINK_DISCONNECT && l->disctime) {
-		hangup_link_chan(l);
-		return 1;
-	}
-	if (l->disced == RPT_LINK_DISCONNECT) {
-		hangup_link_chan(l);
-		return 0;
-	}
-	if (l->disced == RPT_LINK_DISCONNECT_SILENT) {
+	/* Intentional outbound disconnect: do not redial. */
+	if (l->disced != RPT_LINK_DISCONNECT_NONE) {
 		hangup_link_chan(l);
 		return 0;
 	}
@@ -4787,10 +4742,9 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 
 	/*
 	 * Do not exit on disced or !chan alone.
-	 * Intentional DISCONNECT: textq flush (periodic) sends !!DISCONNECT!!, then we
-	 * wait for the peer during disctime and force softhangup only if still up (#1218).
-	 * SILENT: softhangup promptly (no DISCSTR / no grace wait).
-	 * Unexpected inbound loss parks on disctime until LINKDISC AA.
+	 * Intentional disconnect: flush textq (incl. !!DISCONNECT!!) on a live channel,
+	 * wait briefly for TX, then softhangup (#1236). Unexpected inbound loss parks
+	 * on disctime until LINKDISC AA. disctime is not used for local disconnect.
 	 * periodic_process_link returns -1 when that timeout/give-up path finishes.
 	 */
 	while (ms >= 0) {
@@ -4809,9 +4763,22 @@ void process_link_channel(struct rpt *myrpt, struct rpt_link *l)
 		if (periodic_process_link(myrpt, l, rpt_time_elapsed(&looptimestart))) {
 			break;
 		}
-		/* Silent teardown: no DISCSTR grace period — hang up now. */
-		if (l->disced == RPT_LINK_DISCONNECT_SILENT && l->chan && !ast_check_hangup(l->chan)) {
-			ast_softhangup(l->chan, AST_SOFTHANGUP_DEV);
+		/*
+		 * After demote/disced, flush any remaining textq (incl. !!DISCONNECT!!)
+		 * on a live channel, wait briefly for TX, then softhangup (#1236).
+		 */
+		if (l->disced != RPT_LINK_DISCONNECT_NONE && l->chan && !ast_check_hangup(l->chan)) {
+			if (l->pchan) {
+				ast_autoservice_start(l->pchan);
+			}
+			link_process_textq(myrpt, l);
+			ast_safe_sleep(l->chan, MSWAIT * 10);
+			if (l->pchan) {
+				ast_autoservice_stop(l->pchan);
+			}
+			if (l->chan) {
+				ast_softhangup(l->chan, AST_SOFTHANGUP_DEV);
+			}
 		}
 		if (!ms) {
 			/* No channels had activity before the timer expired,

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -183,8 +183,9 @@ enum rpt_function_response function_ilink(struct rpt *myrpt, char *param, char *
 		}
 		ast_copy_string(myrpt->lastlinknode, digitbuf, sizeof(myrpt->lastlinknode));
 		/*
-		 * Queue !!DISCONNECT!! for the link thread, then demote/disced.
-		 * The link thread flushes textq before softhangup (#1236 / #932).
+		 * Queue !!DISCONNECT!! for the link thread, then demote/disced and arm
+		 * disctime. Link thread flushes textq, waits for the peer, force-hangs
+		 * up only after disctime if still connected (#1236 / #1218).
 		 */
 		if (l->chan && l->thisconnected) {
 			rpt_link_queue_disconnect(l);

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -183,17 +183,13 @@ enum rpt_function_response function_ilink(struct rpt *myrpt, char *param, char *
 		}
 		ast_copy_string(myrpt->lastlinknode, digitbuf, sizeof(myrpt->lastlinknode));
 		/*
-		 * Queue !!DISCONNECT!! for the link thread, then demote/softhangup.
-		 * Cross-thread ast_write is unsafe while process_link_channel owns
-		 * the channel in ast_waitfor_n; textq is flushed in remote_hangup_helper
-		 * after softhangup wakes that thread (#1216 / #932).
+		 * Queue !!DISCONNECT!! for the link thread, then demote/disced.
+		 * The link thread flushes textq before softhangup (#1236 / #932).
 		 */
 		if (l->chan && l->thisconnected) {
 			rpt_link_queue_disconnect(l);
 		}
-		rpt_mutex_unlock(&myrpt->lock);
 		rpt_link_stop_retries(l);
-		rpt_mutex_lock(&myrpt->lock);
 		myrpt->linkactivityflag = 1;
 		rpt_mutex_unlock(&myrpt->lock);
 		rpt_telem_select(myrpt, command_source, mylink);

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -183,15 +183,14 @@ enum rpt_function_response function_ilink(struct rpt *myrpt, char *param, char *
 		}
 		ast_copy_string(myrpt->lastlinknode, digitbuf, sizeof(myrpt->lastlinknode));
 		/*
-		 * Local initiator only: queue !!DISCONNECT!!, demote, and arm disctime.
-		 * The link thread flushes textq, waits for the peer, and force-hangs up
-		 * only after expiry. A received DISCSTR does not arm grace (#1236 / #1218).
+		 * Queue !!DISCONNECT!! for the link thread, then demote/disced.
+		 * The link thread flushes textq before softhangup (#1236).
+		 * disctime is not used here — it is only for unexpected inbound loss.
 		 */
 		if (l->chan && l->thisconnected) {
 			rpt_link_queue_disconnect(l);
 		}
 		rpt_link_stop_retries(l);
-		rpt_link_arm_disconnect_grace(l);
 		myrpt->linkactivityflag = 1;
 		rpt_mutex_unlock(&myrpt->lock);
 		rpt_telem_select(myrpt, command_source, mylink);

--- a/apps/app_rpt/rpt_functions.c
+++ b/apps/app_rpt/rpt_functions.c
@@ -183,14 +183,15 @@ enum rpt_function_response function_ilink(struct rpt *myrpt, char *param, char *
 		}
 		ast_copy_string(myrpt->lastlinknode, digitbuf, sizeof(myrpt->lastlinknode));
 		/*
-		 * Queue !!DISCONNECT!! for the link thread, then demote/disced and arm
-		 * disctime. Link thread flushes textq, waits for the peer, force-hangs
-		 * up only after disctime if still connected (#1236 / #1218).
+		 * Local initiator only: queue !!DISCONNECT!!, demote, and arm disctime.
+		 * The link thread flushes textq, waits for the peer, and force-hangs up
+		 * only after expiry. A received DISCSTR does not arm grace (#1236 / #1218).
 		 */
 		if (l->chan && l->thisconnected) {
 			rpt_link_queue_disconnect(l);
 		}
 		rpt_link_stop_retries(l);
+		rpt_link_arm_disconnect_grace(l);
 		myrpt->linkactivityflag = 1;
 		rpt_mutex_unlock(&myrpt->lock);
 		rpt_telem_select(myrpt, command_source, mylink);

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -224,22 +224,10 @@ void rpt_link_stop_retries_common(struct rpt_link *l, enum rpt_link_disconnect d
 	rpt_link_demote_retries(l);
 	l->disced = disced;
 	/*
-	 * Do not softhangup and do not arm disctime here. A received !!DISCONNECT!!
-	 * must close promptly. Only a local initiator arms grace (see
-	 * rpt_link_arm_disconnect_grace) so two updated peers cannot wait on each other.
+	 * Do not softhangup here. Queued !!DISCONNECT!! (and other textq frames) must
+	 * be written by the link thread before the channel is hung up (#1236).
+	 * Do not arm disctime — that timer is only for unexpected inbound loss.
 	 */
-}
-
-void rpt_link_arm_disconnect_grace(struct rpt_link *l)
-{
-	if (l->disctime) {
-		return;
-	}
-	if ((l->name[0] <= '0') || (l->name[0] > '9') || l->isremote) {
-		l->disctime = 1;
-	} else {
-		l->disctime = DISC_TIME;
-	}
 }
 
 void rpt_link_queue_disconnect(struct rpt_link *l)

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -224,16 +224,21 @@ void rpt_link_stop_retries_common(struct rpt_link *l, enum rpt_link_disconnect d
 	rpt_link_demote_retries(l);
 	l->disced = disced;
 	/*
-	 * Do not softhangup here. For RPT_LINK_DISCONNECT the link thread flushes
-	 * textq (incl. !!DISCONNECT!!), arms/waits disctime for the peer to drop,
-	 * and only force-hangs up if still up after expiry (#1236 / #1218).
+	 * Do not softhangup and do not arm disctime here. A received !!DISCONNECT!!
+	 * must close promptly. Only a local initiator arms grace (see
+	 * rpt_link_arm_disconnect_grace) so two updated peers cannot wait on each other.
 	 */
-	if (disced == RPT_LINK_DISCONNECT && !l->disctime) {
-		if ((l->name[0] <= '0') || (l->name[0] > '9') || l->isremote) {
-			l->disctime = 1;
-		} else {
-			l->disctime = DISC_TIME;
-		}
+}
+
+void rpt_link_arm_disconnect_grace(struct rpt_link *l)
+{
+	if (l->disctime) {
+		return;
+	}
+	if ((l->name[0] <= '0') || (l->name[0] > '9') || l->isremote) {
+		l->disctime = 1;
+	} else {
+		l->disctime = DISC_TIME;
 	}
 }
 

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -224,9 +224,17 @@ void rpt_link_stop_retries_common(struct rpt_link *l, enum rpt_link_disconnect d
 	rpt_link_demote_retries(l);
 	l->disced = disced;
 	/*
-	 * Do not softhangup here. Queued !!DISCONNECT!! (and other textq frames) must
-	 * be written by the link thread before the channel is hung up (#1236).
+	 * Do not softhangup here. For RPT_LINK_DISCONNECT the link thread flushes
+	 * textq (incl. !!DISCONNECT!!), arms/waits disctime for the peer to drop,
+	 * and only force-hangs up if still up after expiry (#1236 / #1218).
 	 */
+	if (disced == RPT_LINK_DISCONNECT && !l->disctime) {
+		if ((l->name[0] <= '0') || (l->name[0] > '9') || l->isremote) {
+			l->disctime = 1;
+		} else {
+			l->disctime = DISC_TIME;
+		}
+	}
 }
 
 void rpt_link_queue_disconnect(struct rpt_link *l)

--- a/apps/app_rpt/rpt_link.c
+++ b/apps/app_rpt/rpt_link.c
@@ -223,9 +223,10 @@ void rpt_link_stop_retries_common(struct rpt_link *l, enum rpt_link_disconnect d
 {
 	rpt_link_demote_retries(l);
 	l->disced = disced;
-	if (l->chan) {
-		ast_softhangup(l->chan, AST_SOFTHANGUP_DEV);
-	}
+	/*
+	 * Do not softhangup here. Queued !!DISCONNECT!! (and other textq frames) must
+	 * be written by the link thread before the channel is hung up (#1236).
+	 */
 }
 
 void rpt_link_queue_disconnect(struct rpt_link *l)
@@ -795,11 +796,8 @@ void *rpt_link_connect(void *data)
 		}
 		rpt_mutex_unlock(&myrpt->lock);
 		reconnects = l->reconnects;
-		if (l->chan) {
-			ast_softhangup(l->chan, AST_SOFTHANGUP_DEV);
-		}
-		l->retries = l->max_retries + 1;
-		l->disced = RPT_LINK_DISCONNECT_SILENT;
+		/* Demote before hangup so permalinks cannot redial during mode change. */
+		rpt_link_stop_retries_silent(l);
 		modechange = 1;
 		ao2_ref(l, -1);
 	} else { /* Check to see if this node is already linked */

--- a/apps/app_rpt/rpt_link.h
+++ b/apps/app_rpt/rpt_link.h
@@ -36,9 +36,7 @@ void rpt_qwrite(struct rpt_link *l, struct ast_frame *f);
  *
  * Demotes permanent links off MAX_RETRIES_PERM, marks retries exhausted,
  * clears perma, and sets disced. Does not softhangup and does not arm disctime.
- * The receiver of !!DISCONNECT!! uses this alone so it can close promptly.
- * A locally initiated disconnect must also call rpt_link_arm_disconnect_grace()
- * so the link thread waits for the peer before force-hangup (#1236 / #1218).
+ * The link thread flushes textq (if any) then softhangups (#1236).
  *
  * \note Locking: does not take myrpt->lock and does not touch the channel, so it
  * is safe with or without myrpt->lock held. Do not call while holding a channel lock.
@@ -47,13 +45,6 @@ void rpt_link_stop_retries_common(struct rpt_link *l, enum rpt_link_disconnect d
 
 #define rpt_link_stop_retries(l) rpt_link_stop_retries_common((l), RPT_LINK_DISCONNECT)
 #define rpt_link_stop_retries_silent(l) rpt_link_stop_retries_common((l), RPT_LINK_DISCONNECT_SILENT)
-
-/*!
- * \brief Arm inbound-style disctime so a local disconnect can wait for the peer.
- * \param l Link already marked RPT_LINK_DISCONNECT
- * \note Does not arm if disctime is already running. Do not call for a received DISCSTR.
- */
-void rpt_link_arm_disconnect_grace(struct rpt_link *l);
 
 /*!
  * \brief Queue !!DISCONNECT!! on the link textq for the link thread to flush.

--- a/apps/app_rpt/rpt_link.h
+++ b/apps/app_rpt/rpt_link.h
@@ -35,14 +35,25 @@ void rpt_qwrite(struct rpt_link *l, struct ast_frame *f);
  * \param disced Disconnect flavor (RPT_LINK_DISCONNECT or _SILENT)
  *
  * Demotes permanent links off MAX_RETRIES_PERM, marks retries exhausted,
- * clears perma, and sets disced. For RPT_LINK_DISCONNECT, arms disctime so the
- * link thread can flush textq and wait for the peer before force-hangup (#1236 / #1218).
- * Does not softhangup. Safe under myrpt->lock.
+ * clears perma, and sets disced. Does not softhangup and does not arm disctime.
+ * The receiver of !!DISCONNECT!! uses this alone so it can close promptly.
+ * A locally initiated disconnect must also call rpt_link_arm_disconnect_grace()
+ * so the link thread waits for the peer before force-hangup (#1236 / #1218).
+ *
+ * \note Locking: does not take myrpt->lock and does not touch the channel, so it
+ * is safe with or without myrpt->lock held. Do not call while holding a channel lock.
  */
 void rpt_link_stop_retries_common(struct rpt_link *l, enum rpt_link_disconnect disced);
 
 #define rpt_link_stop_retries(l) rpt_link_stop_retries_common((l), RPT_LINK_DISCONNECT)
 #define rpt_link_stop_retries_silent(l) rpt_link_stop_retries_common((l), RPT_LINK_DISCONNECT_SILENT)
+
+/*!
+ * \brief Arm inbound-style disctime so a local disconnect can wait for the peer.
+ * \param l Link already marked RPT_LINK_DISCONNECT
+ * \note Does not arm if disctime is already running. Do not call for a received DISCSTR.
+ */
+void rpt_link_arm_disconnect_grace(struct rpt_link *l);
 
 /*!
  * \brief Queue !!DISCONNECT!! on the link textq for the link thread to flush.

--- a/apps/app_rpt/rpt_link.h
+++ b/apps/app_rpt/rpt_link.h
@@ -35,8 +35,9 @@ void rpt_qwrite(struct rpt_link *l, struct ast_frame *f);
  * \param disced Disconnect flavor (RPT_LINK_DISCONNECT or _SILENT)
  *
  * Demotes permanent links off MAX_RETRIES_PERM, marks retries exhausted,
- * clears perma, and sets disced. Does not softhangup — the link thread
- * flushes textq first, then softhangups (#1236). Safe under myrpt->lock.
+ * clears perma, and sets disced. For RPT_LINK_DISCONNECT, arms disctime so the
+ * link thread can flush textq and wait for the peer before force-hangup (#1236 / #1218).
+ * Does not softhangup. Safe under myrpt->lock.
  */
 void rpt_link_stop_retries_common(struct rpt_link *l, enum rpt_link_disconnect disced);
 

--- a/apps/app_rpt/rpt_link.h
+++ b/apps/app_rpt/rpt_link.h
@@ -35,8 +35,8 @@ void rpt_qwrite(struct rpt_link *l, struct ast_frame *f);
  * \param disced Disconnect flavor (RPT_LINK_DISCONNECT or _SILENT)
  *
  * Demotes permanent links off MAX_RETRIES_PERM, marks retries exhausted,
- * clears perma, sets disced, and softhangups the link channel.
- * Do not call while holding a channel lock.
+ * clears perma, and sets disced. Does not softhangup — the link thread
+ * flushes textq first, then softhangups (#1236). Safe under myrpt->lock.
  */
 void rpt_link_stop_retries_common(struct rpt_link *l, enum rpt_link_disconnect disced);
 


### PR DESCRIPTION
## Summary
- Fixes #1236: `rpt_link_stop_retries*` only demotes/`disced`; the link thread flushes textq (including `!!DISCONNECT!!`), waits briefly, then softhangups so the peer sees DISCSTR before hangup.
- Mode-change teardown uses `rpt_link_stop_retries_silent()` so permalinks cannot redial mid-change.
- Outbound `!chan` with a non-none disconnect finishes the link thread so `pchan` is not left stranded (e.g. demote during reconnect wait).

## Test plan
- [ ] Permanent outbound link: `ilink 11` / Perm Disconnect — peer receives `!!DISCONNECT!!`; local node does not redial
- [ ] Same path while a reconnect timer is pending — link exits and `pchan` is torn down
- [ ] Mode change on an existing AllStar link — old link demotes cleanly; no unexpected permalink redial
- [ ] Inbound intentional DISCSTR still tears down without parking on `disctime`
- [ ] Unexpected inbound loss still parks on `disctime` for LINKDISC AA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved link disconnect handling to ensure queued disconnect messages are transmitted before the connection closes.
  - Prevented premature channel hangups during link shutdown and mode changes.
  - Improved cleanup when a link is already unavailable, reducing the risk of lingering link state.
- **Documentation**
  - Updated technical documentation to reflect the revised disconnect and message-flushing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->